### PR TITLE
feat: Add metric for blacklisted addresses count

### DIFF
--- a/lib/observability/src/metrics.rs
+++ b/lib/observability/src/metrics.rs
@@ -23,6 +23,9 @@ pub struct GeneralMetrics {
     pub fee_collector_address: LabeledFamily<&'static str, Gauge, 1>,
 
     pub chain_id: Gauge<u64>,
+
+    /// Number of blacklisted addresses in the internal config on server startup
+    pub blacklisted_addresses_count: Gauge<usize>,
 }
 
 #[vise::register]

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -790,12 +790,12 @@ async fn run_main_node_pipeline(
         .general_config
         .rocks_db_path
         .join(PRIORITY_TREE_DB_NAME);
-    let internal_config_path = config
-        .general_config
-        .rocks_db_path
-        .join(INTERNAL_CONFIG_FILE_NAME);
-    let internal_config_manager = InternalConfigManager::new(internal_config_path)
-        .expect("Failed to initialize InternalConfigManager");
+    let internal_config_manager = init_and_report_internal_config_manager(
+        config
+            .general_config
+            .rocks_db_path
+            .join(INTERNAL_CONFIG_FILE_NAME),
+    );
 
     Pipeline::new()
         .pipe(MainNodeCommandSource {
@@ -922,12 +922,13 @@ async fn run_en_pipeline(
     tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     chain_id: u64,
 ) {
-    let internal_config_path = config
-        .general_config
-        .rocks_db_path
-        .join(INTERNAL_CONFIG_FILE_NAME);
-    let internal_config_manager = InternalConfigManager::new(internal_config_path)
-        .expect("Failed to initialize InternalConfigManager");
+    let internal_config_manager = init_and_report_internal_config_manager(
+        config
+            .general_config
+            .rocks_db_path
+            .join(INTERNAL_CONFIG_FILE_NAME),
+    );
+
     Pipeline::new()
         .pipe(ExternalNodeCommandSource {
             starting_block,
@@ -1023,6 +1024,23 @@ fn report_exit<T, E: std::fmt::Debug>(name: &'static str) -> impl Fn(Result<T, E
         Ok(_) => tracing::warn!("{name} component unexpectedly exited"),
         Err(err) => tracing::error!(?err, "{name} component failed"),
     }
+}
+
+fn init_and_report_internal_config_manager(
+    internal_config_path: std::path::PathBuf,
+) -> InternalConfigManager {
+    let internal_config_manager = InternalConfigManager::new(internal_config_path)
+        .expect("Failed to initialize InternalConfigManager");
+
+    // Report blacklisted addresses metric
+    let internal_config = internal_config_manager
+        .read_config()
+        .expect("Failed to read internal config");
+    GENERAL_METRICS
+        .blacklisted_addresses_count
+        .set(internal_config.l2_signer_blacklist.len());
+
+    internal_config_manager
 }
 
 async fn commit_proof_execute_block_numbers(


### PR DESCRIPTION
Add a Prometheus gauge metric to track the number of blacklisted addresses from internal config on server startup. The metric is set when initializing both main node and external node pipelines.
