### PR TITLE
fix: Commit after each tx in revm consistency checker

### DIFF
--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -172,7 +172,11 @@ where
                         zk_tx_into_revm_tx(transaction, tx_output.gas_used, tx_output.is_success())
                     });
 
-                evm.transact_many_commit(revm_txs)?;
+                // Commit after each tx
+                for tx in revm_txs {
+                    evm.transact_commit(tx)?;
+                }
+
                 let compare_report = CompareReport::build(
                     evm.0.db_mut(),
                     &block_output.storage_writes,


### PR DESCRIPTION
## Summary

REVM consistency checker is failing due to how transactions are executed in revm: right now we're committing the state changes only after all txs are executed. This seems to be problematic, as zksync-os-revm might use the db directly, ignoring journaled state. To solve this, this PR changes the way txs are executed, committing after each tx.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

