### PR TITLE
feat: config option to disable batcher hash assertion when rebuilding batches

### DIFF
--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -337,25 +337,32 @@ impl Batcher {
         )?;
 
         // Verify that the rebuilt batch matches the stored batch by comparing hashes
-        let rebuilt_stored_batch_info = rebuilt_batch
-            .batch
-            .batch_info
-            .clone()
-            .into_stored(&rebuilt_batch.batch.protocol_version);
-        let stored_stored_batch_info = existing_batch
-            .batch
-            .batch_info
-            .clone()
-            .into_stored(&existing_batch.batch.protocol_version);
+        if self.batcher_config.assert_rebuilt_batch_hashes {
+            let rebuilt_stored_batch_info = rebuilt_batch
+                .batch
+                .batch_info
+                .clone()
+                .into_stored(&rebuilt_batch.batch.protocol_version);
+            let stored_stored_batch_info = existing_batch
+                .batch
+                .batch_info
+                .clone()
+                .into_stored(&existing_batch.batch.protocol_version);
 
-        anyhow::ensure!(
-            rebuilt_stored_batch_info.hash() == stored_stored_batch_info.hash(),
-            "Rebuilt batch info does not match stored batch info for batch {}. \
-             Rebuilt info: {:?}, Stored info: {:?}",
-            batch_number,
-            rebuilt_stored_batch_info,
-            stored_stored_batch_info
-        );
+            anyhow::ensure!(
+                rebuilt_stored_batch_info.hash() == stored_stored_batch_info.hash(),
+                "Rebuilt batch info does not match stored batch info for batch {}. \
+                 Rebuilt info: {:?}, Stored info: {:?}",
+                batch_number,
+                rebuilt_stored_batch_info,
+                stored_stored_batch_info
+            );
+        } else {
+            tracing::warn!(
+                batch_number,
+                "Batch hash verification is disabled - skipping verification of rebuilt batch"
+            );
+        }
 
         Ok(rebuilt_batch)
     }

--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -384,6 +384,12 @@ pub struct BatcherConfig {
     /// Max number of blocks per batch
     #[config(default_t = 10)]
     pub blocks_per_batch_limit: u64,
+
+    /// Whether to verify that rebuilt batches match stored batches by comparing hashes.
+    /// Enabled by default for safety. Disabling this check can be useful for debugging or
+    /// when recovering from corrupted state.
+    #[config(default_t = true)]
+    pub assert_rebuilt_batch_hashes: bool,
 }
 
 /// Only used on the Main Node.


### PR DESCRIPTION
Helpful if we changed block range in s3 and now want to override it with the new batch. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added configuration option to control batch hash verification behavior during batch recreation. Defaults to strict validation for safety; can be disabled to log warnings instead, providing operational flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->