### PR TITLE
feat: validate genesis batch info against L1

### DIFF
--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -26,10 +26,18 @@ impl CommittedBatchProvider {
         let mut inner = Inner::default();
         // Special case for genesis
         if l1_state.last_executed_batch == 0 {
+            let batch_info = load_genesis_batch_info().await;
+            let batch_hash_l1 = l1_state.diamond_proxy.stored_batch_hash(0).await?;
+            anyhow::ensure!(
+                batch_hash_l1 == batch_info.hash(),
+                "genesis batch hash mismatch: L1 {}, local {}",
+                batch_hash_l1,
+                batch_info.hash(),
+            );
             inner.batches.insert(
                 0,
                 DiscoveredCommittedBatch {
-                    batch_info: load_genesis_batch_info().await,
+                    batch_info,
                     block_range: 0..=0,
                 },
             );


### PR DESCRIPTION
## Summary

Validates genesis batch info against L1 to prevent the node from launching with different genesis params than those used to init the chain on L1.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

