### PR TITLE
ci: re-enable spec tests after the fix

### DIFF
--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -2,8 +2,8 @@ name: Eth spec tests
 
 # Run tests every day or by manual request
 on:
-#  schedule:
-#    - cron: '0 */3 * * *' # every 3 hours
+  schedule:
+    - cron: '0 */3 * * *' # every 3 hours
   workflow_dispatch:
 
 # Set default permissions


### PR DESCRIPTION
## What?

Re-enable spec tests after the fix. `stable` tag for spec tests updated, so don't need any changes in the PR.

## Tests

Test results:
https://github.com/matter-labs/zksync-os-server/actions/runs/18973712727