### PR TITLE
feat: set total difficulty in rpc block headers

### DIFF
--- a/lib/rpc/src/eth_pubsub_impl.rs
+++ b/lib/rpc/src/eth_pubsub_impl.rs
@@ -44,7 +44,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2TransactionPool>
                         notification.block.as_ref().header.clone(),
                         notification.block.hash(),
                     ),
-                    None,
+                    Some(U256::ZERO),
                     Some(U256::from(notification.block.as_ref().deref().rlp_length())),
                 )
             })

--- a/lib/rpc_api/src/types.rs
+++ b/lib/rpc_api/src/types.rs
@@ -23,7 +23,11 @@ impl RpcBlockConvert for Sealed<alloy::consensus::Block<TxHash>> {
         let block = self.unseal();
         let rlp_length = block.rlp_length();
         ZkApiBlock::new(
-            ZkHeader::from_consensus(block.header.seal(hash), None, Some(U256::from(rlp_length))),
+            ZkHeader::from_consensus(
+                block.header.seal(hash),
+                Some(U256::ZERO),
+                Some(U256::from(rlp_length)),
+            ),
             BlockTransactions::Hashes(block.body.transactions),
         )
     }


### PR DESCRIPTION
## Summary

Some tooling (e.g. ethers v5) relies on `total_difficulty` present. Setting 0 to be compatible with more SDKs

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

