### PR TITLE
fix: Interop roots flooding

### DIFF
--- a/lib/mempool/src/interop_tx_stream.rs
+++ b/lib/mempool/src/interop_tx_stream.rs
@@ -2,10 +2,11 @@ use std::{
     collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::Stream;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::Instant};
 use zksync_os_types::{
     IndexedInteropRoot, IndexedInteropRootsEnvelope, InteropRootsEnvelope, InteropRootsLogIndex,
 };
@@ -18,6 +19,7 @@ pub struct InteropTxStream {
     pending_roots: VecDeque<IndexedInteropRoot>,
     used_roots: VecDeque<IndexedInteropRoot>,
     interop_roots_per_tx: usize,
+    next_interop_tx_allowed_after: Instant,
 }
 
 impl Stream for InteropTxStream {
@@ -25,6 +27,11 @@ impl Stream for InteropTxStream {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
+        if Instant::now() < this.next_interop_tx_allowed_after {
+            return Poll::Pending;
+        }
+
         loop {
             match this.receiver.poll_recv(cx) {
                 Poll::Ready(Some(root)) => {
@@ -54,6 +61,7 @@ impl InteropTxStream {
             pending_roots: VecDeque::new(),
             used_roots: VecDeque::new(),
             interop_roots_per_tx,
+            next_interop_tx_allowed_after: Instant::now(),
         }
     }
 
@@ -114,8 +122,14 @@ impl InteropTxStream {
     pub async fn on_canonical_state_change(
         &mut self,
         txs: Vec<InteropRootsEnvelope>,
+        block_time: Option<Duration>,
     ) -> Option<InteropRootsLogIndex> {
-        let mut log_index = None;
+        if txs.is_empty() {
+            return None;
+        }
+
+        let mut log_index = InteropRootsLogIndex::default();
+
         for tx in txs {
             let mut roots = Vec::new();
             for _ in 0..tx.interop_roots_count() {
@@ -125,7 +139,7 @@ impl InteropTxStream {
             let envelope = InteropRootsEnvelope::from_interop_roots(
                 roots.iter().map(|r| r.root.clone()).collect(),
             );
-            log_index = Some(roots.last().unwrap().log_index.clone());
+            log_index = roots.last().unwrap().log_index.clone();
 
             assert_eq!(&envelope, &tx);
         }
@@ -138,6 +152,10 @@ impl InteropTxStream {
         // Clear used roots that were left in the buffer and move them to pending.
         std::mem::swap(&mut self.pending_roots, &mut self.used_roots);
 
-        log_index
+        if let Some(block_time) = block_time {
+            self.next_interop_tx_allowed_after = Instant::now() + 3 * block_time;
+        }
+
+        Some(log_index)
     }
 }

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -8,7 +8,7 @@ use alloy::primitives::{Address, BlockHash, TxHash, U256};
 use anyhow::Context as _;
 use reth_execution_types::ChangedAccount;
 use reth_primitives::SealedBlock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, watch};
 use zksync_os_interface::types::{BlockContext, BlockHashes, BlockOutput};
 use zksync_os_mempool::{
@@ -318,6 +318,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
         block_output: &BlockOutput,
         replay_record: &ReplayRecord,
         cmd_type: BlockCommandType,
+        block_time: Option<Duration>,
     ) {
         let mut l2_transactions = Vec::new();
         let mut interop_txs = Vec::new();
@@ -359,7 +360,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
 
         if let Some(last_interop_log_index) = self
             .interop_tx_stream
-            .on_canonical_state_change(interop_txs)
+            .on_canonical_state_change(interop_txs, block_time)
             .await
         {
             self.next_interop_event_index = InteropRootsLogIndex {

--- a/lib/sequencer/src/execution/mod.rs
+++ b/lib/sequencer/src/execution/mod.rs
@@ -82,6 +82,12 @@ where
             let block_number = cmd.block_number();
             let cmd_type = cmd.command_type();
 
+            let block_time = if let BlockCommand::Produce(produce_command) = &cmd {
+                Some(produce_command.block_time)
+            } else {
+                None
+            };
+
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
             if matches!(cmd, BlockCommand::Produce(_))
                 && let Some(limit) = self.sequencer_config.max_blocks_to_produce
@@ -175,7 +181,7 @@ where
 
             // TODO: would updating mempool in parallel with state make sense?
             self.block_context_provider
-                .on_canonical_state_change(&block_output, &replay_record, cmd_type)
+                .on_canonical_state_change(&block_output, &replay_record, cmd_type, block_time)
                 .await;
             let purged_txs_hashes = purged_txs.into_iter().map(|(hash, _)| hash).collect();
             self.block_context_provider.remove_txs(purged_txs_hashes);


### PR DESCRIPTION
## Summary

This PR fixes possible issue when interop transaction come too often leaving no space for regular ones by adding a `next_interop_tx_allowed_after` value to `InteropTxStream`. This way we allow new interop transactions(blocks) to come 3 times less often than regular blocks
