### PR TITLE
feat: add BatchIndex and more metrics for ObjectStore [ON HOLD]

### DIFF
--- a/lib/object_store/src/metrics.rs
+++ b/lib/object_store/src/metrics.rs
@@ -20,6 +20,8 @@ pub(crate) struct ObjectStoreMetrics {
     /// Size of the payloads stored in the object store.
     #[metrics(buckets = BYTES_BUCKETS, labels = ["bucket"])]
     pub payload_size: LabeledFamily<&'static str, Histogram<usize>>,
+    /// Total number of bytes read from the object store.
+    pub storage_read_total_bytes: Counter,
     /// Number of read/write operations performed, labeled by operation type (`read` or `write`).
     #[metrics(labels = ["op"])]
     pub read_write_ops: LabeledFamily<&'static str, Counter>,

--- a/lib/object_store/src/retries.rs
+++ b/lib/object_store/src/retries.rs
@@ -103,6 +103,11 @@ impl<S: ObjectStore> ObjectStore for StoreWithRetries<S> {
             .await;
         latency.observe();
         OBJECT_STORE_METRICS.read_write_ops[&"read"].inc();
+        if let Ok(ref bytes) = result {
+            OBJECT_STORE_METRICS
+                .storage_read_total_bytes
+                .inc_by(bytes.len() as u64);
+        }
         result
     }
 


### PR DESCRIPTION
PR adds the `block_number->batch_number` and `batch_number->(first_block, last_block)` indexes that help reduce the amount of S3 reads and significantly lower the network load.
#205 #454 (adds read/write counter and total amount of downloaded data)