### PR TITLE
chore: use newer cargo audit version

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Pre-install cargo-audit to avoid using nightly toolchain after checking out code
       - name: Install cargo-audit
-        run: cargo install --locked cargo-audit@0.21.2
+        run: cargo install --locked cargo-audit@0.22.0
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run cargo audit


### PR DESCRIPTION
Older one breaks due to backwards incompatibliity with list of adversarial version