### PR TITLE
feat(batcher): make the limit of transaction count per batch configurable

### DIFF
--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -216,6 +216,7 @@ impl Batcher {
         let mut blocks: Vec<(BlockOutput, ReplayRecord, TreeBatchOutput, ProverInput)> = vec![];
         let mut accumulator = BatchInfoAccumulator::new(
             self.batcher_config.blocks_per_batch_limit,
+            self.batcher_config.tx_per_batch_limit,
             self.pubdata_limit_bytes,
         );
 

--- a/node/bin/src/batcher/seal_criteria.rs
+++ b/node/bin/src/batcher/seal_criteria.rs
@@ -12,6 +12,7 @@ pub(crate) struct BatchInfoAccumulator {
     pub pubdata_bytes: u64,
     pub l2_to_l1_logs_count: u64,
     pub block_count: u64,
+    pub tx_count: u64,
     pub has_upgrade_tx: bool,
 
     pub protocol_versions: HashSet<ProtocolSemanticVersion>,
@@ -19,13 +20,19 @@ pub(crate) struct BatchInfoAccumulator {
 
     // Limits
     pub blocks_per_batch_limit: u64,
+    pub tx_per_batch_limit: u64,
     pub batch_pubdata_limit_bytes: u64,
 }
 
 impl BatchInfoAccumulator {
-    pub fn new(blocks_per_batch_limit: u64, batch_pubdata_limit_bytes: u64) -> Self {
+    pub fn new(
+        blocks_per_batch_limit: u64,
+        tx_per_batch_limit: u64,
+        batch_pubdata_limit_bytes: u64,
+    ) -> Self {
         Self {
             blocks_per_batch_limit,
+            tx_per_batch_limit,
             batch_pubdata_limit_bytes,
             ..Default::default()
         }
@@ -40,6 +47,7 @@ impl BatchInfoAccumulator {
             .map(|tx_result| tx_result.as_ref().map_or(0, |tx| tx.l2_to_l1_logs.len()))
             .sum::<usize>() as u64;
         self.block_count += 1;
+        self.tx_count += replay_record.transactions.len() as u64;
         self.execution_versions
             .insert(replay_record.block_context.execution_version);
         self.protocol_versions
@@ -86,6 +94,12 @@ impl BatchInfoAccumulator {
         if self.block_count > self.blocks_per_batch_limit {
             BATCHER_METRICS.seal_reason[&"blocks_per_batch"].inc();
             tracing::debug!("Batcher: reached blocks per batch limit");
+            return true;
+        }
+
+        if self.tx_count > self.tx_per_batch_limit {
+            BATCHER_METRICS.seal_reason[&"tx_per_batch"].inc();
+            tracing::debug!("Batcher: reached tx per batch limit");
             return true;
         }
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -572,6 +572,10 @@ pub struct BatcherConfig {
     #[config(default_t = 10)]
     pub blocks_per_batch_limit: u64,
 
+    /// Max number of transactions per batch
+    #[config(default_t = 10000)]
+    pub tx_per_batch_limit: u64,
+
     /// Whether to verify that rebuilt batches match stored batches by comparing hashes.
     /// Enabled by default for safety. Disabling this check can be useful for debugging or
     /// when recovering from corrupted state.


### PR DESCRIPTION
This PRs introduces an optional config field `batcher_blocks_per_batch_limit` that sets a limit on the number of transactions (l1 or l2) per batch.

There is no inherent limit (that is, it doesn't matter for the prover or l1 sender how many transactions are there in a batch - it only matters what the total number of operations/gas exist there), but it's still a useful config when doing tests - particularly loadtesting.