### PR TITLE
feat(sequencer): validate last 256 blocks for replayed blocks

### DIFF
--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -151,6 +151,12 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     self.previous_block_timestamp,
                     record.previous_block_timestamp
                 );
+                anyhow::ensure!(
+                    self.block_hashes_for_next_block == record.block_context.block_hashes,
+                    "inconsistent previous block hashes: {} in component state, {} in resolved ReplayRecord",
+                    self.previous_block_timestamp,
+                    record.previous_block_timestamp
+                );
                 PreparedBlockCommand {
                     block_context: record.block_context,
                     seal_policy: SealPolicy::UntilExhausted,


### PR DESCRIPTION
Fixes #509 

This PR makes sequencer validate last 256 block hashes for all replayed blocks. This should stop EN from accepting blocks that do not belong to its chain.

The other part of the ticket will be effectively done in #459 (ENs will compare their state against the batch that will be posted on-chain), so IMHO this is sufficient for now.