### PR TITLE
feat: add execution version enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11754,12 +11754,11 @@ dependencies = [
 name = "zksync_os_multivm"
 version = "0.8.2-non-semver-compat"
 dependencies = [
- "alloy",
  "anyhow",
  "cargo_metadata",
  "forward_system",
+ "num_enum 0.7.4",
  "reqwest",
- "tempfile",
  "url",
  "zksync_os_interface",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ secrecy = "0.10.3"
 cargo_metadata = { version = "0.20.0", default-features = false }
 tracing-logfmt = { version = "0.3.5" }
 url = "2.5.7"
+num_enum = "0.7.2"
 
 # Reth dependencies
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0" }

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -15,8 +15,7 @@ build = "build.rs"
 zksync_os_interface.workspace = true
 zk_os_forward_system.workspace = true
 anyhow.workspace = true
-tempfile.workspace = true
-alloy = { workspace = true, default-features = false }
+num_enum.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -118,7 +118,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     pubdata_limit: self.pubdata_limit,
                     // todo: initialize as source of randomness, i.e. the value of prevRandao
                     mix_hash: Default::default(),
-                    execution_version: LATEST_EXECUTION_VERSION,
+                    execution_version: LATEST_EXECUTION_VERSION as u32,
                 };
                 PreparedBlockCommand {
                     block_context,

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -231,7 +231,7 @@ impl FriJobManager {
             proof: proof_bytes,
             proving_execution_version: proving_run_execution_version(
                 batch_metadata.execution_version,
-            ),
+            ) as u32,
         };
         let envelope = removed_job
             .batch_envelope


### PR DESCRIPTION
Adds `ExecutionVersion` enum. `BlockContext` still keeps execution version as integer, and it should be converted to enum when matching happens. This helps with finding all places where matching happens when adding new version