### PR TITLE
fix: better recognition for missing `IMultisigCommitter`

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -518,7 +518,7 @@ impl<P: Provider> MultisigCommitter<P> {
                 instance,
                 chain_address,
             })),
-            Err(e) if e.as_revert_data().is_some() => Ok(None),
+            Err(e) if e.to_string().contains("revert") => Ok(None),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
## Summary

Current logic does not work for all cases and nodes crash when multisig is missing. This PR should fix that

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

