### PR TITLE
feat: build test contracts automatically

### DIFF
--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -52,9 +52,6 @@ jobs:
         ci_run /root/.foundry/bin/foundryup
         echo /root/.foundry/bin >> $GITHUB_PATH
 
-    - name: Build test-contracts
-      run: ci_run forge build --root integration-tests/test-contracts
-
     # todo: move linting for both core and integration-tests to a separate job
     - name: Run clippy
       run: ci_run cargo clippy --all-targets --all-features -p zksync_os_integration_tests -- -D warnings

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 publish = false
+build = "build.rs"
 
 [dependencies]
 zksync_os_l1_sender.workspace = true

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -1,0 +1,39 @@
+use std::process::Command;
+use std::str::from_utf8;
+
+fn main() {
+    // Rerun build script when test contracts
+    println!("cargo::rerun-if-changed=test-contracts/src");
+    println!("cargo::rerun-if-changed=test-contracts/foundry.toml");
+
+    // Check that `forge` is installed and is executable
+    let Ok(status) = Command::new("forge").arg("--version").status() else {
+        println!("cargo::warning=`forge` not found, skipping build script");
+        println!("cargo::warning=visit https://getfoundry.sh/ for installation instructions");
+        return;
+    };
+    if !status.success() {
+        println!("cargo::warning=could not run `forge --version`, skipping build script");
+        println!("cargo::warning=make sure your foundry installation is working correctly");
+        return;
+    }
+
+    match Command::new("forge")
+        .arg("build")
+        .arg("--root")
+        .arg("test-contracts")
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            // Success, do nothing
+        }
+        Ok(output) => {
+            println!("cargo::error=`forge build` failed, see stdout/stderr below");
+            println!("cargo::error=stdout={}", from_utf8(&output.stdout).unwrap());
+            println!("cargo::error=stderr={}", from_utf8(&output.stderr).unwrap());
+        }
+        Err(err) => {
+            println!("cargo::error=could not run `forge build`: {err}");
+        }
+    }
+}


### PR DESCRIPTION
Adds a build script that invokes `forge build` automatically from `cargo`. That should hopefully reduce development friction.