### PR TITLE
fix: adopt some channel capacity to accomodate all rescheduled jobs

### DIFF
--- a/node/sequencer/src/lib.rs
+++ b/node/sequencer/src/lib.rs
@@ -215,54 +215,7 @@ pub async fn run(
     //       multiple places
     let bridgehub_address = l1_watcher_config.bridgehub_address;
 
-    // ======= Boilerplate - Initialize async channels  ===========
-
-    // Channel between `BlockExecutor` and `Batcher`
-    let (blocks_for_batcher_sender, blocks_for_batcher_receiver) =
-        tokio::sync::mpsc::channel::<(BlockOutput, ReplayRecord)>(10);
-
-    // Channel between `BlockExecutor` and `TreeManager`
-    let (tree_sender, tree_receiver) = tokio::sync::mpsc::channel::<BlockOutput>(10);
-
-    // Channel between `Batcher` and `ProverInputGenerator`
-    let (batch_replay_data_sender, batch_replay_data_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<ProverInputGeneratorBatchData>>(10);
-
-    // Channel between `ProverInputGenerator` and `ProverAPI`
-    let (batch_for_proving_sender, batch_for_prover_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<ProverInput>>(10);
-
-    let (batch_with_proof_sender, batch_with_proof_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(10);
-
-    // Channel between `L1Watcher` and `BlockContextProvider`
-    let (l1_transactions_sender, l1_transactions) = tokio::sync::mpsc::channel(10);
-
-    // Channel between `GaplessCommitter` and `L1Committer`
-    let (batch_for_commit_sender, batch_for_commit_receiver) =
-        tokio::sync::mpsc::channel::<CommitCommand>(10);
-
-    // Channel between `L1Committer` and `SnarkJobManager`
-    let (batch_for_snark_sender, batch_for_snark_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(50);
-
-    // Channel between `SnarkJobManager` and `L1ProofSubmitter`
-    let (batch_for_l1_proving_sender, batch_for_l1_proving_receiver) =
-        tokio::sync::mpsc::channel::<ProofCommand>(10);
-
-    // Channel between `L1ProofSubmitter` and `PriorityTree`
-    let (batch_for_priority_tree_sender, batch_for_priority_tree_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(10);
-
-    // Channel between `PriorityTree` and `L1Executor`
-    let (batch_for_execute_sender, batch_for_execute_receiver) =
-        tokio::sync::mpsc::channel::<ExecuteCommand>(10);
-
-    // Channel between `L1Executor` and `BatchSink`
-    let (fully_processed_batch_sender, fully_processed_batch_receiver) =
-        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(10);
-
-    // =========== Boilerplate - initialize components that don't need state recovery  ===========
+    // =========== Boilerplate - initialize components that don't need state recovery or channels ===========
     tracing::info!("Initializing BlockReplayStorage");
     let block_replay_storage_rocks_db = RocksDB::<BlockReplayColumnFamily>::new(
         &sequencer_config
@@ -304,6 +257,92 @@ pub async fn run(
         mempool_config.max_tx_input_bytes,
     );
 
+    tracing::info!("reading L1 state");
+    let l1_state = get_l1_state(l1_sender_config.clone(), genesis_config.chain_id)
+        .await
+        .expect("Failed to read L1 state");
+
+    // ======= Initialize async channels  ===========
+
+    // Channel between `BlockExecutor` and `Batcher`
+    let (blocks_for_batcher_sender, blocks_for_batcher_receiver) =
+        tokio::sync::mpsc::channel::<(BlockOutput, ReplayRecord)>(10);
+
+    // Channel between `BlockExecutor` and `TreeManager`
+    let (tree_sender, tree_receiver) = tokio::sync::mpsc::channel::<BlockOutput>(10);
+
+    // Channel between `Batcher` and `ProverInputGenerator`
+    let (batch_replay_data_sender, batch_replay_data_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<ProverInputGeneratorBatchData>>(10);
+
+    // Channel between `ProverInputGenerator` and `ProverAPI`
+    let (batch_for_proving_sender, batch_for_prover_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<ProverInput>>(10);
+
+    let (batch_with_proof_sender, batch_with_proof_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(10);
+
+    // Channel between `L1Watcher` and `BlockContextProvider`
+    let (l1_transactions_sender, l1_transactions) = tokio::sync::mpsc::channel(10);
+
+    // Channel between `GaplessCommitter` and `L1Committer`
+    let (batch_for_commit_sender, batch_for_commit_receiver) =
+        tokio::sync::mpsc::channel::<CommitCommand>(10);
+
+    // Channel between `SnarkJobManager` and `L1ProofSubmitter`
+    let (batch_for_l1_proving_sender, batch_for_l1_proving_receiver) =
+        tokio::sync::mpsc::channel::<ProofCommand>(10);
+
+    // Channel between `PriorityTree` and `L1Executor`
+    let (batch_for_execute_sender, batch_for_execute_receiver) =
+        tokio::sync::mpsc::channel::<ExecuteCommand>(10);
+
+    // Channel between `L1Executor` and `BatchSink`
+    let (fully_processed_batch_sender, fully_processed_batch_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(10);
+
+    // There may be batches that are Committed but not Proven on L1 yet, or Proven but not Executed yet.
+    // We will reschedule them by loading `BatchEnvelope`s from ProofStorage
+    // and sending them to the corresponding channels.
+    // Target components don't differentiate whether a batch was rescheduled or loaded during normal operations
+
+    let committed_not_proven_batches = get_committed_not_proven_batches(&l1_state, &proof_storage)
+        .await
+        .expect("Cannot get committed not proven batches");
+
+    let proven_not_executed_batches = get_proven_not_executed_batches(&l1_state, &proof_storage)
+        .await
+        .expect("Cannot get proven not executed batches");
+
+    // We need to adopt capacity in accordance to the number of batches that we need to reschedule.
+    // Otherwise it's possible that not all rescheduled batches fit into the channel.
+    // todo: This may theoretical grow every time node restarts.
+    //  Alternatively, we can start processing messages from these channels in parallel with rescheduling -
+    //  but then we should defer launching real senders before all pending are processed
+
+    // Channel between `L1Committer` and `SnarkJobManager`
+    let (batch_for_snark_sender, batch_for_snark_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(
+            committed_not_proven_batches.len().max(10),
+        );
+
+    // Channel between `L1ProofSubmitter` and `PriorityTree`
+    let (batch_for_priority_tree_sender, batch_for_priority_tree_receiver) =
+        tokio::sync::mpsc::channel::<BatchEnvelope<FriProof>>(
+            proven_not_executed_batches.len().max(10),
+        );
+
+    reschedule_committed_not_proved_batches(committed_not_proven_batches, &batch_for_snark_sender)
+        .await
+        .expect("reschedule not proven batches");
+    reschedule_proven_not_executed_batches(
+        proven_not_executed_batches,
+        &batch_for_priority_tree_sender,
+    )
+    .await
+    .expect("reschedule not executed batches");
+
+    // =========== Initialize TreeManager ========
     tracing::info!("Initializing TreeManager");
     let tree_wrapper = TreeManager::tree_wrapper(Path::new(
         &sequencer_config.rocks_db_path.join(TREE_DB_NAME),
@@ -407,10 +446,6 @@ pub async fn run(
     }
     tracing::info!("Initializing batcher subsystem");
     // ========== Initialize L1 sender ===========
-    tracing::info!("reading L1 state");
-    let l1_state = get_l1_state(l1_sender_config.clone(), genesis_config.chain_id)
-        .await
-        .expect("Failed to read L1 state");
 
     // todo: this will not hold when we do proper batching,
     //  but both number are needed to initialize the batcher
@@ -521,24 +556,6 @@ pub async fn run(
         } else {
             noop_task(stop_receiver)
         };
-
-    // There may be batches that are Committed but not Proven on L1 yet.
-    // Scheduling them for proving.
-    reschedule_committed_not_proved_batches(
-        &l1_state,
-        &proof_storage,
-        batch_for_snark_sender.clone(),
-    )
-    .await
-    .expect("Failed to reschedule committed batches for SNARK proving");
-
-    reschedule_proved_not_executed_batches(
-        &l1_state,
-        &proof_storage,
-        batch_for_priority_tree_sender.clone(),
-    )
-    .await
-    .expect("Failed to reschedule proved batches for execution");
 
     let last_executed_block = proof_storage
         .get(l1_state.last_executed_batch)
@@ -771,11 +788,10 @@ fn run_l1_senders(
     (l1_committer, l1_proof_submitter, l1_executor)
 }
 
-pub async fn reschedule_committed_not_proved_batches(
+async fn get_committed_not_proven_batches(
     l1_state: &L1State,
     proof_storage: &ProofStorage,
-    batch_for_snark_sender: Sender<BatchEnvelope<FriProof>>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<BatchEnvelope<FriProof>>> {
     let mut batch_to_prove = l1_state.last_proved_batch + 1;
     let mut batches_to_reschedule = Vec::new();
     while batch_to_prove <= l1_state.last_committed_batch {
@@ -785,7 +801,13 @@ pub async fn reschedule_committed_not_proved_batches(
         batches_to_reschedule.push(batch_with_proof);
         batch_to_prove += 1;
     }
+    Ok(batches_to_reschedule)
+}
 
+pub async fn reschedule_committed_not_proved_batches(
+    batches_to_reschedule: Vec<BatchEnvelope<FriProof>>,
+    batch_for_snark_sender: &Sender<BatchEnvelope<FriProof>>,
+) -> Result<()> {
     if !batches_to_reschedule.is_empty() {
         tracing::info!(
             "Rescheduling batches {} to {} for SNARK proving",
@@ -806,11 +828,10 @@ pub async fn reschedule_committed_not_proved_batches(
     Ok(())
 }
 
-pub async fn reschedule_proved_not_executed_batches(
+async fn get_proven_not_executed_batches(
     l1_state: &L1State,
     proof_storage: &ProofStorage,
-    batch_for_priority_tree_sender: Sender<BatchEnvelope<FriProof>>,
-) -> anyhow::Result<()> {
+) -> Result<Vec<BatchEnvelope<FriProof>>> {
     let mut batch_to_execute = l1_state.last_executed_batch + 1;
     let mut batches_to_reschedule = Vec::new();
     while batch_to_execute <= l1_state.last_proved_batch {
@@ -820,7 +841,13 @@ pub async fn reschedule_proved_not_executed_batches(
         batches_to_reschedule.push(batch_with_proof);
         batch_to_execute += 1;
     }
+    Ok(batches_to_reschedule)
+}
 
+pub async fn reschedule_proven_not_executed_batches(
+    batches_to_reschedule: Vec<BatchEnvelope<FriProof>>,
+    batch_for_priority_tree_sender: &Sender<BatchEnvelope<FriProof>>,
+) -> anyhow::Result<()> {
     if !batches_to_reschedule.is_empty() {
         tracing::info!(
             "Rescheduling batches {} to {} for execution",


### PR DESCRIPTION
without this fix we would freeze on start when trying to reschedule more jobs than fit into a channel