### PR TITLE
chore: fix version box in the documentation

### DIFF
--- a/docs/js/version-box.js
+++ b/docs/js/version-box.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
     // Get the base URL from the mdBook configuration
-    const baseUrl = document.location.origin + '/zksync-era/core';
+    const baseUrl = document.location.origin + '/zksync-os-server';
 
     // Function to create version selector
     function createVersionSelector(versions) {
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', function () {
         versionSelector.addEventListener('change', function () {
             const selectedVersion = versionSelector.value;
             // Redirect to the selected version URL
-            window.location.href = '/zksync-era/core' + selectedVersion;
+            window.location.href = '/zksync-os-server' + selectedVersion;
         });
 
         return versionSelector;


### PR DESCRIPTION
## Summary

* [x] fix version box in the documentation

## Why?

Old copy-paste from zksync-era prevented to get the right versioning.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

