### PR TITLE
fix(rpc): move executed block check earlier in `zks_getL2ToL1LogProof`

### DIFF
--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -42,40 +42,31 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
         let Some(tx_meta) = self.storage.repository().get_transaction_meta(tx_hash)? else {
             return Ok(None);
         };
-        let Some(batch_number) = self
-            .storage
-            .batch()
-            .get_batch_by_block_number(tx_meta.block_number, self.storage.finality())
-            .await?
-        else {
-            return Err(ZksError::NotBatchedYet);
-        };
-        let Some((from_block, to_block)) = self
-            .storage
-            .batch()
-            .get_batch_range_by_number(batch_number)
-            .await?
-        else {
-            // This should never happen
-            tracing::error!(
-                block_number = tx_meta.block_number,
-                batch_number,
-                "block was included in a batch that could not be found"
-            );
-            return Err(ZksError::NotBatchedYet);
-        };
+        let block_number = tx_meta.block_number;
         // Reading from proof storage can return "dirty" data (i.e., not the one that will be
-        // finalized on L1). To avoid this, we assert that the batch has been executed as there is
+        // finalized on L1). To avoid this, we assert that the block has been executed as there is
         // no use case for fetching non-executed proofs.
         if self
             .storage
             .finality()
             .get_finality_status()
             .last_executed_block
-            < batch_number
+            < block_number
         {
             return Err(ZksError::NotExecutedYet);
         }
+        let batch_number = self
+            .storage
+            .batch()
+            .get_batch_by_block_number(block_number, self.storage.finality())
+            .await?
+            .expect("executed block does not belong to a batch");
+        let (from_block, to_block) = self
+            .storage
+            .batch()
+            .get_batch_range_by_number(batch_number)
+            .await?
+            .expect("executed batch has unknown block range");
         let mut batch_index = None;
         let mut merkle_tree_leaves = vec![];
         for block in from_block..=to_block {
@@ -176,8 +167,6 @@ pub type ZksResult<Ok> = Result<Ok, ZksError>;
 /// General `zks` namespace errors
 #[derive(Debug, thiserror::Error)]
 pub enum ZksError {
-    #[error("transaction has not been included in an L1 batch yet")]
-    NotBatchedYet,
     #[error("L1 batch containing the transaction has not been executed yet")]
     NotExecutedYet,
     /// Historical block could not be found on this node (e.g., pruned).


### PR DESCRIPTION
## Summary

Fixes #703 

We were mistakenly checking block against batch. Also the check should be earlier in the flow to not read dirty data from S3.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

