### PR TITLE
feat: Don't report Passthrough in batch_number metrics

### DIFF
--- a/lib/l1_sender/src/batcher_model.rs
+++ b/lib/l1_sender/src/batcher_model.rs
@@ -148,7 +148,12 @@ impl<E, S> BatchEnvelope<E, S> {
         let last_block_number = self.batch.last_block_number;
         self.latency_tracker.record_stage(stage, |duration| {
             BATCHER_METRICS.execution_stages[&stage].observe(duration);
-            if !matches!(stage, BatchExecutionStage::CommitL1Passthrough | BatchExecutionStage::ProveL1Passthrough | BatchExecutionStage::ExecuteL1Passthrough) {
+            if !matches!(
+                stage,
+                BatchExecutionStage::CommitL1Passthrough
+                    | BatchExecutionStage::ProveL1Passthrough
+                    | BatchExecutionStage::ExecuteL1Passthrough
+            ) {
                 BATCHER_METRICS.batch_number[&stage].set(batch_number);
                 BATCHER_METRICS.block_number[&stage].set(last_block_number);
             }


### PR DESCRIPTION
## Summary

Explicitly check if the stage is Passthrough and don't report batch number for it. Passthrough metrics are reported usually only on restart, so it messes up the graphic.
