### PR TITLE
feat: support multiple config files

### DIFF
--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -73,11 +73,9 @@ fn load_config_defaults(config_sources: &mut ConfigSources, config_paths: Option
                     .unwrap_or_else(|_| {
                         panic!("Failed to parse YAML config file from path '{config_path}'")
                     });
-                config_sources.push(
-                    Yaml::new(config_path, config_yaml).unwrap_or_else(|_| {
-                        panic!("Failed to create YAML config source from path '{config_path}'")
-                    }),
-                );
+                config_sources.push(Yaml::new(config_path, config_yaml).unwrap_or_else(|_| {
+                    panic!("Failed to create YAML config source from path '{config_path}'")
+                }));
             }
             ConfigFormat::Json => {
                 let config_json: serde_json::Map<String, serde_json::Value> =


### PR DESCRIPTION
## Summary

* Support multiple `--config` files.
* Files can be specified by repeating the flag (`--config main.yaml --config overrides.json`) or using `:` as a delimiter (`--config main.yaml:overrides.json`).
* Files are loaded in order, with later files taking precedence. Env variables still override all files.

## Backwards compatibility

Fully backwards compatible. Passing a single `--config file.yaml` works exactly as before.