### PR TITLE
fix(eth-watch): don't save batches with divergent hashes

### DIFF
--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -183,6 +183,7 @@ impl<BatchStorage: WriteBatch, Finality: WriteFinality> ProcessL1Event
                     batch_number,
                     "batch hash mismatch; ignoring"
                 );
+                return Ok(());
             }
 
             self.batch_storage.write(committed_batch);


### PR DESCRIPTION
We saved them, which is incorrect handling of already-reverted batches
