### PR TITLE
feat: record prove time per native

### DIFF
--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -157,7 +157,6 @@ impl FriJobManager {
         proof_bytes: Bytes,
         proving_version: ProvingVersion,
         prover_id: &str,
-        time_taken_prover_end: Option<Duration>,
     ) -> Result<(), SubmitError> {
         // Snapshot the assigned job entry (if any).
         let batch_metadata = match self.jobs.get_job_batch_metadata(batch_number).await {
@@ -191,12 +190,7 @@ impl FriJobManager {
         // Remove the job from the assigned map.
         let Some(removed_job) = self
             .jobs
-            .complete_job(
-                batch_number,
-                ProverType::Real,
-                prover_id,
-                time_taken_prover_end,
-            )
+            .complete_job(batch_number, ProverType::Real, prover_id)
             .await
         else {
             // If already removed due to a race
@@ -343,7 +337,7 @@ impl FriJobManager {
         // Downstream has capacity - we remove the job from `assigned_jobs`.
         let assigned = match self
             .jobs
-            .complete_job(batch_number, ProverType::Fake, prover_id, None)
+            .complete_job(batch_number, ProverType::Fake, prover_id)
             .await
         {
             Some(e) => e,

--- a/node/bin/src/prover_api/metrics.rs
+++ b/node/bin/src/prover_api/metrics.rs
@@ -21,14 +21,16 @@ pub struct ProverMetrics {
     /// The time passed between when a job was picked and reported back
     #[metrics(unit = Unit::Seconds, labels = PROVER_JOB_LABELS, buckets = Buckets::LATENCIES)]
     pub prove_time: LabeledFamily<ProverJobLabels, Histogram<Duration>, 3>,
-    /// The time prover spent actually proving (excluding waiting time). Reported by prover.
-    #[metrics(unit = Unit::Seconds, labels = PROVER_JOB_LABELS, buckets = Buckets::LATENCIES)]
-    pub prove_time_prover_end: LabeledFamily<ProverJobLabels, Histogram<Duration>, 3>,
     /// The time passed between when a job was picked and reported back
     /// divided by the number of transactions in job.
     /// That is, for SNARKs it's divided by the total number of txs in batch range.
     #[metrics(unit = Unit::Seconds, labels = PROVER_JOB_LABELS, buckets = Buckets::LATENCIES)]
     pub prove_time_per_tx: LabeledFamily<ProverJobLabels, Histogram<Duration>, 3>,
+    /// The time passed between when a job was picked and reported back
+    /// divided by the number of native resource in job in millions.
+    /// That is, for SNARKs it's divided by the total number of txs in batch range.
+    #[metrics(unit = Unit::Seconds, labels = PROVER_JOB_LABELS, buckets = Buckets::linear(0.0..=2.399, 0.3))]
+    pub prove_time_per_million_native: LabeledFamily<ProverJobLabels, Histogram<Duration>, 3>,
     #[metrics(labels = ["stage", "type"], buckets = Buckets::values(&[1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 50.0]))]
     pub proved_after_attempts: LabeledFamily<(ProverStage, ProverType), Histogram, 2>,
     /// Time spent waiting to acquire the lock in ProverJobMap
@@ -41,10 +43,6 @@ pub struct ProverMetrics {
     /// Number of computational native proven.
     #[metrics(labels = PROVER_JOB_LABELS, buckets = Buckets::exponential(10_000_000.0..=2_000_000_000.0, 2.0))]
     pub computational_native_proven: LabeledFamily<ProverJobLabels, Histogram<u64>, 3>,
-    /// Rate of computational native proven per millisecond.
-    /// Basically, `computational_native_proven` divided by `prove_time_prover_end_ms`.
-    #[metrics(labels = PROVER_JOB_LABELS, buckets = Buckets::linear(0.0..=20999.9, 3000.0))]
-    pub computational_native_per_ms: LabeledFamily<ProverJobLabels, Histogram<f64>, 3>,
 }
 
 #[derive(Debug, Metrics)]

--- a/node/bin/src/prover_api/prover_job_map/map.rs
+++ b/node/bin/src/prover_api/prover_job_map/map.rs
@@ -268,17 +268,10 @@ impl<T: Clone> ProverJobMap<T> {
         batch_number: u64,
         prover_type: ProverType,
         prover_id: &str,
-        time_taken_prover_end: Option<Duration>,
     ) -> Option<SignedBatchEnvelope<T>> {
-        self.complete_many_jobs(
-            batch_number,
-            batch_number,
-            prover_type,
-            prover_id,
-            time_taken_prover_end,
-        )
-        .await
-        .and_then(|mut envelopes| envelopes.pop())
+        self.complete_many_jobs(batch_number, batch_number, prover_type, prover_id)
+            .await
+            .and_then(|mut envelopes| envelopes.pop())
     }
 
     /// Marks a job as complete by removing it from the map.
@@ -293,7 +286,6 @@ impl<T: Clone> ProverJobMap<T> {
         batch_number_to: u64,
         prover_type: ProverType,
         prover_id: &str,
-        time_taken_prover_end: Option<Duration>,
     ) -> Option<Vec<SignedBatchEnvelope<T>>> {
         let mut jobs = self
             .lock_with_tracking(JobMapMethod::CompleteManyJobs)
@@ -345,31 +337,21 @@ impl<T: Clone> ProverJobMap<T> {
                 PROVER_METRICS.prove_time[&(self.prover_stage, prover_type, prover_id.to_string())]
                     // time since last assignment is proving time
                     .observe(assignment_info.time_since_last_assignment);
-                if let Some(time_taken_prover_end) = time_taken_prover_end {
-                    PROVER_METRICS.prove_time_prover_end
-                        [&(self.prover_stage, prover_type, prover_id.to_string())]
-                        .observe(time_taken_prover_end);
-                }
                 if let Some(total_computational_native_used) = stats.total_computational_native_used
                 {
                     PROVER_METRICS.computational_native_proven
                         [&(self.prover_stage, prover_type, prover_id.to_string())]
                         .observe(total_computational_native_used);
+                    if total_computational_native_used > 0 {
+                        PROVER_METRICS.prove_time_per_million_native
+                            [&(self.prover_stage, prover_type, prover_id.to_string())]
+                            .observe(
+                                assignment_info
+                                    .time_since_last_assignment
+                                    .div_f64(total_computational_native_used as f64 / 1_000_000.0),
+                            );
+                    }
                 }
-
-                if let Some(time_taken_prover_end) = time_taken_prover_end
-                    && let Some(total_computational_native_used) =
-                        stats.total_computational_native_used
-                    && time_taken_prover_end.as_millis() > 0
-                {
-                    PROVER_METRICS.computational_native_per_ms
-                        [&(self.prover_stage, prover_type, prover_id.to_string())]
-                        .observe(
-                            total_computational_native_used as f64
-                                / (time_taken_prover_end.as_secs_f64() * 1000.0), // `as_millis_f64` is unstable
-                        );
-                }
-
                 if stats.total_txs > 0 {
                     PROVER_METRICS.prove_time_per_tx
                         [&(self.prover_stage, prover_type, prover_id.to_string())]
@@ -549,12 +531,7 @@ mod tests {
         assert_eq!(metadata.unwrap().batch_info.commit_info.batch_number, 1);
 
         let result = map
-            .complete_job(
-                1,
-                crate::prover_api::metrics::ProverType::Real,
-                "prover-1",
-                None,
-            )
+            .complete_job(1, crate::prover_api::metrics::ProverType::Real, "prover-1")
             .await;
         assert!(result.is_some());
         assert_eq!(result.unwrap().batch_number(), 1);
@@ -654,7 +631,6 @@ mod tests {
                 3,
                 crate::prover_api::metrics::ProverType::Real,
                 "prover-1",
-                None,
             )
             .await;
         assert!(result.is_some());
@@ -681,7 +657,6 @@ mod tests {
                 3,
                 crate::prover_api::metrics::ProverType::Real,
                 "prover-1",
-                None,
             )
             .await;
         assert!(result.is_none());
@@ -716,13 +691,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Complete a job to make space
-        map.complete_job(
-            1,
-            crate::prover_api::metrics::ProverType::Real,
-            "prover-1",
-            None,
-        )
-        .await;
+        map.complete_job(1, crate::prover_api::metrics::ProverType::Real, "prover-1")
+            .await;
 
         // Now the add should succeed
         tokio::time::timeout(Duration::from_millis(500), add_task)
@@ -778,22 +748,12 @@ mod tests {
         map.add_job(create_test_batch_envelope(1)).await;
 
         let result1 = map
-            .complete_job(
-                1,
-                crate::prover_api::metrics::ProverType::Real,
-                "prover-1",
-                None,
-            )
+            .complete_job(1, crate::prover_api::metrics::ProverType::Real, "prover-1")
             .await;
         assert!(result1.is_some());
 
         let result2 = map
-            .complete_job(
-                1,
-                crate::prover_api::metrics::ProverType::Real,
-                "prover-1",
-                None,
-            )
+            .complete_job(1, crate::prover_api::metrics::ProverType::Real, "prover-1")
             .await;
         assert!(result2.is_none());
     }

--- a/node/bin/src/prover_api/prover_server/v1/handlers.rs
+++ b/node/bin/src/prover_api/prover_server/v1/handlers.rs
@@ -81,7 +81,7 @@ pub(super) async fn submit_fri_proof(
     })?;
     let result = match state
         .fri_job_manager
-        .submit_proof(payload.batch_number, proof_bytes.into(), proving_version, &prover_id, payload.time_taken_prover_end)
+        .submit_proof(payload.batch_number, proof_bytes.into(), proving_version, &prover_id)
         .await
     {
         Ok(()) => Ok((StatusCode::NO_CONTENT, "proof accepted".to_string()).into_response()),
@@ -202,7 +202,6 @@ pub(super) async fn submit_snark_proof(
             proving_version,
             proof_bytes,
             query.id,
-            payload.time_taken_prover_end,
         )
         .await
     {

--- a/node/bin/src/prover_api/prover_server/v1/models.rs
+++ b/node/bin/src/prover_api/prover_server/v1/models.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct BatchDataPayload {
@@ -18,7 +17,6 @@ pub(super) struct FriProofPayload {
     pub batch_number: u64,
     pub vk_hash: String,
     pub proof: String,
-    pub time_taken_prover_end: Option<Duration>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,7 +33,6 @@ pub(super) struct SnarkProofPayload {
     pub to_batch_number: u64,
     pub vk_hash: String,
     pub proof: String,
-    pub time_taken_prover_end: Option<Duration>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/node/bin/src/prover_api/snark_job_manager.rs
+++ b/node/bin/src/prover_api/snark_job_manager.rs
@@ -100,7 +100,6 @@ impl SnarkJobManager {
         proving_version: ProvingVersion,
         payload: Vec<u8>,
         prover_id: String,
-        time_taken_prover_end: Option<Duration>,
     ) -> anyhow::Result<()> {
         // note: we still hold mutex while verifying the proof -
         // this is desired since we don't want the batches to timeout
@@ -113,13 +112,7 @@ impl SnarkJobManager {
         // prove is valid - consuming proven batches
         let Some(consumed_batches_proven) = self
             .jobs
-            .complete_many_jobs(
-                batch_from,
-                batch_to,
-                ProverType::Real,
-                &prover_id,
-                time_taken_prover_end,
-            )
+            .complete_many_jobs(batch_from, batch_to, ProverType::Real, &prover_id)
             .await
         else {
             anyhow::bail!("race condition: some batches were completed earlier")
@@ -197,7 +190,7 @@ impl SnarkJobManager {
             for (job, _) in assigned {
                 if let Some(envelope) = self
                     .jobs
-                    .complete_job(job.batch_number, ProverType::Fake, "fake_prover", None)
+                    .complete_job(job.batch_number, ProverType::Fake, "fake_prover")
                     .await
                 {
                     completed.push(envelope);


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

Adds metrics: `computational_native_proven`, `prove_time_per_million_native` that are recorded on prover API side. Those are extremely helpful in coming up with a reasonable value for native price

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

