### PR TITLE
fix(l1-watcher): update batch finality

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -110,9 +110,14 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> L1CommitWatcher<Finality,
                     .expect("committed batch is missing");
                 self.finality.update_finality_status(|finality| {
                     assert!(
+                        batch_number > finality.last_committed_batch,
+                        "non-monotonous committed batch"
+                    );
+                    assert!(
                         last_committed_block > finality.last_committed_block,
                         "non-monotonous committed block"
                     );
+                    finality.last_committed_batch = batch_number;
                     finality.last_committed_block = last_committed_block;
                 });
             }

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -104,9 +104,14 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> L1ExecuteWatcher<Finality
                     .expect("executed batch is missing");
                 self.finality.update_finality_status(|finality| {
                     assert!(
+                        batch_number > finality.last_executed_batch,
+                        "non-monotonous executed batch"
+                    );
+                    assert!(
                         last_executed_block > finality.last_executed_block,
                         "non-monotonous executed block"
                     );
+                    finality.last_executed_batch = batch_number;
                     finality.last_executed_block = last_executed_block;
                 });
                 tracing::debug!(


### PR DESCRIPTION
Fixes a bug reported by @dutterbutter. Introduced in #485 - l1 watcher only updates last committed/executed **block** but not **batch** for new L1 events.