### PR TITLE
ci: add hardhat projects into regression tests

### DIFF
--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -172,8 +172,6 @@ jobs:
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup
-        with:
-          cache_shared_key: 'build-format-and-lint'
 
       - name: Run anvil L1
         run: anvil --load-state ./zkos-l1-state.json --port 8545 &
@@ -194,6 +192,22 @@ jobs:
             sleep 3
           done
           echo "Sequencer is up and running."
+
+      - name: Checkout solidity tests
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: antonbaliasnikov/solidity-tester
+          ref: main # use latest main branch to get test updates on early stages
+          path: solidity-tester
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Run tests
+        working-directory: solidity-tester
+        run: cargo nextest run
 
       - name: Checkout tests
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

* [x] Add a small set of e2e tests based on Hardhat projects into daily regression together with Eth spec tests

## Why?

To always make sure libraries and projects are in sync and working with the latest version of the server.
The projects list can be found [here](https://github.com/antonbaliasnikov/solidity-tester/blob/main/tests/projects.toml) and includes:
* hardhat-ethers and hardhat-viem examples
* uniswap-v4
* olympus dao testing contracts

adapted for the ZKsync OS run with custom chain ID and low confirmation number for deployments.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

