### PR TITLE
fix: falling behind interop roots during replays

### DIFF
--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -83,10 +83,12 @@ impl ProcessL1Event for InteropWatcher {
             sides: vec![tx.chainRoot],
         };
 
-        self.tx_pool.add_root(IndexedInteropRoot {
-            log_index: current_log_index,
-            root: interop_root,
-        });
+        self.tx_pool
+            .add_root(IndexedInteropRoot {
+                log_index: current_log_index,
+                root: interop_root,
+            })
+            .await;
 
         Ok(())
     }

--- a/lib/mempool/src/interop_tx_stream.rs
+++ b/lib/mempool/src/interop_tx_stream.rs
@@ -1,11 +1,12 @@
 use std::{
     collections::VecDeque,
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use futures::{Stream, StreamExt, ready};
+use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tokio::{
     sync::broadcast::{self},
@@ -30,26 +31,30 @@ impl InteropTxPool {
 }
 
 impl InteropTxPool {
-    pub fn interop_transactions_with_delay(
+    pub async fn interop_transactions_with_delay(
         &self,
         interop_roots_per_tx: usize,
         next_tx_allowed_after: Instant,
     ) -> InteropTransactions {
         self.inner
             .read()
-            .unwrap()
+            .await
             .interop_transactions_with_delay(interop_roots_per_tx, next_tx_allowed_after)
     }
 
-    pub fn add_root(&mut self, root: IndexedInteropRoot) {
-        self.inner.write().unwrap().add_root(root);
+    pub async fn add_root(&mut self, root: IndexedInteropRoot) {
+        self.inner.write().await.add_root(root);
     }
 
-    pub fn on_canonical_state_change(
+    pub async fn on_canonical_state_change(
         &mut self,
         txs: Vec<InteropRootsEnvelope>,
     ) -> Option<InteropRootsLogIndex> {
-        self.inner.write().unwrap().on_canonical_state_change(txs)
+        self.inner.write().await.on_canonical_state_change(txs)
+    }
+
+    pub async fn pending_interop_roots_count(&self) -> usize {
+        self.inner.read().await.pending_interop_roots_count()
     }
 }
 
@@ -143,6 +148,10 @@ impl InteropTxPoolInner {
     pub fn add_root(&mut self, root: IndexedInteropRoot) {
         let _ = self.sender.send(root.root.clone());
         self.pending_roots.push_front(root);
+    }
+
+    pub fn pending_interop_roots_count(&self) -> usize {
+        self.pending_roots.len()
     }
 
     /// Cleans up the stream and removes all roots that were sent in transactions

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -115,10 +115,12 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 let mut best_txs = best_transactions(
                     &self.l2_mempool,
                     &mut self.l1_transactions,
-                    self.interop_tx_pool.interop_transactions_with_delay(
-                        self.interop_roots_per_tx,
-                        self.next_interop_tx_allowed_after,
-                    ),
+                    self.interop_tx_pool
+                        .interop_transactions_with_delay(
+                            self.interop_roots_per_tx,
+                            self.next_interop_tx_allowed_after,
+                        )
+                        .await,
                     &mut self.upgrade_transactions,
                 );
 
@@ -371,8 +373,23 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
             }
         }
 
-        if let Some(last_interop_log_index) =
-            self.interop_tx_pool.on_canonical_state_change(interop_txs)
+        let interop_roots_count = interop_txs
+            .iter()
+            .map(|tx| tx.interop_roots_count())
+            .sum::<u64>();
+
+        let sleep_duration = Duration::from_millis(100);
+
+        while self.interop_tx_pool.pending_interop_roots_count().await
+            < interop_roots_count as usize
+        {
+            tokio::time::sleep(sleep_duration).await;
+        }
+
+        if let Some(last_interop_log_index) = self
+            .interop_tx_pool
+            .on_canonical_state_change(interop_txs)
+            .await
         {
             self.next_interop_tx_allowed_after = Instant::now() + self.service_block_delay;
             self.next_interop_event_index = InteropRootsLogIndex {


### PR DESCRIPTION
## Summary

During replay we rely on the fact that we will receive the exact same events with interop roots as we have them in replay record. In the usual case we block the thread waiting for such transaction to come from watcher. However, this is not the case with interop transactions, since the roots are added in the pool independently(so at the point when `on_canonical_state_change` is called, we might not have enough roots for all transactions). This PR introduces simple fix to this issue - loop with a sleep for waiting until all the roots become available