### PR TITLE
fix: use correct previous_block_timestamp on server restart

### DIFF
--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -124,6 +124,12 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                         ZkEnvelope::Upgrade(_) => {}
                     }
                 }
+                anyhow::ensure!(
+                    self.previous_block_timestamp == record.previous_block_timestamp,
+                    "inconsistent previous block timestamp: {} in component state, {} in resolved ReplayRecord",
+                    self.previous_block_timestamp,
+                    record.previous_block_timestamp
+                );
                 PreparedBlockCommand {
                     block_context: record.block_context,
                     seal_policy: SealPolicy::UntilExhausted,

--- a/node/bin/src/block_replay_storage.rs
+++ b/node/bin/src/block_replay_storage.rs
@@ -248,11 +248,11 @@ impl ReadReplay for BlockReplayStorage {
             .db
             .get_cf(BlockReplayColumnFamily::Txs, &key)
             .expect("Failed to read from Txs CF");
+        // todo: save `previous_block_timestamp` as another column in the next breaking change to
+        //       replay record format
         let previous_block_timestamp = if block_number == 0 {
             // Genesis does not have previous block and this value should never be used, but we
             // return `0` here for the flow to work.
-            // todo: consider creating some API separation between block context and replay record
-            //       former makes sense for genesis, later does not
             0
         } else {
             self.get_context(block_number - 1)

--- a/node/bin/src/block_replay_storage.rs
+++ b/node/bin/src/block_replay_storage.rs
@@ -248,10 +248,17 @@ impl ReadReplay for BlockReplayStorage {
             .db
             .get_cf(BlockReplayColumnFamily::Txs, &key)
             .expect("Failed to read from Txs CF");
-        let previous_block_timestamp = self
-            .get_context(block_number)
-            .map(|context| context.timestamp)
-            .unwrap_or(0);
+        let previous_block_timestamp = if block_number == 0 {
+            // Genesis does not have previous block and this value should never be used, but we
+            // return `0` here for the flow to work.
+            // todo: consider creating some API separation between block context and replay record
+            //       former makes sense for genesis, later does not
+            0
+        } else {
+            self.get_context(block_number - 1)
+                .map(|context| context.timestamp)
+                .unwrap_or(0)
+        };
 
         let node_version_result = self
             .db

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -332,7 +332,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     let previous_block_timestamp: u64 = first_replay_record
         .as_ref()
-        .map_or(0, |record| record.block_context.timestamp); // if no previous block, assume genesis block
+        .map_or(0, |record| record.previous_block_timestamp); // if no previous block, assume genesis block
 
     let block_hashes_for_next_block = first_replay_record
         .as_ref()

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -99,6 +99,12 @@ impl FriJobManager {
     pub fn pick_next_job(&self, min_inbound_age: Duration) -> Option<(u64, ProverInput)> {
         // 1) Prefer a timed-out reassignment
         if let Some((batch_number, prover_input)) = self.assigned_jobs.pick_timed_out_job() {
+            tracing::info!(
+                batch_number,
+                assigned_jobs_count = self.assigned_jobs.len(),
+                ?min_inbound_age,
+                "Assigned a timed out job"
+            );
             return Some((batch_number, prover_input));
         }
 


### PR DESCRIPTION
To generate prover input, we need to provide the previous block timestamp. This value is maintained and provided by `BlockContextProvider` component. We need to initialize its state with the previous block timestamp. Instead, we passed the CURRENT block timestamp. 

This PR fixes this bug. 