### PR TITLE
feat: make bytecode supplier address config value optional

### DIFF
--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -61,6 +61,7 @@ pub async fn run_jsonrpsee_server<RpcStorage: ReadRpcStorage, Mempool: L2Transac
     config: RpcConfig,
     chain_id: u64,
     bridgehub_address: Address,
+    bytecode_supplier_address: Address,
     storage: RpcStorage,
     mempool: Mempool,
     genesis_input_source: Arc<dyn GenesisInputSource>,
@@ -94,7 +95,13 @@ pub async fn run_jsonrpsee_server<RpcStorage: ReadRpcStorage, Mempool: L2Transac
     )?;
     rpc.merge(EthPubsubNamespace::new(storage.clone(), mempool).into_rpc())?;
     rpc.merge(
-        ZksNamespace::new(bridgehub_address, storage.clone(), genesis_input_source).into_rpc(),
+        ZksNamespace::new(
+            bridgehub_address,
+            bytecode_supplier_address,
+            storage.clone(),
+            genesis_input_source,
+        )
+        .into_rpc(),
     )?;
     rpc.merge(OtsNamespace::new(storage.clone()).into_rpc())?;
     rpc.merge(DebugNamespace::new(storage.clone(), eth_call_handler).into_rpc())?;

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -15,6 +15,7 @@ const LOG_PROOF_SUPPORTED_METADATA_VERSION: u8 = 1;
 
 pub struct ZksNamespace<RpcStorage> {
     bridgehub_address: Address,
+    bytecode_supplier_address: Address,
     storage: RpcStorage,
     genesis_input_source: Arc<dyn GenesisInputSource>,
 }
