### PR TITLE
chore: increase polling timeout for unit tests

### DIFF
--- a/integration-tests/src/assert_traits.rs
+++ b/integration-tests/src/assert_traits.rs
@@ -8,7 +8,7 @@ use alloy::rpc::types::trace::geth::{CallConfig, CallFrame, GethDebugTracingOpti
 use anyhow::Context;
 use std::time::Duration;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[allow(async_fn_in_trait)]
 pub trait EthCallAssert {


### PR DESCRIPTION
## What?

* [x] Increase polling timeout for unit tests from 20 to 30 seconds

## Why?

To fix code coverage tests failures in `main` when server is working a lot slower with code coverage enabled.

## Testing

Ran code coverage tests multiple times to confirm they are fixed.