### PR TITLE
chore: increase test timeout from 2 to 3 minutes

### DIFF
--- a/integration-tests/src/assert_traits.rs
+++ b/integration-tests/src/assert_traits.rs
@@ -8,7 +8,7 @@ use alloy::rpc::types::trace::geth::{CallConfig, CallFrame, GethDebugTracingOpti
 use anyhow::Context;
 use std::time::Duration;
 
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 
 #[allow(async_fn_in_trait)]
 pub trait EthCallAssert {


### PR DESCRIPTION
## Summary

* [x] Increase test timeout from 2 to 3 minutes

## Why?

Tests in code coverage mode can take up to 150 seconds to run, 120 seconds default timeout is not always enough, so increase the timeout for 1min.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

