### PR TITLE
fix(l1-watcher): pick the most recent upgrade cut

### DIFF
--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -156,13 +156,15 @@ impl L1UpgradeTxWatcher {
             );
         }
         if upgrade_cut_data_logs.len() > 1 {
-            anyhow::bail!(
-                "multiple upgrade cuts found for the suggested protocol version: {}",
-                protocol_version
+            tracing::warn!(
+                %protocol_version,
+                "multiple upgrade cuts found for the suggested protocol version; picking the most recent one"
             );
         }
-        let raw_diamond_cut: Log<NewUpgradeCutData> =
-            upgrade_cut_data_logs[0].log_decode().unwrap();
+        // Safe unwrap because of checks above
+        // `last()` because, even though we scan backwards, each scan returns a list of ascending result
+        let upgrade_cut_data = upgrade_cut_data_logs.last().unwrap();
+        let raw_diamond_cut: Log<NewUpgradeCutData> = upgrade_cut_data.log_decode()?;
         let diamond_cut_data = raw_diamond_cut.inner.data.diamondCutData;
         let proposed_upgrade =
             ProposedUpgrade::abi_decode(&diamond_cut_data.initCalldata[4..]).unwrap(); // TODO: we're in fact parsing `upgrade(..)` signature here


### PR DESCRIPTION
## Summary

If there are multiple upgrades, it will only pick the most recent. This is to support cases where there are multiple upgrade fixes (i.e. you may do first upgrade and fix it by issuing another one on top that replaces it).

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

