### PR TITLE
ci: temporary disable code coverage measurements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,35 +91,38 @@ jobs:
           compare_to_earlier_commit: false # Do not compare with `main` due to different number of iterations
 
 
+  # Temporary disable code coverage measurements in main due to llvm-cov issue with rustc v1.89:
+  # https://github.com/rust-lang/rust/issues/141577
+  # TODO: re-enable the job after upgrading Rust to >=1.90
   ######################################
   # Measure code coverage on main push #
   ######################################
-  code-coverage:
-    # Code coverage is measured only on push to main branch
-    # as it slows down PR testing significantly (2m -> 15m for tests execution)
-    # due to overhead with LLVM instrumentation.
-    # So, we keep the main numbers, but not force every PR to wait for it.
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: matterlabs-ci-runner-high-performance
-    env:
-      RUSTC_BOOTSTRAP: 1
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup runner
-        uses: ./.github/actions/runner-setup
-
-      - name: Measure coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info nextest --workspace --release --profile coverage
-
-      - name: Generate codecov report
-        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
-        if: always() && !cancelled()
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          slug: ${{ github.repository }}
+  # code-coverage:
+  #   # Code coverage is measured only on push to main branch
+  #   # as it slows down PR testing significantly (2m -> 15m for tests execution)
+  #   # due to overhead with LLVM instrumentation.
+  #   # So, we keep the main numbers, but not force every PR to wait for it.
+  #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  #   runs-on: matterlabs-ci-runner-high-performance
+  #   env:
+  #     RUSTC_BOOTSTRAP: 1
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #
+  #     - name: Setup runner
+  #       uses: ./.github/actions/runner-setup
+  #
+  #     - name: Measure coverage
+  #       run: cargo llvm-cov --lcov --output-path lcov.info nextest --workspace --release --profile coverage
+  #
+  #     - name: Generate codecov report
+  #       uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+  #       if: always() && !cancelled()
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
+  #         files: lcov.info
+  #         slug: ${{ github.repository }}
 
 
   ############################################


### PR DESCRIPTION
## Summary

Temporary disable code coverage measurements in main due to llvm-cov issue with rustc v1.89:
https://github.com/rust-lang/rust/issues/141577

It should be re-enabled after upgrading Rust to >=1.90 later.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

