### PR TITLE
feat: keep rolled back blocks available by hash

### DIFF
--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -225,8 +225,6 @@ impl RepositoryDb {
                 for tx_hash in &old_repo_block.body.transactions {
                     // Deletes only `InitiatorAndNonceToHash` entry.
                     // `Tx`, `TxMeta` and `TxReceipt` entries are preserved so that the transaction and its receipt are still queryable by hash.
-                    batch.delete_cf(RepositoryCF::TxReceipt, &tx_hash.0);
-
                     let tx = self
                         .get_transaction(*tx_hash)?
                         .expect("tx to rollback must be present in DB");


### PR DESCRIPTION
## Summary

It's helpful to keep rolled back blocks and transactions in repo DB for debugging purposes

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

