### PR TITLE
chore: fix run_local script to require config specified

### DIFF
--- a/docs/src/setup/local_run.md
+++ b/docs/src/setup/local_run.md
@@ -7,17 +7,14 @@
 The `run_local.sh` script automates starting Anvil and chain node(s):
 
 ```bash
-# Run a single chain (auto-detects latest version)
-./run_local.sh
-
-# Run a single chain (explicit path)
-./run_local.sh ./local-chains/v31.0/default
+# Run a single chain
+./run_local.sh ./local-chains/v30.2/default
 
 # Run multiple chains
-./run_local.sh ./local-chains/v31.0/multi_chain
+./run_local.sh ./local-chains/v30.2/multi_chain
 
 # Run with logging to files
-./run_local.sh ./local-chains/v31.0/multi_chain --logs-dir ./logs
+./run_local.sh ./local-chains/v30.2/multi_chain --logs-dir ./logs
 ```
 
 ### Manual setup

--- a/local-chains/README.md
+++ b/local-chains/README.md
@@ -88,17 +88,14 @@ If you are changing source code of any of the `initial_contracts` you should als
 The `run_local.sh` script automates starting Anvil and chain node(s):
 
 ```bash
-# Run a single chain (auto-detects latest version)
-./run_local.sh
-
-# Run a single chain (explicit path)
-./run_local.sh ./local-chains/v31.0/default
+# Run a single chain
+./run_local.sh ./local-chains/v30.2/default
 
 # Run multiple chains
-./run_local.sh ./local-chains/v31.0/multi_chain
+./run_local.sh ./local-chains/v30.2/multi_chain
 
 # Run with logging to files
-./run_local.sh ./local-chains/v31.0/multi_chain --logs-dir ./logs
+./run_local.sh ./local-chains/v30.2/multi_chain --logs-dir ./logs
 ```
 
 #### How the Script Works

--- a/run_local.sh
+++ b/run_local.sh
@@ -49,28 +49,6 @@ cleanup() {
 # Set up trap for cleanup on script exit
 trap cleanup SIGINT SIGTERM EXIT
 
-# Function to find the latest version in local-chains directory
-# Supports versioning like v30, v31, v30.2, v31.0, etc.
-find_latest_version() {
-    local chains_dir="$REPO_ROOT/local-chains"
-    if [ ! -d "$chains_dir" ]; then
-        echo ""
-        return
-    fi
-    
-    # Find all version directories (v* pattern) and sort them properly
-    # Sort by major version first, then by minor version (defaulting to 0 if not present)
-    local latest=$(ls -d "$chains_dir"/v* 2>/dev/null | while read dir; do
-        basename "$dir"
-    done | sed 's/^v//' | sort -t. -k1,1n -k2,2n | tail -1)
-    
-    if [ -n "$latest" ]; then
-        echo "$chains_dir/v$latest"
-    else
-        echo ""
-    fi
-}
-
 # Parse command line arguments
 CONFIG_DIR=""
 LOGS_DIR=""
@@ -87,7 +65,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -*)
             echo -e "${RED}Error: Unknown option $1${NC}"
-            echo -e "Usage: $0 [folder-path] [--logs-dir <path>]"
+            echo -e "Usage: $0 <folder-path> [--logs-dir <path>]"
             exit 1
             ;;
         *)
@@ -102,23 +80,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Check if folder path is provided, otherwise try to detect the latest version
+# Check if folder path is provided
 if [ -z "$CONFIG_DIR" ]; then
-    LATEST_VERSION=$(find_latest_version)
-    if [ -z "$LATEST_VERSION" ]; then
-        echo -e "${RED}Usage: $0 [folder-path] [--logs-dir <path>]${NC}"
-        echo -e "Example: $0 ./local-chains/v31.0/default"
-        echo -e "Example: $0 ./local-chains/v31.0/multi_chain"
-        echo -e "Example: $0 ./local-chains/v31.0/default --logs-dir ./logs"
-        exit 1
-    fi
-    # Default to single chain setup in the default folder
-    CONFIG_DIR="$LATEST_VERSION/default"
-    echo -e "${BLUE}No path provided, using latest version: $CONFIG_DIR${NC}"
-else
-    # Resolve to absolute path
-    CONFIG_DIR="$(realpath "$CONFIG_DIR")"
+    echo -e "${RED}Usage: $0 <folder-path> [--logs-dir <path>]${NC}"
+    echo -e "Example: $0 ./local-chains/v30.2/default"
+    echo -e "Example: $0 ./local-chains/v30.2/multi_chain"
+    echo -e "Example: $0 ./local-chains/v30.2/default --logs-dir ./logs"
+    exit 1
 fi
+
+# Resolve to absolute path
+CONFIG_DIR="$(realpath "$CONFIG_DIR")"
 
 # Verify the directory exists
 if [ ! -d "$CONFIG_DIR" ]; then


### PR DESCRIPTION
## Summary

Remove version autodetection for `run_local.sh`.

**Rationale:**
The highest available version(s) on `local-chains/` might not be the stable one, but rather the _next_ protocol version still under development. To avoid overcomplicating things with autodetection, I decided it's better for the user to explicitly specify the config folder and made the argument required.