### PR TITLE
fix(tree): report backpressure

### DIFF
--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -117,6 +117,7 @@ impl PipelineComponent for TreeManager {
                     block: block_number,
                 },
             };
+            latency_tracker.enter_state(GenericComponentState::WaitingSend);
             output
                 .send((block_output, replay_record, tree_block))
                 .await?;


### PR DESCRIPTION
Currently tree manager shows up as "working" when it's actually backpressured