### PR TITLE
chore: bump bytes to `1.11.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,9 +3033,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -4177,7 +4177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`cargo-deny`/`cargo-audit` are failing on `main` because of vulnerability in `bytes` crate

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

