### PR TITLE
feat(l1): retry RPC requests on internal error

### DIFF
--- a/node/bin/src/l1_provider.rs
+++ b/node/bin/src/l1_provider.rs
@@ -26,6 +26,10 @@ impl RetryPolicy for OptimisticRetryPolicy {
                 // networking issues.
                 msg.contains("error sending request")
             }
+            TransportError::ErrorResp(e) => {
+                // Internal error as observed on Infura
+                e.code == -32603
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
Makes node retry RPC request when it receives an internal error response. Was recently observed on Infura.