### PR TITLE
fix: priority tree caching

### DIFF
--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -259,11 +259,11 @@ impl<ReplayStorage: ReadReplay> PriorityTreeManager<ReplayStorage> {
                     .checked_sub(tree.start_index())
                     .unwrap();
                 tree.trim_start(leaves_to_trim);
+                self.db
+                    .cache_tree(&tree, last_block_number)
+                    .context("failed to cache tree")?;
+                tracing::debug!(batch_number, "cached priority tree");
             }
-            self.db
-                .cache_tree(&tree, last_block_number)
-                .context("failed to cache tree")?;
-            tracing::debug!(batch_number, "cached priority tree");
         }
     }
 }


### PR DESCRIPTION
fixes priority tree caching, previously incorrect tree could be saved in case first processed block has 0 l1->l2 txs after node has initilized with empty cache