### PR TITLE
fix(rpc): revert "make `eth_estimateGas` work when sender has no balance (#807)"

### DIFF
--- a/integration-tests/tests/api.rs
+++ b/integration-tests/tests/api.rs
@@ -1,6 +1,6 @@
 use alloy::eips::Encodable2718;
 use alloy::network::{ReceiptResponse, TransactionBuilder, TxSigner};
-use alloy::primitives::{TxHash, U256, address, bytes};
+use alloy::primitives::{TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use regex::Regex;
@@ -193,20 +193,5 @@ async fn send_raw_transaction_sync_timeout() -> anyhow::Result<()> {
             .contains("The transaction was added to the mempool but wasn't processed within")
     );
 
-    Ok(())
-}
-
-#[test_log::test(tokio::test)]
-async fn estimate_gas_without_balance() -> anyhow::Result<()> {
-    // Test that the node can estimate transaction's gas even if sender does not have enough balance.
-    let tester = Tester::setup().await?;
-    let _estimated_gas = tester
-        .l2_provider
-        .estimate_gas(
-            TransactionRequest::default()
-                .to(address!("0x6e3338eB78A71C5FfF5Cd2673f9C63b7229fAa0b"))
-                .input(bytes!("0x38711eC715A5A32180427792Dc0e97f8E3303071").into()),
-        )
-        .await?;
     Ok(())
 }

--- a/lib/rpc/src/call_fees.rs
+++ b/lib/rpc/src/call_fees.rs
@@ -19,6 +19,7 @@ impl CallFees {
         call_max_fee_per_gas: Option<u128>,
         call_max_priority_fee_per_gas: Option<u128>,
         block_base_fee: u128,
+        for_estimate_gas: bool,
     ) -> Result<Self, CallFeesError> {
         match (
             call_gas_price,
@@ -26,14 +27,19 @@ impl CallFees {
             call_max_priority_fee_per_gas,
         ) {
             (gas_price, None, None) => {
-                // either legacy transaction or no fee fields are specified
-                // when no fields are specified, set gas price to zero
-                let gas_price = gas_price.unwrap_or_default();
-                // only enforce the fee cap if provided input is not zero
-                // this is consistent with reth/geth behavior: https://github.com/ethereum/go-ethereum/blob/0dd173a727dd2d2409b8e401b22e85d20c25b71f/internal/ethapi/transaction_args.go#L443-L447
-                if gas_price != 0 && gas_price < block_base_fee {
-                    return Err(CallFeesError::FeeCapTooLow);
-                }
+                let gas_price = match (for_estimate_gas, gas_price) {
+                    (false, _) => {
+                        // either legacy transaction or no fee fields are specified
+                        // when no fields are specified, set gas price to zero
+                        gas_price.unwrap_or_default()
+                    }
+                    // only enforce the fee cap if provided input is not zero
+                    (_, None | Some(0)) => block_base_fee,
+                    (_, Some(gas_price)) if gas_price < block_base_fee => {
+                        return Err(CallFeesError::FeeCapTooLow);
+                    }
+                    (_, Some(gas_price)) => gas_price,
+                };
                 Ok(Self {
                     gas_price,
                     max_priority_fee_per_gas: None,
@@ -45,7 +51,6 @@ impl CallFees {
                         let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or_default();
 
                         // only enforce the fee cap if provided input is not zero
-                        // this is consistent with reth/geth behavior: https://github.com/ethereum/go-ethereum/blob/0dd173a727dd2d2409b8e401b22e85d20c25b71f/internal/ethapi/transaction_args.go#L443-L447
                         if !(max_fee_per_gas == 0 && max_priority_fee_per_gas == 0)
                             && max_fee_per_gas < block_base_fee
                         {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -67,6 +67,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         &self,
         request: TransactionRequest,
         block_context: &BlockContext,
+        for_estimate_gas: bool,
     ) -> Result<ZkTransaction, EthCallError> {
         let tx_type = request.minimal_tx_type();
 
@@ -112,6 +113,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             max_fee_per_gas,
             max_priority_fee_per_gas,
             block_context.eip1559_basefee.saturating_to(),
+            for_estimate_gas,
         )?;
         let chain_id = chain_id.unwrap_or(self.chain_id);
         let from = from.unwrap_or_default();
@@ -284,7 +286,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         }
 
         let block_context = self.resolve_block_context(block)?;
-        let transaction = self.create_tx_from_request(request, &block_context)?;
+        let transaction = self.create_tx_from_request(request, &block_context, false)?;
 
         Ok(ExecutionEnv {
             transaction,
@@ -451,7 +453,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     fn estimate_gas_with_view<V: ViewState + Clone>(
         &self,
         mut request: TransactionRequest,
-        mut block_context: BlockContext,
+        block_context: BlockContext,
         mut storage_view: V,
     ) -> Result<U256, EthCallError> {
         // Rest of the flow was heavily borrowed from reth, which in turn closely follows the
@@ -516,12 +518,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 .unwrap_or(highest_gas_limit)
                 .min(highest_gas_limit),
         );
-        let tx = self.create_tx_from_request(request, &block_context)?;
-
-        // The basefee should be ignored for eth_estimateGas
-        // See:
-        // <https://github.com/ethereum/go-ethereum/blob/ee8e83fa5f6cb261dad2ed0a7bbcde4930c41e6c/internal/ethapi/api.go#L985>
-        block_context.eip1559_basefee = U256::from(0);
+        let tx = self.create_tx_from_request(request, &block_context, true)?;
 
         // Execute the transaction with the highest possible gas limit.
         let mut res = execute(tx.clone(), block_context, storage_view.clone())


### PR DESCRIPTION
## Summary

This reverts commit 4ce1018e436063ba8d480fd3a5cdb19d6022ac72 (PR #807).

We discovered that this change breaks gas estimation and a proper fix will be delivered on zksync-os side with v0.2.6.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

