### PR TITLE
Attempt to pin value, ran into errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,210 +2277,130 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "basic_bootloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "arrayvec 0.7.6",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "paste",
- "ruint",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
-]
-
-[[package]]
-name = "basic_bootloader"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
-dependencies = [
- "arrayvec 0.7.6",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "hex",
  "paste",
  "ruint",
  "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "basic_bootloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "arrayvec 0.7.6",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "hex",
  "paste",
  "ruint",
  "serde",
  "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "basic_bootloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "arrayvec 0.7.6",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "paste",
  "ruint",
  "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "basic_bootloader"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "arrayvec 0.7.6",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "paste",
- "ruint",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "basic_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
-dependencies = [
- "arrayvec 0.7.6",
- "cfg-if",
- "const-hex",
- "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "paste",
- "ruint",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "strum_macros",
- "zerocopy",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
-]
-
-[[package]]
-name = "basic_system"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "arrayvec 0.7.6",
  "cfg-if",
  "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "paste",
  "rand 0.9.2",
  "ruint",
  "serde",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "basic_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "arrayvec 0.7.6",
  "cfg-if",
  "const-hex",
  "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rand 0.9.2",
  "ruint",
  "serde",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "basic_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "arrayvec 0.7.6",
  "cfg-if",
  "const-hex",
  "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rand 0.9.2",
  "ruint",
  "serde",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "strum_macros",
  "zerocopy",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "basic_system"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "arrayvec 0.7.6",
- "cfg-if",
- "const-hex",
- "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "paste",
- "ruint",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "strum_macros",
- "zerocopy",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -3128,81 +3048,47 @@ dependencies = [
 [[package]]
 name = "callable_oracles"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
+dependencies = [
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "num-bigint 0.3.3",
+ "num-traits",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "ruint",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+]
+
+[[package]]
+name = "callable_oracles"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
+dependencies = [
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "num-bigint 0.3.3",
+ "num-traits",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "ruint",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+]
+
+[[package]]
+name = "callable_oracles"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "alloy-consensus",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "c-kzg",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "num-bigint 0.4.6",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "num-bigint 0.3.3",
  "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
-]
-
-[[package]]
-name = "callable_oracles"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
-dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "num-bigint 0.4.6",
- "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
-]
-
-[[package]]
-name = "callable_oracles"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
-dependencies = [
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "num-bigint 0.4.6",
- "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
-]
-
-[[package]]
-name = "callable_oracles"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "alloy-consensus",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "c-kzg",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "num-bigint 0.4.6",
- "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "callable_oracles"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "alloy-consensus",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "c-kzg",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "num-bigint 0.4.6",
- "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -3872,7 +3758,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3899,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3926,61 +3812,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "blake2 0.10.6",
- "cfg-if",
- "const_for",
- "educe",
- "itertools 0.14.0",
- "k256",
- "num-bigint 0.4.6",
- "num-traits",
- "p256",
- "ripemd",
- "ruint",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "crypto"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "blake2 0.10.6",
- "cfg-if",
- "const_for",
- "educe",
- "itertools 0.14.0",
- "k256",
- "num-bigint 0.4.6",
- "num-traits",
- "p256",
- "ripemd",
- "ruint",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "crypto"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4136,27 +3968,17 @@ dependencies = [
 [[package]]
 name = "cycle_marker"
 version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 
 [[package]]
 name = "cycle_marker"
 version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 
 [[package]]
 name = "cycle_marker"
 version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
-
-[[package]]
-name = "cycle_marker"
-version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-
-[[package]]
-name = "cycle_marker"
-version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 
 [[package]]
 name = "darling"
@@ -4850,80 +4672,48 @@ dependencies = [
 [[package]]
 name = "evm_interpreter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "arrayvec 0.7.6",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "either",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "zksync_os_evm_errors",
 ]
 
 [[package]]
 name = "evm_interpreter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "arrayvec 0.7.6",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "either",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "zksync_os_evm_errors",
 ]
 
 [[package]]
 name = "evm_interpreter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "arrayvec 0.7.6",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "either",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "evm_interpreter"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "arrayvec 0.7.6",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "either",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "evm_interpreter"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "arrayvec 0.7.6",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "either",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_evm_errors",
 ]
 
