### PR TITLE
feat: do not require batch storage for priority tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15617,6 +15617,7 @@ dependencies = [
  "zksync_os_contract_interface",
  "zksync_os_crypto",
  "zksync_os_l1_sender",
+ "zksync_os_l1_watcher",
  "zksync_os_mini_merkle_tree",
  "zksync_os_observability",
  "zksync_os_pipeline",

--- a/lib/priority_tree/Cargo.toml
+++ b/lib/priority_tree/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 zksync_os_contract_interface.workspace = true
 zksync_os_crypto.workspace = true
 zksync_os_l1_sender.workspace = true
+zksync_os_l1_watcher.workspace = true
 zksync_os_mini_merkle_tree.workspace = true
 zksync_os_storage_api.workspace = true
 zksync_os_types.workspace = true

--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -11,10 +11,11 @@ use zksync_os_crypto::hasher::keccak::KeccakHasher;
 use zksync_os_l1_sender::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_l1_sender::commands::L1SenderCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;
+use zksync_os_l1_watcher::CommittedBatchProvider;
 use zksync_os_mini_merkle_tree::{HashEmptySubtree, MiniMerkleTree};
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::PeekableReceiver;
-use zksync_os_storage_api::{ReadBatch, ReadFinality, ReadReplay, ReplayRecord};
+use zksync_os_storage_api::{ReadFinality, ReadReplay, ReplayRecord};
 use zksync_os_types::ZkEnvelope;
 
 type InputChannel = PeekableReceiver<SignedBatchEnvelope<FriProof>>;
@@ -23,23 +24,23 @@ type OutputChannel = mpsc::Sender<L1SenderCommand<ExecuteCommand>>;
 mod db;
 
 #[derive(Clone)]
-pub struct PriorityTreeManager<ReplayStorage, Finality, BatchStorage> {
+pub struct PriorityTreeManager<ReplayStorage, Finality> {
     merkle_tree: Arc<Mutex<MiniMerkleTree<PriorityOpsLeaf>>>,
     replay_storage: ReplayStorage,
     db: PriorityTreeDB,
     finality: Finality,
-    batch_storage: BatchStorage,
+    committed_batch_provider: CommittedBatchProvider,
     last_executed_batch_on_init: u64,
 }
 
-impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
-    PriorityTreeManager<ReplayStorage, Finality, BatchStorage>
+impl<ReplayStorage: ReadReplay, Finality: ReadFinality>
+    PriorityTreeManager<ReplayStorage, Finality>
 {
     pub async fn new(
         replay_storage: ReplayStorage,
         db_path: &Path,
         finality: Finality,
-        batch_storage: BatchStorage,
+        committed_batch_provider: CommittedBatchProvider,
     ) -> anyhow::Result<Self> {
         let started_at = Instant::now();
         let db = PriorityTreeDB::new(db_path);
@@ -77,7 +78,7 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
             replay_storage,
             db,
             finality,
-            batch_storage,
+            committed_batch_provider,
             last_executed_batch_on_init: last_executed_batch,
         })
     }
@@ -141,7 +142,7 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
                         .map(|e| {
                             (
                                 e.batch.batch_info.batch_number,
-                                (e.batch.first_block_number, e.batch.last_block_number),
+                                (e.batch.first_block_number..=e.batch.last_block_number),
                             )
                         })
                         .collect::<Vec<_>>();
@@ -154,24 +155,22 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
                     (Some(envelopes), ranges)
                 }
                 None => {
+                    let next_batch_number = last_processed_batch + 1;
                     let _ = self
                         .finality
                         .subscribe()
-                        .wait_for(|f| last_processed_batch < f.last_executed_batch)
+                        .wait_for(|f| next_batch_number <= f.last_executed_batch)
                         .await
                         .context("failed to wait for next finalized batch")?;
-
-                    let next_batch_number = last_processed_batch + 1;
+                    // Below should be infallible as batch is guaranteed to have been processed as
+                    // executed. Hence, already discovered as committed.
+                    // todo: non-local reasoning, refactor once `CommittedBatchProvider` loads
+                    //       batches asynchronously
                     let range = self
-                        .batch_storage
-                        .get_batch_range_by_number(next_batch_number)
-                        .await
-                        .with_context(|| {
-                            format!("failed to get batch {next_batch_number} from storage")
-                        })?
-                        .with_context(|| {
-                            format!("batch {next_batch_number} not found in storage")
-                        })?;
+                        .committed_batch_provider
+                        .get(next_batch_number)
+                        .with_context(|| format!("unexpected state: batch {next_batch_number} was executed but not discovered as committed"))?
+                        .block_range;
                     let ranges = vec![(next_batch_number, range)];
                     (None, ranges)
                 }
