### PR TITLE
ci: run release-please workflow sequentially

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,11 @@ on:
       - main
   workflow_dispatch:
 
+# Ensure all release-please jobs are sequentially executed for all commits
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false # never cancel in-progress runs
+
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:


### PR DESCRIPTION
## What?

* [x] Run `release-please` workflow sequentially

## Why?

To prevent occasional failures when 2 or more PRs are merged into `main` very quickly causing problems with Cargo.lock updates in the release PR.