### PR TITLE
chore: speed-up release builds on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,7 @@ zksync_os_state = { path = "lib/state" }
 zksync_os_types = { path = "lib/types" }
 
 zksync_os_sequencer = { path = "node/sequencer" }
+
+[profile.release]
+# This is needed for zksync-airbender crates to compile in a reasonable time for x86-64-unknown-linux-gnu
+overflow-checks = true


### PR DESCRIPTION
Enabling overflow-checks improved build times for me locally from 60m to 3.5m (reasoning on why is unclear). Likely to help CI too.