### PR TITLE
fix(tracer): Fix call tracer behavior for 'empty' transactions

### DIFF
--- a/lib/rpc/src/sandbox.rs
+++ b/lib/rpc/src/sandbox.rs
@@ -41,6 +41,7 @@ pub fn call_trace_simulate(
     call_config: CallConfig,
 ) -> anyhow::Result<CallFrame> {
     let mut tracer = CallTracer::new_with_config(
+        vec![tx.clone()],
         call_config.with_log.unwrap_or_default(),
         call_config.only_top_call.unwrap_or_default(),
     );
@@ -71,6 +72,7 @@ pub fn call_trace(
     call_config: CallConfig,
 ) -> anyhow::Result<Vec<CallFrame>> {
     let mut tracer = CallTracer::new_with_config(
+        txs.clone(),
         call_config.with_log.unwrap_or_default(),
         call_config.only_top_call.unwrap_or_default(),
     );
@@ -92,6 +94,7 @@ pub fn call_trace(
 
 #[derive(Default)]
 pub struct CallTracer {
+    input_transactions: Vec<ZkTransaction>,
     transactions: Vec<CallFrame>,
     unfinished_calls: Vec<CallFrame>,
     finished_calls: Vec<CallFrame>,
@@ -109,8 +112,13 @@ enum CreateType {
 }
 
 impl CallTracer {
-    pub fn new_with_config(collect_logs: bool, only_top_call: bool) -> Self {
+    pub fn new_with_config(
+        input_transactions: Vec<ZkTransaction>,
+        collect_logs: bool,
+        only_top_call: bool,
+    ) -> Self {
         Self {
+            input_transactions,
             transactions: vec![],
             unfinished_calls: vec![],
             finished_calls: vec![],
@@ -260,10 +268,32 @@ impl EvmTracer for CallTracer {
         // Sanity check
         assert!(self.create_operation_requested.is_none());
 
-        // We can have some edge cases when tx fails before any call frame is created
-        // In this case currently we just skip that transaction
         if let Some(top_level_call) = self.finished_calls.pop() {
             self.transactions.push(top_level_call);
+        } else {
+            // We can have some edge cases when tx fails before any call frame is created
+            // In this case currently we populate minimal call frame info from the input tx data
+            let empty_tx = self.input_transactions.get(self.transactions.len());
+            if let Some(tx) = empty_tx {
+                self.transactions.push(CallFrame {
+                    from: tx.signer(),
+                    gas: U256::from(tx.gas_limit()),
+                    gas_used: U256::from(tx.gas_limit()),
+                    to: tx.to(),
+                    input: tx.input().clone(),
+                    output: None,
+                    error: Some("transaction failed before execution".to_string()),
+                    revert_reason: None,
+                    calls: vec![],
+                    logs: vec![],
+                    value: Some(tx.value()), // Can't have STATICCALL here
+                    typ: if tx.to().is_some() {
+                        "CALL".to_string()
+                    } else {
+                        "CREATE".to_string()
+                    },
+                });
+            }
         }
     }
 

--- a/lib/types/src/transaction/mod.rs
+++ b/lib/types/src/transaction/mod.rs
@@ -11,7 +11,7 @@ use alloy::consensus::crypto::RecoveryError;
 use alloy::consensus::transaction::{Recovered, SignerRecoverable};
 use alloy::consensus::{Transaction, TransactionEnvelope};
 use alloy::eips::Encodable2718;
-use alloy::primitives::{Address, B256, TxNonce};
+use alloy::primitives::{Address, B256, Bytes, TxNonce, U256};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -127,6 +127,14 @@ impl ZkTransaction {
 
     pub fn to(&self) -> Option<Address> {
         self.inner.to()
+    }
+
+    pub fn value(&self) -> U256 {
+        self.inner.value()
+    }
+
+    pub fn input(&self) -> &Bytes {
+        self.inner.input()
     }
 
     pub fn gas_limit(&self) -> u64 {


### PR DESCRIPTION
## Summary

Currently our call tracer can panic in some edge cases when tx fails _before_ any EVM frame is created. We have to populate the trace somehow, otherwise it may break data consumers assumptions

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

