### PR TITLE
Fake FRI provers feature

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -11,7 +11,9 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use zksync_os_l1_sender::config::L1SenderConfig;
 use zksync_os_l1_watcher::L1WatcherConfig;
-use zksync_os_sequencer::config::{MempoolConfig, ProverApiConfig, RpcConfig, SequencerConfig};
+use zksync_os_sequencer::config::{
+    FakeProversConfig, MempoolConfig, ProverApiConfig, RpcConfig, SequencerConfig,
+};
 
 pub mod assert_traits;
 pub mod contracts;
@@ -88,6 +90,10 @@ impl Tester {
             ..Default::default()
         };
         let prover_api_config = ProverApiConfig {
+            fake_provers: FakeProversConfig {
+                enabled: true,
+                ..Default::default()
+            },
             address: format!("0.0.0.0:{}", prover_api_locked_port.port),
             ..Default::default()
         };

--- a/node/sequencer/src/config.rs
+++ b/node/sequencer/src/config.rs
@@ -92,11 +92,36 @@ pub struct ProverInputGeneratorConfig {
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
 #[config(derive(Default))]
 pub struct ProverApiConfig {
+    #[config(nest)]
+    pub fake_provers: FakeProversConfig,
+
     /// Timeout after which a prover job is assigned to another Prover Worker.
-    #[config(default_t = Duration::from_secs(180))]
+    #[config(default_t = Duration::from_secs(300))]
     pub job_timeout: Duration,
 
     /// Prover API address to listen on.
     #[config(default_t = "0.0.0.0:3124".into())]
     pub address: String,
+}
+
+#[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
+#[config(derive(Default))]
+pub struct FakeProversConfig {
+    /// Whether to enable the fake provers pool.
+    #[config(default_t = false)]
+    pub enabled: bool,
+
+    /// Number of fake provers to run in parallel.
+    #[config(default_t = 10)]
+    pub workers: usize,
+
+    /// Amount of time it takes to compute a proof for one batch.
+    /// todo: Doesn't account for batch size at the moment
+    #[config(default_t = Duration::from_millis(2000))]
+    pub compute_time: Duration,
+
+    /// Only pick up jobs that are this time old
+    /// This gives real provers a head start when picking jobs
+    #[config(default_t = Duration::from_millis(3000))]
+    pub min_age: Duration,
 }

--- a/node/sequencer/src/model/batches.rs
+++ b/node/sequencer/src/model/batches.rs
@@ -57,6 +57,12 @@ impl Trace {
         self.stages.push((stage, Instant::now()));
         self
     }
+    pub fn last_stage_age(&self) -> std::time::Duration {
+        self.stages
+            .last()
+            .map(|(_, instant)| instant.elapsed())
+            .unwrap_or(self.start_instant.elapsed())
+    }
 }
 impl Default for Trace {
     fn default() -> Self {

--- a/node/sequencer/src/prover_api/fake_provers_pool.rs
+++ b/node/sequencer/src/prover_api/fake_provers_pool.rs
@@ -1,0 +1,83 @@
+use futures::future::try_join_all;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::{Instant, sleep};
+
+use crate::prover_api::prover_job_manager::ProverJobManager;
+
+const POLL_INTERVAL_MS: u64 = 100;
+const PROVER_LABEL: &str = "fake_prover";
+
+/// Emulates a pool of provers:
+/// - Picks jobs whose inbound age is at least `min_inbound_age`,
+/// - Waits `compute_time` to emulate proving,
+/// - Submits a fake proof via `ProverJobManager::submit_fake_proof`.
+#[derive(Clone, Debug)]
+pub struct FakeProversPool {
+    job_manager: Arc<ProverJobManager>,
+    workers: usize,
+    compute_time: Duration,
+    min_inbound_age: Duration,
+}
+
+impl FakeProversPool {
+    pub fn new(
+        job_manager: Arc<ProverJobManager>,
+        workers: usize,
+        compute_time: Duration,
+        min_inbound_age: Duration,
+    ) -> Self {
+        Self {
+            job_manager,
+            workers,
+            compute_time,
+            min_inbound_age,
+        }
+    }
+
+    /// Run the fake prover pool. Spawns `workers` tasks and waits for them.
+    pub async fn run(self) -> anyhow::Result<()> {
+        let mut joins = Vec::with_capacity(self.workers);
+        for _ in 0..self.workers {
+            let jm = Arc::clone(&self.job_manager);
+            let compute_time = self.compute_time;
+            let min_age = self.min_inbound_age;
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    // Only take inbound items whose age >= min_age.
+                    match jm.pick_next_job(min_age) {
+                        Some((batch_number, _prover_input)) => {
+                            // Emulate proving work.
+                            let start = Instant::now();
+                            sleep(compute_time).await;
+
+                            if let Err(e) = jm.submit_fake_proof(batch_number, PROVER_LABEL).await {
+                                tracing::warn!(
+                                    batch_number,
+                                    ?e,
+                                    elapsed_ms = start.elapsed().as_millis() as u64,
+                                    "fake prover failed to submit proof"
+                                );
+                            } else {
+                                tracing::info!(
+                                    batch_number,
+                                    elapsed_ms = start.elapsed().as_millis() as u64,
+                                    "fake prover submitted proof"
+                                );
+                            }
+                        }
+                        None => {
+                            // Nothing eligible now; back off a bit.
+                            sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;
+                        }
+                    }
+                }
+            });
+            joins.push(handle);
+        }
+
+        try_join_all(joins).await?;
+        Ok(())
+    }
+}

