### PR TITLE
feat: pipeline framework (PR 2/X) - `pipe()` syntax; consume `self`; migrate batcher

### DIFF
--- a/lib/pipeline/src/lib.rs
+++ b/lib/pipeline/src/lib.rs
@@ -14,6 +14,6 @@ pub mod builder;
 pub mod peekable_receiver;
 pub mod traits;
 
-pub use builder::ConfiguredPipeline;
+pub use builder::{Pipeline, PipelineWithOutput};
 pub use peekable_receiver::PeekableReceiver;
 pub use traits::{PipelineComponent, Sink, Source};

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -8,43 +8,36 @@ use tokio::sync::mpsc;
 use zksync_os_pipeline::Source;
 use zksync_os_sequencer::model::blocks::BlockCommand;
 
-/// Parameters for the main node command source
+/// Main node command source
 #[derive(Debug)]
-pub struct MainNodeCommandSourceParams {
+pub struct MainNodeCommandSource {
     pub block_replay_storage: BlockReplayStorage,
     pub starting_block: u64,
     pub block_time: Duration,
     pub max_transactions_in_block: usize,
 }
 
-/// Parameters for the external node command source
+/// External node command source
 #[derive(Debug)]
-pub struct ExternalNodeCommandSourceParams {
+pub struct ExternalNodeCommandSource {
     pub starting_block: u64,
     pub replay_download_address: String,
 }
 
-#[derive(Debug)]
-pub struct MainNodeCommandSource;
-
-#[derive(Debug)]
-pub struct ExternalNodeCommandSource;
-
 #[async_trait]
 impl Source for MainNodeCommandSource {
     type Output = BlockCommand;
-    type Params = MainNodeCommandSourceParams;
 
     const NAME: &'static str = "command_source";
     const OUTPUT_BUFFER_SIZE: usize = 5;
 
-    async fn run(params: Self::Params, output: mpsc::Sender<Self::Output>) -> anyhow::Result<()> {
+    async fn run(self, output: mpsc::Sender<Self::Output>) -> anyhow::Result<()> {
         // TODO: no need for a Stream in `command_source` - just send to channel right away instead
         let mut stream = command_source(
-            &params.block_replay_storage,
-            params.starting_block,
-            params.block_time,
-            params.max_transactions_in_block,
+            &self.block_replay_storage,
+            self.starting_block,
+            self.block_time,
+            self.max_transactions_in_block,
         );
 
         while let Some(command) = stream.next().await {
@@ -62,22 +55,18 @@ impl Source for MainNodeCommandSource {
 #[async_trait]
 impl Source for ExternalNodeCommandSource {
     type Output = BlockCommand;
-    type Params = ExternalNodeCommandSourceParams;
 
     const NAME: &'static str = "external_node_command_source";
     const OUTPUT_BUFFER_SIZE: usize = 5;
 
-    async fn run(params: Self::Params, output: mpsc::Sender<Self::Output>) -> anyhow::Result<()> {
+    async fn run(self, output: mpsc::Sender<Self::Output>) -> anyhow::Result<()> {
         // TODO: no need for a Stream in `replay_receiver` - just send to channel right away instead
-        let mut stream = replay_receiver(
-            params.starting_block,
-            params.replay_download_address.clone(),
-        )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to connect to main node to receive blocks: {e}");
-            e
-        })?;
+        let mut stream = replay_receiver(self.starting_block, self.replay_download_address.clone())
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to connect to main node to receive blocks: {e}");
+                e
+            })?;
 
         while let Some(command) = stream.next().await {
             tracing::debug!(?command, "Received block command from main node");

--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -20,10 +20,7 @@ pub struct BlockMerkleTreeData {
 }
 
 #[derive(Debug)]
-pub(crate) struct TreeManager;
-
-#[derive(Debug)]
-pub struct TreeManagerParams {
+pub(crate) struct TreeManager {
     pub tree: MerkleTree<RocksDBWrapper>,
 }
 
@@ -35,16 +32,15 @@ impl PipelineComponent for TreeManager {
         zksync_os_storage_api::ReplayRecord,
         BlockMerkleTreeData,
     );
-    type Params = TreeManagerParams;
     const NAME: &'static str = "merkle_tree";
     const OUTPUT_BUFFER_SIZE: usize = 10;
 
     async fn run(
-        params: Self::Params,
+        self,
         mut input: PeekableReceiver<Self::Input>,
         output: mpsc::Sender<Self::Output>,
     ) -> anyhow::Result<()> {
-        let tree = params.tree;
+        let tree = self.tree;
 
         // only used to skip blocks that were already processed by the tree -
         // will be removed once idempotency is handled on the framework level


### PR DESCRIPTION
* migrates Batcher to the pipeline framework
* simplifies the framework taking @itegulov 's suggestions into account
