### PR TITLE
fix: skip already committed blocks before main batcher loop

### DIFF
--- a/node/sequencer/src/batcher/mod.rs
+++ b/node/sequencer/src/batcher/mod.rs
@@ -146,7 +146,10 @@ impl Batcher {
                 }
             }
         }
-        tracing::info!(self.first_block_to_process, "Received the first block after the last committed one.");
+        tracing::info!(
+            self.first_block_to_process,
+            "Received the first block after the last committed one."
+        );
         loop {
             latency_tracker.enter_state(GenericComponentState::WaitingRecv);
             tokio::select! {


### PR DESCRIPTION
Skip already committed blocks before the main batcher loop