### PR TITLE
ci: do not compare tests with main due to different iterations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           check_name: 'Test results'
           files: target/nextest/default/${{ env.TEST_RESULTS_XML }}
           action_fail_on_inconclusive: true
+          compare_to_earlier_commit: false # Do not compare with `main` due to different number of iterations
 
 
   ######################################


### PR DESCRIPTION
## What?

* [x] Do not compare results with `main` due to different number of iterations in test runs.

## Why?

To fix reports like this with wrong comparison:
<img width="720" height="228" alt="image" src="https://github.com/user-attachments/assets/b03f6010-65b8-431f-9dbb-266cabd65605" />
