### PR TITLE
feat: make mempool configurable

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -182,6 +182,7 @@ impl Tester {
             },
             rpc_config,
             mempool_config: Default::default(),
+            tx_validator_config: Default::default(),
             sequencer_config,
             l1_sender_config: Default::default(),
             l1_watcher_config: Default::default(),

--- a/lib/mempool/src/config.rs
+++ b/lib/mempool/src/config.rs
@@ -1,0 +1,4 @@
+pub struct TxValidatorConfig {
+    /// Max input size of a transaction to be accepted by mempool
+    pub max_input_bytes: usize,
+}

--- a/lib/mempool/src/lib.rs
+++ b/lib/mempool/src/lib.rs
@@ -10,31 +10,36 @@ pub use traits::L2TransactionPool;
 mod transaction;
 pub use transaction::L2PooledTransaction;
 
+mod config;
+pub use config::TxValidatorConfig;
+
 // Re-export some of the reth mempool's types.
 pub use reth_transaction_pool::error::PoolError;
 pub use reth_transaction_pool::{
-    CanonicalStateUpdate, NewSubpoolTransactionStream, NewTransactionEvent, PoolUpdateKind,
-    TransactionPool as RethTransactionPool, TransactionPoolExt as RethTransactionPoolExt,
+    CanonicalStateUpdate, NewSubpoolTransactionStream, NewTransactionEvent, PoolConfig,
+    PoolUpdateKind, SubPoolLimit, TransactionPool as RethTransactionPool,
+    TransactionPoolExt as RethTransactionPoolExt,
 };
 
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_storage_api::StateProviderFactory;
+use reth_transaction_pool::CoinbaseTipOrdering;
 use reth_transaction_pool::blobstore::NoopBlobStore;
 use reth_transaction_pool::validate::EthTransactionValidatorBuilder;
-use reth_transaction_pool::{CoinbaseTipOrdering, PoolConfig};
 
 pub fn in_memory<Client: ChainSpecProvider<ChainSpec: EthereumHardforks> + StateProviderFactory>(
     client: Client,
-    max_input_bytes: usize,
+    pool_config: PoolConfig,
+    validator_config: TxValidatorConfig,
 ) -> RethPool<Client> {
     let blob_store = NoopBlobStore::default();
     RethPool::new(
         EthTransactionValidatorBuilder::new(client)
             .no_prague()
-            .with_max_tx_input_bytes(max_input_bytes)
+            .with_max_tx_input_bytes(validator_config.max_input_bytes)
             .build(blob_store),
         CoinbaseTipOrdering::default(),
         blob_store,
-        PoolConfig::default(),
+        pool_config,
     )
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -204,7 +204,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     tracing::info!("Initializing mempools");
     let l2_mempool = zksync_os_mempool::in_memory(
         ZkClient::new(repositories.clone(), state.clone(), chain_id),
-        config.mempool_config.max_tx_input_bytes,
+        config.mempool_config.clone().into(),
+        config.tx_validator_config.clone().into(),
     );
 
     let (last_l1_committed_block, last_l1_proved_block, last_l1_executed_block) =

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::watch;
 use zksync_os_bin::config::{
     BatcherConfig, Config, GeneralConfig, GenesisConfig, L1SenderConfig, L1WatcherConfig,
     LogConfig, MempoolConfig, ProverApiConfig, ProverInputGeneratorConfig, RpcConfig,
-    SequencerConfig, StateBackendConfig, StatusServerConfig,
+    SequencerConfig, StateBackendConfig, StatusServerConfig, TxValidatorConfig,
 };
 use zksync_os_bin::run;
 use zksync_os_bin::sentry::init_sentry;
@@ -171,6 +171,12 @@ fn build_configs() -> Config {
         .parse()
         .expect("Failed to parse mempool config");
 
+    let tx_validator_config = repo
+        .single::<TxValidatorConfig>()
+        .expect("Failed to load tx validator config")
+        .parse()
+        .expect("Failed to parse tx validator config");
+
     let mut sequencer_config = repo
         .single::<SequencerConfig>()
         .expect("Failed to load sequencer config")
@@ -241,6 +247,7 @@ fn build_configs() -> Config {
         genesis_config,
         rpc_config,
         mempool_config,
+        tx_validator_config,
         sequencer_config,
         l1_sender_config,
         l1_watcher_config,


### PR DESCRIPTION
Fixes #432 

Moves existing mempool configuration to `TxValidatorConfig` (because that's what it actually is) and introduces new configuration based off of reth's mempool `PoolConfig` (only max pending txs and max pending txs size for now).