@@ -5236,125 +5026,75 @@ dependencies = [
 [[package]]
 name = "forward_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "alloy",
  "arrayvec 0.7.6",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
  "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "zksync_os_evm_errors",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "forward_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "alloy",
  "arrayvec 0.7.6",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "zksync_os_evm_errors",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "forward_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "alloy",
  "arrayvec 0.7.6",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
  "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_evm_errors",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
-]
-
-[[package]]
-name = "forward_system"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "alloy",
- "arrayvec 0.7.6",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "paste",
- "ruint",
- "serde",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "zksync_os_evm_errors",
- "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "forward_system"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "alloy",
- "arrayvec 0.7.6",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "paste",
- "ruint",
- "serde",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "zksync_os_evm_errors",
- "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -7394,27 +7134,17 @@ dependencies = [
 [[package]]
 name = "modexp"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 
 [[package]]
 name = "modexp"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 
 [[package]]
 name = "modexp"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
-
-[[package]]
-name = "modexp"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-
-[[package]]
-name = "modexp"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 
 [[package]]
 name = "modular-bitfield"
@@ -8055,46 +7785,28 @@ dependencies = [
 [[package]]
 name = "oracle_provider"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "oracle_provider"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "oracle_provider"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
-]
-
-[[package]]
-name = "oracle_provider"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "oracle_provider"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -12137,46 +11849,28 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage_models"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "storage_models"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "storage_models"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
-]
-
-[[package]]
-name = "storage_models"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "storage_models"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -12358,71 +12052,43 @@ dependencies = [
 [[package]]
 name = "system_hooks"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "arrayvec 0.7.6",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "system_hooks"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "arrayvec 0.7.6",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
 ]
 
 [[package]]
 name = "system_hooks"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "arrayvec 0.7.6",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "paste",
  "ruint",
  "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
