### PR TITLE
chore: remove non-semver-compat suffix from cargo version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,6 @@ jobs:
       manifest: '.github/release-please/manifest.json'      # Path to the manifest file
       update-cargo-lock: true                               # Update Cargo.lock file in the release PR
       publish-to-crates-io: false                           # Enable publishing to crates.io
-      version-suffix: 'non-semver-compat'                   # Version suffix for the crates.io release
       dependencies: 'clang libclang-dev'                    # Additional Linux dependencies to install
 
   # Trigger workflow to generate artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15121,7 +15121,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_base_token_adjuster"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15137,7 +15137,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_batch_types"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
@@ -15157,7 +15157,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_batch_verification"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15198,7 +15198,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_contract_interface"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15212,7 +15212,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_crypto"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "blake2 0.10.6",
@@ -15227,7 +15227,7 @@ checksum = "8b3ad55a8aa3498e304565de55b61dc930bac227c8c5e81284b623c69f2143d2"
 
 [[package]]
 name = "zksync_os_external_price_api"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15273,7 +15273,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_gas_adjuster"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15287,7 +15287,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_generate_deposit"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15299,7 +15299,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_genesis"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15319,7 +15319,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_integration_tests"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15364,7 +15364,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_internal_config"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15375,7 +15375,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_l1_sender"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15408,7 +15408,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_l1_watcher"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15431,7 +15431,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_mempool"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "auto_impl",
@@ -15449,7 +15449,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_merkle_tree"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15484,14 +15484,14 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_metadata"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "semver 1.0.26",
 ]
 
 [[package]]
 name = "zksync_os_mini_merkle_tree"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "criterion",
@@ -15502,7 +15502,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_multivm"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15521,7 +15521,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_network"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -15549,7 +15549,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_object_store"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -15570,7 +15570,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_observability"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -15596,7 +15596,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_pipeline"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15607,7 +15607,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_priority_tree"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15653,7 +15653,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_reth_compat"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "reth-chainspec",
@@ -15667,7 +15667,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_revm_consistency_checker"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15705,7 +15705,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_rocksdb"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -15718,7 +15718,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_rpc"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15757,7 +15757,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_rpc_api"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -15824,7 +15824,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_sequencer"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15858,7 +15858,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_server"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15961,7 +15961,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_socket"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -15971,7 +15971,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_state"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -15990,7 +15990,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_state_full_diffs"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -16008,7 +16008,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_status_server"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -16019,7 +16019,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_storage"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "bincode 2.0.1",
@@ -16040,7 +16040,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_storage_api"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -16068,7 +16068,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_types"
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ resolver = "3"
 default-members = ["node/bin"]
 
 [workspace.package]
-version = "0.14.1-non-semver-compat"
+version = "0.14.1"
 edition = "2024"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -218,42 +218,42 @@ reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.3" }
 
 # "Local" dependencies
