### PR TITLE
fix: stamp rebuilt blocks with fresh timestamp

### DIFF
--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -256,7 +256,9 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     native_price: rebuild.replay_record.block_context.native_price,
                     pubdata_price: rebuild.replay_record.block_context.pubdata_price,
                     block_number,
-                    timestamp: rebuild.replay_record.block_context.timestamp,
+                    // Since we are rebuilding the block we stamp it with a fresh timestamp.
+                    // This allows us to rebuild and commit potentially old blocks.
+                    timestamp: (millis_since_epoch() / 1000) as u64,
                     blob_fee: rebuild.replay_record.block_context.blob_fee,
                     chain_id: self.chain_id,
                     coinbase: self.fee_collector_address,


### PR DESCRIPTION
## Summary

Old blocks should be rebuilt with a fresh timestamp. Otherwise we can never commit them to L1.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

