### PR TITLE
fix(batcher): rebuild batches from S3 even when they are not committed

### DIFF
--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -13,7 +13,7 @@ use zksync_os_contract_interface::models::StoredBatchInfo;
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_l1_sender::batcher_metrics::BATCHER_METRICS;
 use zksync_os_l1_sender::batcher_model::{
-    BatchEnvelope, BatchForSigning, MissingSignature, ProverInput,
+    BatchEnvelope, BatchForSigning, FriProof, MissingSignature, ProverInput, SignedBatchEnvelope,
 };
 use zksync_os_merkle_tree::TreeBatchOutput;
 use zksync_os_observability::{
@@ -90,14 +90,37 @@ impl PipelineComponent for Batcher {
                 .context("batcher inbound channel unexpectedly closed")?;
             latency_tracker.enter_state(GenericComponentState::Processing);
 
-            let should_recreate = next_block_number <= self.startup_config.last_committed_block;
+            // Reuse batch range from S3 even if it wasn't committed yet. Otherwise, there is a risk
+            // of a race condition where we will end up with diverging S3 and L1 batch ranges.
+            let (batch_envelope, recreated) = if let Some(existing_batch) = self
+                .batch_storage
+                .get_batch_with_proof(prev_batch_info.batch_number + 1)
+                .await?
+            {
+                // Validate that the existing batch's first block matches the next block in the stream
+                anyhow::ensure!(
+                    existing_batch.batch.first_block_number == next_block_number,
+                    "Existing batch first block ({}) does not match next block in stream ({})",
+                    existing_batch.batch.first_block_number,
+                    next_block_number
+                );
 
-            let batch_envelope = if should_recreate {
-                self.recreate_existing_batch(&mut input, &latency_tracker, &prev_batch_info)
-                    .await?
+                (
+                    self.recreate_existing_batch(
+                        &mut input,
+                        &latency_tracker,
+                        &prev_batch_info,
+                        existing_batch,
+                    )
+                    .await?,
+                    true,
+                )
             } else {
-                self.create_batch(&mut input, &latency_tracker, &prev_batch_info)
-                    .await?
+                (
+                    self.create_batch(&mut input, &latency_tracker, &prev_batch_info)
+                        .await?,
+                    false,
+                )
             };
 
             let time_since_last_batch =
@@ -127,7 +150,7 @@ impl PipelineComponent for Batcher {
                 block_count = batch_envelope.batch.last_block_number - batch_envelope.batch.first_block_number + 1,
                 new_state_commitment = ?batch_envelope.batch.batch_info.new_state_commitment,
                 time_since_last_batch = ?time_since_last_batch,
-                "Batch {}", if should_recreate { "recreated" } else { "created" }
+                "Batch {}", if recreated { "recreated" } else { "created" }
             );
 
             tracing::debug!(
@@ -274,17 +297,9 @@ impl Batcher {
         )>,
         latency_tracker: &ComponentStateHandle<GenericComponentState>,
         prev_batch_info: &StoredBatchInfo,
+        existing_batch: SignedBatchEnvelope<FriProof>,
     ) -> anyhow::Result<BatchForSigning<ProverInput>> {
-        let batch_number = prev_batch_info.batch_number + 1;
-
-        // Load the existing batch from storage - we'll rebuild it and verify it matches
-        let existing_batch = self
-            .batch_storage
-            .get_batch_with_proof(batch_number)
-            .await?
-            .context(format!(
-                "Batch {batch_number} that is being rebuilt should exist in storage"
-            ))?;
+        let batch_number = existing_batch.batch_number();
 
         tracing::info!(
             batch_number,


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

Addresses a race condition that can happen if we start-up while there is an L1 commit transaction in progress. This can lead to batcher overwriting S3 data with a new batch that has different block range.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reuse existing validated batches (with proofs) to rebuild and resume batch processing when available.
  * Metrics/logging now label events as "recreated" or "created" for clearer operational visibility.

* **Refactor**
  * Rebuild flow now accepts an existing batch payload and derives batch numbers from it.
  * Removed redundant storage-load steps when reconstructing batches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->