### PR TITLE
fix: consume l1 txs processed in rebuild commands

### DIFF
--- a/lib/sequencer/src/execution/mod.rs
+++ b/lib/sequencer/src/execution/mod.rs
@@ -73,6 +73,7 @@ where
                 anyhow::bail!("inbound channel closed");
             };
             let block_number = cmd.block_number();
+            let cmd_type = cmd.command_type();
 
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
             if matches!(cmd, BlockCommand::Produce(_))
@@ -158,7 +159,8 @@ where
 
             // TODO: would updating mempool in parallel with state make sense?
             self.block_context_provider
-                .on_canonical_state_change(&block_output, &replay_record);
+                .on_canonical_state_change(&block_output, &replay_record, cmd_type)
+                .await;
             let purged_txs_hashes = purged_txs.into_iter().map(|(hash, _)| hash).collect();
             self.block_context_provider.remove_txs(purged_txs_hashes);
 

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -25,6 +25,14 @@ pub enum BlockCommand {
     Rebuild(Box<RebuildCommand>),
 }
 
+/// Type of the block command.
+#[derive(Debug, Clone, Copy)]
+pub enum BlockCommandType {
+    Replay,
+    Produce,
+    Rebuild,
+}
+
 /// Command to produce a new block.
 #[derive(Clone, Debug)]
 pub struct ProduceCommand {
@@ -46,6 +54,14 @@ impl BlockCommand {
             BlockCommand::Replay(record) => record.block_context.block_number,
             BlockCommand::Produce(command) => command.block_number,
             BlockCommand::Rebuild(command) => command.replay_record.block_context.block_number,
+        }
+    }
+
+    pub fn command_type(&self) -> BlockCommandType {
+        match self {
+            BlockCommand::Replay(_) => BlockCommandType::Replay,
+            BlockCommand::Produce(_) => BlockCommandType::Produce,
+            BlockCommand::Rebuild(_) => BlockCommandType::Rebuild,
         }
     }
 }


### PR DESCRIPTION
Consume l1 txs processed in rebuild commands, like it was already done for replay