### PR TITLE
fix(tracer): Fix handling of errors in subcalls

### DIFF
--- a/lib/rpc/src/sandbox.rs
+++ b/lib/rpc/src/sandbox.rs
@@ -351,6 +351,11 @@ impl EvmTracer for CallTracer {
 
     /// Opcode failed for some reason. Note: call frame ends immediately
     fn on_opcode_error(&mut self, error: &EvmError, _frame_state: impl EvmFrameInterface) {
+        if self.only_top_call && self.current_call_depth > 1 {
+            // Ignore errors in subcalls if only the top call should be traced
+            return;
+        }
+
         let current_call = self.unfinished_calls.last_mut().expect("Should exist");
         current_call.error = Some(fmt_error_msg(error));
 
@@ -363,6 +368,11 @@ impl EvmTracer for CallTracer {
     /// Special cases, when error happens in frame before any opcode is executed (unfortunately we can't provide access to state)
     /// Note: call frame ends immediately
     fn on_call_error(&mut self, error: &EvmError) {
+        if self.only_top_call && self.current_call_depth > 1 {
+            // Ignore errors in subcalls if only the top call should be traced
+            return;
+        }
+
         let current_call = self.unfinished_calls.last_mut().expect("Should exist");
         current_call.error = Some(fmt_error_msg(error));
 


### PR DESCRIPTION
## Summary

Currently errors in subcalls will pollute the `error` field of the top-level frame if `only_top_call` is true

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

