### PR TITLE
feat: add block hash to revm divergence panic message

### DIFF
--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -44,6 +44,7 @@ where
 
     pub fn handle_report(
         &self,
+        block_output: &BlockOutput,
         replay_record: &ReplayRecord,
         report: &CompareReport,
     ) -> anyhow::Result<()> {
@@ -63,8 +64,9 @@ where
             );
 
             let message = format!(
-                "REVM consistency check failed for block {}",
-                replay_record.block_context.block_number
+                "REVM consistency check failed for block number {}, block hash {}",
+                replay_record.block_context.block_number,
+                block_output.header.hash(),
             );
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;
@@ -176,7 +178,7 @@ where
                     &block_output.storage_writes,
                     &block_output.account_diffs,
                 )?;
-                self.handle_report(&replay_record, &compare_report)?;
+                self.handle_report(&block_output, &replay_record, &compare_report)?;
             }
 
             latency_tracker.enter_state(GenericComponentState::WaitingSend);


### PR DESCRIPTION
## Summary

Add block hash to revm divergence panic message for easier debugging

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

