### PR TITLE
feat!: add `execution_version` 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,16 +2028,34 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
  "arrayvec 0.7.6",
- "basic_system",
- "crypto",
- "cycle_marker",
- "evm_interpreter",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "hex",
  "paste",
  "ruint",
  "strum_macros",
- "system_hooks",
- "zk_ee",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "basic_bootloader"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "hex",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -2048,18 +2066,40 @@ dependencies = [
  "arrayvec 0.7.6",
  "cfg-if",
  "const_for",
- "crypto",
- "cycle_marker",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "either",
- "evm_interpreter",
- "modexp",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "paste",
  "rand 0.9.2",
  "ruint",
  "serde",
- "storage_models",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "strum_macros",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "basic_system"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "cfg-if",
+ "const_for",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "either",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "paste",
+ "rand 0.9.2",
+ "ruint",
+ "serde",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -2480,13 +2520,27 @@ name = "callable_oracles"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
- "crypto",
- "num-bigint 0.4.6",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "num-bigint 0.3.3",
  "num-traits",
- "oracle_provider",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
  "ruint",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "callable_oracles"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "num-bigint 0.3.3",
+ "num-traits",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
+ "ruint",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -3112,6 +3166,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "blake2 0.10.6",
+ "cfg-if",
+ "const_for",
+ "educe",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p256 0.13.2",
+ "ripemd",
+ "ruint",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3300,11 @@ dependencies = [
 name = "cycle_marker"
 version = "0.0.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
+
+[[package]]
+name = "cycle_marker"
+version = "0.0.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
 
 [[package]]
 name = "darling"
@@ -3723,13 +3809,28 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
  "arrayvec 0.7.6",
- "crypto",
- "cycle_marker",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "either",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "evm_interpreter"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "either",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -3974,20 +4075,43 @@ source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47f
 dependencies = [
  "alloy",
  "arrayvec 0.7.6",
- "basic_bootloader",
- "basic_system",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "bincode 1.3.3",
- "callable_oracles",
- "evm_interpreter",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "hex",
- "oracle_provider",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "paste",
  "ruint",
  "serde",
  "strum_macros",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "zksync_os_interface",
- "zksync_os_runner",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "forward_system"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "alloy",
+ "arrayvec 0.7.6",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "bincode 1.3.3",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "hex",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "paste",
+ "ruint",
+ "serde",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "zksync_os_interface",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -5773,6 +5897,11 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 
 [[package]]
+name = "modexp"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+
+[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6184,7 +6313,16 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "oracle_provider"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -9143,8 +9281,17 @@ name = "storage_models"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
- "crypto",
- "zk_ee",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "storage_models"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -9301,12 +9448,26 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
  "arrayvec 0.7.6",
- "cycle_marker",
- "evm_interpreter",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+]
+
+[[package]]
+name = "system_hooks"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -10861,8 +11022,24 @@ dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.1",
  "cfg-if",
- "crypto",
- "cycle_marker",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "paste",
+ "ruint",
+ "serde",
+ "strum_macros",
+]
+
+[[package]]
+name = "zk_ee"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "paste",
  "ruint",
  "serde",
@@ -11024,19 +11201,19 @@ dependencies = [
 [[package]]
 name = "zksync_os_api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
 dependencies = [
  "alloy",
- "basic_system",
- "callable_oracles",
- "crypto",
- "evm_interpreter",
- "forward_system",
- "oracle_provider",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
  "ruint",
- "zk_ee",
- "zksync_os_runner",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
 ]
 
 [[package]]
@@ -11049,12 +11226,12 @@ dependencies = [
  "axum 0.7.9",
  "backon",
  "base64 0.22.1",
- "basic_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "bincode 2.0.1",
  "blake2 0.10.6",
  "dashmap",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "full_statement_verifier",
  "futures",
  "http 1.3.1",
@@ -11080,7 +11257,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.20",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_api",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -11155,14 +11332,14 @@ version = "0.6.4-non-semver-compat"
 dependencies = [
  "alloy",
  "anyhow",
- "basic_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "blake2 0.10.6",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "ruint",
  "serde",
  "serde_json",
  "tokio",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_api",
  "zksync_os_contract_interface",
  "zksync_os_l1_watcher",
@@ -11215,9 +11392,9 @@ dependencies = [
  "anyhow",
  "async-stream",
  "backon",
- "basic_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "blake2 0.10.6",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "futures",
  "itertools 0.14.0",
  "ruint",
@@ -11227,7 +11404,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_contract_interface",
  "zksync_os_interface",
  "zksync_os_merkle_tree",
@@ -11274,10 +11451,10 @@ version = "0.6.4-non-semver-compat"
 dependencies = [
  "alloy",
  "anyhow",
- "basic_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "blake2 0.10.6",
  "clap",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "insta",
  "leb128",
  "once_cell",
@@ -11292,7 +11469,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.20",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_crypto",
  "zksync_os_rocksdb",
 ]
@@ -11312,9 +11489,11 @@ dependencies = [
 name = "zksync_os_multivm"
 version = "0.6.4-non-semver-compat"
 dependencies = [
+ "alloy",
  "anyhow",
  "cargo_metadata",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "tempfile",
  "zksync_os_interface",
 ]
@@ -11396,7 +11575,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dashmap",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "futures",
  "hyper 1.6.0",
  "jsonrpsee",
@@ -11409,7 +11588,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_api",
  "zksync_os_interface",
  "zksync_os_mempool",
@@ -11436,7 +11615,18 @@ name = "zksync_os_runner"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.23#376c6d1c9d47fe306126b963a4f6374fd487d879"
 dependencies = [
- "cycle_marker",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.23)",
+ "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
+ "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
+]
+
+[[package]]
+name = "zksync_os_runner"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.24#38a0bbc3a68332d1666c155cd21d1c585042ce3f"
+dependencies = [
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.4.3)",
@@ -11448,8 +11638,8 @@ version = "0.6.4-non-semver-compat"
 dependencies = [
  "alloy",
  "anyhow",
- "basic_system",
- "forward_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "futures",
  "reth-execution-types",
  "reth-primitives",
@@ -11461,7 +11651,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_mempool",
@@ -11478,12 +11668,12 @@ dependencies = [
  "alloy",
  "anyhow",
  "dashmap",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "ruint",
  "tokio",
  "tracing",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -11496,12 +11686,12 @@ version = "0.6.4-non-semver-compat"
 dependencies = [
  "alloy",
  "anyhow",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "ruint",
  "tempfile",
  "tracing",
  "vise",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -11525,7 +11715,7 @@ version = "0.6.4-non-semver-compat"
 dependencies = [
  "alloy",
  "dashmap",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "tokio",
  "tracing",
  "vise",
@@ -11544,9 +11734,9 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "async-trait",
- "basic_system",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "bincode 2.0.1",
- "forward_system",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "futures",
  "semver 1.0.26",
  "serde",
@@ -11554,7 +11744,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "zk_ee",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.24)",
  "zksync_os_interface",
  "zksync_os_observability",
  "zksync_os_rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,13 @@ serde_json = "1"
 #zk_os_api = { package = "zksync_os_api", path = "../zksync-os/api" }
 
 zksync_os_interface = { version = "=0.0.5" }
-zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.23", features = ["evm-compatibility", "no_print"] }
-zk_ee = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.23" }
-zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.23" }
-zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.23" }
+
+zk_os_forward_system_0_0_23 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.23", features = ["evm-compatibility", "no_print"] }
+
+zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.24", features = ["evm-compatibility", "no_print"] }
+zk_ee = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.24" }
+zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.24" }
+zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.24" }
 
 #execution_utils = { package = "execution_utils", path = "../zksync-airbender/execution_utils" }
 #full_statement_verifier = { package = "full_statement_verifier", path = "../zksync-airbender/full_statement_verifier" }

--- a/lib/l1_sender/src/batcher_model.rs
+++ b/lib/l1_sender/src/batcher_model.rs
@@ -1,5 +1,6 @@
 use crate::batcher_metrics::{BATCHER_METRICS, BatchExecutionStage};
 use crate::commitment::{CommitBatchInfo, StoredBatchInfo};
+use alloy::primitives::B256;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -97,12 +98,25 @@ pub type ProverInput = Vec<u32>;
 pub enum FriProof {
     // Fake proof for testing purposes
     Fake,
-    Real(Vec<u8>),
+    Real(RealFriProof),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RealFriProof {
+    pub proof: Vec<u8>,
+    pub vk: B256,
 }
 
 impl FriProof {
     pub fn is_fake(&self) -> bool {
         matches!(self, FriProof::Fake)
+    }
+
+    pub fn vk(&self) -> Option<B256> {
+        match self {
+            FriProof::Fake => None,
+            FriProof::Real(proof) => Some(proof.vk),
+        }
     }
 }
 
@@ -110,7 +124,7 @@ impl Debug for FriProof {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             FriProof::Fake => write!(f, "Fake"),
-            FriProof::Real(proof) => write!(f, "Real(len: {:?})", proof.len()),
+            FriProof::Real(proof) => write!(f, "Real(len: {:?})", proof.proof.len()),
         }
     }
 }

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -14,8 +14,10 @@ build = "build.rs"
 [dependencies]
 zksync_os_interface.workspace = true
 zk_os_forward_system.workspace = true
+zk_os_forward_system_0_0_23.workspace = true
 anyhow.workspace = true
 tempfile.workspace = true
+alloy = { workspace = true, default-features = false }
 
 [build-dependencies]
 cargo_metadata = { workspace = true, default-features = false }

--- a/lib/multivm/build.rs
+++ b/lib/multivm/build.rs
@@ -2,19 +2,27 @@ use cargo_metadata::MetadataCommand;
 
 fn main() {
     let metadata = MetadataCommand::new().exec().unwrap();
+    let versions = vec!["0.0.23", "0.0.24"];
 
     // Find forward_system crate and expose its path to the directory containing `app*.bin` files.
     for package in &metadata.packages {
-        if package.name.as_str() == "forward_system"
-            && package.source.as_ref().is_some_and(|s| {
-                s.to_string()
-                    .contains("https://github.com/matter-labs/zksync-os?tag=v0.0.23")
-            })
-        {
-            let forward_system_source = package.manifest_path.parent().unwrap();
-            let zksync_os_source = forward_system_source.parent().unwrap().join("zksync_os");
-            println!("cargo:rustc-env=ZKSYNC_OS_0_0_23_SOURCE_PATH={zksync_os_source}");
-            break;
+        for version in &versions {
+            if package.name.as_str() == "forward_system"
+                && package.source.as_ref().is_some_and(|s| {
+                    s.to_string().contains(&format!(
+                        "https://github.com/matter-labs/zksync-os?tag=v{version}"
+                    ))
+                })
+            {
+                let forward_system_source = package.manifest_path.parent().unwrap();
+                let zksync_os_source = forward_system_source.parent().unwrap().join("zksync_os");
+
+                let snake_case_version = version.replace('.', "_");
+                println!(
+                    "cargo:rustc-env=ZKSYNC_OS_{snake_case_version}_SOURCE_PATH={zksync_os_source}"
+                );
+                break;
+            }
         }
     }
 }

--- a/lib/multivm/src/apps/mod.rs
+++ b/lib/multivm/src/apps/mod.rs
@@ -1,4 +1,5 @@
 pub mod v1 {
+    use alloy::primitives::{B256, b256};
     use std::path::{Path, PathBuf};
     use std::sync::OnceLock;
 
@@ -58,4 +59,73 @@ pub mod v1 {
         })
         .clone()
     }
+
+    pub const VERIFICATION_KEY: B256 =
+        b256!("0x0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9"); // TODO!
+}
+
+pub mod v2 {
+    use alloy::primitives::{B256, b256};
+    use std::path::{Path, PathBuf};
+    use std::sync::OnceLock;
+
+    pub const SERVER_APP: &[u8] = include_bytes!(concat!(
+        env!("ZKSYNC_OS_0_0_24_SOURCE_PATH"),
+        "/server_app.bin"
+    ));
+
+    pub fn server_app_path(base_dir: &Path) -> PathBuf {
+        static PATH: OnceLock<PathBuf> = OnceLock::new();
+
+        PATH.get_or_init(|| {
+            let dir_path = base_dir.join("v2");
+            std::fs::create_dir_all(&dir_path).unwrap();
+
+            let full_path = dir_path.join("server_app.bin");
+            std::fs::write(&full_path, SERVER_APP).unwrap();
+            full_path
+        })
+        .clone()
+    }
+
+    pub const SERVER_APP_LOGGING_ENABLED: &[u8] = include_bytes!(concat!(
+        env!("ZKSYNC_OS_0_0_24_SOURCE_PATH"),
+        "/server_app_logging_enabled.bin"
+    ));
+
+    pub fn server_app_logging_enabled_path(base_dir: &Path) -> PathBuf {
+        static PATH: OnceLock<PathBuf> = OnceLock::new();
+
+        PATH.get_or_init(|| {
+            let dir_path = base_dir.join("v2");
+            std::fs::create_dir_all(&dir_path).unwrap();
+
+            let full_path = dir_path.join("server_app_logging_enabled.bin");
+            std::fs::write(&full_path, SERVER_APP_LOGGING_ENABLED).unwrap();
+            full_path
+        })
+        .clone()
+    }
+
+    pub const MULTIBLOCK_BATCH: &[u8] = include_bytes!(concat!(
+        env!("ZKSYNC_OS_0_0_24_SOURCE_PATH"),
+        "/multiblock_batch.bin"
+    ));
+
+    pub fn multiblock_batch_path(base_dir: &Path) -> PathBuf {
+        static PATH: OnceLock<PathBuf> = OnceLock::new();
+
+        PATH.get_or_init(|| {
+            let dir_path = base_dir.join("v2");
+            std::fs::create_dir_all(&dir_path).unwrap();
+
+            let full_path = dir_path.join("multiblock_batch.bin");
+            std::fs::write(&full_path, MULTIBLOCK_BATCH).unwrap();
+            full_path
+        })
+        .clone()
+    }
+
+    pub const VERIFICATION_KEY: B256 =
+        b256!("0x0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9"); // TODO!
 }

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -2,7 +2,9 @@
 //! When adding new ZKsync OS execution version, make sure it is handled in `run_block` and `simulate_tx` methods.
 //! Also, update the `LATEST_EXECUTION_VERSION` constant accordingly.
 
-use zk_os_forward_system::run::RunBlockForward;
+use alloy::primitives::B256;
+use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV2;
+use zk_os_forward_system_0_0_23::run::RunBlockForward as RunBlockForwardV1;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::traits::{
     PreimageSource, ReadStorage, RunBlock, SimulateTx, TxResultCallback, TxSource,
@@ -21,7 +23,20 @@ pub fn run_block<S: ReadStorage, PS: PreimageSource, TS: TxSource, TR: TxResultC
 ) -> Result<BlockOutput, anyhow::Error> {
     match block_context.execution_version {
         1 => {
-            let object = RunBlockForward {};
+            let object = RunBlockForwardV1 {};
+            object
+                .run_block(
+                    (),
+                    block_context,
+                    storage,
+                    preimage_source,
+                    tx_source,
+                    tx_result_callback,
+                )
+                .map_err(|err| anyhow::anyhow!(err))
+        }
+        2 => {
+            let object = RunBlockForwardV2 {};
             object
                 .run_block(
                     (),
@@ -45,7 +60,13 @@ pub fn simulate_tx<S: ReadStorage, PS: PreimageSource>(
 ) -> Result<Result<TxOutput, InvalidTransaction>, anyhow::Error> {
     match block_context.execution_version {
         1 => {
-            let object = RunBlockForward {};
+            let object = RunBlockForwardV1 {};
+            object
+                .simulate_tx((), transaction, block_context, storage, preimage_source)
+                .map_err(|err| anyhow::anyhow!(err))
+        }
+        2 => {
+            let object = RunBlockForwardV2 {};
             object
                 .simulate_tx((), transaction, block_context, storage, preimage_source)
                 .map_err(|err| anyhow::anyhow!(err))
@@ -54,4 +75,19 @@ pub fn simulate_tx<S: ReadStorage, PS: PreimageSource>(
     }
 }
 
-pub const LATEST_EXECUTION_VERSION: u32 = 1;
+pub const LATEST_EXECUTION_VERSION: u32 = 2;
+
+pub fn proving_run_execution_version(forward_run_execution_version: u32) -> u32 {
+    match forward_run_execution_version {
+        1 | 2 => 2,
+        v => panic!("Unsupported ZKsync OS execution version: {v}"),
+    }
+}
+
+pub fn vk_for_execution_version(forward_run_execution_version: u32) -> B256 {
+    match proving_run_execution_version(forward_run_execution_version) {
+        1 => apps::v1::VERIFICATION_KEY,
+        2 => apps::v2::VERIFICATION_KEY,
+        v => panic!("Unsupported ZKsync OS execution version: {v}"),
+    }
+}

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -26,7 +26,8 @@ use tokio::sync::mpsc::Permit;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Mutex, mpsc};
 use zksync_os_l1_sender::batcher_metrics::BatchExecutionStage;
-use zksync_os_l1_sender::batcher_model::{BatchEnvelope, FriProof, ProverInput};
+use zksync_os_l1_sender::batcher_model::{BatchEnvelope, FriProof, ProverInput, RealFriProof};
+use zksync_os_multivm::vk_for_execution_version;
 use zksync_os_observability::{
     ComponentStateHandle, ComponentStateReporter, GenericComponentState,
 };
@@ -210,9 +211,13 @@ impl FriJobManager {
         tracing::info!(batch_number, "Real proof accepted");
 
         // Prepare the envelope and send it downstream.
+        let proof = RealFriProof {
+            proof: proof_bytes,
+            vk: vk_for_execution_version(batch_metadata.execution_version),
+        };
         let envelope = removed_job
             .batch_envelope
-            .with_data(FriProof::Real(proof_bytes))
+            .with_data(FriProof::Real(proof))
             .with_stage(BatchExecutionStage::FriProvedReal);
 
         permit.send(envelope);

--- a/node/bin/src/prover_api/prover_server.rs
+++ b/node/bin/src/prover_api/prover_server.rs
@@ -115,11 +115,11 @@ async fn submit_fri_proof(
 async fn get_fri_proof(Path(block): Path<u64>, State(state): State<AppState>) -> Response {
     match state.proof_storage.get(block).await {
         Ok(Some(BatchEnvelope {
-            data: FriProof::Real(proof_bytes),
+            data: FriProof::Real(real),
             ..
         })) => Json(FriProofPayload {
             block_number: block,
-            proof: general_purpose::STANDARD.encode(&proof_bytes),
+            proof: general_purpose::STANDARD.encode(&real.proof),
         })
         .into_response(),
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
@@ -140,7 +140,7 @@ async fn pick_snark_job(State(state): State<AppState>) -> Response {
             let fri_proofs = batches
                 .into_iter()
                 .filter_map(|(batch_number, proof)| match proof {
-                    FriProof::Real(bytes) => Some(general_purpose::STANDARD.encode(bytes)),
+                    FriProof::Real(real) => Some(general_purpose::STANDARD.encode(real.proof)),
                     FriProof::Fake => {
                         // Should never happen; defensive guard
                         error!(


### PR DESCRIPTION
- adds `execution_version` 2 which uses new zksync-os dependency
- adds hardcoded vk to mutlivm; vk is now also stored in real proof structs
- `SnarkJobManager::pick_real_job` groups fri proofs only with the same vk