### PR TITLE
feat(l1-watcher): monitor `ReportCommittedBatchRangeZKsyncOS` events

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -212,6 +212,11 @@ alloy::sol! {
 
         event BlockCommit(uint256 indexed batchNumber, bytes32 indexed batchHash, bytes32 indexed commitment);
         event BlockExecution(uint256 indexed batchNumber, bytes32 indexed batchHash, bytes32 indexed commitment);
+        event ReportCommittedBatchRangeZKsyncOS(
+            uint64 indexed batchNumber,
+            uint64 indexed firstBlockNumber,
+            uint64 indexed lastBlockNumber
+        );
 
         function commitBatchesSharedBridge(
             address _chainAddress,

--- a/lib/contract_interface/src/models.rs
+++ b/lib/contract_interface/src/models.rs
@@ -77,6 +77,22 @@ impl From<&StoredBatchInfo> for IExecutor::StoredBatchInfo {
     }
 }
 
+impl From<IExecutor::StoredBatchInfo> for StoredBatchInfo {
+    fn from(value: IExecutor::StoredBatchInfo) -> Self {
+        Self {
+            batch_number: value.batchNumber,
+            state_commitment: value.batchHash,
+            number_of_layer1_txs: value.numberOfLayer1Txs.to(),
+            priority_operations_hash: value.priorityOperationsHash,
+            dependency_roots_rolling_hash: value.dependencyRootsRollingHash,
+            l2_to_l1_logs_root_hash: value.l2LogsTreeRoot,
+            commitment: value.commitment,
+            // fixme: unused?
+            last_block_timestamp: 0,
+        }
+    }
+}
+
 /// User-friendly version of [`crate::L2DACommitmentScheme`] with statically known possible variants.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[repr(u8)]

--- a/lib/l1_watcher/src/batch_range_watcher.rs
+++ b/lib/l1_watcher/src/batch_range_watcher.rs
@@ -1,0 +1,164 @@
+use crate::watcher::{L1Watcher, L1WatcherError};
+use crate::{L1WatcherConfig, ProcessL1Event, util};
+use alloy::consensus::Transaction;
+use alloy::primitives::{Address, BlockNumber};
+use alloy::providers::{DynProvider, Provider};
+use alloy::rpc::types::Log;
+use alloy::sol_types::{SolCall, SolValue};
+use std::sync::Arc;
+use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
+use zksync_os_contract_interface::models::{CommitBatchInfo, StoredBatchInfo};
+use zksync_os_contract_interface::{IExecutor, ZkChain};
+
+/// Don't try to process that many block linearly
+const MAX_L1_BLOCKS_LOOKBEHIND: u64 = 100_000;
+
+/// Discovers block ranges for batches `[last_executed_batch + 1; last_committed_batch]`. This is
+/// needed to rebuild batches correctly in Batcher during replay.
+pub struct BatchRangeWatcher {
+    contract_address: Address,
+    provider: DynProvider,
+    next_batch_number: u64,
+    last_batch_number: u64,
+}
+
+impl BatchRangeWatcher {
+    pub async fn create_watcher(
+        config: L1WatcherConfig,
+        zk_chain: ZkChain<DynProvider>,
+        last_executed_batch: u64,
+        last_committed_batch: u64,
+    ) -> anyhow::Result<L1Watcher> {
+        let current_l1_block = zk_chain.provider().get_block_number().await?;
+        tracing::info!(
+            current_l1_block,
+            last_executed_batch,
+            last_committed_batch,
+            config.max_blocks_to_process,
+            ?config.poll_interval,
+            zk_chain_address = ?zk_chain.address(),
+            "initializing L1 batch range watcher"
+        );
+        let last_l1_block = find_l1_commit_block_by_batch_number(zk_chain.clone(), last_executed_batch)
+            .await
+            .or_else(|err| {
+                // This may error on Anvil with `--load-state` - as it doesn't support `eth_call` even for recent blocks.
+                // We default to `0` in this case - `eth_getLogs` are still supported.
+                // Assert that we don't fallback on longer chains (e.g. Sepolia)
+                if current_l1_block > MAX_L1_BLOCKS_LOOKBEHIND {
+                    anyhow::bail!(
+                        "Binary search failed with {err}. Cannot default starting block to zero for a long chain. Current L1 block number: {current_l1_block}. Limit: {MAX_L1_BLOCKS_LOOKBEHIND}."
+                    )
+                } else {
+                    Ok(0)
+                }
+            })?;
+        tracing::info!(last_l1_block, "resolved on L1");
+
+        let this = Self {
+            contract_address: *zk_chain.address(),
+            provider: zk_chain.provider().clone(),
+            next_batch_number: last_executed_batch + 1,
+            last_batch_number: last_committed_batch,
+        };
+        let l1_watcher = L1Watcher::new(
+            zk_chain.provider().clone(),
+            // We start from last L1 block as it may contain more committed batches apart from the last
+            // one.
+            last_l1_block,
+            config.max_blocks_to_process,
+            config.poll_interval,
+            this.into(),
+        );
+
+        Ok(l1_watcher)
+    }
+}
+
+async fn find_l1_commit_block_by_batch_number(
+    zk_chain: ZkChain<DynProvider>,
+    batch_number: u64,
+) -> anyhow::Result<BlockNumber> {
+    util::find_l1_block_by_predicate(Arc::new(zk_chain), move |zk, block| async move {
+        let res = zk.get_total_batches_committed(block.into()).await?;
+        Ok(res >= batch_number)
+    })
+    .await
+}
+
+#[async_trait::async_trait]
+impl ProcessL1Event for BatchRangeWatcher {
+    const NAME: &'static str = "batch_range";
+
+    type SolEvent = ReportCommittedBatchRangeZKsyncOS;
+    type WatchedEvent = ReportCommittedBatchRangeZKsyncOS;
+
+    fn contract_address(&self) -> Address {
+        self.contract_address
+    }
+
+    async fn process_event(
+        &mut self,
+        event: ReportCommittedBatchRangeZKsyncOS,
+        log: Log,
+    ) -> Result<(), L1WatcherError> {
+        const V30_ENCODING_VERSION: u8 = 3;
+
+        let batch_number = event.batchNumber;
+        let first_block_number = event.firstBlockNumber;
+        let last_block_number = event.lastBlockNumber;
+        if batch_number < self.next_batch_number {
+            tracing::debug!(
+                batch_number,
+                first_block_number,
+                last_block_number,
+                "skipping already processed batch range",
+            );
+        } else if batch_number > self.last_batch_number {
+            tracing::trace!(batch_number, "batch is outside of range of interest");
+            // todo: provide a way to safely terminate early here (or defer indefinitely)
+        } else {
+            let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
+            // todo: retry-backoff logic in case tx is missing
+            let tx = self
+                .provider
+                .get_transaction_by_hash(tx_hash)
+                .await?
+                .expect("tx not found");
+            let commit_call =
+                <IExecutor::commitBatchesSharedBridgeCall as SolCall>::abi_decode(tx.input())?;
+            let commit_data = commit_call._commitData;
+            if commit_data[0] != V30_ENCODING_VERSION {
+                return Err(L1WatcherError::Other(anyhow::anyhow!(
+                    "unexpected encoding version: {}",
+                    commit_data[0]
+                )));
+            }
+
+            let (stored_batch_info, mut commit_batch_infos) =
+                <(
+                    IExecutor::StoredBatchInfo,
+                    Vec<IExecutor::CommitBatchInfoZKsyncOS>,
+                )>::abi_decode_params(&commit_data[1..])?;
+            if commit_batch_infos.len() != 1 {
+                return Err(L1WatcherError::Other(anyhow::anyhow!(
+                    "unexpected number of committed batch infos: {}",
+                    commit_batch_infos.len()
+                )));
+            }
+
+            let stored_batch_info = StoredBatchInfo::from(stored_batch_info);
+            let commit_batch_info = CommitBatchInfo::from(commit_batch_infos.remove(0));
+
+            tracing::info!(
+                batch_number,
+                first_block_number,
+                last_block_number,
+                ?stored_batch_info,
+                ?commit_batch_info,
+                "discovered committed batch range"
+            );
+        }
+        Ok(())
+    }
+}

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -2,6 +2,7 @@ use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::{DynProvider, Provider};
+use alloy::rpc::types::Log;
 use std::sync::Arc;
 use zksync_os_contract_interface::IExecutor::BlockCommit;
 use zksync_os_contract_interface::ZkChain;
@@ -94,7 +95,11 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> ProcessL1Event
         self.contract_address
     }
 