-zksync_os_contract_interface = { version = "=0.14.1-non-semver-compat", path = "lib/contract_interface" }
-zksync_os_crypto = { version = "=0.14.1-non-semver-compat", path = "lib/crypto" }
-zksync_os_l1_sender = { version = "=0.14.1-non-semver-compat", path = "lib/l1_sender" }
-zksync_os_l1_watcher = { version = "=0.14.1-non-semver-compat", path = "lib/l1_watcher" }
-zksync_os_mempool = { version = "=0.14.1-non-semver-compat", path = "lib/mempool" }
-zksync_os_mini_merkle_tree = { version = "=0.14.1-non-semver-compat", path = "lib/mini_merkle_tree" }
-zksync_os_merkle_tree = { version = "=0.14.1-non-semver-compat", path = "lib/merkle_tree" }
-zksync_os_priority_tree = { version = "=0.14.1-non-semver-compat", path = "lib/priority_tree" }
-zksync_os_observability = { version = "=0.14.1-non-semver-compat", path = "lib/observability" }
-zksync_os_rocksdb = { version = "=0.14.1-non-semver-compat", path = "lib/rocksdb" }
-zksync_os_rpc = { version = "=0.14.1-non-semver-compat", path = "lib/rpc" }
-zksync_os_rpc_api = { version = "=0.14.1-non-semver-compat", path = "lib/rpc_api" }
-zksync_os_sequencer = { version = "=0.14.1-non-semver-compat", path = "lib/sequencer" }
-zksync_os_state = { version = "=0.14.1-non-semver-compat", path = "lib/state" }
-zksync_os_state_full_diffs = { version = "=0.14.1-non-semver-compat", path = "lib/state_full_diffs" }
-zksync_os_storage = { version = "=0.14.1-non-semver-compat", path = "lib/storage" }
-zksync_os_storage_api = { version = "=0.14.1-non-semver-compat", path = "lib/storage_api" }
-zksync_os_types = { version = "=0.14.1-non-semver-compat", path = "lib/types" }
-zksync_os_genesis = { version = "=0.14.1-non-semver-compat", path = "lib/genesis" }
-zksync_os_object_store = { version = "=0.14.1-non-semver-compat", path = "lib/object_store" }
-zksync_os_status_server = { version = "=0.14.1-non-semver-compat", path = "lib/status" }
-zksync_os_multivm = { version = "=0.14.1-non-semver-compat", path = "lib/multivm" }
-zksync_os_pipeline = { version = "=0.14.1-non-semver-compat", path = "lib/pipeline" }
-zksync_os_revm_consistency_checker = { version = "=0.14.1-non-semver-compat", path = "lib/revm_consistency_checker" }
-zksync_os_gas_adjuster = { version = "=0.14.1-non-semver-compat", path = "lib/gas_adjuster" }
-zksync_os_batch_verification = { version = "=0.14.1-non-semver-compat", path = "lib/batch_verification" }
-zksync_os_batch_types = { version = "=0.14.1-non-semver-compat", path = "lib/batch_types" }
-zksync_os_socket = { version = "=0.14.1-non-semver-compat", path = "lib/socket" }
-zksync_os_internal_config = { version = "=0.14.1-non-semver-compat", path = "lib/internal_config" }
-zksync_os_network = { version = "=0.14.1-non-semver-compat", path = "lib/network" }
-zksync_os_metadata = { version = "=0.14.1-non-semver-compat", path = "lib/metadata" }
-zksync_os_external_price_api = { version = "=0.14.1-non-semver-compat", path = "lib/external_price_api" }
-zksync_os_base_token_adjuster = { version = "=0.14.1-non-semver-compat", path = "lib/base_token_adjuster" }
-zksync_os_reth_compat = { version = "=0.14.1-non-semver-compat", path = "lib/reth_compat" }
+zksync_os_contract_interface = { version = "=0.14.1", path = "lib/contract_interface" }
+zksync_os_crypto = { version = "=0.14.1", path = "lib/crypto" }
+zksync_os_l1_sender = { version = "=0.14.1", path = "lib/l1_sender" }
+zksync_os_l1_watcher = { version = "=0.14.1", path = "lib/l1_watcher" }
+zksync_os_mempool = { version = "=0.14.1", path = "lib/mempool" }
+zksync_os_mini_merkle_tree = { version = "=0.14.1", path = "lib/mini_merkle_tree" }
+zksync_os_merkle_tree = { version = "=0.14.1", path = "lib/merkle_tree" }
+zksync_os_priority_tree = { version = "=0.14.1", path = "lib/priority_tree" }
+zksync_os_observability = { version = "=0.14.1", path = "lib/observability" }
+zksync_os_rocksdb = { version = "=0.14.1", path = "lib/rocksdb" }
+zksync_os_rpc = { version = "=0.14.1", path = "lib/rpc" }
+zksync_os_rpc_api = { version = "=0.14.1", path = "lib/rpc_api" }
+zksync_os_sequencer = { version = "=0.14.1", path = "lib/sequencer" }
+zksync_os_state = { version = "=0.14.1", path = "lib/state" }
+zksync_os_state_full_diffs = { version = "=0.14.1", path = "lib/state_full_diffs" }
+zksync_os_storage = { version = "=0.14.1", path = "lib/storage" }
+zksync_os_storage_api = { version = "=0.14.1", path = "lib/storage_api" }
+zksync_os_types = { version = "=0.14.1", path = "lib/types" }
+zksync_os_genesis = { version = "=0.14.1", path = "lib/genesis" }
+zksync_os_object_store = { version = "=0.14.1", path = "lib/object_store" }
+zksync_os_status_server = { version = "=0.14.1", path = "lib/status" }
+zksync_os_multivm = { version = "=0.14.1", path = "lib/multivm" }
+zksync_os_pipeline = { version = "=0.14.1", path = "lib/pipeline" }
+zksync_os_revm_consistency_checker = { version = "=0.14.1", path = "lib/revm_consistency_checker" }
+zksync_os_gas_adjuster = { version = "=0.14.1", path = "lib/gas_adjuster" }
+zksync_os_batch_verification = { version = "=0.14.1", path = "lib/batch_verification" }
+zksync_os_batch_types = { version = "=0.14.1", path = "lib/batch_types" }
+zksync_os_socket = { version = "=0.14.1", path = "lib/socket" }
+zksync_os_internal_config = { version = "=0.14.1", path = "lib/internal_config" }
+zksync_os_network = { version = "=0.14.1", path = "lib/network" }
+zksync_os_metadata = { version = "=0.14.1", path = "lib/metadata" }
+zksync_os_external_price_api = { version = "=0.14.1", path = "lib/external_price_api" }
+zksync_os_base_token_adjuster = { version = "=0.14.1", path = "lib/base_token_adjuster" }
+zksync_os_reth_compat = { version = "=0.14.1", path = "lib/reth_compat" }
 
-zksync_os_server = { version = "=0.14.1-non-semver-compat", path = "node/bin" }
+zksync_os_server = { version = "=0.14.1", path = "node/bin" }
 
 #[patch.crates-io]
 #zksync_os_interface = { path = "../zksync-os-interface/crates/interface" }


### PR DESCRIPTION
## Summary

* [x] Remove non-semver-compat suffix from cargo version

## Why?

Before, when semver rules were not that clear for the server, we chose to add `-non-semver-compat` suffix to the version explicitly specifying that the server is not semver compatible, and we can have breaking changes occasionally with patch version change, etc.

For now, the requirements for semver and version compatibilities are clearer; we have a description of breaking changes, etc. so this suffix is more of a burden, so let's remove it.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

