### PR TITLE
fix: adapt mint value for L1 txs for v31 

### DIFF
--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -25,7 +25,7 @@ use zksync_os_storage_api::ViewState;
 use zksync_os_storage_api::{
     RepositoryError, StateError, state_override_view::OverriddenStateView,
 };
-use zksync_os_types::ZksyncOsEncode;
+use zksync_os_types::{ExecutionVersion, ZksyncOsEncode};
 use zksync_os_types::{
     L1_TX_MINIMAL_GAS_LIMIT, L1Envelope, L1PriorityTxType, L1Tx, L1TxType, L2Envelope,
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType, ZkEnvelope,
@@ -555,7 +555,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         if optimistic_gas_limit < highest_gas_limit {
             // Set the transaction's gas limit to the calculated optimistic gas limit.
             let mut optimistic_tx = tx.clone();
-            set_gas_limit(&mut optimistic_tx, optimistic_gas_limit);
+            set_gas_limit(&mut optimistic_tx, optimistic_gas_limit, &block_context);
 
             // Re-execute the transaction with the new gas limit and update the result and
             // environment.
@@ -600,7 +600,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             };
 
             let mut mid_tx = tx.clone();
-            set_gas_limit(&mut mid_tx, mid_gas_limit);
+            set_gas_limit(&mut mid_tx, mid_gas_limit, &block_context);
             tracing::trace!(
                 gas_limit = mid_tx.gas_limit(),
                 "trying to simulate transaction"
@@ -648,7 +648,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     }
 }
 
-fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
+fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64, block_context: &BlockContext) {
     match tx.inner.inner_mut() {
         ZkEnvelope::System(_) => {
             unreachable!("system transactions don't have explicit gas limit");
@@ -661,7 +661,13 @@ fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
         ZkEnvelope::L1(envelope) => {
             let tx = &mut envelope.inner;
             tx.gas_limit = gas_limit;
-            tx.to_mint = tx.value + U256::from(tx.max_fee_per_gas) * U256::from(gas_limit);
+            let to_mint = if block_context.execution_version >= ExecutionVersion::V6 as u32 {
+                // After V31, L1 transactions only need to mint the fee
+                U256::from(tx.max_fee_per_gas) * U256::from(gas_limit)
+            } else {
+                tx.value + U256::from(tx.max_fee_per_gas) * U256::from(gas_limit)
+            };
+            tx.to_mint = to_mint;
         }
         ZkEnvelope::Upgrade(envelope) => envelope.inner.gas_limit = gas_limit,
     }


### PR DESCRIPTION
## Summary
For Stage 1 support, v31 changes the first reserved field of L1 txs (total_deposited). Before, L1 txs had to deposit their total cost (fee + value). Now, they are required to mint the fee, while the value can be used from their L2 balance. This PR fixes the eth call handler to reflect this.
<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

