### PR TITLE
feat: consensus integration preparation (Sequencer split to `BlockExecutor` and `BlockApplier`) [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ markers.bench
 
 lcov.info
 setup_compact.key
+l1-state.json

--- a/docs/src/setup/external_node.md
+++ b/docs/src/setup/external_node.md
@@ -5,17 +5,27 @@ receives block replays from another node instead of producing its own blocks. Th
 from L1 and check that they match the ones in the replay but it won't change L1 state.
 
 To run the external node locally, you need to enable networking on both main node and external node. Then set external node's services' ports so they don't overlap with the main node.
-
-For example:
-
+Main Node:
 ```bash
 network_enabled=true \
-network_secret_key=9cc842aaeb1492e567d989a34367c7239d1db21bad31557689c3d9d16e45b0b3 \
+network_secret_key=0af6153646bbf600f55ce455e1995283542b1ae25ce2622ce1fda443927c5308 \
+network_boot_nodes=enode://246e07030b4c48b8f28ab1fdf797a02308b0ca724696b695aabee48ea48298ff221144a0c0f14ebf030aea6d5fb6b31bd3a02676204bb13e78336bb824e32f1d@127.0.0.1:3060,enode://d2db8005d59694a5b79b7c58d4d375c60c9323837e852bbbfd05819621c48a4218cefa37baf39a164e2a6f6c1b34c379c4a72c7480b5fbcc379d1befb881e8fc@127.0.0.1:3060 \
+cargo run
+```
+EN: 
+```bash
+RUST_LOG="info,zksync_os_storage_api=debug" \
+network_enabled=true \
+network_secret_key=c2c8042b03801e2e14b395ed24f970ead7646a9ff315b54f747bcefdb99afda7 \
 network_address=127.0.0.1 \
 network_port=3061 \
-network_boot_nodes=enode://dbd18888f17bad7df7fa958b57f4993f47312ba5364508fd0d9027e62ea17a037ca6985d6b0969c4341f1d4f8763a802785961989d07b1fb5373ced9d43969f6@127.0.0.1:3060 \
-sequencer_rocks_db_path=./db/en \
-sequencer_prometheus_port=3313 \
+network_boot_nodes="enode://246e07030b4c48b8f28ab1fdf797a02308b0ca724696b695aabee48ea48298ff221144a0c0f14ebf030aea6d5fb6b31bd3a02676204bb13e78336bb824e32f1d@127.0.0.1:3060,enode://d2db8005d59694a5b79b7c58d4d375c60c9323837e852bbbfd05819621c48a4218cefa37baf39a164e2a6f6c1b34c379c4a72c7480b5fbcc379d1befb881e8fc@127.0.0.1:3060" \
+general_main_node_rpc_url="http://127.0.0.1:3050" \
+general_node_role=external \
+observability_prometheus_port=3313 \
+network_port="3061" \
+general_rocks_db_path="db/en" \
+status_server_enabled=false \
 rpc_address=0.0.0.0:3051 \
-cargo run --release
+cargo run 
 ```

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -311,7 +311,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             Some(overrides) => execute(
                 execution_env.transaction,
                 execution_env.block_context,
-                OverriddenStateView::new(storage_view, overrides),
+                OverriddenStateView::with_state_overrides(storage_view, overrides),
             ),
             None => execute(
                 execution_env.transaction,
@@ -350,7 +350,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             Some(overrides) => call_trace_simulate(
                 execution_env.transaction,
                 execution_env.block_context,
-                OverriddenStateView::new(storage_view, overrides),
+                OverriddenStateView::with_state_overrides(storage_view, overrides),
                 call_config,
             ),
             None => call_trace_simulate(
@@ -379,7 +379,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         let mut tracer_output = match state_overrides {
             Some(overrides) => {
-                let view = OverriddenStateView::new(storage_view, overrides);
+                let view = OverriddenStateView::with_state_overrides(storage_view, overrides);
                 let mut tracer = js_tracer::tracer::JsTracer::new(view.clone(), js_cfg)
                     .map_err(|e| EthCallError::ForwardSubsystemError(anyhow::anyhow!(e)))?;
 
@@ -442,7 +442,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             Some(overrides) => self.estimate_gas_with_view(
                 request,
                 block_context,
-                OverriddenStateView::new(storage_view, overrides),
+                OverriddenStateView::with_state_overrides(storage_view, overrides),
             ),
             None => self.estimate_gas_with_view(request, block_context, storage_view),
         }

--- a/lib/sequencer/src/execution/block_applier.rs
+++ b/lib/sequencer/src/execution/block_applier.rs
@@ -1,0 +1,81 @@
+use crate::config::SequencerConfig;
+use crate::model::blocks::BlockCommandType;
+use alloy::consensus::Sealed;
+use anyhow::Context;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use zksync_os_interface::types::BlockOutput;
+use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_storage_api::{ReplayRecord, WriteReplay, WriteRepository, WriteState};
+
+/// Persists blocks in various local storages.
+/// Used to be part of the Sequencer - was split into `BlockExecutor` and `BlockApplier`.
+pub struct BlockApplier<State, Replay, Repo>
+where
+    State: WriteState + Clone + Send + 'static,
+    Replay: WriteReplay + Send + 'static,
+    Repo: WriteRepository + Send + 'static,
+{
+    pub state: State,
+    pub replay: Replay,
+    pub repositories: Repo,
+    pub config: SequencerConfig,
+}
+
+#[async_trait]
+impl<State, Replay, Repo> PipelineComponent for BlockApplier<State, Replay, Repo>
+where
+    State: WriteState + Clone + Send + 'static,
+    Replay: WriteReplay + Send + 'static,
+    Repo: WriteRepository + Send + 'static,
+{
+    type Input = (BlockOutput, ReplayRecord, BlockCommandType);
+    type Output = (BlockOutput, ReplayRecord);
+
+    const NAME: &'static str = "block_applier";
+    const OUTPUT_BUFFER_SIZE: usize = 5;
+
+    async fn run(
+        mut self,
+        mut input: PeekableReceiver<Self::Input>,
+        output: mpsc::Sender<Self::Output>,
+    ) -> anyhow::Result<()> {
+        loop {
+            let Some((block_output, executed_replay, cmd_type)) = input.recv().await else {
+                anyhow::bail!("inbound channel closed");
+            };
+
+            let block_number = executed_replay.block_context.block_number;
+            let override_allowed = match cmd_type {
+                BlockCommandType::Rebuild => true,
+                _ if self.config.node_role.is_external() => true,
+                _ => false,
+            };
+
+            tracing::info!(block_number, "Persisting block {block_number}");
+            self.replay.write(
+                Sealed::new_unchecked(executed_replay.clone(), block_output.header.hash()),
+                override_allowed,
+            );
+
+            self.state.add_block_result(
+                block_number,
+                block_output.storage_writes.clone(),
+                block_output
+                    .published_preimages
+                    .iter()
+                    .map(|(k, v)| (*k, v)),
+                override_allowed,
+            )?;
+
+            self.repositories
+                .populate(block_output.clone(), executed_replay.transactions.clone())
+                .await?;
+
+            output
+                .send((block_output, executed_replay))
+                .await
+                .context("send downstream")?;
+        }
+    }
+}

--- a/lib/sequencer/src/execution/block_canonizer.rs
+++ b/lib/sequencer/src/execution/block_canonizer.rs
@@ -1,0 +1,140 @@
+use crate::model::blocks::BlockCommandType;
+use async_trait::async_trait;
+use std::collections::VecDeque;
+use tokio::sync::mpsc;
+use zksync_os_interface::types::BlockOutput;
+use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_storage_api::ReplayRecord;
+
+/// Pipeline component that ensures that only canonized blocks are sent downstream,
+///  effectively serving as a canonization fence.
+/// Assumes that all **Replay** commands from upstream are already canonized:
+/// they are either:
+///         from local storage (replayed on startup)
+///         or are produced by some other node - thus already canonized by the consensus protocol
+/// **Produce** (proposed) commands are first waiting the canonization
+///  (This component sends them to Consensus and wait for them to return as Replays).
+///
+/// This component doesn't rely on or track the node role (leader vs replica) -
+/// it can handle both Produce and Replay upstream commands.
+pub struct BlockCanonizer<Consensus>
+where
+    Consensus: ConsensusInterface,
+{
+    pub consensus: Consensus,
+    /// Channel to send new canonized blocks to for the node to replay.
+    /// They are sent to `NodeCommandSource` and then through the whole pipeline.
+    pub canonized_blocks_for_execution: mpsc::Sender<ReplayRecord>,
+}
+
+#[async_trait]
+pub trait ConsensusInterface: Send + 'static {
+    async fn propose(&self, record: ReplayRecord) -> anyhow::Result<()>;
+    async fn next_canonized(&mut self) -> anyhow::Result<ReplayRecord>;
+}
+
+/// Degenerate consensus implementation - just an async channel to itself.
+pub struct LoopbackConsensus {
+    pub sender: mpsc::Sender<ReplayRecord>,
+    pub receiver: mpsc::Receiver<ReplayRecord>,
+}
+
+#[async_trait]
+impl ConsensusInterface for LoopbackConsensus {
+    async fn propose(&self, record: ReplayRecord) -> anyhow::Result<()> {
+        self.sender.send(record).await?;
+        Ok(())
+    }
+
+    async fn next_canonized(&mut self) -> anyhow::Result<ReplayRecord> {
+        self.receiver
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("consensus replay channel closed"))
+    }
+}
+
+#[async_trait]
+impl<Consensus> PipelineComponent for BlockCanonizer<Consensus>
+where
+    Consensus: ConsensusInterface,
+{
+    // Input from BlockExecutor
+    type Input = (BlockOutput, ReplayRecord, BlockCommandType);
+    // Output to BlockApplier
+    type Output = (BlockOutput, ReplayRecord, BlockCommandType);
+
+    const NAME: &'static str = "block_canonizer";
+    const OUTPUT_BUFFER_SIZE: usize = 2;
+
+    async fn run(
+        mut self,
+        mut input: PeekableReceiver<Self::Input>,
+        output: mpsc::Sender<Self::Output>,
+    ) -> anyhow::Result<()> {
+        let mut produced_queue: VecDeque<(BlockOutput, ReplayRecord, BlockCommandType)> =
+            VecDeque::new();
+
+        loop {
+            tokio::select! {
+                // Select arm that receives canonized blocks from Consensus.
+                // If this block was earlier proposed by this node - sends downstream.
+                // Otherwise - sends to the beginning of pipeline for execution.
+                canonized = self.consensus.next_canonized() => {
+                    let record = canonized?;
+                    if let Some((block_output, produced_replay, cmd_type)) =
+                        produced_queue.pop_front()
+                    {
+                        tracing::debug!(
+                            "Received a Replay block {} (block output hash: {}) from Consensus while having a pending block. \
+                            Matching with locally produced block and sending downstream for persistence. \
+                            additional pending blocks in the queue: {}",
+                            record.block_context.block_number,
+                            record.block_output_hash,
+                            produced_queue.len(),
+                        );
+                        if produced_replay != record {
+                            anyhow::bail!(
+                                "canonized replay record mismatch at block {}. \
+                                Other node became the leader?",
+                                produced_replay.block_context.block_number
+                            );
+                        }
+                        output.send((block_output, produced_replay, cmd_type)).await?;
+                    } else {
+                        tracing::debug!(
+                            "Received new block {} (block output hash: {}) from Consensus. \
+                            Sending as Replay command to the pipeline beginning.",
+                            record.block_context.block_number,
+                            record.block_output_hash,
+                        );
+
+                        self.canonized_blocks_for_execution.send(record).await?;
+                    }
+                }
+                // Select arm that receives executed blocks from `BlockExecutor` (upstream).
+                maybe_executed = input.recv() => {
+                    let Some((block_output, replay_record, cmd_type)) = maybe_executed else {
+                        anyhow::bail!("inbound channel closed");
+                    };
+                    match cmd_type {
+                        BlockCommandType::Replay => {
+                        output
+                            .send((block_output, replay_record, cmd_type))
+                            .await?;
+                        }
+                        BlockCommandType::Produce => {
+                            let proposed = replay_record.clone();
+                            self.consensus.propose(proposed).await?;
+                            produced_queue.push_back((block_output, replay_record, cmd_type));
+                        }
+                        BlockCommandType::Rebuild => {
+                            // TODO: handle rebuild with consensus integration.
+                            todo!();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -44,6 +44,9 @@ pub struct BlockContextProvider<Mempool> {
     l2_mempool: Mempool,
     block_hashes_for_next_block: BlockHashes,
     previous_block_timestamp: u64,
+    next_block_number: u64,
+    block_time: Duration,
+    max_transactions_in_block: usize,
     chain_id: u64,
     gas_limit: u64,
     pubdata_limit: u64,
@@ -71,6 +74,9 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
         l2_mempool: Mempool,
         block_hashes_for_next_block: BlockHashes,
         previous_block_timestamp: u64,
+        next_block_number: u64,
+        block_time: Duration,
+        max_transactions_in_block: usize,
         chain_id: u64,
         gas_limit: u64,
         pubdata_limit: u64,
@@ -92,6 +98,9 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
             l2_mempool,
             block_hashes_for_next_block,
             previous_block_timestamp,
+            next_block_number,
+            block_time,
+            max_transactions_in_block,
             chain_id,
             gas_limit,
             pubdata_limit,
@@ -111,7 +120,8 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
         block_command: BlockCommand,
     ) -> anyhow::Result<PreparedBlockCommand> {
         let prepared_command = match block_command {
-            BlockCommand::Produce(produce_command) => {
+            BlockCommand::Produce(_) => {
+                let block_number = self.next_block_number;
                 // Create stream:
                 // - If available, upgrade tx goes first (expected to be the only tx in the block, enforced by sequencer).
                 // - L1 transactions first, then L2 transactions.
@@ -131,7 +141,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 if peeked_tx.is_none() {
                     return Err(anyhow::anyhow!(
                         "BestTransactionsStream closed unexpectedly for block {}",
-                        produce_command.block_number
+                        block_number
                     ));
                 }
 
@@ -144,7 +154,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     && upgrade_tx.protocol_version > self.protocol_version
                 {
                     tracing::info!(
-                        block_number = produce_command.block_number,
+                        block_number,
                         upgrade_tx = ?upgrade_tx,
                         "including protocol upgrade transaction in the block"
                     );
@@ -179,7 +189,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     eip1559_basefee,
                     native_price,
                     pubdata_price,
-                    block_number: produce_command.block_number,
+                    block_number,
                     timestamp,
                     chain_id: self.chain_id,
                     coinbase: self.fee_collector_address,
@@ -197,8 +207,8 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                     block_context,
                     tx_source: Box::pin(best_txs),
                     seal_policy: SealPolicy::Decide(
-                        produce_command.block_time,
-                        produce_command.max_transactions_in_block,
+                        self.block_time,
+                        self.max_transactions_in_block,
                     ),
                     invalid_tx_policy: InvalidTxPolicy::RejectAndContinue,
                     metrics_label: "produce",
@@ -212,6 +222,12 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 }
             }
             BlockCommand::Replay(record) => {
+                anyhow::ensure!(
+                    self.next_block_number == record.block_context.block_number,
+                    "blocks received our of order: {} in component state, {} in resolved ReplayRecord",
+                    self.next_block_number,
+                    record.block_context.block_number
+                );
                 anyhow::ensure!(
                     self.previous_block_timestamp == record.previous_block_timestamp,
                     "inconsistent previous block timestamp: {} in component state, {} in resolved ReplayRecord",
@@ -403,6 +419,7 @@ impl<Mempool: L2TransactionPool> BlockContextProvider<Mempool> {
                 .try_into()
                 .unwrap(),
         );
+        self.next_block_number += 1;
         self.previous_block_timestamp = block_output.header.timestamp;
         self.fee_provider.on_canonical_state_change(replay_record);
 

--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -13,9 +13,7 @@ use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::types::{BlockContext, BlockOutput};
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_observability::ComponentStateHandle;
-use zksync_os_storage_api::{
-    MeteredViewState, OverriddenStateView, ReadStateHistory, ReplayRecord, WriteState,
-};
+use zksync_os_storage_api::{MeteredViewState, OverriddenStateView, ReplayRecord, ViewState};
 use zksync_os_types::{SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
 // Note that this is a pure function without a container struct (e.g. `struct BlockExecutor`)
 // MAINTAIN this to ensure the function is completely stateless - explicit or implicit.
@@ -23,9 +21,9 @@ use zksync_os_types::{SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
 // a side effect of this is that it's harder to pass config values (normally we'd just pass the whole config object)
 // please be mindful when adding new parameters here
 
-pub async fn execute_block<R: ReadStateHistory + WriteState>(
+pub async fn execute_block_in_vm<V: ViewState>(
     mut command: PreparedBlockCommand<'_>,
-    state: R,
+    state_view: V,
     latency_tracker: &ComponentStateHandle<SequencerState>,
 ) -> Result<(BlockOutput, ReplayRecord, Vec<(TxHash, InvalidTransaction)>), BlockDump> {
     tracing::debug!(command = ?command, block_number=command.block_context.block_number, "Executing command");
@@ -33,13 +31,6 @@ pub async fn execute_block<R: ReadStateHistory + WriteState>(
     let ctx = command.block_context;
 
     /* ---------- VM & state ----------------------------------------- */
-    let state_view = state
-        .state_view_at(ctx.block_number - 1)
-        .map_err(|e| BlockDump {
-            ctx,
-            txs: Vec::new(),
-            error: e.to_string(),
-        })?;
     // Inject any forced preimages into the state view, these are expected to be added to the persistent state
     // after the block is executed.
     let state_view_with_force_preimages =

--- a/lib/sequencer/src/execution/metrics.rs
+++ b/lib/sequencer/src/execution/metrics.rs
@@ -1,4 +1,4 @@
-use crate::execution::block_executor::SealReason;
+use crate::execution::execute_block_in_vm::SealReason;
 use std::time::Duration;
 use vise::{Buckets, Gauge, Histogram, LabeledFamily, Metrics, Unit};
 use vise::{Counter, EncodeLabelValue};

--- a/lib/sequencer/src/execution/mod.rs
+++ b/lib/sequencer/src/execution/mod.rs
@@ -1,45 +1,43 @@
 use crate::config::SequencerConfig;
 use crate::execution::block_context_provider::BlockContextProvider;
-use crate::execution::block_executor::execute_block;
+use crate::execution::execute_block_in_vm::execute_block_in_vm;
 use crate::execution::metrics::{EXECUTION_METRICS, SequencerState};
 use crate::execution::utils::save_dump;
-use crate::model::blocks::BlockCommand;
-use alloy::consensus::Sealed;
+use crate::model::blocks::{BlockCommand, BlockCommandType};
 use anyhow::Context;
 use async_trait::async_trait;
-use tokio::sync::{mpsc::Sender, watch};
+use tokio::sync::{mpsc, watch};
 use tokio::time::Instant;
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_mempool::L2TransactionPool;
 use zksync_os_observability::{ComponentStateHandle, ComponentStateReporter};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
-use zksync_os_storage_api::{
-    ReadStateHistory, ReplayRecord, WriteReplay, WriteRepository, WriteState,
-};
+use zksync_os_storage_api::{OverlayBuffer, ReadStateHistory, ReplayRecord, WriteState};
 use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
 pub use fee_provider::{FeeConfig, FeeParams, FeeProvider};
 
+pub mod block_applier;
+pub mod block_canonizer;
 pub mod block_context_provider;
-pub mod block_executor;
+pub mod execute_block_in_vm;
 mod fee_provider;
 pub(crate) mod metrics;
 pub(crate) mod utils;
 pub mod vm_wrapper;
 
-/// Sequencer pipeline component
-/// Contains all the dependencies needed to run the sequencer
-pub struct Sequencer<Mempool, State, Replay, Repo>
+pub use block_applier::BlockApplier;
+pub use block_canonizer::{BlockCanonizer, ConsensusInterface, LoopbackConsensus};
+/// Executes blocks, while only updating local in-memory state (mempool, block context).
+/// Does not persist anything to disk.
+/// Does not track the node role - reacts on the ordered inbound commands instead (`Produce` vs `Replay`)
+pub struct BlockExecutor<Mempool, State>
 where
     Mempool: L2TransactionPool + Send + 'static,
     State: ReadStateHistory + WriteState + Clone + Send + 'static,
-    Replay: WriteReplay + Send + 'static,
-    Repo: WriteRepository + Send + 'static,
 {
     pub block_context_provider: BlockContextProvider<Mempool>,
     pub state: State,
-    pub replay: Replay,
-    pub repositories: Repo,
     pub config: SequencerConfig,
     /// Controls transaction acceptance state.
     /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
@@ -47,32 +45,35 @@ where
 }
 
 #[async_trait]
-impl<Mempool, State, Replay, Repo> PipelineComponent for Sequencer<Mempool, State, Replay, Repo>
+impl<Mempool, State> PipelineComponent for BlockExecutor<Mempool, State>
 where
     Mempool: L2TransactionPool + Send + 'static,
     State: ReadStateHistory + WriteState + Clone + Send + 'static,
-    Replay: WriteReplay + Send + 'static,
-    Repo: WriteRepository + Send + 'static,
 {
     type Input = BlockCommand;
-    type Output = (BlockOutput, ReplayRecord);
+    /// Outputs executed blocks. Passes along information whether it's a replayed or new block -
+    ///  new blocks need to be canonized by network (enforced by `BlockCanonizer`)
+    type Output = (BlockOutput, ReplayRecord, BlockCommandType);
 
-    const NAME: &'static str = "sequencer";
-    const OUTPUT_BUFFER_SIZE: usize = 5;
+    const NAME: &'static str = "block_executor";
+    const OUTPUT_BUFFER_SIZE: usize = 1;
 
     async fn run(
         mut self,
         mut input: PeekableReceiver<Self::Input>, // PeekableReceiver<BlockCommand>
-        output: Sender<Self::Output>,             // Sender<BlockOutput>
+        output: mpsc::Sender<Self::Output>, // Sender<(BlockOutput, ReplayRecord, BlockCommandType)>
     ) -> anyhow::Result<()> {
         let latency_tracker = ComponentStateReporter::global()
-            .handle_for("sequencer", SequencerState::WaitingForCommand);
+            .handle_for("block_executor", SequencerState::WaitingForCommand);
 
         // Track how many Produce commands we've processed (for `sequencer_max_blocks_to_produce` config)
         let mut produced_blocks_count = 0u64;
 
         // Only used for metrics/logs
         let mut last_processed_block_at: Option<Instant> = None;
+        // `BlockExecutor` doesn't persist/update state after block execution.
+        // Instead, we keep the diff in memory - and apply it on top of the last persisted block
+        let mut state_overlay_buffer = OverlayBuffer::default();
 
         loop {
             latency_tracker.enter_state(SequencerState::WaitingForCommand);
@@ -80,7 +81,6 @@ where
             let Some(cmd) = input.recv().await else {
                 anyhow::bail!("inbound channel closed");
             };
-            let block_number = cmd.block_number();
             let cmd_type = cmd.command_type();
 
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
@@ -96,14 +96,7 @@ where
                 .await;
                 produced_blocks_count += 1;
             }
-            let override_allowed = match &cmd {
-                BlockCommand::Rebuild(_) => true,
-                BlockCommand::Replay(_) if self.config.node_role.is_external() => true,
-                _ => false,
-            };
-
-            tracing::info!(
-                block_number,
+            tracing::debug!(
                 cmd = cmd.to_string(),
                 "starting command. Turning into PreparedCommand.."
             );
@@ -111,14 +104,21 @@ where
 
             let prepared_command = self.block_context_provider.prepare_command(cmd).await?;
 
-            tracing::debug!(
+            let block_number = prepared_command.block_context.block_number;
+            tracing::info!(
                 block_number,
-                starting_l1_priority_id = prepared_command.starting_l1_priority_id,
-                "Prepared command. Executing..",
+                "Prepared context for block {block_number}. expected_block_output_hash: {:?}, starting_l1_priority_id: {}, timestamp: {}, execution_version: {}. Executing..",
+                prepared_command.expected_block_output_hash,
+                prepared_command.starting_l1_priority_id,
+                prepared_command.block_context.timestamp,
+                prepared_command.block_context.execution_version,
             );
 
+            let exec_view = state_overlay_buffer
+                .sync_with_base_and_build_view_for_block(&self.state, block_number)?;
+
             let (block_output, replay_record, purged_txs) =
-                execute_block(prepared_command, self.state.clone(), &latency_tracker)
+                execute_block_in_vm(prepared_command, exec_view, &latency_tracker)
                     .await
                     .map_err(|dump| {
                         let error = anyhow::anyhow!("{}", dump.error);
@@ -139,53 +139,25 @@ where
             }
             last_processed_block_at = Some(Instant::now());
 
-            tracing::debug!(block_number, "Executed. Adding to block replay storage...");
-            latency_tracker.enter_state(SequencerState::AddingToReplayStorage);
-
-            self.replay.write(
-                Sealed::new_unchecked(replay_record.clone(), block_output.header.hash()),
-                override_allowed,
-            );
-
-            tracing::debug!(block_number, "Added to replay storage. Adding to state...");
-            latency_tracker.enter_state(SequencerState::AddingToState);
-
-            // Although, the plan is to always allow overrides for each storage except for replay,
-            // for FullDiffs state backend it requires iterating over each storage write which is costly.
-            // Therefore, we pass the override_allowed flag here. If it's set to true then override happens, otherwise,
-            // changes are validated against existing storage.
-            self.state.add_block_result(
-                block_number,
-                block_output.storage_writes.clone(),
-                block_output
-                    .published_preimages
-                    .iter()
-                    .map(|(k, v)| (*k, v)),
-                override_allowed,
-            )?;
-
-            tracing::debug!(block_number, "Added to state. Adding to repos...");
-            latency_tracker.enter_state(SequencerState::AddingToRepos);
-
-            // todo: do not call if api is not enabled.
-            self.repositories
-                .populate(block_output.clone(), replay_record.transactions.clone())
-                .await?;
-
-            tracing::debug!(block_number, "Added to repos. Updating mempools...",);
+            tracing::debug!(block_number, "Executed. Updating mempools...");
             latency_tracker.enter_state(SequencerState::UpdatingMempool);
 
-            // TODO: would updating mempool in parallel with state make sense?
             self.block_context_provider
                 .on_canonical_state_change(&block_output, &replay_record, cmd_type)
                 .await;
             let purged_txs_hashes = purged_txs.into_iter().map(|(hash, _)| hash).collect();
             self.block_context_provider.remove_txs(purged_txs_hashes);
 
+            state_overlay_buffer.add_block(
+                block_number,
+                block_output.storage_writes.clone(),
+                block_output.published_preimages.clone(),
+            )?;
+
             tracing::debug!(
                 block_number,
                 time_since_last_block = ?time_since_last_block,
-                "Block processed in sequencer! Sending downstream..."
+                "Block processed in `BlockExecutor`. Sending downstream..."
             );
             EXECUTION_METRICS.block_number.set(block_number);
             EXECUTION_METRICS
@@ -194,7 +166,7 @@ where
 
             latency_tracker.enter_state(SequencerState::WaitingSend);
             if output
-                .send((block_output.clone(), replay_record.clone()))
+                .send((block_output.clone(), replay_record.clone(), cmd_type))
                 .await
                 .is_err()
             {

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -18,8 +18,6 @@ pub enum BlockCommand {
     /// Replay a block from block replay storage.
     Replay(Box<ReplayRecord>),
     /// Produce a new block from the mempool.
-    /// Second argument - local seal criteria - target block time and max transaction number
-    /// (Avoid container struct for now)
     Produce(ProduceCommand),
     /// Rebuild an existing block.
     Rebuild(Box<RebuildCommand>),
@@ -35,11 +33,7 @@ pub enum BlockCommandType {
 
 /// Command to produce a new block.
 #[derive(Clone, Debug)]
-pub struct ProduceCommand {
-    pub block_number: u64,
-    pub block_time: Duration,
-    pub max_transactions_in_block: usize,
-}
+pub struct ProduceCommand;
 
 /// Command to rebuild existing block.
 #[derive(Clone, Debug)]
@@ -49,14 +43,6 @@ pub struct RebuildCommand {
 }
 
 impl BlockCommand {
-    pub fn block_number(&self) -> u64 {
-        match self {
-            BlockCommand::Replay(record) => record.block_context.block_number,
-            BlockCommand::Produce(command) => command.block_number,
-            BlockCommand::Rebuild(command) => command.replay_record.block_context.block_number,
-        }
-    }
-
     pub fn command_type(&self) -> BlockCommandType {
         match self {
             BlockCommand::Replay(_) => BlockCommandType::Replay,
@@ -76,7 +62,7 @@ impl Display for BlockCommand {
                 record.transactions.len(),
                 record.starting_l1_priority_id,
             ),
-            BlockCommand::Produce(command) => write!(f, "Produce block: {command:?}"),
+            BlockCommand::Produce(_) => write!(f, "Produce block"),
             BlockCommand::Rebuild(command) => write!(
                 f,
                 "Rebuild block {} ({} txs);",

--- a/lib/state_full_diffs/src/storage.rs
+++ b/lib/state_full_diffs/src/storage.rs
@@ -72,9 +72,8 @@ impl FullDiffsStorage {
 
         if override_allowed && block_number <= latest_block {
             tracing::info!(
-                "Rolling back state for block range [{}; {}]",
-                block_number,
-                latest_block
+                "Persisting block {block_number}. Latest block in storage: {latest_block} \
+                Rolling back state for block range {block_number}..={latest_block}",
             );
             let mut batch = self.rocks.new_write_batch();
             // Iterate through all keys and delete those with block_number >= the given block_number

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -25,3 +25,6 @@ pub use state::{ReadStateHistory, StateError, StateResult, ViewState, WriteState
 
 pub mod state_override_view;
 pub use state_override_view::OverriddenStateView;
+
+mod overlay_buffer;
+pub use overlay_buffer::{BlockOverlay, OverlayBuffer};

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -1,0 +1,131 @@
+use std::collections::{BTreeMap, HashMap};
+
+use alloy::primitives::B256;
+use anyhow::bail;
+use zksync_os_interface::types::StorageWrite;
+
+use crate::{OverriddenStateView, ReadStateHistory, ViewState};
+
+#[derive(Debug, Clone)]
+pub struct BlockOverlay {
+    pub storage_writes: Vec<StorageWrite>,
+    pub preimages: Vec<(B256, Vec<u8>)>,
+}
+
+#[derive(Debug, Default)]
+pub struct OverlayBuffer {
+    overlays: BTreeMap<u64, BlockOverlay>,
+}
+
+impl OverlayBuffer {
+    /// Drops records for blocks that already persist in `base`;
+    /// Builds a state view to accommodate for the execution of `block_number_to_execute` block.
+    /// Note: to execute block N, we need state (+ overlays) to reach N - 1.
+    pub fn sync_with_base_and_build_view_for_block<'a, S>(
+        &'a mut self,
+        base: &'a S,
+        block_number_to_execute: u64,
+    ) -> anyhow::Result<OverriddenStateView<impl ViewState + 'a>>
+    where
+        S: ReadStateHistory + 'a,
+    {
+        let base_latest = *base.block_range_available().end();
+        tracing::debug!(
+            "before Synced overlay buffer with base (base_latest={base_latest}, overlays_len={}, overlays_range={:?}..={:?}). \
+            Preparing storage view to execute block {block_number_to_execute}.",
+            self.overlays.len(),
+            self.overlays.keys().next().copied(),
+            self.overlays.keys().next_back().copied(),
+        );
+        self.purge_already_persisted_blocks(base_latest)?;
+        let first_overlay = self.overlays.keys().next().copied();
+        let last_overlay = self.overlays.keys().next_back().copied();
+        tracing::debug!(
+            "Synced overlay buffer with base (base_latest={base_latest}, overlays_len={}, overlays_range={first_overlay:?}..={last_overlay:?}). \
+            Preparing storage view to execute block {block_number_to_execute}.",
+            self.overlays.len(),
+        );
+        if base_latest >= block_number_to_execute - 1 {
+            let base_view = base
+                .state_view_at(block_number_to_execute - 1)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            return Ok(OverriddenStateView::new(
+                base_view,
+                HashMap::new(),
+                HashMap::new(),
+            ));
+        }
+
+        let base_view = base
+            .state_view_at(base_latest)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        if first_overlay != Some(base_latest + 1)
+            || last_overlay != Some(block_number_to_execute - 1)
+        {
+            // This assert is defensive - we could build overlay maps from a subset of overlay records,
+            // but this behaviour is unexpected as we execute blocks in strict accession.
+            bail!(
+                "Unexpected state of `overlay_buffer` when preparing state view for block {} from base_latest {}; overlays_range={:?}..={:?}",
+                block_number_to_execute,
+                base_latest,
+                first_overlay,
+                last_overlay
+            );
+        }
+        let (overrides, preimages) = self.build_maps();
+        Ok(OverriddenStateView::new(base_view, overrides, preimages))
+    }
+
+    pub fn add_block(
+        &mut self,
+        block_number: u64,
+        storage_writes: Vec<StorageWrite>,
+        preimages: Vec<(B256, Vec<u8>)>,
+    ) -> anyhow::Result<()> {
+        if let Some(&last) = self.overlays.keys().next_back()
+            && block_number != last + 1
+        {
+            bail!(
+                "Overlay head must be contiguous: got {}, expected {}",
+                block_number,
+                last + 1
+            );
+        }
+        self.overlays.insert(
+            block_number,
+            BlockOverlay {
+                storage_writes,
+                preimages,
+            },
+        );
+        Ok(())
+    }
+
+    fn purge_already_persisted_blocks(&mut self, base_latest: u64) -> anyhow::Result<()> {
+        if let Some(&last) = self.overlays.keys().next() && base_latest + 1 < last {
+            bail!(
+                "Cannot clean tail: base_latest {} is behind overlay tail {}",
+                base_latest,
+                last
+            );
+        }
+        self.overlays.retain(|block, _| *block > base_latest);
+        Ok(())
+    }
+
+    fn build_maps(&self) -> (HashMap<B256, B256>, HashMap<B256, Vec<u8>>) {
+        let mut overrides: HashMap<B256, B256> = HashMap::new();
+        let mut preimages: HashMap<B256, Vec<u8>> = HashMap::new();
+
+        for (_, overlay) in self.overlays.iter() {
+            for write in &overlay.storage_writes {
+                overrides.insert(write.key, write.value);
+            }
+            for (hash, bytes) in &overlay.preimages {
+                preimages.insert(*hash, bytes.clone());
+            }
+        }
+
+        (overrides, preimages)
+    }
+}

--- a/lib/storage_api/src/replay.rs
+++ b/lib/storage_api/src/replay.rs
@@ -1,12 +1,14 @@
 use crate::ReplayRecord;
 use alloy::primitives::{BlockNumber, Sealed};
 use futures::Stream;
+use futures::future::BoxFuture;
 use futures::stream::{BoxStream, StreamExt};
 use pin_project::pin_project;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::task::Poll;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tokio::time::{Instant, Sleep};
 use zksync_os_interface::types::BlockContext;
 
@@ -87,6 +89,37 @@ pub trait ReadReplayExt: ReadReplay {
             }
         });
         Box::pin(stream)
+    }
+
+    /// Forwards replay records in range [`start`, `end`] to the provided channel after mapping them.
+    fn forward_range_with<'a, T, F>(
+        &'a self,
+        start: u64,
+        end: u64,
+        output: mpsc::Sender<T>,
+        mut f: F,
+    ) -> BoxFuture<'a, anyhow::Result<()>>
+    where
+        T: Send + 'static,
+        F: FnMut(ReplayRecord) -> T + Send + 'a,
+        Self: Sized + 'a,
+    {
+        Box::pin(async move {
+            let latest = self.latest_record();
+            assert!(
+                latest >= end,
+                "Requested range end {end} exceeds latest record {latest}"
+            );
+            for block_num in start..=end {
+                if let Some(record) = self.get_replay_record(block_num)
+                    && output.send(f(record)).await.is_err()
+                {
+                    tracing::warn!("Replay output channel closed, stopping replay forwarder");
+                    break;
+                }
+            }
+            Ok(())
+        })
     }
 
     /// Streams replay records with block_number ≥ `start`, in ascending block order.

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -23,7 +23,19 @@ pub struct OverriddenStateView<V: ViewState> {
 }
 
 impl<V: ViewState> OverriddenStateView<V> {
-    pub fn new(inner: V, state_overrides: StateOverride) -> Self {
+    pub fn new(
+        inner: V,
+        overrides: HashMap<B256, B256>,
+        preimage_overrides: HashMap<B256, Vec<u8>>,
+    ) -> Self {
+        Self {
+            inner,
+            overrides,
+            preimage_overrides,
+        }
+    }
+
+    pub fn with_state_overrides(inner: V, state_overrides: StateOverride) -> Self {
         let (overrides, preimage_overrides) = build_state_override_maps(&inner, state_overrides);
 
         Self {

--- a/lib/types/src/node.rs
+++ b/lib/types/src/node.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// A node's role in the network.
+/// todo: rename to Leader/Replica.
+/// Use the term "External node" only for nodes that don't participate in consensus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeRole {
     #[serde(rename = "main")]

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -98,7 +98,7 @@ impl PipelineComponent for Batcher {
             }
             tracing::debug!(
                 block_number = next_block_number,
-                "skipping already executed block"
+                "skipping already executed on L1 block {next_block_number} (first unexecuted on L1 block is {first_expected_block})"
             );
             input
                 .recv()

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,21 +1,24 @@
 use async_trait::async_trait;
-use futures::StreamExt;
-use futures::stream::BoxStream;
 use std::collections::HashSet;
-use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
 use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
 use zksync_os_storage_api::{ReadReplay, ReadReplayExt, ReplayRecord};
 
-/// Main node command source
+/// Command source for Main Node.
+/// Replays local WAL starting from `starting_block` and then produces new blocks.
 #[derive(Debug)]
 pub struct MainNodeCommandSource<Replay> {
+    /// Local block replays (aka `WAL`).
     pub block_replay_storage: Replay,
+    /// Block number to start replaying from.
     pub starting_block: u64,
+    /// If set, the node will start with proposing block rebuilds for already sealed blocks
+    /// This is essentially a block rollback.
     pub rebuild_options: Option<RebuildOptions>,
-    pub block_time: Duration,
-    pub max_transactions_in_block: usize,
+    /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
+    pub replays_to_execute: mpsc::Receiver<ReplayRecord>,
 }
 
 #[derive(Debug)]
@@ -24,7 +27,7 @@ pub struct RebuildOptions {
     pub blocks_to_empty: HashSet<u64>,
 }
 
-/// External node command source
+/// External node command source.
 #[derive(Debug)]
 pub struct ExternalNodeCommandSource {
     pub up_to_block: Option<u64>,
@@ -37,31 +40,120 @@ impl<Replay: ReadReplay> PipelineComponent for MainNodeCommandSource<Replay> {
     type Input = ();
     type Output = BlockCommand;
 
-    const NAME: &'static str = "command_source";
-    const OUTPUT_BUFFER_SIZE: usize = 5;
+    const NAME: &'static str = "node_command_source";
+    const OUTPUT_BUFFER_SIZE: usize = 1;
 
     async fn run(
-        self,
+        mut self,
         _input: PeekableReceiver<()>,
         output: mpsc::Sender<BlockCommand>,
     ) -> anyhow::Result<()> {
-        // TODO: no need for a Stream in `command_source` - just send to channel right away instead
-        let mut stream = command_source(
-            &self.block_replay_storage,
+        let last_block_in_wal = self.block_replay_storage.latest_record();
+
+        let replay_until = if let Some(rebuild_options) = &self.rebuild_options {
+            assert!(
+                rebuild_options.rebuild_from_block >= self.starting_block,
+                "rebuild_from_block must be >= starting_block, got {} < {}",
+                rebuild_options.rebuild_from_block,
+                self.starting_block
+            );
+            assert!(
+                rebuild_options.rebuild_from_block <= last_block_in_wal,
+                "rebuild_from_block must be <= last_block_in_wal, got {} > {}",
+                rebuild_options.rebuild_from_block,
+                last_block_in_wal
+            );
+            rebuild_options.rebuild_from_block - 1
+        } else {
+            last_block_in_wal
+        };
+
+        tracing::info!(
+            "Replaying WAL blocks from {} until {}.",
             self.starting_block,
-            self.block_time,
-            self.max_transactions_in_block,
-            self.rebuild_options,
+            replay_until
         );
 
-        while let Some(command) = stream.next().await {
-            tracing::debug!(?command, "Sending block command");
+        self.block_replay_storage
+            .forward_range_with(
+                self.starting_block,
+                replay_until,
+                output.clone(),
+                |record| BlockCommand::Replay(Box::new(record)),
+            )
+            .await?;
+
+        if let Some(rebuild_options) = &self.rebuild_options {
+            self.send_block_rebuilds(rebuild_options, last_block_in_wal, &output)
+                .await?;
+        }
+
+        tracing::info!("All WAL blocks replayed. Starting main loop.");
+
+        self.run_loop(output).await
+    }
+}
+
+impl<Replay: ReadReplay> MainNodeCommandSource<Replay> {
+    /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
+    /// Produces `Produce` commands and errors if any replay records are received.
+    /// When consensus is integrated, this method will switch the mode from Replica to Leader.
+    async fn run_loop(mut self, output: mpsc::Sender<BlockCommand>) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                maybe_record = self.replays_to_execute.recv() => {
+                    let Some(record) = maybe_record else {
+                        anyhow::bail!("inbound replay channel closed");
+                    };
+                    anyhow::bail!(
+                        "Leader node received block {} produced by someone else!",
+                        record.block_context.block_number,
+                    );
+                }
+                send_res = output.send(BlockCommand::Produce(ProduceCommand)) => {
+                    if send_res.is_err() {
+                        tracing::warn!("Command output channel closed, stopping source");
+                        break;
+                    }
+                }
+                // todo: once consensus is integrated, add an arm here that switches the mode from Replica to Leader
+            }
+        }
+
+        anyhow::bail!("Execution loop in MainNodeCommandSource ended unexpectedly");
+    }
+
+    async fn send_block_rebuilds(
+        &self,
+        rebuild_options: &RebuildOptions,
+        last_block_in_wal: u64,
+        output: &mpsc::Sender<BlockCommand>,
+    ) -> anyhow::Result<()> {
+        tracing::warn!(
+            "Starting block rebuilds! {rebuild_options:?}, last_block_in_wal: {last_block_in_wal}"
+        );
+        for block_number in rebuild_options.rebuild_from_block..=last_block_in_wal {
+            let replay_record = self
+                .block_replay_storage
+                .get_replay_record(block_number)
+                .expect("Replay record must exist for rebuild");
+            let make_empty = rebuild_options.blocks_to_empty.contains(&block_number);
+            tracing::warn!(
+                "Processing block rebuild {block_number} with original block_output_hash {:?}, \
+                 timestamp {} ({} seconds ago), make_empty: {make_empty}.",
+                replay_record.block_output_hash,
+                replay_record.block_context.timestamp,
+                (millis_since_epoch() / 1000) as u64 - replay_record.block_context.timestamp
+            );
+            let command = BlockCommand::Rebuild(Box::new(RebuildCommand {
+                replay_record,
+                make_empty,
+            }));
             if output.send(command).await.is_err() {
                 tracing::warn!("Command output channel closed, stopping source");
                 break;
             }
         }
-
         Ok(())
     }
 }
@@ -80,11 +172,12 @@ impl PipelineComponent for ExternalNodeCommandSource {
         output: mpsc::Sender<BlockCommand>,
     ) -> anyhow::Result<()> {
         while let Some(record) = self.replays_for_sequencer.recv().await {
+            let block_number = record.block_context.block_number;
             let command = BlockCommand::Replay(Box::new(record));
             tracing::debug!(?command, "Received block command from main node");
 
             if let Some(up_to_block) = self.up_to_block
-                && command.block_number() > up_to_block
+                && block_number > up_to_block
             {
                 tracing::info!(
                     up_to_block,
@@ -102,79 +195,4 @@ impl PipelineComponent for ExternalNodeCommandSource {
 
         Ok(())
     }
-}
-
-fn command_source(
-    block_replay_wal: &impl ReadReplay,
-    block_to_start: u64,
-    block_time: Duration,
-    max_transactions_in_block: usize,
-    rebuild_options: Option<RebuildOptions>,
-) -> BoxStream<BlockCommand> {
-    let last_block_in_wal = block_replay_wal.latest_record();
-    tracing::info!(
-        last_block_in_wal,
-        block_to_start,
-        ?rebuild_options,
-        "starting command source"
-    );
-
-    let (replay_end, rebuild_stream): (u64, BoxStream<BlockCommand>) =
-        if let Some(rebuild_options) = rebuild_options {
-            assert!(
-                rebuild_options.rebuild_from_block >= block_to_start,
-                "rebuild_from_block must be >= block_to_start, got {} < {}",
-                rebuild_options.rebuild_from_block,
-                block_to_start
-            );
-
-            assert!(
-                rebuild_options.rebuild_from_block <= last_block_in_wal,
-                "rebuild_from_block must be <= last_block_in_wal, got {} > {}",
-                rebuild_options.rebuild_from_block,
-                last_block_in_wal
-            );
-
-            let command_iterator =
-                (rebuild_options.rebuild_from_block..=last_block_in_wal).map(move |block_number| {
-                    let replay_record = block_replay_wal
-                        .get_replay_record(block_number)
-                        .expect("Replay record must exist for rebuild");
-                    let make_empty = rebuild_options.blocks_to_empty.contains(&block_number);
-                    BlockCommand::Rebuild(Box::new(RebuildCommand {
-                        replay_record,
-                        make_empty,
-                    }))
-                });
-            (
-                rebuild_options.rebuild_from_block - 1,
-                futures::stream::iter(command_iterator).boxed(),
-            )
-        } else {
-            (last_block_in_wal, futures::stream::empty().boxed())
-        };
-
-    // Stream of replay commands from WAL
-    // Guaranteed to stream exactly `[block_to_start; replay_end]`.
-    let replay_wal_stream = block_replay_wal
-        .stream(block_to_start, replay_end)
-        .map(|record| BlockCommand::Replay(Box::new(record)));
-
-    let produce_stream: BoxStream<BlockCommand> =
-        futures::stream::unfold(last_block_in_wal + 1, move |block_number| async move {
-            Some((
-                BlockCommand::Produce(ProduceCommand {
-                    block_number,
-                    block_time,
-                    max_transactions_in_block,
-                }),
-                block_number + 1,
-            ))
-        })
-        .boxed();
-    // Combined source: run WAL replay first, then rebuild (normally empty), then produce blocks from mempool
-    let stream = replay_wal_stream
-        .chain(rebuild_stream)
-        .chain(produce_stream);
-    stream.boxed()
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -84,7 +84,9 @@ use zksync_os_revm_consistency_checker::node::RevmConsistencyChecker;
 use zksync_os_rpc::{RpcStorage, run_jsonrpsee_server};
 use zksync_os_rpc_api::eth::EthApiClient;
 use zksync_os_sequencer::execution::block_context_provider::BlockContextProvider;
-use zksync_os_sequencer::execution::{FeeParams, FeeProvider, Sequencer};
+use zksync_os_sequencer::execution::{
+    BlockApplier, BlockCanonizer, BlockExecutor, FeeParams, FeeProvider, LoopbackConsensus,
+};
 use zksync_os_status_server::run_status_server;
 use zksync_os_storage::db::{BlockReplayStorage, ExecutedBatchStorage};
 use zksync_os_storage::in_memory::Finality;
@@ -162,7 +164,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 .expect("Missing `main_node_rpc_url` in external node config");
             load_remote_config(&main_node_rpc_url, &config.genesis_config)
                 .await
-                .unwrap()
+                .expect("Cannot load remote config from Main Node")
         };
     let fee_collector_address: &'static str = config
         .sequencer_config
@@ -608,6 +610,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         l2_mempool.clone(),
         block_hashes_for_next_block,
         previous_block_timestamp,
+        starting_block,
+        config.sequencer_config.block_time,
+        config.sequencer_config.max_transactions_in_block,
         chain_id,
         config.sequencer_config.block_gas_limit,
         config.sequencer_config.block_pubdata_limit_bytes,
@@ -718,7 +723,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             tree_db,
             finality_storage.clone(),
             chain_id,
-            stop_receiver.clone(),
             tx_acceptance_state_sender,
             sidecar_sender,
             committed_batch_provider.clone(),
@@ -741,6 +745,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             stop_receiver.clone(),
             tx_acceptance_state_sender,
             chain_id,
+            starting_block,
         )
         .await;
     };
@@ -805,7 +810,6 @@ async fn run_main_node_pipeline(
     tree: MerkleTree<RocksDBWrapper>,
     finality: impl ReadFinality + Clone,
     chain_id: u64,
-    _stop_receiver: watch::Receiver<bool>,
     tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     sidecar_sender: tokio::sync::mpsc::Sender<BlobTransactionSidecar>,
     committed_batch_provider: CommittedBatchProvider,
@@ -865,25 +869,38 @@ async fn run_main_node_pipeline(
             .join(INTERNAL_CONFIG_FILE_NAME),
     );
 
+    let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::channel(128);
+    let (consensus_sender, consensus_replays) = tokio::sync::mpsc::channel(128);
+
     Pipeline::new()
         .pipe(MainNodeCommandSource {
             block_replay_storage: block_replay_storage.clone(),
             starting_block,
-            block_time: config.sequencer_config.block_time,
-            max_transactions_in_block: config.sequencer_config.max_transactions_in_block,
             rebuild_options: config
                 .sequencer_config
                 .block_rebuild
                 .clone()
                 .map(Into::into),
+            replays_to_execute,
         })
-        .pipe(Sequencer {
+        .pipe(BlockExecutor {
             block_context_provider,
+            state: state.clone(),
+            config: config.into(),
+            tx_acceptance_state_sender,
+        })
+        .pipe(BlockCanonizer {
+            consensus: LoopbackConsensus {
+                sender: consensus_sender,
+                receiver: consensus_replays,
+            },
+            canonized_blocks_for_execution: replays_to_execute_sender,
+        })
+        .pipe(BlockApplier {
             state: state.clone(),
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
         })
         .pipe_opt(
             config
@@ -989,6 +1006,7 @@ async fn run_en_pipeline(
     stop_receiver: watch::Receiver<bool>,
     tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     chain_id: u64,
+    _starting_block: u64,
 ) {
     let internal_config_manager = init_and_report_internal_config_manager(
         config
@@ -999,17 +1017,21 @@ async fn run_en_pipeline(
 
     Pipeline::new()
         .pipe(ExternalNodeCommandSource {
-            up_to_block: config.sequencer_config.en_sync_up_to_block,
             replays_for_sequencer,
+            up_to_block: config.sequencer_config.en_sync_up_to_block,
             stop_receiver: stop_receiver.clone(),
         })
-        .pipe(Sequencer {
+        .pipe(BlockExecutor {
             block_context_provider,
+            state: state.clone(),
+            config: config.into(),
+            tx_acceptance_state_sender,
+        })
+        .pipe(BlockApplier {
             state: state.clone(),
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
         })
         .pipe_opt(
             config


### PR DESCRIPTION
This prepares the node for the consensus integration. 
There are no changes to node or network behavior.  
Main Node wiring is modified:
* Split Sequencer into `BlockExecutor` (executes, updates mempools) and `BlockApplier` (saves result to the DB)
* Introduce BlockCanonizer between them:
```
BlockExecutor ~> BlockCanonizer ~> BlockApplier
```
`BlockCanonizer` will wait for the proposed blocks to be canonized by consensus before advancing them in the pipeline - this behavior is stubbed for now. 
* Modify the `MainNodeCommandSource` so that it can replay blocks recieved from consensus. This behaviour is not currently used (as we don't have consensus yet - ENs are still using the `ENCommandSource`)

