### PR TITLE
chore: ignore unsoundness in `lru` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9526,9 +9526,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,10 @@ feature-depth = 1
 
 [advisories]
 ignore = [
-    "RUSTSEC-2025-0137",  # Unsoundness in reciprocal_mg10 - not used by our code
+    # Unsoundness in lru <0.16.3. Waiting for:
+    #  * aws-sdk-s3 to upgrade (https://github.com/smithy-lang/smithy-rs/pull/4470)
+    #  * alloy-provider to upgrade (https://github.com/alloy-rs/alloy/pull/3460)
+    "RUSTSEC-2026-0002",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Bumps ruint to 0.17.2 to resolve old RUSTSEC warning and ignores the new `lru`-related one (waiting for dependencies to upgrade)

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

