### PR TITLE
fix: temporary disable l1 commit and execute watchers

### DIFF
--- a/integration-tests/tests/l1.rs
+++ b/integration-tests/tests/l1.rs
@@ -1,5 +1,5 @@
 use alloy::eips::eip1559::Eip1559Estimation;
-use alloy::network::{ReceiptResponse, TxSigner};
+use alloy::network::TxSigner;
 use alloy::primitives::{Address, B256, U256};
 use alloy::providers::utils::Eip1559Estimator;
 use alloy::providers::{PendingTransactionBuilder, Provider};
@@ -8,7 +8,6 @@ use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_integration_tests::Tester;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
-use zksync_os_integration_tests::contracts::{L1AssetRouter, L2BaseToken};
 use zksync_os_integration_tests::provider::ZksyncApi;
 use zksync_os_types::{L2ToL1Log, ZkTxType};
 
@@ -117,40 +116,40 @@ async fn l1_deposit() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test_log::test(tokio::test)]
-async fn l1_withdraw() -> anyhow::Result<()> {
-    // Test that we can withdraw L2 funds to L1
-    let tester = Tester::setup().await?;
-    let alice = tester.l2_wallet.default_signer().address();
-    let alice_l1_initial_balance = tester.l1_provider.get_balance(alice).await?;
-    let alice_l2_initial_balance = tester.l2_provider.get_balance(alice).await?;
-    let amount = U256::from(100);
-
-    let l2_base_token = L2BaseToken::new(tester.l2_zk_provider.clone());
-    let withdrawal_l2_receipt = l2_base_token
-        .withdraw(alice, amount)
-        .await?
-        .expect_to_execute()
-        .await?;
-    let l2_fee = U256::from(
-        withdrawal_l2_receipt.effective_gas_price() * withdrawal_l2_receipt.gas_used() as u128,
-    );
-
-    let l1_asset_router =
-        L1AssetRouter::new(tester.l1_provider.clone(), tester.l2_zk_provider.clone()).await?;
-    let l1_nullifier = l1_asset_router.l1_nullifier().await?;
-    let finalize_withdrawal_l1_receipt = l1_nullifier
-        .finalize_withdrawal(withdrawal_l2_receipt)
-        .await?;
-    let l1_fee = U256::from(
-        finalize_withdrawal_l1_receipt.effective_gas_price()
-            * finalize_withdrawal_l1_receipt.gas_used() as u128,
-    );
-
-    let alice_l1_final_balance = tester.l1_provider.get_balance(alice).await?;
-    let alice_l2_final_balance = tester.l2_provider.get_balance(alice).await?;
-    assert!(alice_l1_final_balance >= alice_l1_initial_balance - l1_fee + amount);
-    assert!(alice_l2_final_balance <= alice_l2_initial_balance - l2_fee - amount);
-
-    Ok(())
-}
+// #[test_log::test(tokio::test)]
+// async fn l1_withdraw() -> anyhow::Result<()> {
+//     // Test that we can withdraw L2 funds to L1
+//     let tester = Tester::setup().await?;
+//     let alice = tester.l2_wallet.default_signer().address();
+//     let alice_l1_initial_balance = tester.l1_provider.get_balance(alice).await?;
+//     let alice_l2_initial_balance = tester.l2_provider.get_balance(alice).await?;
+//     let amount = U256::from(100);
+//
+//     let l2_base_token = L2BaseToken::new(tester.l2_zk_provider.clone());
+//     let withdrawal_l2_receipt = l2_base_token
+//         .withdraw(alice, amount)
+//         .await?
+//         .expect_to_execute()
+//         .await?;
+//     let l2_fee = U256::from(
+//         withdrawal_l2_receipt.effective_gas_price() * withdrawal_l2_receipt.gas_used() as u128,
+//     );
+//
+//     let l1_asset_router =
+//         L1AssetRouter::new(tester.l1_provider.clone(), tester.l2_zk_provider.clone()).await?;
+//     let l1_nullifier = l1_asset_router.l1_nullifier().await?;
+//     let finalize_withdrawal_l1_receipt = l1_nullifier
+//         .finalize_withdrawal(withdrawal_l2_receipt)
+//         .await?;
+//     let l1_fee = U256::from(
+//         finalize_withdrawal_l1_receipt.effective_gas_price()
+//             * finalize_withdrawal_l1_receipt.gas_used() as u128,
+//     );
+//
+//     let alice_l1_final_balance = tester.l1_provider.get_balance(alice).await?;
+//     let alice_l2_final_balance = tester.l2_provider.get_balance(alice).await?;
+//     assert!(alice_l1_final_balance >= alice_l1_initial_balance - l1_fee + amount);
+//     assert!(alice_l2_final_balance <= alice_l2_initial_balance - l2_fee - amount);
+//
+//     Ok(())
+// }

--- a/node/sequencer/src/lib.rs
+++ b/node/sequencer/src/lib.rs
@@ -61,7 +61,7 @@ use zksync_os_l1_sender::commands::prove::ProofCommand;
 use zksync_os_l1_sender::config::L1SenderConfig;
 use zksync_os_l1_sender::l1_discovery::{L1State, get_l1_state};
 use zksync_os_l1_sender::run_l1_sender;
-use zksync_os_l1_watcher::{L1CommitWatcher, L1ExecuteWatcher, L1TxWatcher, L1WatcherConfig};
+use zksync_os_l1_watcher::{L1TxWatcher, L1WatcherConfig};
 use zksync_os_observability::ComponentStateLatencyTracker;
 use zksync_os_priority_tree::PriorityTreeManager;
 use zksync_os_rocksdb::RocksDB;
@@ -499,33 +499,33 @@ pub async fn run(
             last_committed_block,
             last_executed_block,
         });
-        tasks.spawn(
-            L1CommitWatcher::new(
-                l1_watcher_config.clone(),
-                l1_provider.clone(),
-                l1_state.diamond_proxy,
-                finality_storage.clone(),
-                proof_storage.clone(),
-            )
-            .await
-            .expect("failed to start L1 commit watcher")
-            .run()
-            .map(report_exit("L1 commit watcher")),
-        );
+        // tasks.spawn(
+        //     L1CommitWatcher::new(
+        //         l1_watcher_config.clone(),
+        //         l1_provider.clone(),
+        //         l1_state.diamond_proxy,
+        //         finality_storage.clone(),
+        //         proof_storage.clone(),
+        //     )
+        //     .await
+        //     .expect("failed to start L1 commit watcher")
+        //     .run()
+        //     .map(report_exit("L1 commit watcher")),
+        // );
 
-        tasks.spawn(
-            L1ExecuteWatcher::new(
-                l1_watcher_config.clone(),
-                l1_provider.clone(),
-                l1_state.diamond_proxy,
-                finality_storage.clone(),
-                proof_storage.clone(),
-            )
-            .await
-            .expect("failed to start L1 execute watcher")
-            .run()
-            .map(report_exit("L1 execute watcher")),
-        );
+        // tasks.spawn(
+        //     L1ExecuteWatcher::new(
+        //         l1_watcher_config.clone(),
+        //         l1_provider.clone(),
+        //         l1_state.diamond_proxy,
+        //         finality_storage.clone(),
+        //         proof_storage.clone(),
+        //     )
+        //     .await
+        //     .expect("failed to start L1 execute watcher")
+        //     .run()
+        //     .map(report_exit("L1 execute watcher")),
+        // );
 
         // ========== Start proving end ===========
 


### PR DESCRIPTION
THese components are breaking stage - I think because we assume one block == one batch