### PR TITLE
feat: set gas per pubdata to `1`

### DIFF
--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -87,7 +87,8 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 let block_context = BlockContext {
                     eip1559_basefee: U256::from(1000),
                     native_price: U256::from(1),
-                    gas_per_pubdata: Default::default(),
+                    // todo: make dynamic once zksync-os sets max gas per pubdata >1 for L2 txs
+                    gas_per_pubdata: U256::from(1),
                     block_number: produce_command.block_number,
                     timestamp,
                     chain_id: self.chain_id,


### PR DESCRIPTION
Fixes #265 

This PR increases gas per pubdata from `0` to `1` which is currently the max value allowed for L2 transactions. A proper estimator is implemented in https://github.com/matter-labs/zksync-os-server/pull/373 but we cannot merge it before the next version of zksync-os is released.