### PR TITLE
fix: move BlacklistedSigner error to different enum

### DIFF
--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -43,9 +43,7 @@ impl<Mempool: L2TransactionPool> TxHandler<Mempool> {
             .map_err(|_| EthSendRawTransactionError::InvalidTransactionSignature)?;
         let hash = *l2_tx.hash();
         if self.l2_signer_blacklist.contains(&l2_tx.signer()) {
-            return Err(EthSendRawTransactionError::NotAcceptingTransactions(
-                NotAcceptingReason::BlacklistedSigner,
-            ));
+            return Err(EthSendRawTransactionError::BlacklistedSigner);
         }
         self.mempool.add_l2_transaction(l2_tx).await?;
 
@@ -68,4 +66,6 @@ pub enum EthSendRawTransactionError {
     /// Errors related to the transaction pool
     #[error(transparent)]
     PoolError(#[from] PoolError),
+    #[error("Signer is blacklisted")]
+    BlacklistedSigner,
 }

--- a/lib/types/src/transaction_acceptance_state.rs
+++ b/lib/types/src/transaction_acceptance_state.rs
@@ -13,6 +13,4 @@ pub enum NotAcceptingReason {
     BlockProductionDisabled,
     #[error("Transaction submission not implemented on external nodes.")]
     ExternalNode,
-    #[error("Signer is blacklisted.")]
-    BlacklistedSigner,
 }


### PR DESCRIPTION
moves BlacklistedSigner error to different enum