-]
-
-[[package]]
-name = "system_hooks"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "arrayvec 0.7.6",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
-]
-
-[[package]]
-name = "system_hooks"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "arrayvec 0.7.6",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -14544,29 +14210,13 @@ dependencies = [
 [[package]]
 name = "zk_ee"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.4",
  "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "paste",
- "ruint",
- "strum_macros",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "zk_ee"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
-dependencies = [
- "arrayvec 0.7.6",
- "bitflags 2.9.4",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
@@ -14577,13 +14227,13 @@ dependencies = [
 [[package]]
 name = "zk_ee"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.4",
  "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
@@ -14594,32 +14244,16 @@ dependencies = [
 [[package]]
 name = "zk_ee"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.4",
  "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "paste",
  "ruint",
  "serde",
- "strum_macros",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "zk_ee"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "arrayvec 0.7.6",
- "bitflags 2.9.4",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
- "paste",
- "ruint",
  "strum_macros",
  "zksync_os_evm_errors",
 ]
@@ -14824,20 +14458,20 @@ dependencies = [
 [[package]]
 name = "zksync_os_api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
  "alloy",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
 ]
 
 [[package]]
@@ -14861,12 +14495,12 @@ name = "zksync_os_batch_types"
 version = "0.15.1"
 dependencies = [
  "alloy",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "blake2 0.10.6",
  "ruint",
  "serde",
  "thiserror 2.0.17",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_contract_interface",
  "zksync_os_interface",
  "zksync_os_merkle_tree",
@@ -14883,10 +14517,10 @@ dependencies = [
  "async-trait",
  "axum",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "bincode 2.0.1",
  "dashmap",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "futures",
  "hyper",
  "hyper-util",
@@ -14902,7 +14536,7 @@ dependencies = [
  "tower",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
  "zksync_os_interface",
@@ -15023,7 +14657,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "blake2 0.10.6",
  "serde",
  "serde_json",
@@ -15044,7 +14678,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "flate2",
  "fs2",
  "futures",
@@ -15100,7 +14734,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "blake2 0.10.6",
  "futures",
  "itertools 0.14.0",
@@ -15113,7 +14747,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
  "zksync_os_interface",
@@ -15132,7 +14766,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "futures",
  "rangemap",
  "serde",
@@ -15174,10 +14808,10 @@ version = "0.15.1"
 dependencies = [
  "alloy",
  "anyhow",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "blake2 0.10.6",
  "clap",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "insta",
  "leb128",
  "once_cell",
@@ -15192,7 +14826,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.20",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_crypto",
  "zksync_os_rocksdb",
 ]
@@ -15222,11 +14856,9 @@ dependencies = [
  "alloy",
  "anyhow",
  "cargo_metadata",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "reqwest",
  "tracing",
  "url",
@@ -15387,9 +15019,9 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "blake2 0.10.6",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "futures",
  "reth-execution-types",
  "reth-primitives",
@@ -15404,7 +15036,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync-os-revm",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -15438,11 +15070,11 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "boa_engine",
  "boa_gc",
  "dashmap",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "futures",
  "hyper",
  "jsonrpsee",
@@ -15457,7 +15089,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_api",
  "zksync_os_evm_errors",
  "zksync_os_genesis",
@@ -15487,9 +15119,9 @@ dependencies = [
 [[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4#988460ccb9fc53648f5fe8bb52fbdeffbb04ec6a"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain#41dbfacaa887a17e8fd3481556770dacb302d0b6"
 dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260122-4)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-0-26-new-rust-toolchain)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
@@ -15498,9 +15130,9 @@ dependencies = [
 [[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2#2d60650b4f91fd03f595b45981856e8f5e1c4900"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain#30f6bbdf91fd2ea3bffa127c359d90a174d188c4"
 dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.26-rc2)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-1-0-new-rust-toolchain)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
@@ -15509,31 +15141,9 @@ dependencies = [
 [[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1#19ec28c281088cde70ef4572b71e47fee9d50bee"
+source = "git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain#7d04f6f6d1b4790ffe05f293eb027ff2ee0c3beb"
 dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.0-rc1)",
- "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
-]
-
-[[package]]
-name = "zksync_os_runner"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.5#135013888f4ec0be3211dfd488050bbad8bd58c1"
-dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
-]
-
-[[package]]
-name = "zksync_os_runner"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only#e43a695c90332d01df914a96332cdca07cf75c03"
-dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.6-simulation-only)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
@@ -15546,8 +15156,8 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "futures",
  "num",
  "reth-execution-types",
@@ -15560,7 +15170,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_gas_adjuster",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -15582,12 +15192,12 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "bincode 2.0.1",
  "blake2 0.10.6",
  "clap",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.5.2)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "full_statement_verifier",
  "futures",
  "http 1.3.1",
@@ -15610,7 +15220,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_base_token_adjuster",
  "zksync_os_batch_types",
  "zksync_os_batch_verification",
@@ -15687,12 +15297,12 @@ dependencies = [
  "alloy",
  "anyhow",
  "dashmap",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "ruint",
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -15705,12 +15315,12 @@ version = "0.15.1"
 dependencies = [
  "alloy",
  "anyhow",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "ruint",
  "tempfile",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -15757,7 +15367,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "auto_impl",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "bincode 2.0.1",
  "futures",
  "pin-project 1.1.10",
@@ -15767,7 +15377,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.5)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?branch=vv-0-2-5-new-rust-toolchain)",
  "zksync_os_api",
  "zksync_os_batch_types",
  "zksync_os_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,11 +84,11 @@ zksync_os_interface = { version = "0.0.10" }
 # Historical versions of zksync-os that are kept to be able to replay old blocks and simulate calls on them. Only
 # forward system dependencies are expected to be in this section.
 
-zk_os_forward_system_0_0_26 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.0.26-rc2", features = [
+zk_os_forward_system_0_0_26 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-0-26-new-rust-toolchain", features = [
     "evm-compatibility",
     "no_print",
 ] }
-zk_os_forward_system_0_1_0 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.1.0-rc1", features = [
+zk_os_forward_system_0_1_0 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-1-0-new-rust-toolchain", features = [
     "production",
     "no_print",
     # We had an issue in this version - it's compilable only with the testing feature.
@@ -97,10 +97,10 @@ zk_os_forward_system_0_1_0 = { package = "forward_system", git = "https://github
 ], default-features = false }
 # v0.2.x is not historical yet, but we use a separate version for simulation so that `eth_estimateGas` can work with
 # 0-balance accounts. The fix was not a part of v0.2.5 and unfortunately cannot be included without changing `app.bin`.
-zk_os_forward_system_0_2_6 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.6-simulation-only", features = [
-    "production",
-    "no_print",
-], default-features = false }
+# zk_os_forward_system_0_2_6 = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "vv-0-2-5-new-rust-toolchain", features = [
+#     "production",
+#     "no_print",
+# ], default-features = false }
 
 # Previous version of zksync-os that can still be used to prove and submit batches. Also includes airbender dependencies
 # that are necessary to verify said proofs on the server end.
@@ -122,14 +122,14 @@ zk_os_forward_system_0_2_6 = { package = "forward_system", git = "https://github
 #
 # When a new version is released this version gets downgraded to the "previous version" section above.
 
-zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.5", features = [
+zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-2-5-new-rust-toolchain", features = [
     "production",
     "no_print",
 ], default-features = false }
-zk_ee = { git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.5" }
-zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.5" }
-zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.5" }
-zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.5" }
+zk_ee = { git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-2-5-new-rust-toolchain" }
+zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-2-5-new-rust-toolchain" }
+zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-2-5-new-rust-toolchain" }
+zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", branch = "vv-0-2-5-new-rust-toolchain" }
 execution_utils = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 full_statement_verifier = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 zksync_os_prover_service = { git = "https://github.com/matter-labs/zksync-airbender-prover.git", tag = "v0.7.0" }
@@ -138,10 +138,10 @@ zksync_os_prover_service = { git = "https://github.com/matter-labs/zksync-airben
 #
 # Can be updated at any time and changing it does not count as a breaking change.
 
-zk_os_forward_system_dev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "dev-20260122-4", features = [
-    "production",
-    "no_print",
-], default-features = false }
+# zk_os_forward_system_dev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "dev-20260122-4", features = [
+#     "production",
+#     "no_print",
+# ], default-features = false }
 
 # Other dependencies.
 
@@ -155,7 +155,7 @@ futures = "0.3"
 vise = "0.3.0"
 vise-exporter = "0.3.0"
 bincode = { version = "2.0.1", features = ["serde"] }
-smart-config = { version = "0.4.0-pre.2"}
+smart-config = { version = "0.4.0-pre.2" }
 smart-config-commands = { version = "0.4.0-pre.2" }
 thiserror = "2.0.12"
 clap = "4.2.2"

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -16,11 +16,15 @@ zksync_os_interface.workspace = true
 zk_os_forward_system.workspace = true
 zk_os_forward_system_0_1_0.workspace = true
 zk_os_forward_system_0_0_26.workspace = true
-zk_os_forward_system_0_2_6.workspace = true
-zk_os_forward_system_dev.workspace = true
+# zk_os_forward_system_0_2_6.workspace = true
+# zk_os_forward_system_dev.workspace = true
 anyhow.workspace = true
 zksync_os_types.workspace = true
-alloy = { workspace = true, default-features = false, features = ["consensus", "eips", "rlp"] }
+alloy = { workspace = true, default-features = false, features = [
+    "consensus",
+    "eips",
+    "rlp",
+] }
 tracing.workspace = true
 
 [build-dependencies]

--- a/lib/multivm/build.rs
+++ b/lib/multivm/build.rs
@@ -1,13 +1,32 @@
 use cargo_metadata::{MetadataCommand, PackageId};
 use url::Url;
 
-fn parse_git_tag(package_id: &PackageId) -> anyhow::Result<String> {
+fn parse_git_ref(package_id: &PackageId) -> anyhow::Result<String> {
     let url = Url::parse(&package_id.to_string())?;
     let mut query_pairs = url.query_pairs();
-    let (_, tag) = query_pairs
-        .find(|(key, _)| key == "tag")
-        .ok_or_else(|| anyhow::anyhow!("missing tag in git url `{url}`"))?;
-    Ok(tag.to_string())
+    let (_, git_ref) = query_pairs
+        .find(|(key, _)| key == "branch")
+        .or_else(|| query_pairs.find(|(key, _)| key == "tag"))
+        .ok_or_else(|| anyhow::anyhow!("missing branch / tag in git url `{url}`"))?;
+    Ok(git_ref.to_string())
+}
+
+fn version_key(git_ref: &str) -> String {
+    // Branches like `vv-0-2-5-new-rust-toolchain` and tags like `v0.2.5` both map to `0_2_5`.
+    let numeric_parts = git_ref
+        .split(|ch: char| !ch.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .take(3)
+        .collect::<Vec<_>>();
+    if numeric_parts.len() == 3 {
+        return numeric_parts.join("_");
+    }
+
+    git_ref
+        .trim_start_matches("v")
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
 }
 
 fn main() {
@@ -19,15 +38,15 @@ fn main() {
         if package.name.as_str() != "forward_system" {
             continue;
         }
-        let tag = match parse_git_tag(&package.id) {
-            Ok(tag) => tag,
+        let git_ref = match parse_git_ref(&package.id) {
+            Ok(git_ref) => git_ref,
             Err(err) => {
-                println!("cargo::error=failed to parse forward_system's git tag: {err}");
+                println!("cargo::error=failed to parse forward_system's git ref: {err}");
                 return;
             }
         };
 
-        let dir = format!("{manifest_dir}/apps/{tag}");
+        let dir = format!("{manifest_dir}/apps/{git_ref}");
         std::fs::create_dir_all(&dir).expect("failed to create directory");
         for variant in [
             "multiblock_batch",
@@ -35,7 +54,7 @@ fn main() {
             "singleblock_batch_logging_enabled",
         ] {
             let url = format!(
-                "https://github.com/matter-labs/zksync-os/releases/download/{tag}/{variant}.bin"
+                "https://github.com/matter-labs/zksync-os/releases/download/{git_ref}/{variant}.bin"
             );
             let path = format!("{dir}/{variant}.bin");
             if std::fs::exists(&path).expect("failed to check file existence") {
@@ -46,7 +65,7 @@ fn main() {
             std::fs::write(path, body).expect("failed to write file");
         }
 
-        let snake_case_version = tag.trim_start_matches("v").replace('.', "_");
+        let snake_case_version = version_key(&git_ref);
         println!("cargo:rustc-env=ZKSYNC_OS_{snake_case_version}_SOURCE_PATH={dir}");
     }
 }

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -3,10 +3,11 @@
 //! Also, update the `LATEST_EXECUTION_VERSION` constant accordingly.
 
 use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV5Running;
+use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV5Simulation;
 use zk_os_forward_system_0_0_26::run::RunBlockForward as RunBlockForwardV3;
 use zk_os_forward_system_0_1_0::run::RunBlockForward as RunBlockForwardV4;
-use zk_os_forward_system_0_2_6::run::RunBlockForward as RunBlockForwardV5Simulation;
-use zk_os_forward_system_dev::run::RunBlockForward as RunBlockForwardV6;
+// use zk_os_forward_system_0_2_6::run::RunBlockForward as RunBlockForwardV5Simulation;
+// use zk_os_forward_system_dev::run::RunBlockForward as RunBlockForwardV6;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::AnyTracer;
 use zksync_os_interface::traits::{
@@ -89,18 +90,19 @@ pub fn run_block<
                 .map_err(|err| anyhow::anyhow!(err))
         }
         ExecutionVersion::V6 => {
-            let object = RunBlockForwardV6 {};
-            object
-                .run_block(
-                    (),
-                    block_context,
-                    storage,
-                    preimage_source,
-                    tx_source,
-                    tx_result_callback,
-                    tracer,
-                )
-                .map_err(|err| anyhow::anyhow!(err))
+            panic!("Gutting out v6 for the time being");
+            // let object = RunBlockForwardV6 {};
+            // object
+            //     .run_block(
+            //         (),
+            //         block_context,
+            //         storage,
+            //         preimage_source,
+            //         tx_source,
+            //         tx_result_callback,
+            //         tracer,
+            //     )
+            //     .map_err(|err| anyhow::anyhow!(err))
         }
     }
 }
@@ -163,17 +165,18 @@ pub fn simulate_tx<Storage: ReadStorage, PreimgSrc: PreimageSource, Tracer: AnyT
                 .map_err(|err| anyhow::anyhow!(err))
         }
         ExecutionVersion::V6 => {
-            let object = RunBlockForwardV6 {};
-            object
-                .simulate_tx(
-                    (),
-                    transaction,
-                    block_context,
-                    storage,
-                    preimage_source,
-                    tracer,
-                )
-                .map_err(|err| anyhow::anyhow!(err))
+            panic!("Gutting out v6 for the time being");
+            // let object = RunBlockForwardV6 {};
+            // object
+            //     .simulate_tx(
+            //         (),
+            //         transaction,
+            //         block_context,
+            //         storage,
+            //         preimage_source,
+            //         tracer,
+            //     )
+            //     .map_err(|err| anyhow::anyhow!(err))
         }
     }
 }

--- a/run_local.sh
+++ b/run_local.sh
@@ -51,7 +51,7 @@ cleanup() {
     done
 
     echo -e "${GREEN}All services stopped${NC}"
-    rm -rf "$TEMP_DIR"
+    # rm -rf "$TEMP_DIR"
     exit 0
 }
 
@@ -154,7 +154,8 @@ if [ -n "$LOGS_DIR" ]; then
     anvil --load-state "$L1_STATE_FILE" --port 8545 > "$ANVIL_LOG_FILE" 2>&1 &
     echo -e "${GREEN}Anvil logs: $ANVIL_LOG_FILE${NC}"
 else
-    anvil --load-state "$L1_STATE_FILE" --port 8545 > /dev/null 2>&1 &
+    echo "EMIL WAS HERE $L1_STATE_FILE"
+    anvil --load-state "$L1_STATE_FILE" --port 8545
 fi
 ANVIL_PID=$!
 PIDS+=($ANVIL_PID)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-05-23"
+channel = "nightly-2026-01-22"


### PR DESCRIPTION
Actual error:
```
2026-02-12T22:13:47.307781Z DEBUG zksync_os_server::prover_input_generator: ProverInputGenerator started processing block 1 with 1 transactions block_number=1
ZK RISC-V simulator is starting
[/home/evl/.cargo/git/checkouts/zksync-airbender-8ab8222a00c65218/c23fd00/risc_v_simulator/src/sim/mod.rs:192:13] path.as_ref() = "./db/node1/app_bins/v6/singleblock_batch.bin"

thread 'tokio-runtime-worker' (346892) panicked at /home/evl/.cargo/git/checkouts/zksync-airbender-8ab8222a00c65218/c23fd00/risc_v_simulator/src/sim/mod.rs:197:13:
assertion `left == right` failed
  left: 1
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2026-02-12T22:13:47.308723Z ERROR zksync_os_pipeline::builder: prover_input_generator component failed err=task 107 panicked with message "assertion `left == right` failed\n  left: 1\n right: 0"
2026-02-12T22:13:47.308756Z ERROR zksync_os_pipeline::builder: batcher component failed err=batcher inbound channel unexpectedly closed
2026-02-12T22:13:47.308775Z  WARN zksync_os_pipeline::builder: batch_verification component unexpectedly exited
2026-02-12T22:13:47.308779Z  INFO zksync_os_server: One of the subsystems exited - exiting process.
2026-02-12T22:13:47.308792Z ERROR zksync_os_pipeline::builder: fri_proving component failed err=FRI proving input stream ended unexpectedly
2026-02-12T22:13:47.308811Z ERROR zksync_os_pipeline::builder: gapless_committer component failed err=GaplessCommitter input stream ended unexpectedly
2026-02-12T22:13:47.308839Z ERROR zksync_os_pipeline::builder: upgrade_gatekeeper component failed err=UpgradeGatekeeper input stream ended unexpectedly
2026-02-12T22:13:47.308859Z ERROR zksync_os_pipeline::builder: commit component failed err=inbound channel closed
2026-02-12T22:13:47.308874Z ERROR zksync_os_pipeline::builder: snark_proving component failed err=SNARK proving input stream ended unexpectedly
2026-02-12T22:13:47.308894Z ERROR zksync_os_pipeline::builder: gapless_l1_proof_sender component failed err=GaplessL1ProofSender input stream ended unexpectedly
2026-02-12T22:13:47.309004Z  WARN zksync_os_server: Main task unexpectedly exited
2026-02-12T22:13:47.309049Z DEBUG zksync_os_sequencer::execution::block_executor: stream exhausted → sealing block_number=2 txs=6
2026-02-12T22:13:47.309123Z  INFO zksync_os_sequencer::execution: Saving dump..
2026-02-12T22:13:47.315872Z ERROR zksync_os_pipeline::builder: sequencer component failed err=execute_block
```

I believe the problem is wrong app.bin after all my changes (especially around simulation). The simulation doesn't have a branch so I tried to overwrite it with older version (assuming it might just work, but it doesn't).

## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

