### PR TITLE
fix(sequencer): save replay record first

### DIFF
--- a/lib/sequencer/src/execution/mod.rs
+++ b/lib/sequencer/src/execution/mod.rs
@@ -118,10 +118,7 @@ where
                     })
                     .context("execute_block")?;
 
-            tracing::debug!(
-                block_number,
-                "Executed. Adding to block replay storage..."
-            );
+            tracing::debug!(block_number, "Executed. Adding to block replay storage...");
             latency_tracker.enter_state(SequencerState::AddingToReplayStorage);
 
             self.replay.append(replay_record.clone());


### PR DESCRIPTION
Save replay record before updating state and adding block to repos. API relies on the fact that all blocks in repos are present in replay storage and returns "block not found" error if it's missing. This change should make this fact true