### PR TITLE
fix: revm-consistency-checker legacy pre-eip155 transactions

### DIFF
--- a/lib/revm_consistency_checker/src/helpers.rs
+++ b/lib/revm_consistency_checker/src/helpers.rs
@@ -104,12 +104,8 @@ pub fn zk_tx_into_revm_tx(
         .nonce(tx.nonce())
         .access_list(access_list)
         .tx_type(Some(tx.tx_type().ty()))
+        .chain_id(chain_id)
         .blob_hashes(vec![]); // ZkSync transactions don't use blobs yet
-
-    // Add optional fields
-    if let Some(chain) = chain_id {
-        tx_env_builder = tx_env_builder.chain_id(Some(chain));
-    }
 
     if let Some(priority_fee) = gas_priority_fee {
         tx_env_builder = tx_env_builder.gas_priority_fee(Some(priority_fee));


### PR DESCRIPTION
## Summary

Fixed an issue in the REVM consistency checker integration. The tool incorrectly set the `chain_id` for legacy transaction types. Instead of setting `chain_id` to `None`, it skipped setting it altogether. Unfortunately, REVM defaults to `Some(1)` for `chain_id` when it is not explicitly set.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

