### PR TITLE
feat: add pubdata price cap

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,8 +16,9 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use zksync_os_object_store::{ObjectStoreConfig, ObjectStoreMode};
 use zksync_os_server::config::{
-    BatchVerificationConfig, Config, FakeFriProversConfig, FakeSnarkProversConfig, GeneralConfig,
-    ProverApiConfig, ProverInputGeneratorConfig, RpcConfig, SequencerConfig, StatusServerConfig,
+    BatchVerificationConfig, Config, FakeFriProversConfig, FakeSnarkProversConfig, FeeConfig,
+    GeneralConfig, ProverApiConfig, ProverInputGeneratorConfig, RpcConfig, SequencerConfig,
+    StatusServerConfig,
 };
 use zksync_os_server::default_protocol_version::{NEXT_PROTOCOL_VERSION, PROTOCOL_VERSION};
 use zksync_os_state_full_diffs::FullDiffsState;
@@ -383,6 +384,8 @@ pub struct TesterBuilder {
     enable_prover: bool,
     block_time: Option<Duration>,
     batch_verification_threshold: Option<u64>,
+    fee_config: Option<FeeConfig>,
+    estimate_gas_pubdata_price_factor: Option<f64>,
 }
 
 impl TesterBuilder {
@@ -399,6 +402,16 @@ impl TesterBuilder {
 
     pub fn batch_verification(mut self, threshold: u64) -> Self {
         self.batch_verification_threshold = Some(threshold);
+        self
+    }
+
+    pub fn fee_config(mut self, c: FeeConfig) -> Self {
+        self.fee_config = Some(c);
+        self
+    }
+
+    pub fn estimate_gas_pubdata_price_factor(mut self, factor: f64) -> Self {
+        self.estimate_gas_pubdata_price_factor = Some(factor);
         self
     }
 
@@ -425,6 +438,12 @@ impl TesterBuilder {
             if let Some(batch_verification_threshold) = self.batch_verification_threshold {
                 config.batch_verification_config.server_enabled = true;
                 config.batch_verification_config.threshold = batch_verification_threshold;
+            }
+            if let Some(fee_config) = self.fee_config.clone() {
+                config.fee_config = fee_config;
+            }
+            if let Some(factor) = self.estimate_gas_pubdata_price_factor {
+                config.rpc_config.estimate_gas_pubdata_price_factor = factor;
             }
         };
 

--- a/integration-tests/tests/api.rs
+++ b/integration-tests/tests/api.rs
@@ -1,6 +1,6 @@
 use alloy::eips::Encodable2718;
 use alloy::network::{ReceiptResponse, TransactionBuilder, TxSigner};
-use alloy::primitives::{TxHash, U256};
+use alloy::primitives::{TxHash, U128, U256, address};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use regex::Regex;
@@ -8,6 +8,7 @@ use std::time::Duration;
 use zksync_os_integration_tests::Tester;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
+use zksync_os_server::config::FeeConfig;
 
 #[test_log::test(tokio::test)]
 async fn get_code() -> anyhow::Result<()> {
@@ -192,6 +193,43 @@ async fn send_raw_transaction_sync_timeout() -> anyhow::Result<()> {
             .to_string()
             .contains("The transaction was added to the mempool but wasn't processed within")
     );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn estimate_gas_with_high_prices() -> anyhow::Result<()> {
+    // Tests the estimations are accurate with high fee overrides.
+    // Following config has high pubdata price, that makes base token transfer to take >21000 gas.
+    let fee_config = FeeConfig {
+        native_price_usd: 3e-9, // doesn't matter
+        pubdata_price_override: Some(U128::from(10_000_000_000_000u64)),
+        native_price_override: Some(U128::from(1_000_000u64)),
+        base_fee_override: Some(U128::from(100_000_000u64)),
+        native_per_gas: 100, // doesn't matter
+        pubdata_price_cap: None,
+    };
+    let tester = Tester::builder()
+        .fee_config(fee_config)
+        .estimate_gas_pubdata_price_factor(1.0)
+        .build()
+        .await?;
+
+    // Random address.
+    let to = address!("0xa5d85D1D865F89a23A95d4F5F74850f289Dbc5f9");
+    // Create a transaction
+    let tx = TransactionRequest::default().to(to).value(U256::ONE);
+
+    let gas = tester.l2_provider.estimate_gas(tx.clone()).await?;
+    tracing::info!("Estimated gas: {gas}");
+
+    let receipt = tester
+        .l2_provider
+        .send_transaction(tx)
+        .await?
+        .expect_successful_receipt()
+        .await?;
+    tracing::info!("Got receipt, gas used: {}", receipt.gas_used);
 
     Ok(())
 }

--- a/lib/sequencer/src/execution/fee_provider.rs
+++ b/lib/sequencer/src/execution/fee_provider.rs
@@ -1,6 +1,6 @@
 use crate::execution::metrics::EXECUTION_METRICS;
 use alloy::eips::eip4844::FIELD_ELEMENTS_PER_BLOB;
-use alloy::primitives::{U128, U256};
+use alloy::primitives::U256;
 use num::rational::Ratio;
 use num::{BigUint, ToPrimitive};
 use tokio::sync::watch;
@@ -15,15 +15,20 @@ pub struct FeeConfig {
     pub native_price_usd: Ratio<BigUint>,
     /// Override for base fee (in base token units).
     /// If set, base fee will be constant and equal to this value.
-    pub base_fee_override: Option<U128>,
+    pub base_fee_override: Option<BigUint>,
     /// Defines how many native resource units are equivalent to one gas unit in terms of price.
     pub native_per_gas: u64,
     /// Override for pubdata price (in base token units).
     /// If set, pubdata price will be constant and equal to this value.
-    pub pubdata_price_override: Option<U128>,
+    pub pubdata_price_override: Option<BigUint>,
+    /// Cap for pubdata price (in base token units). If set, pubdata price will not exceed this value.
+    /// Note:
+    /// - has no effect if `pubdata_price_override` is set.
+    /// - if pubdata cap is reached, chain operator may operate at a loss.
+    pub pubdata_price_cap: Option<BigUint>,
     /// Override for native price (in base token units).
     /// If set, native price will be constant and equal to this value.
-    pub native_price_override: Option<U128>,
+    pub native_price_override: Option<BigUint>,
 }
 
 /// Provider of fee parameters for block execution.
@@ -97,8 +102,8 @@ impl FeeProvider {
     }
 
     fn calculate_native_price(&self, token_prices: &TokenPricesForFees) -> BigUint {
-        if let Some(o) = self.fee_config.native_price_override {
-            return BigUint::from(o.to::<u128>());
+        if let Some(o) = self.fee_config.native_price_override.clone() {
+            return o;
         }
 
         let desired_native_price_usd = &self.fee_config.native_price_usd;
@@ -148,8 +153,8 @@ impl FeeProvider {
     }
 
     fn calculate_base_fee(&self, native_price: &BigUint) -> BigUint {
-        if let Some(o) = self.fee_config.base_fee_override {
-            return BigUint::from(o.to::<u128>());
+        if let Some(o) = self.fee_config.base_fee_override.clone() {
+            return o;
         }
 
         // EIP-1559 base fee is proportional to native price.
@@ -162,8 +167,8 @@ impl FeeProvider {
         native_price: &BigUint,
         token_prices: &TokenPricesForFees,
     ) -> BigUint {
-        if let Some(o) = self.fee_config.pubdata_price_override {
-            return BigUint::from(o.to::<u128>());
+        if let Some(o) = self.fee_config.pubdata_price_override.clone() {
+            return o;
         }
 
         let base_pubdata_price_in_sl_token = BigUint::from(
@@ -227,7 +232,7 @@ impl FeeProvider {
         };
 
         // Limit pubdata price increase to 1.5x per block.
-        let pubdata_price = if let Some(prev_pubdata_price) =
+        let mut pubdata_price = if let Some(prev_pubdata_price) =
             self.previous_block_fee_params.map(|p| p.pubdata_price)
         {
             let capped_price = {
@@ -251,6 +256,17 @@ impl FeeProvider {
         } else {
             desired_pubdata_price
         };
+
+        if let Some(cap) = self.fee_config.pubdata_price_cap.clone()
+            && pubdata_price > cap
+        {
+            tracing::debug!(
+                %cap,
+                %pubdata_price,
+                "Capping pubdata price according to config",
+            );
+            pubdata_price = cap;
+        }
 
         if let Some(p) = pubdata_price.to_u64() {
             EXECUTION_METRICS.pubdata_price.set(p);

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -3,7 +3,7 @@ use self::util::SigningKeyDeserializer;
 use crate::{command_source::RebuildOptions, default_protocol_version::DEFAULT_ROCKS_DB_PATH};
 use alloy::primitives::{Address, Bytes, U128};
 use alloy::signers::k256::ecdsa::SigningKey;
-use num::{BigInt, rational::Ratio};
+use num::{BigInt, BigUint, rational::Ratio};
 use serde::{Deserialize, Serialize};
 use smart_config::metadata::TimeUnit;
 use smart_config::value::SecretString;
@@ -906,6 +906,11 @@ pub struct FeeConfig {
     /// Override for pubdata price (in base token units).
     /// If set, pubdata price will be constant and equal to this value.
     pub pubdata_price_override: Option<U128>,
+    /// Cap for pubdata price (in base token units). If set, pubdata price will not exceed this value.
+    /// Note:
+    /// - has no effect if `pubdata_price_override` is set.
+    /// - if pubdata cap is reached, chain operator may operate at a loss.
+    pub pubdata_price_cap: Option<U128>,
     /// Override for native price (in base token units).
     /// If set, native price will be constant and equal to this value.
     pub native_price_override: Option<U128>,
@@ -1132,10 +1137,15 @@ impl From<FeeConfig> for zksync_os_sequencer::execution::FeeConfig {
 
         Self {
             native_price_usd,
-            base_fee_override: c.base_fee_override,
+            base_fee_override: c.base_fee_override.map(|n| BigUint::from(n.to::<u128>())),
             native_per_gas: c.native_per_gas,
-            pubdata_price_override: c.pubdata_price_override,
-            native_price_override: c.native_price_override,
+            pubdata_price_override: c
+                .pubdata_price_override
+                .map(|n| BigUint::from(n.to::<u128>())),
+            pubdata_price_cap: c.pubdata_price_cap.map(|n| BigUint::from(n.to::<u128>())),
+            native_price_override: c
+                .native_price_override
+                .map(|n| BigUint::from(n.to::<u128>())),
         }
     }
 }


### PR DESCRIPTION
## Summary

Sepolia blob price sometimes grows to the moon, making simple transfer tx to take more than `100_000_000` gas which is the default value for block gas limit.
I added a config variable `pubdata_price_cap` to limit the effective pubdata price; it can be set to some high value e.g. `10_000_000_000_000` so that transfers still work even if blob price is huge.
Also, added a test that checks transfer works with huge pubdata price.

