### PR TITLE
fix(config): add config attributes to fee overrides

### DIFF
--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -3,7 +3,7 @@ use crate::model::blocks::{
     BlockCommand, BlockCommandType, InvalidTxPolicy, PreparedBlockCommand, SealPolicy,
 };
 use alloy::consensus::{Block, BlockBody, Header};
-use alloy::primitives::{Address, BlockHash, TxHash, U256};
+use alloy::primitives::{Address, BlockHash, TxHash, U128, U256};
 use reth_execution_types::ChangedAccount;
 use reth_primitives::SealedBlock;
 use std::sync::Arc;
@@ -61,9 +61,9 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
         node_version: semver::Version,
         genesis: Arc<Genesis>,
         fee_collector_address: Address,
-        base_fee_override: Option<U256>,
-        pubdata_price_override: Option<U256>,
-        native_price_override: Option<U256>,
+        base_fee_override: Option<U128>,
+        pubdata_price_override: Option<U128>,
+        native_price_override: Option<U128>,
         pubdata_price_provider: watch::Receiver<Option<u128>>,
         pending_block_context_sender: watch::Sender<Option<BlockContext>>,
     ) -> Self {
@@ -79,9 +79,9 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
             node_version,
             genesis,
             fee_collector_address,
-            base_fee_override,
-            pubdata_price_override,
-            native_price_override,
+            base_fee_override: base_fee_override.map(U256::from),
+            pubdata_price_override: pubdata_price_override.map(U256::from),
+            native_price_override: native_price_override.map(U256::from),
             pubdata_price_provider,
             pending_block_context_sender,
         }

--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -1,6 +1,6 @@
 use crate::command_source::RebuildOptions;
 use alloy::consensus::constants::GWEI_TO_WEI;
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, U128};
 use serde::{Deserialize, Serialize};
 use smart_config::metadata::TimeUnit;
 use smart_config::value::SecretString;
@@ -179,15 +179,15 @@ pub struct SequencerConfig {
 
     /// Override for base fee (in wei). If set, base fee will be constant and equal to this value.
     #[config(default_t = None, with = Optional(Serde![str]))]
-    pub base_fee_override: Option<U256>,
+    pub base_fee_override: Option<U128>,
 
     /// Override for pubdata price (in wei). If set, pubdata price will be constant and equal to this value.
     #[config(default_t = None, with = Optional(Serde![str]))]
-    pub pubdata_price_override: Option<U256>,
+    pub pubdata_price_override: Option<U128>,
 
     /// Override for native price (in wei). If set, native price will be constant and equal to this value.
     #[config(default_t = None, with = Optional(Serde![str]))]
-    pub native_price_override: Option<U256>,
+    pub native_price_override: Option<U128>,
 
     /// Maximum number of blocks to produce.
     /// `None` means unlimited (default, standard operations),


### PR DESCRIPTION
Fee overrides were not configurable, the values from the ENV couldn't be converted to the config. 
This PR also changes the type of the configs to U256 to align with the usage of the config vars in the code. 