### PR TITLE
feat(mempool-config): make minimal_protocol_basefee configurable

### DIFF
--- a/node/bin/src/config.rs
+++ b/node/bin/src/config.rs
@@ -351,6 +351,10 @@ pub struct MempoolConfig {
     pub max_pending_txs: usize,
     #[config(default_t = usize::MAX)]
     pub max_pending_size: usize,
+    /// Minimal fee per gas (in WEI) for a transaction to be accepted by mempool
+    /// Defaults to `7` which is the lowest possible value of base fee under mainnet EIP-1559 params
+    #[config(default_t = 7)]
+    pub minimal_protocol_basefee: u64,
 }
 
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
@@ -678,6 +682,7 @@ impl From<MempoolConfig> for zksync_os_mempool::PoolConfig {
     fn from(c: MempoolConfig) -> Self {
         Self {
             pending_limit: SubPoolLimit::new(c.max_pending_txs, c.max_pending_size),
+            minimal_protocol_basefee: c.minimal_protocol_basefee,
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary

Adds a `minimal_protocol_basefee` field to the `MempoolConfig`. 
This is necessary for zero-gas-fees chains, if it is not set to 0 - all the transactions will be rejected by the mempool. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable minimal protocol base fee setting for mempool transaction processing with a default value of 7.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->