### PR TITLE
ci: fix issues with config tests

### DIFF
--- a/.github/scripts/test-configs.sh
+++ b/.github/scripts/test-configs.sh
@@ -12,9 +12,11 @@ CONFIGS=(
   "v30 default|local-chains/v30.2/default/zkos-l1-state.json|local-chains/v30.2/default/config.yaml"
   "v30 multi-chain 1|local-chains/v30.2/multi_chain/zkos-l1-state.json|local-chains/v30.2/multi_chain/chain_6565.yaml"
   "v30 multi-chain 2|local-chains/v30.2/multi_chain/zkos-l1-state.json|local-chains/v30.2/multi_chain/chain_6566.yaml"
-  "v31 default|local-chains/v31.0/default/zkos-l1-state.json|local-chains/v31.0/default/config.yaml"
-  "v31 multi-chain 1|local-chains/v31.0/multi_chain/zkos-l1-state.json|local-chains/v31.0/multi_chain/chain_6565.yaml"
-  "v31 multi-chain 2|local-chains/v31.0/multi_chain/zkos-l1-state.json|local-chains/v31.0/multi_chain/chain_6566.yaml"
+  # TODO: Temporary disable v31 config tests due to wrong state files without balance
+  # to be re-enabled soon after fixing the issue with state files size and re-generation
+#  "v31 default|local-chains/v31.0/default/zkos-l1-state.json|local-chains/v31.0/default/config.yaml"
+#  "v31 multi-chain 1|local-chains/v31.0/multi_chain/zkos-l1-state.json|local-chains/v31.0/multi_chain/chain_6565.yaml"
+#  "v31 multi-chain 2|local-chains/v31.0/multi_chain/zkos-l1-state.json|local-chains/v31.0/multi_chain/chain_6566.yaml"
 )
 
 cleanup() {
@@ -95,6 +97,7 @@ for entry in "${CONFIGS[@]}"; do
   echo "✅ Server is up"
 
   TEST_PRIVATE_KEY=0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110
+  FROM=0x36615cf349d7f6344891b1e7ca7c72883f5dc049
   TO=0x5A67EE02274D9Ec050d412b96fE810Be4D71e7A0
 
   echo "Sending test transaction..."
@@ -102,6 +105,7 @@ for entry in "${CONFIGS[@]}"; do
   RETRY_DELAY=2  # seconds
   attempt=1
   while true; do
+    cast balance --rpc-url "http://localhost:${RPC_PORT}" "${FROM}"
     if cast send \
       --private-key "${TEST_PRIVATE_KEY}" \
       --rpc-url "http://localhost:${RPC_PORT}" \
@@ -112,6 +116,7 @@ for entry in "${CONFIGS[@]}"; do
     fi
     if [ "${attempt}" -ge "${MAX_RETRIES}" ]; then
       echo "❌ Test transaction failed after ${MAX_RETRIES} attempts!"
+      cat "${SERVER_LOGFILE}"
       exit 1
     fi
     echo "⚠️  Cast send failed (attempt ${attempt}/${MAX_RETRIES}), retrying in ${RETRY_DELAY}s..."


### PR DESCRIPTION
## Summary

* [x] Temporary disable v31 config tests

## Why?

v31 configs were not properly generated with the last update https://github.com/matter-labs/zksync-os-server/pull/791.

Due to the issue with config sizes, with @itegulov we decided to switch v31 configs testing off now to unblock other PRs and CI, and when we fix both issues with configs and their size, we can re-enable everything back.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

