### PR TITLE
fix: Add TxValidatorConfig to schema

### DIFF
--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -118,6 +118,9 @@ fn build_configs() -> Config {
         .insert(&MempoolConfig::DESCRIPTION, "mempool")
         .expect("Failed to insert mempool config");
     schema
+        .insert(&TxValidatorConfig::DESCRIPTION, "tx_validator")
+        .expect("Failed to insert tx_validator config");
+    schema
         .insert(&SequencerConfig::DESCRIPTION, "sequencer")
         .expect("Failed to insert sequencer config");
     schema


### PR DESCRIPTION
Server will fail at clean bootup without TxValidatorConfig. PR registers it to schema.