### PR TITLE
ci: run gpu prover test only once after merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           # This is required to make sure that the paths to workspace artifacts like zkos-l1-state.json
           # are correct inside prebuilt binary.
           # This variable overwrites the default relative `./` in the .cargo/config.toml.
-          WORKSPACE_DIR: "/home/./runner/_work/zksync-os-server/zksync-os-server"
+          WORKSPACE_DIR: "/opt/./actions-runner/_work/zksync-os-server/zksync-os-server"
           BELLMAN_CUDA_DIR: ${{ github.workspace }}/bellman-cuda
         run: |
           cargo nextest archive --release -p zksync_os_integration_tests \
@@ -239,6 +239,8 @@ jobs:
 
       - name: Check Nvidia driver version
         run: |
+          echo $WORKSPACE
+          pwd
           nvidia-smi
 
       - name: Download prebuilt tests


### PR DESCRIPTION
## Summary

* [x] run gpu prover test only once after merge to main
* [x] use hetzner gpu runner 

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

