### PR TITLE
feat: Remove Passthrough from metrics

### DIFF
--- a/lib/l1_sender/src/batcher_metrics.rs
+++ b/lib/l1_sender/src/batcher_metrics.rs
@@ -18,16 +18,13 @@ pub enum BatchExecutionStage {
     FriProofStored,
     CommitL1TxSent,
     CommitL1TxMined,
-    CommitL1Passthrough,
     SnarkProverPicked,
     SnarkProvedReal,
     SnarkProvedFake,
     ProveL1TxSent,
     ProveL1TxMined,
-    ProveL1Passthrough,
     ExecuteL1TxSent,
     ExecuteL1TxMined,
-    ExecuteL1Passthrough,
 }
 
 #[derive(Debug, Metrics)]

--- a/lib/l1_sender/src/commands/commit.rs
+++ b/lib/l1_sender/src/commands/commit.rs
@@ -26,7 +26,6 @@ impl SendToL1 for CommitCommand {
     const NAME: &'static str = "commit";
     const SENT_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1TxSent;
     const MINED_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1TxMined;
-    const PASSTHROUGH_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1Passthrough;
 
     fn solidity_call(&self) -> impl SolCall {
         IExecutor::commitBatchesSharedBridgeCall::new((

--- a/lib/l1_sender/src/commands/execute.rs
+++ b/lib/l1_sender/src/commands/execute.rs
@@ -31,8 +31,6 @@ impl SendToL1 for ExecuteCommand {
     const SENT_STAGE: BatchExecutionStage = BatchExecutionStage::ExecuteL1TxSent;
     const MINED_STAGE: BatchExecutionStage = BatchExecutionStage::ExecuteL1TxMined;
 
-    const PASSTHROUGH_STAGE: BatchExecutionStage = BatchExecutionStage::ExecuteL1Passthrough;
-
     fn solidity_call(&self) -> impl SolCall {
         IExecutor::executeBatchesSharedBridgeCall::new((
             self.batches.first().unwrap().batch.batch_info.chain_address,

--- a/lib/l1_sender/src/commands/mod.rs
+++ b/lib/l1_sender/src/commands/mod.rs
@@ -42,7 +42,6 @@ pub trait SendToL1:
     const NAME: &'static str;
     const SENT_STAGE: BatchExecutionStage;
     const MINED_STAGE: BatchExecutionStage;
-    const PASSTHROUGH_STAGE: BatchExecutionStage;
     fn solidity_call(&self) -> impl SolCall;
 
     fn blob_sidecar(&self) -> Option<BlobTransactionSidecar> {

--- a/lib/l1_sender/src/commands/prove.rs
+++ b/lib/l1_sender/src/commands/prove.rs
@@ -29,7 +29,6 @@ impl SendToL1 for ProofCommand {
     const NAME: &'static str = "prove";
     const SENT_STAGE: BatchExecutionStage = BatchExecutionStage::ProveL1TxSent;
     const MINED_STAGE: BatchExecutionStage = BatchExecutionStage::ProveL1TxMined;
-    const PASSTHROUGH_STAGE: BatchExecutionStage = BatchExecutionStage::ProveL1Passthrough;
 
     fn solidity_call(&self) -> impl SolCall {
         proveBatchesSharedBridgeCall::new((

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -263,9 +263,7 @@ async fn process_prepending_passthrough_commands<Input: SendToL1>(
                             "Not actually sending to L1, just passing through"
                         );
                         latency_tracker.enter_state(L1SenderState::WaitingSend);
-                        outbound
-                            .send((*batch).with_stage(Input::PASSTHROUGH_STAGE))
-                            .await?;
+                        outbound.send(*batch).await?;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Remove `Passthrough` stage from metrics. They are usually only emitted after the restart and it messes up the dashboards(when they are not emitted for a long time)

