### PR TITLE
fix: state tracking for sequencer

### DIFF
--- a/lib/sequencer/src/execution/metrics.rs
+++ b/lib/sequencer/src/execution/metrics.rs
@@ -29,9 +29,10 @@ pub enum SequencerState {
 impl StateLabel for SequencerState {
     fn generic(&self) -> GenericComponentState {
         match self {
-            Self::WaitingForCommand | Self::WaitingForTx | Self::ConfiguredBlockLimitReached => {
-                GenericComponentState::WaitingRecv
-            }
+            Self::WaitingForCommand
+            | Self::WaitingForTx
+            | Self::ConfiguredBlockLimitReached
+            | Self::BlockContextTxs => GenericComponentState::WaitingRecv,
             Self::WaitingSend => GenericComponentState::WaitingSend,
             _ => GenericComponentState::Processing,
         }


### PR DESCRIPTION
Currently Sequencer is reported as BUSY on `BlockContextTxs` - this is incorrect as it should be "waiting_recv" . This PR fixes it.