### PR TITLE
test: Add P256 integration tests with REVM consistency checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14847,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.2#ddf34b7d8bc0396148bce47464e838d7ebad09a0"
+source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.3#063e00193f143c30af7bfe7aa6f85d8d54967c5b"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 
-zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.2" }
+zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.3" }
 
 # "Local" dependencies
 zksync_os_contract_interface = { version = "=0.13.0-non-semver-compat", path = "lib/contract_interface" }


### PR DESCRIPTION
## Summary

We have found a bug in zksync-os-revm, that leads to incorrect gas calculations in P256 precompile. To avoid inconsistency in the future:
1) Enabling the revm-consistency-checker in integration tests
2) Adding test for P256 precompile

## Impact on CI

The change slow down the integration tests pipeline, by local benchmarks from 213s to 286s:

Before:
<img width="618" height="112" alt="image" src="https://github.com/user-attachments/assets/abba30a3-e065-409e-93c0-48619d54822d" />


After:
![telegram-cloud-photo-size-2-5429135414779383328-y](https://github.com/user-attachments/assets/10a9ebdc-7427-47f1-99f7-346582091c80)

 
## Relevant PRs

PR with a fix in `zksync-os-revm`:
- https://github.com/matter-labs/zksync-os-revm/pull/8
