### PR TITLE
ci: fix eth spec tests notifications in case of failures

### DIFF
--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -253,42 +253,14 @@ jobs:
           check_name: "ZK OS Execution Spec Tests"
           files: "${{ env.TESTS_WORKING_DIR }}/lib/execution-spec-tests/junit-report*.xml"
           compare_to_earlier_commit: false
+          action_fail: true # Fail the action if any of the tests failed
 
-      - name: Slack failure notification
-        if: failure()
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+      - name: Slack notification
+        if: ${{ failure() }}
+        uses: ./.github/actions/slack-notify
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
-          webhook-type: incoming-webhook
-          payload: |
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "*🚨 ZKsync OS Server Eth Spec Tests scheduled run failed!*"
-              - type: "section"
-                fields:
-                  - type: "mrkdwn"
-                    text: "*Repository:*\n`${{ github.repository }}`"
-                  - type: "mrkdwn"
-                    text: "*Workflow:*\n`${{ github.workflow }}`"
-                  - type: "mrkdwn"
-                    text: "*Branch:*\n`${{ github.ref_name }}`"
-                  - type: "mrkdwn"
-                    text: "*Triggered By:*\n`${{ github.actor }}`"
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "You can view the detailed logs and troubleshoot the issue by visiting the link below:"
-              - type: "actions"
-                elements:
-                  - type: "button"
-                    text:
-                      type: "plain_text"
-                      text: "View Workflow Logs"
-                      emoji: true
-                    url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    style: "danger"
+          context: "ZKsync OS Server Eth Spec Tests scheduled run failed"
 
 
   # Create a compatibility table from both test runs


### PR DESCRIPTION
## What?

* [x] Fix eth spec tests notifications in case of failures
* [x] Remove code duplication in slack notification 

## Why?

By default, tests were reported as failed, but the action was successful, and a notification was not sent.
Use the `action_fail` parameter to fix this behavior and fail the action on any failed tests as it should happen.