### PR TITLE
chore(generate-deposit): take default bridgehub address if not specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12054,6 +12054,7 @@ dependencies = [
  "clap",
  "tokio",
  "zksync_os_contract_interface",
+ "zksync_os_server",
  "zksync_os_types",
 ]
 

--- a/tools/generate-deposit/Cargo.toml
+++ b/tools/generate-deposit/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 [dependencies]
 zksync_os_contract_interface.workspace = true
 zksync_os_types.workspace = true
+zksync_os_server.workspace = true
 
 alloy = { workspace = true, default-features = false, features = ["provider-anvil-node", "rand", "json-rpc", "signer-local", "reqwest"] }
 anyhow.workspace = true

--- a/tools/generate-deposit/src/main.rs
+++ b/tools/generate-deposit/src/main.rs
@@ -4,11 +4,11 @@ use alloy::primitives::{Address, U256};
 use alloy::providers::utils::Eip1559Estimator;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::signers::local::LocalSigner;
+use clap::Parser;
 use std::str::FromStr;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
-
-use clap::Parser;
+use zksync_os_server::config_constants::BRIDGEHUB_ADDRESS;
 use zksync_os_types::REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE;
 
 #[derive(Parser, Debug)]
@@ -16,7 +16,7 @@ use zksync_os_types::REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE;
 struct Args {
     /// Bridgehub address
     #[arg(short, long)]
-    bridgehub: Address,
+    bridgehub: Option<Address>,
     /// L1 RPC URL
     #[arg(short, long)]
     l1_rpc_url: Option<String>,
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
         // Private key for 0x36615cf349d7f6344891b1e7ca7c72883f5dc049
         "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110".to_owned()
     });
-    let bridgehub_address = args.bridgehub;
+    let bridgehub_address = args.bridgehub.unwrap_or(BRIDGEHUB_ADDRESS.parse()?);
     // Deposit 10k ETH by default
     let amount = args
         .amount


### PR DESCRIPTION
## Summary

* [x] Take default bridgehub address if not specified when generating L1 -> L2 deposit transaction during the state generation process.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated a workspace dependency into the generate-deposit tool configuration to streamline project linkage.

* **Enhancement**
  * The bridgehub parameter in the generate-deposit tool is now optional; if omitted the tool falls back to a configured default value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->