### PR TITLE
chore: use default timeout in external node tests

### DIFF
--- a/integration-tests/tests/external_node.rs
+++ b/integration-tests/tests/external_node.rs
@@ -35,7 +35,7 @@ async fn batch_verification_works() -> anyhow::Result<()> {
         .l2_zk_provider
         .wait_finalized_with_timeout(
             deploy_tx_receipt.block_number.unwrap(),
-            Duration::from_secs(60),
+            zksync_os_integration_tests::assert_traits::DEFAULT_TIMEOUT,
         )
         .await?;
     Ok(())
@@ -63,7 +63,10 @@ async fn batch_verification_without_enough_ens() -> anyhow::Result<()> {
     // First block should not get finalized because EN with 2FA is needed.
     main_node
         .l2_zk_provider
-        .wait_not_finalized(1, Duration::from_secs(60))
+        .wait_not_finalized(
+            1,
+            zksync_os_integration_tests::assert_traits::DEFAULT_TIMEOUT,
+        )
         .await?;
     Ok(())
 }
@@ -84,7 +87,10 @@ async fn batch_verification_with_2_ens() -> anyhow::Result<()> {
     // First block should not get finalized because 2 EN with 2FA are needed.
     main_node
         .l2_zk_provider
-        .wait_not_finalized(1, Duration::from_secs(60))
+        .wait_not_finalized(
+            1,
+            zksync_os_integration_tests::assert_traits::DEFAULT_TIMEOUT,
+        )
         .await?;
 
     let _en2 = main_node
@@ -107,7 +113,7 @@ async fn batch_verification_with_2_ens() -> anyhow::Result<()> {
         .l2_zk_provider
         .wait_finalized_with_timeout(
             deploy_tx_receipt.block_number.unwrap(),
-            Duration::from_secs(60),
+            zksync_os_integration_tests::assert_traits::DEFAULT_TIMEOUT,
         )
         .await?;
     Ok(())


### PR DESCRIPTION
## Summary

* [x] Use default timeout in external node tests to fix code coverage CI in main.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