-    async fn process_event(&mut self, batch_commit: BlockCommit) -> Result<(), L1WatcherError> {
+    async fn process_event(
+        &mut self,
+        batch_commit: BlockCommit,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
         let batch_number = batch_commit.batchNumber.to::<u64>();
         let batch_hash = batch_commit.batchHash;
         let batch_commitment = batch_commit.commitment;

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -2,6 +2,7 @@ use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::{DynProvider, Provider};
+use alloy::rpc::types::Log;
 use std::sync::Arc;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
 use zksync_os_contract_interface::ZkChain;
@@ -94,7 +95,11 @@ impl<Finality: WriteFinality, BatchStorage: ReadBatch> ProcessL1Event
         self.contract_address
     }
 
-    async fn process_event(&mut self, batch_execute: BlockExecution) -> Result<(), L1WatcherError> {
+    async fn process_event(
+        &mut self,
+        batch_execute: BlockExecution,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
         let batch_number = batch_execute.batchNumber.to::<u64>();
         let batch_hash = batch_execute.batchHash;
         let batch_commitment = batch_execute.commitment;

--- a/lib/l1_watcher/src/lib.rs
+++ b/lib/l1_watcher/src/lib.rs
@@ -15,6 +15,9 @@ pub use execute_watcher::L1ExecuteWatcher;
 mod upgrade_tx_watcher;
 pub use upgrade_tx_watcher::L1UpgradeTxWatcher;
 
+mod batch_range_watcher;
+pub use batch_range_watcher::BatchRangeWatcher;
+
 pub mod util;
 mod watcher;
 

--- a/lib/l1_watcher/src/traits.rs
+++ b/lib/l1_watcher/src/traits.rs
@@ -55,7 +55,7 @@ where
         let sol_event = T::SolEvent::decode_log(&log.inner)?.data;
         let watched_event =
             T::WatchedEvent::erased_try_from(sol_event).map_err(L1WatcherError::Convert)?;
-        self.process_event(watched_event).await?;
+        self.process_event(watched_event, log).await?;
         Ok(())
     }
 }
@@ -85,7 +85,11 @@ pub trait ProcessL1Event {
     fn contract_address(&self) -> Address;
 
     /// Invoked each time a new event is found.
-    async fn process_event(&mut self, event: Self::WatchedEvent) -> Result<(), L1WatcherError>;
+    async fn process_event(
+        &mut self,
+        event: Self::WatchedEvent,
+        log: Log,
+    ) -> Result<(), L1WatcherError>;
 }
 
 /// Implementation of `TryFrom` that erases the error type to `anyhow::Error`.

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -2,6 +2,7 @@ use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::{DynProvider, Provider};
+use alloy::rpc::types::Log;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
@@ -88,7 +89,11 @@ impl ProcessL1Event for L1TxWatcher {
         self.contract_address
     }
 
-    async fn process_event(&mut self, tx: L1PriorityEnvelope) -> Result<(), L1WatcherError> {
+    async fn process_event(
+        &mut self,
+        tx: L1PriorityEnvelope,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
         if tx.priority_id() < self.next_l1_priority_id {
             tracing::debug!(
                 priority_id = tx.priority_id(),

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -273,7 +273,11 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
         self.admin_contract
     }
 
-    async fn process_event(&mut self, request: L1UpgradeRequest) -> Result<(), L1WatcherError> {
+    async fn process_event(
+        &mut self,
+        request: L1UpgradeRequest,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
         if request.protocol_version <= self.current_protocol_version {
             tracing::info!(
                 ?request.protocol_version,

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -83,9 +83,15 @@ impl L1Watcher {
         let new_logs = self.provider.get_logs(&filter).await?;
 
         if new_logs.is_empty() {
-            tracing::trace!(l1_block_from = from, l1_block_to = to, "no new events");
+            tracing::trace!(
+                event_name = &self.processor.name(),
+                l1_block_from = from,
+                l1_block_to = to,
+                "no new events"
+            );
         } else {
             tracing::info!(
+                event_name = &self.processor.name(),
                 event_count = new_logs.len(),
                 l1_block_from = from,
                 l1_block_to = to,
@@ -109,6 +115,8 @@ pub enum L1WatcherError {
     Batch(anyhow::Error),
     #[error(transparent)]
     Convert(anyhow::Error),
+    #[error(transparent)]
+    Other(anyhow::Error),
     #[error("output has been closed")]
     OutputClosed,
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -63,7 +63,9 @@ use zksync_os_l1_sender::commands::commit::CommitCommand;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
 use zksync_os_l1_sender::pipeline_component::L1Sender;
 use zksync_os_l1_sender::upgrade_gatekeeper::UpgradeGatekeeper;
-use zksync_os_l1_watcher::{L1CommitWatcher, L1ExecuteWatcher, L1TxWatcher, L1UpgradeTxWatcher};
+use zksync_os_l1_watcher::{
+    BatchRangeWatcher, L1CommitWatcher, L1ExecuteWatcher, L1TxWatcher, L1UpgradeTxWatcher,
+};
 use zksync_os_mempool::L2TransactionPool;
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_object_store::ObjectStoreFactory;
@@ -355,6 +357,19 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         .expect("failed to start L1 execute watcher")
         .run()
         .map(report_exit("L1 execute watcher")),
+    );
+
+    tasks.spawn(
+        BatchRangeWatcher::create_watcher(
+            config.l1_watcher_config.clone().into(),
+            node_startup_state.l1_state.diamond_proxy.clone(),
+            node_startup_state.l1_state.last_executed_batch,
+            node_startup_state.l1_state.last_committed_batch,
+        )
+        .await
+        .expect("failed to start L1 batch range watcher")
+        .run()
+        .map(report_exit("L1 batch range watcher")),
     );
 
     let first_replay_record = block_replay_storage.get_replay_record(starting_block);
@@ -935,7 +950,7 @@ async fn determine_starting_batch(
             // We need to replay old unexecuted blocks to rebuild and execute the batches they are in
             node_startup_state.last_l1_executed_block + 1,
             // We want to replay at least one block that is already committed -
-            //  this way we can always get previous_batch_info from storage
+            // this way we can always get previous_batch_info from storage
             node_startup_state.last_l1_committed_block,
             // Repositories' persistence may have fallen behind - we need to replay blocks to rebuild it
             node_startup_state.repositories_persisted_block + 1,
@@ -946,7 +961,7 @@ async fn determine_starting_batch(
             // For FullDiffs state (default) - this is always ahead of `last_l1_executed_block`.
             state.block_range_available().end() + 1,
             // If block rebuild (aka block reversion) is configured, we should ensure we replay
-            //  all the blocks we are rebuilding
+            // all the blocks we are rebuilding
             config
                 .sequencer_config
                 .block_rebuild


### PR DESCRIPTION
## Summary

Introduces a new component that monitors `ReportCommittedBatchRangeZKsyncOS` events for batches `[last_executed_batch + 1; last_committed_batch]`. Later this data will be used to initialize Batcher while it is replaying already committed batches. For now there is no important functionality - data is just monitored, decoded and logged.

First part of #510 

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch range monitoring capability to track committed batch ranges from Layer 1.
  * Introduced new event reporting for committed batch ranges with batch number and block range information.

* **Refactor**
  * Updated event processing infrastructure to include additional log context for better tracking and diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->