### PR TITLE
fix: serialization of L1/Upgrade txs in API

### DIFF
--- a/lib/types/src/transaction/l1.rs
+++ b/lib/types/src/transaction/l1.rs
@@ -52,8 +52,10 @@ impl L1TxType for UpgradeTxType {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct L1Tx<T: L1TxType> {
+    #[serde(rename = "txHash")]
     pub hash: TxHash,
     /// The 160-bit address of the initiator on L1.
+    #[serde(rename = "initiator")]
     pub from: Address,
     /// The 160-bit address of the message call’s recipient. Cannot be missing as L1->L2 transaction cannot be `Create`.
     pub to: Address,


### PR DESCRIPTION
The rpc returns blocks in a structure of `ZkApiBlock` (e.g. `getBlockByNumber` method). The `ZkApiBlock` contains `ZkApiTransaction` transactions. The `ZkApiTransaction` has a problem with serialization/deserialization. 

When serialized `ZkApiTransaction` serialized all the fields in inner structure via `#[serde(flatten)]`. In L1 transaction case it also contains `hash` and `from` fields. But under the hood the alloy wrapper also serialize `from` and `hash`:
- https://github.com/alloy-rs/alloy/blob/v1.0.36/crates/rpc-types-eth/src/transaction/mod.rs#L504
- https://github.com/alloy-rs/alloy/blob/v1.0.36/crates/consensus/src/signed.rs#L552

This makes the serialized L1->L2 and upgrade txs to contain two `from` and  two `hash` fields. Deserialization of such json failed. 