### PR TITLE
feat!: make EN replay streams HTTP 1.0

### DIFF
--- a/node/bin/src/replay_transport.rs
+++ b/node/bin/src/replay_transport.rs
@@ -113,7 +113,7 @@ pub async fn replay_receiver(
 
     // This makes it valid HTTP
     socket
-        .write(b"POST /block_replays HTTP/1.0\r\n\r\n")
+        .write_all(b"POST /block_replays HTTP/1.0\r\n\r\n")
         .await?;
 
     // Instead of negotiating an upgrade, we just drop down to the TCP layer after the headers.

--- a/node/bin/src/replay_transport.rs
+++ b/node/bin/src/replay_transport.rs
@@ -68,7 +68,7 @@ pub async fn replay_server(
 }
 
 async fn skip_http_headers<R: AsyncBufRead + Unpin>(reader: &mut R) -> Result<(), std::io::Error> {
-    // Detects two consecutive line endings, which may be \r\n on \n.
+    // Detects two consecutive line endings, which may be \r\n or \n.
     let mut empty_line = false;
     loop {
         let buf = reader.fill_buf().await?;


### PR DESCRIPTION
Allows requests to be routed through one socket as they can be distinguished by the route /block_replays.

Plays nice with HTTP load balancers hopefully.