@@ -22,11 +23,13 @@ pub struct ZksNamespace<RpcStorage> {
 impl<RpcStorage> ZksNamespace<RpcStorage> {
     pub fn new(
         bridgehub_address: Address,
+        bytecode_supplier_address: Address,
         storage: RpcStorage,
         genesis_input_source: Arc<dyn GenesisInputSource>,
     ) -> Self {
         Self {
             bridgehub_address,
+            bytecode_supplier_address,
             storage,
             genesis_input_source,
         }
@@ -162,6 +165,10 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
 impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
     async fn get_bridgehub_contract(&self) -> RpcResult<Address> {
         Ok(self.bridgehub_address)
+    }
+
+    async fn get_bytecode_supplier_contract(&self) -> RpcResult<Address> {
+        Ok(self.bytecode_supplier_address)
     }
 
     async fn get_l2_to_l1_log_proof(

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -11,6 +11,9 @@ pub trait ZksApi {
     #[method(name = "getBridgehubContract")]
     async fn get_bridgehub_contract(&self) -> RpcResult<Address>;
 
+    #[method(name = "getBytecodeSupplierContract")]
+    async fn get_bytecode_supplier_contract(&self) -> RpcResult<Address>;
+
     #[method(name = "getL2ToL1LogProof")]
     async fn get_l2_to_l1_log_proof(
         &self,

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -206,8 +206,8 @@ pub struct GenesisConfig {
     /// so it has to be provided explicitly.
     // For updating state.json: you can check the `deployedBytecode` in `BytecodesSupplier.json` artifact and then
     // find it in `zkos-l1-state.json`
-    #[config(default_t = crate::config_constants::BYTECODE_SUPPLIER_ADDRESS.parse().unwrap())]
-    pub bytecode_supplier_address: Address,
+    #[config(default_t = Some(crate::config_constants::BYTECODE_SUPPLIER_ADDRESS.parse().unwrap()))]
+    pub bytecode_supplier_address: Option<Address>,
 
     /// Chain ID of the chain node operates on.
     #[config(default_t = Some(crate::config_constants::CHAIN_ID))]

--- a/node/bin/src/en_remote_config.rs
+++ b/node/bin/src/en_remote_config.rs
@@ -7,10 +7,12 @@ use zksync_os_genesis::{FileGenesisInputSource, GenesisInputSource};
 use zksync_os_rpc_api::eth::EthApiClient;
 use zksync_os_rpc_api::zks::ZksApiClient;
 
+/// Returns
+/// (bridgehub_address, bytecode_supplier_address, chain_id, genesis_input_source)
 pub async fn load_remote_config(
     main_node_rpc_url: &str,
     en_local_genesis_config: &GenesisConfig,
-) -> anyhow::Result<(Address, u64, Arc<dyn GenesisInputSource>)> {
+) -> anyhow::Result<(Address, Address, u64, Arc<dyn GenesisInputSource>)> {
     let main_node_rpc_client =
         jsonrpsee::http_client::HttpClientBuilder::new().build(main_node_rpc_url)?;
 
@@ -21,6 +23,32 @@ pub async fn load_remote_config(
             "Bridgehub address mismatch: remote = {remote_bridgehub_address}, local = {local_bridgehub_address}",
         );
     }
+
+    let bytecode_supplier_address = match main_node_rpc_client
+        .get_bytecode_supplier_contract()
+        .await
+    {
+        Ok(result) => {
+            if let Some(local_bytecode_supplier_address) =
+                en_local_genesis_config.bytecode_supplier_address
+            {
+                anyhow::ensure!(
+                    result == local_bytecode_supplier_address,
+                    "Bytecode Supplier address mismatch: remote = {result}, local = {local_bytecode_supplier_address}",
+                );
+            }
+            result
+        }
+        // todo: remove when `main_node_rpc_client.get_bytecode_supplier_contract()` is deployed everywhere
+        Err(_) => {
+            tracing::info!(
+                "Cannot read bytecode supplier contract address from the Main Node. This is expected if Main Node runs an older version. Using local config value instead..."
+            );
+            en_local_genesis_config
+                .bytecode_supplier_address
+                .context("`genesis_bytecode_supplier_address` config must be provided when running against an older version of Main Node (`main_node_rpc_client.get_bytecode_supplier_contract()` is not available)")?
+        }
+    };
 
     let remote_chain_id: u64 = u64::from_be_bytes(
         main_node_rpc_client
@@ -54,6 +82,7 @@ pub async fn load_remote_config(
 
     Ok((
         remote_bridgehub_address,
+        bytecode_supplier_address,
         remote_chain_id,
         genesis_input_source,
     ))

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -120,7 +120,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     }
     tracing::info!(version = %node_version, role, "Initializing Node");
 
-    let (bridgehub_address, chain_id, genesis_input_source) =
+    let (bridgehub_address, bytecode_supplier_address, chain_id, genesis_input_source) =
         if config.sequencer_config.is_main_node() {
             let genesis_input_source: Arc<dyn GenesisInputSource> =
                 Arc::new(FileGenesisInputSource::new(
@@ -135,6 +135,10 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                     .genesis_config
                     .bridgehub_address
                     .expect("Missing `bridgehub_address`"),
+                config
+                    .genesis_config
+                    .bytecode_supplier_address
+                    .expect("Missing `bytecode_supplier_address`"),
                 config.genesis_config.chain_id.expect("Missing `chain_id`"),
                 genesis_input_source,
             )
@@ -445,7 +449,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         run_jsonrpsee_server(
             config.rpc_config.clone().into(),
             chain_id,
-            node_startup_state.l1_state.bridgehub_address(),
+            bridgehub_address,
+            bytecode_supplier_address,
             rpc_storage,
             l2_mempool.clone(),
             genesis_input_source,
@@ -521,7 +526,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         L1UpgradeTxWatcher::create_watcher(
             config.l1_watcher_config.clone().into(),
             node_startup_state.l1_state.diamond_proxy.clone(),
-            config.genesis_config.bytecode_supplier_address,
+            bytecode_supplier_address,
             current_protocol_version,
             l1_upgrade_transactions_sender,
         )


### PR DESCRIPTION
Just like with bridgehub_address, we can read it from the main node. This PR adds this funcitionality in a backwards compatible way, so that newer EN work with older Main Node (which is still missing the new RPC endpoint returning the bytecode supplier address)