### PR TITLE
feat: improve debug logging

### DIFF
--- a/lib/sequencer/src/model/debug_formatting.rs
+++ b/lib/sequencer/src/model/debug_formatting.rs
@@ -1,0 +1,87 @@
+use crate::model::blocks::PreparedBlockCommand;
+use alloy::primitives::B256;
+use std::fmt;
+use zksync_os_interface::types::{BlockContext, BlockOutput};
+
+struct BlockContextDbg<'a>(&'a BlockContext);
+impl<'a> fmt::Debug for BlockContextDbg<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_block_context(self.0, f)
+    }
+}
+
+impl<'a> fmt::Debug for PreparedBlockCommand<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut ds = f.debug_struct("PreparedBlockCommand");
+        ds.field("block_context", &BlockContextDbg(&self.block_context));
+        ds.field("seal_policy", &self.seal_policy);
+        ds.field("invalid_tx_policy", &self.invalid_tx_policy);
+        // ds.field("tx_source", &"<skipped>");
+        ds.field("starting_l1_priority_id", &self.starting_l1_priority_id);
+        ds.field("metrics_label", &self.metrics_label);
+        ds.field("node_version", &self.node_version);
+        ds.field(
+            "expected_block_output_hash",
+            &self.expected_block_output_hash,
+        );
+        ds.field("previous_block_timestamp", &self.previous_block_timestamp);
+        ds.finish()
+    }
+}
+
+fn fmt_block_context(bc: &BlockContext, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    // Keep the log concise: take refs to the ends and show just those two (as opposed to 256 of them)
+    let block_hashes_ends = format!("{}, {}", &bc.block_hashes.0[0], &bc.block_hashes.0[255]);
+
+    f.debug_struct("BlockContext")
+        .field("chain_id", &bc.chain_id)
+        .field("block_number", &bc.block_number)
+        .field("block_hashes", &block_hashes_ends)
+        .field("timestamp", &bc.timestamp)
+        .field("eip1559_basefee", &bc.eip1559_basefee)
+        .field("gas_per_pubdata", &bc.gas_per_pubdata)
+        .field("native_price", &bc.native_price)
+        .field("coinbase", &bc.coinbase)
+        .field("gas_limit", &bc.gas_limit)
+        .field("pubdata_limit", &bc.pubdata_limit)
+        .field("mix_hash", &bc.mix_hash)
+        .field("execution_version", &bc.execution_version)
+        .finish()
+}
+
+pub struct BlockOutputDebug<'a>(pub &'a BlockOutput);
+
+// Helper that prints bytes as 0x...
+struct Hex<'a>(&'a [u8]);
+impl<'a> fmt::Debug for Hex<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("0x")?;
+        for b in self.0 {
+            write!(f, "{b:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> fmt::Debug for BlockOutputDebug<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let o = self.0;
+
+        // Build view of (hash, 0x<hex>) for logging
+        let preimages: Vec<(&B256, Hex<'_>)> = o
+            .published_preimages
+            .iter()
+            .map(|(h, bytes)| (h, Hex(bytes)))
+            .collect();
+
+        f.debug_struct("BlockOutput")
+            .field("header", &o.header)
+            .field("tx_results", &o.tx_results)
+            .field("storage_writes", &o.storage_writes)
+            .field("account_diffs", &o.account_diffs)
+            .field("published_preimages", &preimages)
+            .field("pubdata", &Hex(&o.pubdata))
+            .field("computaional_native_used", &o.computaional_native_used)
+            .finish()
+    }
+}

--- a/lib/sequencer/src/model/mod.rs
+++ b/lib/sequencer/src/model/mod.rs
@@ -1,1 +1,2 @@
 pub mod blocks;
+pub mod debug_formatting;

--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -334,7 +334,7 @@ pub struct FakeFriProversConfig {
     pub enabled: bool,
 
     /// Number of fake provers to run in parallel.
-    #[config(default_t = 10)]
+    #[config(default_t = 5)]
     pub workers: usize,
 
     /// Amount of time it takes to compute a proof for one batch.

--- a/node/bin/src/prover_api/fake_fri_provers_pool.rs
+++ b/node/bin/src/prover_api/fake_fri_provers_pool.rs
@@ -5,7 +5,7 @@ use tokio::time::{Instant, sleep};
 
 use crate::prover_api::fri_job_manager::FriJobManager;
 
-const POLL_INTERVAL_MS: u64 = 100;
+const POLL_INTERVAL_MS: u64 = 250;
 const PROVER_LABEL: &str = "fake_prover";
 
 /// Emulates a pool of provers:

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -149,7 +149,7 @@ impl FriJobManager {
         } else {
             // in fact, we could wait for mutex to unlock -
             // but we return early and let prover poll again
-            tracing::debug!("inbound receiver is contended; returning None");
+            tracing::trace!("inbound receiver is contended; returning None");
             None
         }
     }


### PR DESCRIPTION
This makes essential logging more concise. Now we can run the seequencer with `RUST_LOG="INFO,zksync_os_bin=DEBUG,zksync_os_sequencer=DEBUG"` - particularly for low-load chains, this will result in a useful log output.