### PR TITLE
feat(rpc): use pubdata price factor during gas estimation

### DIFF
--- a/lib/rpc/src/config.rs
+++ b/lib/rpc/src/config.rs
@@ -33,6 +33,12 @@ pub struct RpcConfig {
 
     /// Default timeout for `eth_sendRawTransactionSync`
     pub send_raw_transaction_sync_timeout: Duration,
+
+    /// Factor for pubdata price used during gas limit estimation (`eth_estimateGas`).
+    /// Needed to account for pubdata price market fluctuations. Setting this to `1.0` can lead to
+    /// users submitting unexecutable transactions (fail with `OutOfNativeResourcesDuringValidation`)
+    /// because pubdata price increase in-between estimation and sequencing.
+    pub estimate_gas_pubdata_price_factor: f64,
 }
 
 impl RpcConfig {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -300,7 +300,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     ) -> Result<U256, EthCallError> {
         let block_id = block_number.unwrap_or_default();
 
-        let block_context = {
+        let mut block_context = {
             let Some(resolved_block_number) = self.storage.resolve_block_number(block_id)? else {
                 return Err(EthCallError::BlockNotFound(block_id));
             };
@@ -326,6 +326,12 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     .ok_or(EthCallError::BlockNotFound(block_id))?,
             }
         };
+
+        // Overestimate pubdata price to leave some space for fluctuations. Usual Ethereum tooling
+        // assumes that gas limit stays constant in most scenarios, which is not the case in our system.
+        block_context.pubdata_price = U256::from(
+            f64::from(block_context.pubdata_price) * self.config.estimate_gas_pubdata_price_factor,
+        );
 
         // Choose storage view (with optional overrides) once and reuse it throughout.
         let base_view = self.storage.state_view_at(block_context.block_number)?;

--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -268,6 +268,13 @@ pub struct RpcConfig {
     /// Default timeout for `eth_sendRawTransactionSync`
     #[config(default_t = 2 * TimeUnit::Seconds)]
     pub send_raw_transaction_sync_timeout: Duration,
+
+    /// Factor for pubdata price used during gas limit estimation (`eth_estimateGas`).
+    /// Needed to account for pubdata price market fluctuations. Setting this to `1.0` can lead to
+    /// users submitting unexecutable transactions (fail with `OutOfNativeResourcesDuringValidation`)
+    /// because pubdata price increase in-between estimation and sequencing.
+    #[config(default_t = 1.5)]
+    pub estimate_gas_pubdata_price_factor: f64,
 }
 
 /// Only used on the Main Node.
@@ -617,6 +624,7 @@ impl From<RpcConfig> for zksync_os_rpc::RpcConfig {
             l2_signer_blacklist: c.l2_signer_blacklist,
             stale_filter_ttl: c.stale_filter_ttl,
             send_raw_transaction_sync_timeout: c.send_raw_transaction_sync_timeout,
+            estimate_gas_pubdata_price_factor: c.estimate_gas_pubdata_price_factor,
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #668 

Introduces `rpc_estimate_gas_pubdata_price_factor` that can be used to protect users from submitting unuexecutable transactions (not enough gas for validation due to pubdata price fluctuations).

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable pubdata price multiplier for gas estimation in `eth_estimateGas` operations (default: 1.5), enabling adjusted gas cost calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->