### PR TITLE
chore: add retries in check transactions for config tests

### DIFF
--- a/.github/scripts/test-configs.sh
+++ b/.github/scripts/test-configs.sh
@@ -98,11 +98,26 @@ for entry in "${CONFIGS[@]}"; do
   TO=0x5A67EE02274D9Ec050d412b96fE810Be4D71e7A0
 
   echo "Sending test transaction..."
-  cast send \
-    --private-key "${TEST_PRIVATE_KEY}" \
-    --rpc-url "http://localhost:${RPC_PORT}" \
-    "${TO}" \
-    --value 100
+  MAX_RETRIES=5
+  RETRY_DELAY=2  # seconds
+  attempt=1
+  while true; do
+    if cast send \
+      --private-key "${TEST_PRIVATE_KEY}" \
+      --rpc-url "http://localhost:${RPC_PORT}" \
+      "${TO}" \
+      --value 100; then
+      echo "✅ Test transaction succeeded!"
+      break
+    fi
+    if [ "${attempt}" -ge "${MAX_RETRIES}" ]; then
+      echo "❌ Test transaction failed after ${MAX_RETRIES} attempts!"
+      exit 1
+    fi
+    echo "⚠️  Cast send failed (attempt ${attempt}/${MAX_RETRIES}), retrying in ${RETRY_DELAY}s..."
+    attempt=$((attempt + 1))
+    sleep "${RETRY_DELAY}"
+  done
 
   echo "✅ ${CUR_NAME} passed"
 done


### PR DESCRIPTION
## Summary

* [x] add retries in check transactions for config tests

## Why?

To workaround the case when server RPC is up, but server still not fully ready to accept transactions that can cause test flakiness.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

