### PR TITLE
chore: make .github codeowners more granular

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,5 @@
 **/CHANGELOG.md @matter-labs/core-release-managers
 CODEOWNERS @RomanBrodetski @perekopskiy @Deniallugo @popzxc
 .github/workflows/** @matter-labs/devops
-.github/** @antonbaliasnikov
+.github/actions/** @antonbaliasnikov
+.github/workflows/** @antonbaliasnikov


### PR DESCRIPTION
## What?

Make codeowners permissions for @antonbaliasnikov more granular.

## Why?

To not require mandatory approval for release-please folder.
