### PR TITLE
fix: prevent "subtract with overflow" error on EN startup 

### DIFF
--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -82,7 +82,9 @@ async fn find_latest_l1_revert(
     // Early return if latest block is behind start block. This can happen if we hit different
     // L1 nodes between calls where the second node is behind the first.
     if latest_block < start_block_number {
-        tracing::info!("latest block is behind start block (hitting different L1 nodes?), skipping revert checks");
+        tracing::info!(
+            "latest block is behind start block (hitting different L1 nodes?), skipping revert checks"
+        );
         return Ok(None);
     }
 


### PR DESCRIPTION
This happens sometimes when all batches are committed and executed. Adding `1` before subtracting shoudl fix it.