### PR TITLE
fix: upgrade issues

### DIFF
--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -63,7 +63,7 @@ where
             };
             let exec_ver = replay_record.block_context.execution_version;
             let zk_spec = match ZkSpecId::from_exec_version(exec_ver) {
-                Some(spec) => spec,
+                Some(spec) => Some(spec),
                 None => {
                     // Warn once per execution_version. Afterwards log at info level.
                     let first_time = warned_unsupported_versions.insert(exec_ver);
@@ -79,7 +79,7 @@ where
                         );
                     }
                     // Skip executing this block when there is no supported REVM version.
-                    continue;
+                    None
                 }
             };
 
@@ -91,7 +91,7 @@ where
                 .state_view_at(state_block_number)
                 .map_err(anyhow::Error::from)?;
 
-            {
+            if let Some(zk_spec) = zk_spec {
                 // For each block, we create an in-memory cache database to accumulate transaction state changes separately
                 let state_provider =
                     RevmStateProvider::new(state_view, block_hashes, state_block_number);

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -224,11 +224,20 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 }
             }
             BlockCommand::Rebuild(rebuild) => {
+                let block_number = rebuild.replay_record.block_context.block_number;
+                // Kludge for stage env.
+                let execution_version = if self.chain_id == 2702 && block_number == 29544 {
+                    5
+                } else {
+                    // TODO: This is inherently wrong to `execution_version` from the record for blocks where an upgrade happened.
+                    //  If you're rebuild blocks near the upgrade consider it to be an undefined behavior.
+                    rebuild.replay_record.block_context.execution_version
+                };
                 let block_context = BlockContext {
                     eip1559_basefee: rebuild.replay_record.block_context.eip1559_basefee,
                     native_price: rebuild.replay_record.block_context.native_price,
                     pubdata_price: rebuild.replay_record.block_context.pubdata_price,
-                    block_number: rebuild.replay_record.block_context.block_number,
+                    block_number,
                     timestamp: rebuild.replay_record.block_context.timestamp,
                     blob_fee: rebuild.replay_record.block_context.blob_fee,
                     chain_id: self.chain_id,
@@ -238,7 +247,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     pubdata_limit: self.pubdata_limit,
                     // todo: initialize as source of randomness, i.e. the value of prevRandao
                     mix_hash: Default::default(),
-                    execution_version: rebuild.replay_record.block_context.execution_version,
+                    execution_version,
                 };
                 let txs = if rebuild.make_empty {
                     Vec::new()
@@ -335,6 +344,8 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
         EXECUTION_METRICS
             .next_l1_priority_id
             .set(self.next_l1_priority_id);
+        // We update protocol version here, so that we take into account replay records with protocol version bumps.
+        self.protocol_version = replay_record.protocol_version.clone();
 
         // Advance `block_hashes_for_next_block`.
         let last_block_hash = block_output.header.hash();


### PR DESCRIPTION
## Summary

- Fixes revm checher so it passes blocks down the pipeline even if check is skipped.
- Resets exec version for block 29544 on stage when rebuilding.
- Adds TODO comment about incorrect execution version used for rebuild commands, I don't have a solution at the moment, it's not trivial.
- Updates `protocol_version` in `on_canonical_state_change`

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution version handling and block processing control flow to ensure more reliable execution in edge cases where supported versions are unavailable.

* **Refactor**
  * Refined block context management for enhanced consistency across the execution layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->