### PR TITLE
chore: fix default-features syntax warning

### DIFF
--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -21,5 +21,5 @@ thiserror.workspace = true
 bincode.workspace = true
 
 [features]
-default-features = ["reth"]
+features = ["reth"]
 reth = ["dep:reth-primitives-traits"]


### PR DESCRIPTION
## What?

Fixes warning:
```
warning: /zksync-os-server/lib/types/Cargo.toml: `default-features = [".."]` was found in [features]. Did you mean to use `default = [".."]`?
```