--- a/node/sequencer/src/prover_api/mod.rs
+++ b/node/sequencer/src/prover_api/mod.rs
@@ -1,3 +1,4 @@
+pub mod fake_provers_pool;
 pub mod gapless_committer;
 mod metrics;
 pub mod proof_storage;

--- a/node/sequencer/src/util/mod.rs
+++ b/node/sequencer/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod peekable_receiver;

--- a/node/sequencer/src/util/peekable_receiver.rs
+++ b/node/sequencer/src/util/peekable_receiver.rs
@@ -1,0 +1,86 @@
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+
+/// A wrapper around `tokio::sync::mpsc::Receiver<T>` that adds a non‑consuming
+/// `peek_with` while preserving the original `recv()` / `try_recv()` semantics.
+///
+/// Semantics:
+/// - `recv().await` / `try_recv()` will first drain the internal head buffer (if present),
+///   otherwise delegate to the inner receiver.
+/// - `peek_with()` exposes a reference to the current head without consuming it:
+///     * If no head is buffered, it performs a **non‑blocking** `try_recv()` to pull one
+///       from the channel and stores it in the head buffer.
+///     * If the channel is empty, returns `None`.
+/// - `consume_head()` consumes the **buffered head only** (never pulls a fresh item).
+#[derive(Debug)]
+pub struct PeekableReceiver<T> {
+    rx: mpsc::Receiver<T>,
+    head: Option<T>,
+}
+
+#[allow(dead_code)]
+impl<T> PeekableReceiver<T> {
+    pub fn new(rx: mpsc::Receiver<T>) -> Self {
+        Self { rx, head: None }
+    }
+
+    /// Receive the next item, awaiting if necessary.
+    /// If a head item exists, it is returned first.
+    pub async fn recv(&mut self) -> Option<T> {
+        if self.head.is_some() {
+            return self.head.take();
+        }
+        self.rx.recv().await
+    }
+
+    /// Try to receive the next item without waiting.
+    /// If a head item exists, it is returned first.
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        if let Some(v) = self.head.take() {
+            return Ok(v);
+        }
+        self.rx.try_recv()
+    }
+
+    /// Peek at the next item **without consuming it**, applying `f` to a reference.
+    /// Returns `None` if the channel is currently empty.
+    pub fn peek_with<R, F>(&mut self, f: F) -> Option<R>
+    where
+        F: FnOnce(&T) -> R,
+    {
+        if self.head.is_none() {
+            if let Ok(v) = self.rx.try_recv() {
+                self.head = Some(v);
+            } else {
+                return None;
+            }
+        }
+        self.head.as_ref().map(f)
+    }
+
+    /// Consume the **buffered head** if present (never pulls from the channel).
+    pub fn consume_head(&mut self) -> Option<T> {
+        self.head.take()
+    }
+
+    /// Returns `true` if the channel is closed and no further messages will arrive.
+    /// Note: There still may be a head item buffered locally.
+    pub fn is_closed(&self) -> bool {
+        self.rx.is_closed()
+    }
+
+    /// Close the receiver (stop accepting new messages).
+    pub fn close(&mut self) {
+        self.rx.close();
+    }
+
+    /// Returns the approximate number of messages in the channel **excluding** the head buffer.
+    pub fn len(&self) -> usize {
+        self.rx.len()
+    }
+
+    /// Returns `true` if the channel is currently empty **and** there is no head item buffered.
+    pub fn is_empty(&self) -> bool {
+        self.head.is_none() && self.rx.is_empty()
+    }
+}


### PR DESCRIPTION
Unlike in the old system, here we can run fake provers alongside real once - so we can continiously test proving logic without proving all the blocks.

