### PR TITLE
fix(l1-watch): support new deployments

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -292,4 +292,15 @@ impl<P: Provider> ZkChain<P> {
             .await
             .map(|n| n.saturating_to())
     }
+
+    /// Returns true iff the contract has non-empty code at `block_id`.
+    pub async fn code_exists_at_block(&self, block_id: BlockId) -> alloy::contract::Result<bool> {
+        let code = self
+            .provider()
+            .get_code_at(*self.address())
+            .block_id(block_id)
+            .await?;
+
+        Ok(!code.0.is_empty())
+    }
 }

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -166,6 +166,10 @@ async fn build_provider<Input: L1SenderCommand>(
     );
     let balance = res.get_balance(address).await?;
 
+    if balance.is_zero() {
+        anyhow::bail!("L1 sender's address {} has zero balance", address);
+    }
+
     tracing::info!(
         "{} L1 sender: initialized sender address {} with balance {}",
         Input::NAME,


### PR DESCRIPTION
It didn't work on sepolia because binsearch would return `0` so we scanned the whole blockchain to get the fist priority transcaiton