### PR TITLE
feat: get rid of `Source`/`Sink`

### DIFF
--- a/lib/pipeline/src/builder.rs
+++ b/lib/pipeline/src/builder.rs
@@ -1,62 +1,37 @@
+use crate::PipelineComponent;
 use crate::peekable_receiver::PeekableReceiver;
-use crate::{PipelineComponent, Source};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::mpsc;
 
-/// Fluent pipeline builder with automatic channel wiring
-///
-/// Example:
-/// ```ignore
-/// Pipeline::new()
-///     .pipe(CommandSource { ... })  // Source component
-///     .pipe(Sequencer { ... })      // Transformer component
-///     .pipe(TreeManager { ... })    // Transformer component
-///     .execute()
-///     .await
-/// ```
-pub struct Pipeline {
+/// Pipeline with an active output stream that can be piped to more components
+pub struct Pipeline<Output: Send + 'static> {
     tasks: Vec<Box<dyn FnOnce() -> tokio::task::JoinHandle<Result<()>> + Send>>,
+    receiver: PeekableReceiver<Output>,
 }
 
-impl Pipeline {
-    /// Create a new empty pipeline
-    pub fn new() -> Self {
-        Self { tasks: Vec::new() }
-    }
-
-    /// Add a source component to start the pipeline
-    pub fn pipe<S>(mut self, source: S) -> PipelineWithOutput<S::Output>
-    where
-        S: Source,
-    {
-        let (sender, receiver) = mpsc::channel(S::OUTPUT_BUFFER_SIZE);
-
-        self.tasks.push(Box::new(move || {
-            tokio::spawn(async move { source.run(sender).await })
-        }));
-
-        PipelineWithOutput {
-            tasks: self.tasks,
-            receiver: PeekableReceiver::new(receiver),
-        }
-    }
-}
-
-impl Default for Pipeline {
+impl Default for Pipeline<()> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Pipeline with an active output stream that can be piped to more components
-pub struct PipelineWithOutput<Output: Send + 'static> {
-    tasks: Vec<Box<dyn FnOnce() -> tokio::task::JoinHandle<Result<()>> + Send>>,
-    receiver: PeekableReceiver<Output>,
+impl Pipeline<()> {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::channel(1);
+        Self {
+            tasks: vec![Box::new(move || {
+                tokio::spawn(
+                    async move { sender.send(()).await.context("failed to send source input") },
+                )
+            })],
+            receiver: PeekableReceiver::new(receiver),
+        }
+    }
 }
 
-impl<Output: Send + 'static> PipelineWithOutput<Output> {
+impl<Output: Send + 'static> Pipeline<Output> {
     /// Add a transformer component to the pipeline
-    pub fn pipe<C>(mut self, component: C) -> PipelineWithOutput<C::Output>
+    pub fn pipe<C>(mut self, component: C) -> Pipeline<C::Output>
     where
         C: PipelineComponent<Input = Output>,
     {
@@ -67,7 +42,7 @@ impl<Output: Send + 'static> PipelineWithOutput<Output> {
             tokio::spawn(async move { component.run(input_receiver, output_sender).await })
         }));
 
-        PipelineWithOutput {
+        Pipeline {
             tasks: self.tasks,
             receiver: PeekableReceiver::new(output_receiver),
         }

--- a/lib/pipeline/src/lib.rs
+++ b/lib/pipeline/src/lib.rs
@@ -14,6 +14,6 @@ pub mod builder;
 pub mod peekable_receiver;
 pub mod traits;
 
-pub use builder::{Pipeline, PipelineWithOutput};
+pub use builder::Pipeline;
 pub use peekable_receiver::PeekableReceiver;
-pub use traits::{PipelineComponent, Sink, Source};
+pub use traits::PipelineComponent;

--- a/lib/pipeline/src/traits.rs
+++ b/lib/pipeline/src/traits.rs
@@ -3,25 +3,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
-/// A component that generates messages and starts the pipeline.
-/// Examples: command_source, block replay streams
-///
-/// Components construct themselves with all needed parameters, then get consumed by `run()`.
-#[async_trait]
-pub trait Source: Send + 'static {
-    /// The type of messages this source produces
-    type Output: Send + 'static;
-
-    /// Human-readable name for logging and metrics
-    const NAME: &'static str;
-
-    /// Buffer size for the output channel
-    const OUTPUT_BUFFER_SIZE: usize = 5;
-
-    /// Run the source component, sending messages to the output.
-    async fn run(self, output: mpsc::Sender<Self::Output>) -> Result<()>;
-}
-
 /// A component that transforms messages in the pipeline.
 /// Examples: ProverInputGenerator, Batcher, L1 senders
 ///
@@ -46,20 +27,4 @@ pub trait PipelineComponent: Send + 'static {
         input: PeekableReceiver<Self::Input>,
         output: mpsc::Sender<Self::Output>,
     ) -> Result<()>;
-}
-
-/// A component that consumes messages and ends the pipeline.
-/// Examples: BatchSink, logging components
-///
-/// Components construct themselves with all needed parameters, then get consumed by `run()`.
-#[async_trait]
-pub trait Sink: Send + 'static {
-    /// The type of messages this sink receives
-    type Input: Send + 'static;
-
-    /// Human-readable name for logging and metrics
-    const NAME: &'static str;
-
-    /// Run the sink component, receiving messages from the input.
-    async fn run(self, input: PeekableReceiver<Self::Input>) -> Result<()>;
 }


### PR DESCRIPTION
Small improvement to pipeline logic that streamlines how we initialize pipeline sources