### PR TITLE
fix: fix calculation of da fields for validium v4

### DIFF
--- a/lib/l1_sender/src/commitment.rs
+++ b/lib/l1_sender/src/commitment.rs
@@ -277,6 +277,10 @@ fn calculate_da_fields(
                 // blob_commitment should be set to zero in ZK OS
                 operator_da_input.extend(B256::ZERO.as_slice());
 
+                if pubdata_mode == PubdataMode::Validium {
+                    operator_da_input = U256::ZERO.to_be_bytes_vec();
+                }
+
                 (da_commitment, operator_da_input, None)
             }
             (PubdataMode::Validium, _) => (B256::ZERO, vec![0u8; 32], None),


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

Fixes calculation of da fields for validium v4. For v4 validiums da_commitment should be calculated as if it's rollup with calldata

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated data availability field calculations to support multiple execution versions and operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->