### PR TITLE
feat: use newer version of zkyns-os-revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14847,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.2#ddf34b7d8bc0396148bce47464e838d7ebad09a0"
+source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.3#063e00193f143c30af7bfe7aa6f85d8d54967c5b"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 
-zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.2" }
+zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.3" }
 
 # "Local" dependencies
 zksync_os_contract_interface = { version = "=0.13.0-non-semver-compat", path = "lib/contract_interface" }


### PR DESCRIPTION
There was a bug in the previous one that resulted in a divergency when invoking P256 precompile