### PR TITLE
test: make interop test wait for message inclusion

### DIFF
--- a/integration-tests/src/assert_traits.rs
+++ b/integration-tests/src/assert_traits.rs
@@ -1,5 +1,7 @@
+use crate::contracts::L2InteropRootStorage;
 use alloy::eips::BlockId;
 use alloy::network::{Ethereum, Network, ReceiptResponse};
+use alloy::primitives::B256;
 use alloy::providers::ext::DebugApi;
 use alloy::providers::{EthCall, PendingTransaction, PendingTransactionBuilder, Provider};
 use alloy::rpc::json_rpc::RpcRecv;
@@ -9,6 +11,7 @@ use anyhow::Context;
 use std::time::Duration;
 
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
+pub const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[allow(async_fn_in_trait)]
 pub trait EthCallAssert {
@@ -75,7 +78,6 @@ impl<N: Network> ReceiptAssert<N> for PendingTransactionBuilder<N> {
             .block_number()
             .context("mined receipt is missing block number")?;
         // Wait until the expected block is executed.
-        const POLL_INTERVAL: Duration = Duration::from_millis(100);
         let mut retries = DEFAULT_TIMEOUT.div_duration_f64(POLL_INTERVAL).floor() as u64;
         while retries > 0 {
             // Finalized block is mapped to the latest executed block.
@@ -132,5 +134,40 @@ impl ReceiptsAssert for Vec<PendingTransactionBuilder<Ethereum>> {
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;
         Ok(receipts)
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait ProviderAssert {
+    async fn expect_interop_root_inclusion(
+        &self,
+        chain_id: u64,
+        batch_number: u64,
+    ) -> anyhow::Result<B256>;
+}
+
+impl<P: Provider<Ethereum>> ProviderAssert for P {
+    async fn expect_interop_root_inclusion(
+        &self,
+        chain_id: u64,
+        batch_number: u64,
+    ) -> anyhow::Result<B256> {
+        let root_storage = L2InteropRootStorage::new(&self);
+        // Wait until the expected block is executed.
+        let mut retries = DEFAULT_TIMEOUT.div_duration_f64(POLL_INTERVAL).floor() as u64;
+        while retries > 0 {
+            let root = root_storage
+                .get_interop_root(chain_id, batch_number)
+                .await?;
+            if root.is_zero() {
+                tracing::info!(chain_id, batch_number, "interop root not included yet");
+                retries -= 1;
+                tokio::time::sleep(POLL_INTERVAL).await;
+            } else {
+                tracing::info!(chain_id, batch_number, ?root, "interop root was included");
+                return Ok(root);
+            }
+        }
+        Err(anyhow::anyhow!("interop root not included on time"))
     }
 }

--- a/integration-tests/src/contracts.rs
+++ b/integration-tests/src/contracts.rs
@@ -5,7 +5,7 @@ use crate::assert_traits::ReceiptAssert;
 use crate::network::Zksync;
 use crate::provider::ZksyncApi;
 use alloy::network::ReceiptResponse;
-use alloy::primitives::{Address, U256, address};
+use alloy::primitives::{Address, B256, U256, address};
 use alloy::providers::{PendingTransactionBuilder, Provider};
 use alloy::rpc::types::{Log, TransactionReceipt};
 use zksync_os_contract_interface::Bridgehub;
@@ -90,10 +90,17 @@ alloy::sol! {
         function l2TokenAddress(address _l1Token) public view returns (address);
         function withdraw(address _l1Receiver, address _l2Token, uint256 _amount);
     }
+
+    #[sol(rpc)]
+    contract IL2InteropRootStorage {
+        function interopRoots(uint256 chainId, uint256 batchNumber) external view returns (bytes32);
+    }
 }
 
 const L1_MESSENGER_ADDRESS: Address = address!("0000000000000000000000000000000000008008");
 const L2_BASE_TOKEN_ADDRESS: Address = address!("000000000000000000000000000000000000800a");
+const L2_INTEROP_ROOT_STORAGE_ADDRESS: Address =
+    address!("0x0000000000000000000000000000000000010008");
 
 pub struct L2BaseToken<P: Provider<Zksync>>(IBaseToken::IBaseTokenInstance<P, Zksync>);
 
@@ -213,6 +220,34 @@ impl<P1: Provider, P2: Provider<Zksync>> L1Nullifier<P1, P2> {
             .send()
             .await?
             .expect_successful_receipt()
+            .await
+    }
+}
+
+pub struct L2InteropRootStorage<P: Provider>(
+    IL2InteropRootStorage::IL2InteropRootStorageInstance<P>,
+);
+
+impl<P: Provider> L2InteropRootStorage<P> {
+    pub fn new(l2_provider: P) -> Self {
+        Self(IL2InteropRootStorage::new(
+            L2_INTEROP_ROOT_STORAGE_ADDRESS,
+            l2_provider,
+        ))
+    }
+
+    pub fn address(&self) -> &Address {
+        self.0.address()
+    }
+
+    pub async fn get_interop_root(
+        &self,
+        chain_id: u64,
+        batch_number: u64,
+    ) -> alloy::contract::Result<B256> {
+        self.0
+            .interopRoots(U256::from(chain_id), U256::from(batch_number))
+            .call()
             .await
     }
 }

--- a/integration-tests/tests/interop.rs
+++ b/integration-tests/tests/interop.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use test_log::test;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
+use zksync_os_integration_tests::assert_traits::ProviderAssert;
 use zksync_os_integration_tests::{
     MultiChainTester, Tester, assert_traits::ReceiptAssert, contracts::TestERC20,
     provider::ZksyncApi,
@@ -74,12 +75,6 @@ sol! {
             bytes calldata _bundle,
             MessageInclusionProof calldata _proof
         ) external;
-    }
-
-    #[sol(rpc)]
-    contract IL2InteropRootStorage {
-        function interopRoots(uint256 chainId, uint256 batchNumber) external view returns (bytes32);
-        function addInteropRoot(uint256 chainId, uint256 batchNumber, bytes32[] memory sides) external;
     }
 
     // Bundle attribute functions for encoding
@@ -402,7 +397,7 @@ async fn test_interop_bundle_send() -> Result<()> {
     let destination_chain_id = format_evm_v1(chain_b_id);
 
     // Send sendBundle transaction
-    let pending_tx = interop_center
+    let receipt = interop_center
         .sendBundle(destination_chain_id.clone(), calls, bundle_attributes)
         .value(U256::ZERO)
         .gas(10_000_000)
@@ -410,14 +405,10 @@ async fn test_interop_bundle_send() -> Result<()> {
         .max_priority_fee_per_gas(0)
         .send()
         .await
-        .context("Failed to send bundle transaction")?;
-
-    let hash = *pending_tx.tx_hash();
-    let receipt = pending_tx.get_receipt().await?;
-
-    if !receipt.status() {
-        anyhow::bail!("Bundle transaction reverted on chain A");
-    }
+        .context("Failed to send bundle transaction")?
+        .expect_successful_receipt()
+        .await
+        .context("sendBundle on chain A")?;
 
     // Extract bundle data from the L1Messenger log (log #3)
     let l1_messenger_log = receipt.logs().get(3).expect("L1Messenger log not found");
@@ -432,7 +423,18 @@ async fn test_interop_bundle_send() -> Result<()> {
 
     // Get message proof
     let block_number = receipt.block_number.expect("Block number not found");
-    let log_proof = relayer_get_message_proof(&chain_a.l2_zk_provider, hash, block_number).await?;
+    let log_proof = relayer_get_message_proof(
+        &chain_a.l2_zk_provider,
+        receipt.transaction_hash,
+        block_number,
+    )
+    .await?;
+
+    // Wait for interop root to get included on chain B
+    chain_b
+        .l2_provider
+        .expect_interop_root_inclusion(chain_a_id, log_proof.batch_number)
+        .await?;
 
     // Build MessageInclusionProof
     let proof_data: Vec<FixedBytes<32>> = log_proof.proof.clone();
@@ -458,20 +460,14 @@ async fn test_interop_bundle_send() -> Result<()> {
         interop_handler.executeBundle(bundle.clone(), message_inclusion_proof.clone());
 
     // Send executeBundle with high gas limit
-    let pending_tx = execute_call
+    let _execute_receipt = execute_call
         .gas(50_000_000)
         .send()
         .await
-        .context("Failed to send executeBundle transaction")?;
-
-    let execute_receipt = pending_tx
-        .get_receipt()
+        .context("Failed to send executeBundle transaction")?
+        .expect_successful_receipt()
         .await
-        .context("Failed to get executeBundle receipt")?;
-
-    if !execute_receipt.status() {
-        anyhow::bail!("executeBundle transaction reverted on chain B");
-    }
+        .context("executeBundle on chain B")?;
 
     // Verify token balance on chain B
     let vault_b = IL2NativeTokenVault::new(L2_NATIVE_TOKEN_VAULT_ADDRESS, &chain_b.l2_provider);


### PR DESCRIPTION
## Summary

The test is flaky on `main` because we do not wait for message inclusion on chain B.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

