### PR TITLE
fix: rebuild_from_block assert for EN

### DIFF
--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -320,7 +320,13 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         last_l1_executed_block,
     };
 
-    if let Some(block_rebuild) = &config.sequencer_config.block_rebuild {
+    if let Some(block_rebuild) = &config.sequencer_config.block_rebuild
+        && config.sequencer_config.is_main_node()
+    {
+        // The assertion is only relevant for the main node.
+        // External node can be started at any point and doesn't have to be in sync with L1.
+        // But the main node is expected to only produce blocks on top of committed L1 blocks,
+        // as those can't be re-sequenced.
         assert!(
             block_rebuild.from_block > node_startup_state.last_l1_committed_block,
             "rebuild_from_block must be > last_l1_committed_block, got {} <= {}",


### PR DESCRIPTION
## Summary

The `rebuild_from_block must be > last_l1_committed_block` assert is incorrect in EN context. The main node might have already committed new batches to L1 which makes the `rebuild_from_block` in EN permanently outdated.
This assertion only makes sense in the context of main node. 

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

