### PR TITLE
fix: Update revm to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12471,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.1#a686621c51fcb62d729cdaa475b9794920091a44"
+source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.2#ddf34b7d8bc0396148bce47464e838d7ebad09a0"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3"
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 
-zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.1" }
+zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.2" }
 
 # "Local" dependencies
 zksync_os_contract_interface = { version = "=0.12.1-non-semver-compat", path = "lib/contract_interface" }


### PR DESCRIPTION
## Summary

Currently ZKsync doesn't warm P256 precompile. This small deviation can cause a mismatch in REVM consistency checker. We have implemented temporary fix to zksync-os-revm to avoid hitting the divergence in the short term. Later we will upgrade ZKsync OS.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

