### PR TITLE
feat: implement bootstrap running mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15594,6 +15594,8 @@ dependencies = [
  "num",
  "rand 0.9.2",
  "reqwest",
+ "reth-chainspec",
+ "reth-provider",
  "ruint",
  "semver 1.0.26",
  "sentry",

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -9,7 +9,9 @@ use reth_eth_wire::HelloMessageWithProtocols;
 use reth_net_nat::NatResolver;
 use reth_network::error::NetworkError;
 use reth_network::types::peers::config::PeerBackoffDurations;
-use reth_network::{NetworkConfig as RethNetworkConfig, NetworkManager, PeersConfig};
+use reth_network::{
+    NetworkConfig as RethNetworkConfig, NetworkConfigBuilder, NetworkManager, PeersConfig,
+};
 use reth_provider::BlockNumReader;
 use std::net::{SocketAddr, SocketAddrV4};
 use std::sync::{Arc, RwLock};
@@ -43,6 +45,42 @@ impl NetworkService {
         client: impl ChainSpecProvider<ChainSpec: Hardforks> + BlockNumReader + 'static,
         replay_sender: mpsc::Sender<ReplayRecord>,
     ) -> Result<Self, NetworkError> {
+        let sub_protocol_installer = |net_cfg_builder: NetworkConfigBuilder, protocol_tx| {
+            // Add latest version of `zks` subprotocol. In the future this can be extended so that
+            // several versions are registered here.
+            net_cfg_builder.add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV1, _> {
+                replay,
+                node_role,
+                starting_block: Arc::new(RwLock::new(starting_block)),
+                record_overrides,
+                state: ProtocolState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS),
+                replay_sender,
+                _phantom: Default::default(),
+            })
+        };
+
+        Self::new_inner(config, client, sub_protocol_installer).await
+    }
+
+    /// Special bootstrapping mode where no subprotocols are registered. These types of nodes are
+    /// used primarily for peer discovery and do not operate an actual ZKsync OS node.
+    pub async fn bootstrap(
+        config: NetworkConfig,
+        client: impl ChainSpecProvider<ChainSpec: Hardforks> + BlockNumReader + 'static,
+    ) -> Result<Self, NetworkError> {
+        let noop_installer = |net_cfg_builder: NetworkConfigBuilder, _protocol_tx| net_cfg_builder;
+
+        Self::new_inner(config, client, noop_installer).await
+    }
+
+    async fn new_inner(
+        config: NetworkConfig,
+        client: impl ChainSpecProvider<ChainSpec: Hardforks> + BlockNumReader + 'static,
+        sub_protocol_installer: impl FnOnce(
+            NetworkConfigBuilder,
+            mpsc::UnboundedSender<ProtocolEvent>,
+        ) -> NetworkConfigBuilder,
+    ) -> Result<Self, NetworkError> {
         match NatResolver::Any.external_addr().await {
             None => {
                 tracing::info!("could not resolve external IP (STUN)");
@@ -53,7 +91,7 @@ impl NetworkService {
         };
         let rlpx_address = SocketAddr::V4(SocketAddrV4::new(config.address, config.port));
         let (protocol_tx, protocol_rx) = mpsc::unbounded_channel();
-        let net_cfg = RethNetworkConfig::builder(config.secret_key)
+        let net_cfg_builder = RethNetworkConfig::builder(config.secret_key)
             .boot_nodes(config.boot_nodes.clone())
             // Configure node identity
             .apply(|builder| {
@@ -110,19 +148,8 @@ impl NetworkService {
             // Do not require any block hashes in `eth` RLPx protocol as it is unused
             .required_block_hashes(vec![])
             // Set network id to ZKsync OS chain's id, otherwise we might connect to unrelated peers
-            .network_id(Some(client.chain_spec().chain_id()))
-            // Add latest version of `zks` subprotocol. In the future this can be extended so that
-            // several versions are registered here.
-            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV1, _> {
-                replay,
-                node_role,
-                starting_block: Arc::new(RwLock::new(starting_block)),
-                record_overrides,
-                state: ProtocolState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS),
-                replay_sender,
-                _phantom: Default::default(),
-            })
-            .build(client);
+            .network_id(Some(client.chain_spec().chain_id()));
+        let net_cfg = sub_protocol_installer(net_cfg_builder, protocol_tx).build(client);
         tracing::debug!(?net_cfg, "starting p2p network service");
         // Create network manager. We are not interested in `txpool` because transaction gossip is
         // disabled. `request_handler` is also unused as it is specific to `eth` protocol.

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -51,6 +51,9 @@ zksync_os_interface.workspace = true
 execution_utils.workspace = true
 full_statement_verifier.workspace = true
 
+reth-provider = { workspace = true, features = ["test-utils"] }
+reth-chainspec = { workspace = true }
+
 anyhow.workspace = true
 alloy = { workspace = true, default-features = false, features = [
     "rlp",

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -1,11 +1,15 @@
 use clap::{Parser, Subcommand};
+use reth_chainspec::{Chain, ChainSpec};
+use reth_provider::test_utils::MockEthProvider;
 use smart_config::{ConfigRepository, ConfigSources, Environment, Json, Yaml};
 use std::{fs, future, path::Path, time::Duration};
 use tempfile::TempDir;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
+use tokio::task::JoinSet;
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_metadata::NODE_VERSION;
+use zksync_os_network::service::NetworkService;
 use zksync_os_object_store::ObjectStoreMode;
 use zksync_os_observability::prometheus::PrometheusExporterConfig;
 use zksync_os_server::config::{
@@ -27,6 +31,7 @@ const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 enum CliCommand {
     /// Configuration-related tools.
     Config(ConfigArgs),
+    Bootstrap,
 }
 
 #[derive(Debug, Parser)]
@@ -138,11 +143,51 @@ pub async fn main() {
 
     let config_repo = ConfigRepository::new(&config_schema).with_all(config_sources);
 
+    // =========== init interruption channel ===========
+    // todo: implement interruption handling in other tasks
+    let (stop_sender, mut stop_receiver) = watch::channel(false);
+
     // =========== handle the CLI subcommand if any ===========
     if let Some(cmd) = opt.cmd {
         match cmd {
             CliCommand::Config(args) => {
                 args.run(config_repo, "").unwrap();
+                return;
+            }
+            CliCommand::Bootstrap => {
+                // Bootstrap mode expects network config and `genesis_chain_id` to be present
+                let network_config = config_repo
+                    .single::<NetworkConfig>()
+                    .expect("Failed to load network config")
+                    .parse()
+                    .expect("Failed to parse network config");
+                let genesis_config = config_repo
+                    .single::<GenesisConfig>()
+                    .expect("Failed to load genesis config")
+                    .parse()
+                    .expect("Failed to parse genesis config");
+                let network_service = NetworkService::bootstrap(
+                    network_config.into(),
+                    MockEthProvider::default().with_chain_spec(
+                        ChainSpec::builder()
+                            .chain(Chain::from_id(genesis_config.chain_id.expect(
+                                "`genesis_chain_id` is required to be set for bootstrap nodes",
+                            )))
+                            .genesis(Default::default())
+                            .build(),
+                    ),
+                )
+                .await
+                .expect("failed to start network service");
+                // Run network service and then wait indefinitely for stop signal
+                let mut tasks: JoinSet<()> = JoinSet::new();
+                network_service.run(&mut tasks, stop_receiver.clone());
+                while !*stop_receiver.borrow() {
+                    stop_receiver
+                        .changed()
+                        .await
+                        .expect("stop receiver changed");
+                }
                 return;
             }
         }
@@ -151,10 +196,7 @@ pub async fn main() {
     let mut config = build_external_config(config_repo);
     tracing::info!(?config, "Loaded config");
     load_internal_config(&mut config);
-    // =========== init interruption channel ===========
 
-    // todo: implement interruption handling in other tasks
-    let (stop_sender, stop_receiver) = watch::channel(false);
     // ======= Run tasks ===========
     let main_stop = stop_receiver.clone(); // keep original for Prometheus
     let ephemeral_enabled = config.general_config.ephemeral;


### PR DESCRIPTION
## Summary

Adds bootstrap running mode that can be used like this:
```
cargo run --release -- bootstrap
```

This mode makes the node initialize and run **only** networking service (without any subprotocols). Its main purpose is providing peer discovery services to all other nodes in the network.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

