### PR TITLE
fix: get rid of broadcast in mempool

### DIFF
--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -82,7 +82,7 @@ impl<T: MigrationProcessor> ProcessL1Event for GatewayMigrationWatcher<T> {
     async fn process_event(&mut self, tx: T::Event, _log: Log) -> Result<(), L1WatcherError> {
         let envelope = SystemTxEnvelope::set_sl_chain_id(T::chain_id(tx));
 
-        self.sl_chain_id_subpool.insert(envelope);
+        self.sl_chain_id_subpool.insert(envelope).await;
         Ok(())
     }
 }

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -83,10 +83,12 @@ impl ProcessL1Event for InteropWatcher {
             sides: vec![tx.chainRoot],
         };
 
-        self.interop_roots_subpool.add_root(IndexedInteropRoot {
-            log_index: current_log_index,
-            root: interop_root,
-        });
+        self.interop_roots_subpool
+            .add_root(IndexedInteropRoot {
+                log_index: current_log_index,
+                root: interop_root,
+            })
+            .await;
 
         Ok(())
     }

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -91,7 +91,7 @@ impl ProcessL1Event for L1TxWatcher {
                 hash = ?tx.hash(),
                 "sending new priority transaction for processing",
             );
-            self.l1_subpool.insert(Arc::new(tx));
+            self.l1_subpool.insert(Arc::new(tx)).await;
         }
         Ok(())
     }

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -327,7 +327,7 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
         );
 
         self.current_protocol_version = upgrade_info.protocol_version().clone();
-        self.upgrade_subpool.insert(upgrade_info);
+        self.upgrade_subpool.insert(upgrade_info).await;
 
         Ok(())
     }

--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -57,17 +57,19 @@ impl<T: L2Subpool> Pool<T> {
         &'a mut self,
         next_interop_tx_allowed_after: Instant,
     ) -> Option<StreamOutcome<'a>> {
-        let mut upgrade_info_stream = self.upgrade_subpool.upgrade_info_stream();
+        let mut upgrade_info_stream = self.upgrade_subpool.upgrade_info_stream().await;
 
         let mut interop_stream = tokio_stream::StreamExt::peekable(
             self.interop_roots_subpool
-                .interop_transactions_with_delay(next_interop_tx_allowed_after),
+                .interop_transactions_with_delay(next_interop_tx_allowed_after)
+                .await,
         );
 
-        let mut sl_chain_id_stream =
-            tokio_stream::StreamExt::peekable(self.sl_chain_id_subpool.best_transactions_stream());
+        let mut sl_chain_id_stream = tokio_stream::StreamExt::peekable(
+            self.sl_chain_id_subpool.best_transactions_stream().await,
+        );
 
