### PR TITLE
fix: report error on reverting `eth_call`

### DIFF
--- a/integration-tests/src/contracts.rs
+++ b/integration-tests/src/contracts.rs
@@ -39,6 +39,13 @@ alloy::sol!(
     "test-contracts/out/TracingSecondary.sol/TracingSecondary.json"
 );
 
+alloy::sol!(
+    /// Simple contract that reverts on demand.
+    #[sol(rpc)]
+    SimpleRevert,
+    "test-contracts/out/SimpleRevert.sol/SimpleRevert.json"
+);
+
 alloy::sol! {
     #[sol(rpc)]
     interface IBaseToken {

--- a/integration-tests/test-contracts/src/SimpleRevert.sol
+++ b/integration-tests/test-contracts/src/SimpleRevert.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.28;
+
+contract SimpleRevert {
+
+    error SimpleError();
+
+    function simpleRevert() external pure returns (uint256) {
+        if (true) revert SimpleError();
+        return 1;
+    }
+
+    function stringRevert() external pure returns (uint256) {
+        revert("my message");
+    }
+}


### PR DESCRIPTION
Fixes #450 

Makes node report reverting calls as errors (with message decoding when possible)