### PR TITLE
feat(l1-watcher): track last committed/executed batch in finality

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -30,11 +30,7 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> L1CommitWatcher<Finality,
     ) -> anyhow::Result<Self> {
         let zk_chain = ZkChain::new(zk_chain_address, provider.clone());
         let current_l1_block = provider.get_block_number().await?;
-        let last_committed_block = finality.get_finality_status().last_committed_block;
-        let last_committed_batch = batch_storage
-            .get_batch_by_block_number(last_committed_block)
-            .await?
-            .expect("commited batch is missing from proof storage");
+        let last_committed_batch = finality.get_finality_status().last_committed_batch;
         tracing::info!(
             current_l1_block,
             last_committed_batch,

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -30,11 +30,7 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> L1ExecuteWatcher<Finality
     ) -> anyhow::Result<Self> {
         let zk_chain = ZkChain::new(zk_chain_address, provider.clone());
         let current_l1_block = provider.get_block_number().await?;
-        let last_executed_block = finality.get_finality_status().last_executed_block;
-        let last_executed_batch = batch_storage
-            .get_batch_by_block_number(last_executed_block)
-            .await?
-            .expect("executed batch is missing from proof storage");
+        let last_executed_batch = finality.get_finality_status().last_executed_batch;
         tracing::info!(
             current_l1_block,
             last_executed_batch,

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -45,7 +45,7 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
         let Some(batch_number) = self
             .storage
             .batch()
-            .get_batch_by_block_number(tx_meta.block_number)
+            .get_batch_by_block_number(tx_meta.block_number, self.storage.finality())
             .await?
         else {
             return Err(ZksError::NotBatchedYet);

--- a/lib/storage_api/src/batch.rs
+++ b/lib/storage_api/src/batch.rs
@@ -1,3 +1,4 @@
+use crate::ReadFinality;
 use alloy::primitives::BlockNumber;
 
 #[async_trait::async_trait]
@@ -6,6 +7,8 @@ pub trait ReadBatch: Send + Sync + 'static {
     async fn get_batch_by_block_number(
         &self,
         block_number: BlockNumber,
+        // todo(#205): remove/refactor once batch storage cache is in place
+        finality: &dyn ReadFinality,
     ) -> anyhow::Result<Option<u64>>;
 
     // todo: return `BatchMetadata` once it is moved to `types` crate

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -81,7 +81,9 @@ impl ReplayRecord {
 #[derive(Clone, Debug)]
 pub struct FinalityStatus {
     pub last_committed_block: u64,
+    pub last_committed_batch: u64,
     pub last_executed_block: u64,
+    pub last_executed_batch: u64,
 }
 
 #[cfg(test)]

--- a/node/bin/src/util/finalized_block_channel.rs
+++ b/node/bin/src/util/finalized_block_channel.rs
@@ -24,10 +24,7 @@ pub async fn send_executed_and_replayed_batch_numbers<
         timer.tick().await;
 
         let finality_status = finality_storage.get_finality_status();
-        let batch_number = batch_storage
-            .get_batch_by_block_number(finality_status.last_executed_block)
-            .await?
-            .context("Missing batch number for the the executed block")?;
+        let batch_number = finality_status.last_executed_batch;
         let prev_cursor = cursor;
         for batch in prev_cursor..=batch_number {
             let last_block_number = batch_storage


### PR DESCRIPTION
Drastically reduces the usage of block->batch lookup across the codebase. Now there are only two places - EN startup and `zks_getL2ToL1LogProof`

Also fixes bug with `ReadBatch` not respecting batch finality and reading non-canon FRI proofs from proof storage.