-        let l1_stream = self.l1_subpool.best_transactions_stream();
+        let l1_stream = self.l1_subpool.best_transactions_stream().await;
         let l2_stream = self.l2_subpool.best_transactions_stream();
         let l2_marker = l2_stream.marker();
         fn prio_left(_: &mut ()) -> PollNext {
@@ -183,7 +185,8 @@ impl<T: L2Subpool> Pool<T> {
             .await;
         let last_interop_log_index = self
             .interop_roots_subpool
-            .on_canonical_state_change(interop_txs);
+            .on_canonical_state_change(interop_txs)
+            .await;
         self.sl_chain_id_subpool
             .on_canonical_state_change(sl_chain_id_txs)
             .await;

--- a/lib/mempool/src/subpools/interop_roots.rs
+++ b/lib/mempool/src/subpools/interop_roots.rs
@@ -2,12 +2,12 @@ use futures::{Stream, StreamExt, ready};
 use std::{
     collections::VecDeque,
     pin::Pin,
-    sync::{Arc, RwLock},
+    sync::Arc,
     task::{Context, Poll},
 };
 use tokio::time::Instant;
 use tokio::{
-    sync::mpsc,
+    sync::{RwLock, mpsc},
     time::{Sleep, sleep_until},
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -36,25 +36,25 @@ impl InteropRootsSubpool {
 }
 
 impl InteropRootsSubpool {
-    pub fn interop_transactions_with_delay(
+    pub async fn interop_transactions_with_delay(
         &self,
         next_tx_allowed_after: Instant,
     ) -> InteropRootsTransactionsStream {
         self.inner
             .write()
-            .unwrap()
+            .await
             .interop_transactions_with_delay(next_tx_allowed_after, self.channel_size)
     }
 
-    pub fn add_root(&mut self, root: IndexedInteropRoot) {
-        self.inner.write().unwrap().add_root(root);
+    pub async fn add_root(&mut self, root: IndexedInteropRoot) {
+        self.inner.write().await.add_root(root).await;
     }
 
-    pub fn on_canonical_state_change(
+    pub async fn on_canonical_state_change(
         &self,
         txs: Vec<&SystemTxEnvelope>,
     ) -> Option<InteropRootsLogIndex> {
-        self.inner.write().unwrap().on_canonical_state_change(txs)
+        self.inner.write().await.on_canonical_state_change(txs)
     }
 }
 
@@ -144,10 +144,10 @@ impl Inner {
         }
     }
 
-    fn add_root(&mut self, root: IndexedInteropRoot) {
+    async fn add_root(&mut self, root: IndexedInteropRoot) {
         if let Some(sender) = &self.sender {
             // If the receiver has been dropped, we should stop sending transactions and clear the sender to avoid unnecessary work.
-            if sender.blocking_send(root.root.clone()).is_err() {
+            if sender.send(root.root.clone()).await.is_err() {
                 self.sender.take();
             }
         }

--- a/lib/mempool/src/subpools/l1.rs
+++ b/lib/mempool/src/subpools/l1.rs
@@ -1,9 +1,9 @@
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::sync::{Notify, mpsc};
+use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_types::{L1PriorityEnvelope, L1TxSerialId, ZkTransaction};
 
@@ -34,9 +34,9 @@ impl L1Subpool {
         }
     }
 
-    pub fn best_transactions_stream(&self) -> L1TransactionsStream {
+    pub async fn best_transactions_stream(&self) -> L1TransactionsStream {
         let (sender, receiver) = mpsc::channel(self.channel_size);
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write().await;
         inner.sender = Some(sender);
         L1TransactionsStream {
             receiver: ReceiverStream::new(receiver),
@@ -44,11 +44,11 @@ impl L1Subpool {
         }
     }
 
-    pub fn insert(&mut self, tx: Arc<L1PriorityEnvelope>) {
-        let mut inner = self.inner.write().unwrap();
+    pub async fn insert(&mut self, tx: Arc<L1PriorityEnvelope>) {
+        let mut inner = self.inner.write().await;
         if let Some(sender) = &inner.sender {
             // If the receiver has been dropped, we should stop sending transactions and clear the sender to avoid unnecessary work.
-            if sender.blocking_send(tx.clone()).is_err() {
+            if sender.send(tx.clone()).await.is_err() {
                 inner.sender.take();
             }
         }
@@ -60,7 +60,7 @@ impl L1Subpool {
         loop {
             let notified = self.notify.notified();
             {
-                let mut inner = self.inner.write().unwrap();
+                let mut inner = self.inner.write().await;
                 if let Some(pending_tx) = inner.pending_txs.pop_back() {
                     return pending_tx;
                 }

--- a/lib/mempool/src/subpools/sl_chain_id.rs
+++ b/lib/mempool/src/subpools/sl_chain_id.rs
@@ -1,9 +1,9 @@
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::task::{Context, Poll, ready};
-use tokio::sync::{Notify, mpsc};
+use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_types::{SystemTxEnvelope, SystemTxType, ZkTransaction};
 
@@ -34,10 +34,10 @@ impl Default for SlChainIdSubpool {
 }
 
 impl SlChainIdSubpool {
-    pub fn best_transactions_stream(&self) -> SlChainIdTransactionsStream {
+    pub async fn best_transactions_stream(&self) -> SlChainIdTransactionsStream {
         // `1` as buffer is enough because `setSLChainId` transactions are rare.
         let (sender, receiver) = mpsc::channel(1);
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write().await;
         inner.sender = Some(sender);
         let state = if let Some(pending_tx) = inner.pending_txs.back() {
             StreamState::Pending(pending_tx.clone())
@@ -47,17 +47,17 @@ impl SlChainIdSubpool {
         SlChainIdTransactionsStream { state }
     }
 
-    pub fn insert(&self, tx: SystemTxEnvelope) {
+    pub async fn insert(&self, tx: SystemTxEnvelope) {
         assert_eq!(
             tx.system_subtype(),
             &SystemTxType::SetSLChainId,
             "tried to insert unrelated system tx ({:?}) into `SlChainIdSubpool`",
             tx.system_subtype()
         );
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write().await;
         if let Some(sender) = &inner.sender {
             // If the receiver has been dropped, we should stop sending transactions and clear the sender to avoid unnecessary work.
-            if sender.blocking_send(tx.clone()).is_err() {
+            if sender.send(tx.clone()).await.is_err() {
                 inner.sender.take();
             }
         }
@@ -69,7 +69,7 @@ impl SlChainIdSubpool {
         loop {
             let notified = self.notify.notified();
             {
-                let mut inner = self.inner.write().unwrap();
+                let mut inner = self.inner.write().await;
                 if let Some(pending_tx) = inner.pending_txs.pop_back() {
                     return pending_tx;
                 }

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -1,9 +1,9 @@
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::task::{Context, Poll, ready};
-use tokio::sync::{Notify, mpsc};
+use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_types::{L1UpgradeEnvelope, ProtocolSemanticVersion, UpgradeInfo, ZkTransaction};
 
@@ -36,10 +36,10 @@ impl UpgradeSubpool {
         }
     }
 
-    pub fn upgrade_info_stream(&self) -> UpgradeInfoStream {
+    pub async fn upgrade_info_stream(&self) -> UpgradeInfoStream {
         // `1` as buffer is enough because upgrade transactions are rare.
         let (sender, receiver) = mpsc::channel(1);
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.inner.write().await;
         inner.sender = Some(sender);
         let state = if let Some(pending_tx) = inner.pending_upgrades.back() {
             StreamState::Pending(pending_tx.clone())
@@ -49,11 +49,11 @@ impl UpgradeSubpool {
         UpgradeInfoStream { state }
     }
 
-    pub fn insert(&self, upgrade: UpgradeInfo) {
-        let mut inner = self.inner.write().unwrap();
+    pub async fn insert(&self, upgrade: UpgradeInfo) {
+        let mut inner = self.inner.write().await;
         if let Some(sender) = &inner.sender {
             // If the receiver has been dropped, we should stop sending transactions and clear the sender to avoid unnecessary work.
-            if sender.blocking_send(upgrade.clone()).is_err() {
+            if sender.send(upgrade.clone()).await.is_err() {
                 inner.sender.take();
             }
         }
@@ -65,7 +65,7 @@ impl UpgradeSubpool {
         loop {
             let notified = self.notify.notified();
             {
-                let mut inner = self.inner.write().unwrap();
+                let mut inner = self.inner.write().await;
                 if let Some(upgrade) = inner.pending_upgrades.pop_back() {
                     tracing::info!(protocol_version = %upgrade.protocol_version(), "advancing protocol version");
                     return upgrade;
@@ -81,8 +81,7 @@ impl UpgradeSubpool {
         txs: Vec<&L1UpgradeEnvelope>,
     ) {
         // We track current protocol version that we end up with after applying upgrade transaction.
-        let mut current_protocol_version =
-            self.inner.read().unwrap().current_protocol_version.clone();
+        let mut current_protocol_version = self.inner.read().await.current_protocol_version.clone();
 
         // If there are no upgrade transactions and current protocol version matches the one in the
         // block, we do not have to do anything.
@@ -129,7 +128,7 @@ impl UpgradeSubpool {
         }
 
         // Write protocol version we ended up with.
-        self.inner.write().unwrap().current_protocol_version = current_protocol_version;
+        self.inner.write().await.current_protocol_version = current_protocol_version;
     }
 }
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -445,7 +445,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 force_preimages: genesis_upgrade.force_deploy_preimages,
             },
         };
-        upgrade_subpool.insert(upgrade_tx);
+        upgrade_subpool.insert(upgrade_tx).await;
     }
 
     if current_protocol_version >= ProtocolSemanticVersion::new(0, 31, 0) {


### PR DESCRIPTION
## Summary

Broadcast channels are replaced with mpsc for subpools.
With broadcast channels messages can be lost and it's a fatal error.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

