### PR TITLE
perf: speed up priority tree init for EN

### DIFF
--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -40,25 +40,15 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
         db_path: &Path,
         finality: Finality,
         batch_storage: BatchStorage,
-        last_executed_batch: u64,
     ) -> anyhow::Result<Self> {
         let started_at = Instant::now();
         let db = PriorityTreeDB::new(db_path);
         let (initial_block_number, mut merkle_tree) = db.init_tree()?;
-        let last_executed_block = batch_storage
-            .get_batch_range_by_number(last_executed_batch)
-            .await
-            .with_context(|| {
-                format!(
-                    "cannot initialize priority tree: failed to get batch {last_executed_batch} from storage"
-                )
-            })?
-            .with_context(|| {
-                format!(
-                    "cannot initialize priority tree: no batch {last_executed_batch} in storage"
-                )
-            })?
-            .1;
+        let finality_state = finality.get_finality_status();
+        let (last_executed_batch, last_executed_block) = (
+            finality_state.last_executed_batch,
+            finality_state.last_executed_block,
+        );
 
         tracing::debug!(
             persisted_up_to = initial_block_number,
@@ -67,12 +57,8 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
         );
 
         for block_number in (initial_block_number + 1)..=last_executed_block {
-            let block = replay_storage
-                .get_replay_record(block_number)
-                .with_context(|| {
-                    format!("cannot re-build priority tree: missing replay block {block_number}")
-                })?;
-            for tx in block.transactions {
+            let record = Self::wait_for_replay_record(&replay_storage, block_number).await;
+            for tx in record.transactions {
                 if let ZkEnvelope::L1(l1_tx) = tx.into_envelope() {
                     merkle_tree.push_hash(*l1_tx.hash());
                 }
@@ -198,7 +184,8 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
                 let mut priority_op_count = 0;
                 for block_number in first_block_number..=last_block_number {
                     // Block is not guaranteed to be present in the replay storage for EN, so we use `wait_for_replay_record`.
-                    let replay = self.wait_for_replay_record(block_number).await;
+                    let replay =
+                        Self::wait_for_replay_record(&self.replay_storage, block_number).await;
                     for tx in replay.transactions {
                         if let ZkEnvelope::L1(l1_tx) = tx.into_envelope() {
                             first_priority_op_id_in_batch
@@ -312,11 +299,14 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
         }
     }
 
-    async fn wait_for_replay_record(&self, block_number: u64) -> ReplayRecord {
+    async fn wait_for_replay_record(
+        replay_storage: &ReplayStorage,
+        block_number: u64,
+    ) -> ReplayRecord {
         let mut timer = tokio::time::interval(Duration::from_millis(100));
         loop {
             timer.tick().await;
-            if let Some(r) = self.replay_storage.get_replay_record(block_number) {
+            if let Some(r) = replay_storage.get_replay_record(block_number) {
                 return r;
             }
         }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -990,9 +990,6 @@ async fn run_en_pipeline(
             ),
             batch_storage,
             finality.clone(),
-            node_state_on_startup
-                .last_l1_executed_block
-                .min(node_state_on_startup.block_replay_storage_last_block),
         )
         .await
         .unwrap();

--- a/node/bin/src/priority_tree_steps/priority_tree_en_step.rs
+++ b/node/bin/src/priority_tree_steps/priority_tree_en_step.rs
@@ -24,30 +24,10 @@ where
         db_path: &Path,
         batch_storage: BatchStorage,
         finality: Finality,
-        last_ready_block: u64,
     ) -> anyhow::Result<Self> {
-        let batch_of_last_ready_block = batch_storage
-            .get_batch_by_block_number(last_ready_block, &finality)
-            .await?
-            .unwrap();
-        let batch_range = batch_storage
-            .get_batch_range_by_number(batch_of_last_ready_block)
-            .await?
-            .unwrap();
-        let last_ready_batch = if last_ready_block == batch_range.1 {
-            batch_of_last_ready_block
-        } else {
-            batch_of_last_ready_block.saturating_sub(1)
-        };
-
-        let priority_tree_manager = PriorityTreeManager::new(
-            block_storage,
-            db_path,
-            finality.clone(),
-            batch_storage,
-            last_ready_batch,
-        )
-        .await?;
+        let priority_tree_manager =
+            PriorityTreeManager::new(block_storage, db_path, finality.clone(), batch_storage)
+                .await?;
 
         Ok(Self {
             priority_tree_manager,

--- a/node/bin/src/priority_tree_steps/priority_tree_pipeline_step.rs
+++ b/node/bin/src/priority_tree_steps/priority_tree_pipeline_step.rs
@@ -35,15 +35,9 @@ where
         batch_storage: BatchStorage,
         finality: Finality,
     ) -> anyhow::Result<Self> {
-        let finality_status = finality.get_finality_status();
-        let priority_tree_manager = PriorityTreeManager::new(
-            block_storage,
-            db_path,
-            finality.clone(),
-            batch_storage,
-            finality_status.last_executed_batch,
-        )
-        .await?;
+        let priority_tree_manager =
+            PriorityTreeManager::new(block_storage, db_path, finality.clone(), batch_storage)
+                .await?;
 
         Ok(Self {
             priority_tree_manager,


### PR DESCRIPTION
## Summary

Priority tree initialization was slow for EN, because it processed batch by batch doing an S3 request per batch to get block range. Previously, `PriorityTreeManager::new` would rebuild a tree for up to the last block in replay storage, and then normal flow (batch-by-batch) would kick in; if node is empty it means that `new` effectively does nothing. I changed it so that `new` inits a tree for up to the last executed block, this way the node only does one S3 request in `new` building an up-to-date priority tree.
Tested locally and now priority tree initialization finished just after the node has replayed the last executed block.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

