### PR TITLE
feat: set default block time to 250ms

### DIFF
--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -151,7 +151,7 @@ pub struct SequencerConfig {
 
     /// Defines the block time for the sequencer.
     /// One of the block Seal Criteria. Only affects the Main Node.
-    #[config(default_t = Duration::from_millis(100))]
+    #[config(default_t = Duration::from_millis(250))]
     pub block_time: Duration,
 
     /// Max number of transactions in a block.


### PR DESCRIPTION
Block time seems to affect the watchdog behaviour (context: watchdog uses ethers js library that has issues working with blockchains that have low block time). 

Changing 100ms to 250ms is unlikely to help, but at least it will be consistent across environments. I'll remove overrides for block time everywhere after this is merged.