### PR TITLE
feat: split l1_state metrics; fix typo in l1_sender metrics

### DIFF
--- a/lib/l1_sender/src/l1_discovery.rs
+++ b/lib/l1_sender/src/l1_discovery.rs
@@ -23,13 +23,14 @@ impl L1State {
         let bridgehub: &'static str = self.bridgehub.to_string().leak();
         let diamond_proxy: &'static str = self.diamond_proxy.to_string().leak();
         let validator_timelock: &'static str = self.validator_timelock.to_string().leak();
+        L1_STATE_METRICS.l1_contract_addresses[&(bridgehub, diamond_proxy, validator_timelock)]
+            .set(1);
+
         let da_input_mode: &'static str = match self.da_input_mode {
             BatchDaInputMode::Rollup => "rollup",
             BatchDaInputMode::Validium => "validium",
         };
-        L1_STATE_METRICS.l1_addresses
-            [&(bridgehub, diamond_proxy, validator_timelock, da_input_mode)]
-            .set(1);
+        L1_STATE_METRICS.da_input_mode[&da_input_mode].set(1);
     }
 }
 

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -10,7 +10,7 @@ mod new_blocks;
 use crate::batcher_model::{BatchEnvelope, FriProof};
 use crate::commands::L1SenderCommand;
 use crate::config::L1SenderConfig;
-use crate::metrics::{L1_SENDER_METRICS, L1SenderState};
+use crate::metrics::{L1_SENDER_METRICS, L1_STATE_METRICS, L1SenderState};
 use crate::new_blocks::NewBlocks;
 use alloy::network::{EthereumWallet, TransactionBuilder};
 use alloy::primitives::utils::format_ether;
@@ -187,6 +187,8 @@ async fn register_operator<
 
     let balance = provider.get_balance(address).await?;
     L1_SENDER_METRICS.balance[&Input::NAME].set(format_ether(balance).parse()?);
+    let address_string: &'static str = address.to_string().leak();
+    L1_STATE_METRICS.l1_operator_address[&(Input::NAME, address_string)].set(1);
 
     if balance.is_zero() {
         anyhow::bail!("L1 sender's address {} has zero balance", address);
@@ -310,7 +312,7 @@ impl Heartbeat {
                 .observe(receipt.gas_used / l2_txs_count as u64);
             L1_SENDER_METRICS.l1_transaction_fee_ether[&Input::NAME]
                 .observe(format_ether(l1_transaction_fee).parse()?);
-            L1_SENDER_METRICS.l1_transaction_fee_ether[&Input::NAME]
+            L1_SENDER_METRICS.l1_transaction_fee_per_l2_tx_ether[&Input::NAME]
                 .observe(format_ether(l1_transaction_fee / l2_txs_count as u128).parse()?);
 
             Ok(())

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -34,9 +34,16 @@ impl StateLabel for L1SenderState {
 pub struct L1StateMetrics {
     /// Used to report L1 contract addresses to Prometheus.
     /// Gauge is always set to one.
-    #[metrics(labels = ["bridgehub", "diamond_proxy", "validator_timelock", "da_input_mode"])]
-    pub l1_addresses:
-        LabeledFamily<(&'static str, &'static str, &'static str, &'static str), Gauge, 4>,
+    #[metrics(labels = ["bridgehub", "diamond_proxy", "validator_timelock"])]
+    pub l1_contract_addresses: LabeledFamily<(&'static str, &'static str, &'static str), Gauge, 3>,
+    /// Used to report L1 operator addresses to Prometheus (commit/prove/execute),
+    /// Gauge is always set to one.
+    #[metrics(labels = ["operation", "operator_address"])]
+    pub l1_operator_address: LabeledFamily<(&'static str, &'static str), Gauge, 2>,
+    /// Used to report the DA mode (rollup/validium).
+    /// Gauge is always set to one.
+    #[metrics(labels = ["da_input_mode"])]
+    pub da_input_mode: LabeledFamily<&'static str, Gauge, 1>,
 }
 
 #[derive(Debug, Metrics)]
@@ -56,7 +63,7 @@ pub struct L1SenderMetrics {
 
     /// L1 Transaction fee in Ether per l2 transaction (`l1_transaction_fee / transactions_per_batch`)
     #[metrics(labels = ["command"], buckets = Buckets::exponential(0.0001..=100.0, 3.0))]
-    pub l1_transaction_fee_per_l2_tx: LabeledFamily<&'static str, Histogram<f64>>,
+    pub l1_transaction_fee_per_l2_tx_ether: LabeledFamily<&'static str, Histogram<f64>>,
 
     /// Total L1 gas used by L1 transaction (i.e. commit/prove/execute)
     #[metrics(labels = ["command"], buckets = Buckets::exponential(1.0..=10_000_000.0, 3.0))]


### PR DESCRIPTION
Follow up to #352  - minor metrtics reorganization and a typo fix