### PR TITLE
chore: Add GH token for cloning priv repos

### DIFF
--- a/.github/workflows/build-from-tag.yaml
+++ b/.github/workflows/build-from-tag.yaml
@@ -37,5 +37,6 @@ jobs:
     uses: ./.github/workflows/build-reusable.yaml
     secrets:
       GITHUB_TOKEN_: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
     with:
       IMAGE_TAG: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -5,6 +5,9 @@ on:
       GITHUB_TOKEN_:
         description: "Github token to push images to ghcr"
         required: true
+      GH_TOKEN:
+        description: "Token for cloning private repositories"
+        required: true
     inputs:
       IMAGE_TAG:
         description: "Image tag name"

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -30,5 +30,6 @@ jobs:
     uses: ./.github/workflows/build-reusable.yaml
     secrets:
       GITHUB_TOKEN_: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
     with:
       IMAGE_TAG: ${{ needs.setup.outputs.image_tag }}


### PR DESCRIPTION
Necessary to be able to depend in tests on zksync-os provers.