@@ -179,10 +178,11 @@ impl<ReplayStorage: ReadReplay, Finality: ReadFinality, BatchStorage: ReadBatch>
             latency_tracker.enter_state(GenericComponentState::Processing);
             let mut priority_ops = Vec::new();
             let mut merkle_tree = self.merkle_tree.lock().await;
-            for (batch_number, (first_block_number, last_block_number)) in batch_ranges.clone() {
+            for (batch_number, block_range) in batch_ranges.clone() {
                 let mut first_priority_op_id_in_batch = None;
                 let mut priority_op_count = 0;
-                for block_number in first_block_number..=last_block_number {
+                let last_block_number = *block_range.end();
+                for block_number in block_range {
                     // Block is not guaranteed to be present in the replay storage for EN, so we use `wait_for_replay_record`.
                     let replay =
                         Self::wait_for_replay_record(&self.replay_storage, block_number).await;

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -670,7 +670,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         // External Node
         run_en_pipeline(
             &config,
-            batch_storage.clone(),
+            committed_batch_provider,
             node_startup_state,
             block_replay_storage.clone(),
             &mut tasks,
@@ -853,7 +853,7 @@ async fn run_main_node_pipeline(
             batcher_config: config.batcher_config.clone(),
             pubdata_mode: config.l1_sender_config.pubdata_mode,
             sidecar_sender,
-            committed_batch_provider,
+            committed_batch_provider: committed_batch_provider.clone(),
         })
         .pipe(BatchVerificationPipelineStep::new(
             config.batch_verification_config.clone().into(),
@@ -888,8 +888,8 @@ async fn run_main_node_pipeline(
             PriorityTreePipelineStep::new(
                 block_replay_storage.clone(),
                 &priority_tree_db_path,
-                batch_storage.clone(),
                 finality,
+                committed_batch_provider,
             )
             .await
             .unwrap(),
@@ -908,7 +908,7 @@ async fn run_main_node_pipeline(
 #[allow(clippy::too_many_arguments)]
 async fn run_en_pipeline(
     config: &Config,
-    batch_storage: ProofStorage,
+    committed_batch_provider: CommittedBatchProvider,
     node_state_on_startup: NodeStateOnStartup,
     block_replay_storage: impl WriteReplay + Clone,
     tasks: &mut JoinSet<()>,
@@ -988,8 +988,8 @@ async fn run_en_pipeline(
                     .rocks_db_path
                     .join(PRIORITY_TREE_DB_NAME),
             ),
-            batch_storage,
             finality.clone(),
+            committed_batch_provider,
         )
         .await
         .unwrap();

--- a/node/bin/src/priority_tree_steps/priority_tree_en_step.rs
+++ b/node/bin/src/priority_tree_steps/priority_tree_en_step.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 use tokio::sync::mpsc;
+use zksync_os_l1_watcher::CommittedBatchProvider;
 use zksync_os_priority_tree::PriorityTreeManager;
-use zksync_os_storage_api::{ReadBatch, ReadFinality, ReadReplay};
+use zksync_os_storage_api::{ReadFinality, ReadReplay};
 
 /// Priority Tree manager for External Nodes.
 ///
@@ -9,25 +10,28 @@ use zksync_os_storage_api::{ReadBatch, ReadFinality, ReadReplay};
 /// - Doesn't act as pipeline step - launched as a standalone task instead
 /// - Doesn't output execute commands (EN doesn't execute on L1)
 /// - Watches finalized batch numbers instead of batch envelopes
-pub struct PriorityTreeENStep<BlockStorage, Finality, BatchStorage> {
-    priority_tree_manager: PriorityTreeManager<BlockStorage, Finality, BatchStorage>,
+pub struct PriorityTreeENStep<BlockStorage, Finality> {
+    priority_tree_manager: PriorityTreeManager<BlockStorage, Finality>,
 }
 
-impl<BlockStorage, Finality, BatchStorage> PriorityTreeENStep<BlockStorage, Finality, BatchStorage>
+impl<BlockStorage, Finality> PriorityTreeENStep<BlockStorage, Finality>
 where
-    BlockStorage: ReadReplay + Clone + Send + Sync + 'static,
-    Finality: ReadFinality + Clone + Send + 'static,
-    BatchStorage: ReadBatch + Clone + Send + Sync + 'static,
+    BlockStorage: ReadReplay + Clone,
+    Finality: ReadFinality + Clone,
 {
     pub async fn new(
         block_storage: BlockStorage,
         db_path: &Path,
-        batch_storage: BatchStorage,
         finality: Finality,
+        committed_batch_provider: CommittedBatchProvider,
     ) -> anyhow::Result<Self> {
-        let priority_tree_manager =
-            PriorityTreeManager::new(block_storage, db_path, finality.clone(), batch_storage)
-                .await?;
+        let priority_tree_manager = PriorityTreeManager::new(
+            block_storage,
+            db_path,
+            finality.clone(),
+            committed_batch_provider,
+        )
+        .await?;
 
         Ok(Self {
             priority_tree_manager,

--- a/node/bin/src/priority_tree_steps/priority_tree_pipeline_step.rs
+++ b/node/bin/src/priority_tree_steps/priority_tree_pipeline_step.rs
@@ -4,9 +4,10 @@ use tokio::sync::mpsc;
 use zksync_os_l1_sender::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_l1_sender::commands::L1SenderCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;
+use zksync_os_l1_watcher::CommittedBatchProvider;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_priority_tree::PriorityTreeManager;
-use zksync_os_storage_api::{ReadBatch, ReadFinality, ReadReplay};
+use zksync_os_storage_api::{ReadFinality, ReadReplay};
 
 /// Pipeline step for the Priority Tree manager.
 ///
@@ -18,26 +19,28 @@ use zksync_os_storage_api::{ReadBatch, ReadFinality, ReadReplay};
 /// Internally manages:
 /// - `prepare_execute_commands` task: processes proven batches and generates execute commands
 /// - `keep_caching` task: persists priority tree for executed batches
-pub struct PriorityTreePipelineStep<BlockStorage, Finality, BatchStorage> {
-    priority_tree_manager: PriorityTreeManager<BlockStorage, Finality, BatchStorage>,
+pub struct PriorityTreePipelineStep<BlockStorage, Finality> {
+    priority_tree_manager: PriorityTreeManager<BlockStorage, Finality>,
 }
 
-impl<BlockStorage, Finality, BatchStorage>
-    PriorityTreePipelineStep<BlockStorage, Finality, BatchStorage>
+impl<BlockStorage, Finality> PriorityTreePipelineStep<BlockStorage, Finality>
 where
-    BlockStorage: ReadReplay + Clone + Send + Sync + 'static,
-    Finality: ReadFinality + Clone + Send + 'static,
-    BatchStorage: ReadBatch + Clone + Send + Sync + 'static,
+    BlockStorage: ReadReplay + Clone,
+    Finality: ReadFinality + Clone,
 {
     pub async fn new(
         block_storage: BlockStorage,
         db_path: &Path,
-        batch_storage: BatchStorage,
         finality: Finality,
+        committed_batch_provider: CommittedBatchProvider,
     ) -> anyhow::Result<Self> {
-        let priority_tree_manager =
-            PriorityTreeManager::new(block_storage, db_path, finality.clone(), batch_storage)
-                .await?;
+        let priority_tree_manager = PriorityTreeManager::new(
+            block_storage,
+            db_path,
+            finality.clone(),
+            committed_batch_provider,
+        )
+        .await?;
 
         Ok(Self {
             priority_tree_manager,
@@ -46,12 +49,10 @@ where
 }
 
 #[async_trait]
-impl<BlockStorage, Finality, BatchStorage> PipelineComponent
-    for PriorityTreePipelineStep<BlockStorage, Finality, BatchStorage>
+impl<BlockStorage, Finality> PipelineComponent for PriorityTreePipelineStep<BlockStorage, Finality>
 where
-    BlockStorage: ReadReplay + Clone + Send + Sync + 'static,
-    Finality: ReadFinality + Clone + Send + 'static,
-    BatchStorage: ReadBatch + Clone + Send + Sync + 'static,
+    BlockStorage: ReadReplay + Clone,
+    Finality: ReadFinality + Clone,
 {
     type Input = SignedBatchEnvelope<FriProof>;
     type Output = L1SenderCommand<ExecuteCommand>;


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/matter-labs/zksync-os-server/pull/824 and https://github.com/matter-labs/zksync-os-server/pull/810.

Now local ENs can run with priority tree enabled. Only RPC relies on S3.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

