### PR TITLE
refactor(mempool): do not use channels, rely on notify instead

### DIFF
--- a/lib/mempool/src/subpools/interop_roots.rs
+++ b/lib/mempool/src/subpools/interop_roots.rs
@@ -1,16 +1,9 @@
-use futures::{Stream, StreamExt, ready};
-use std::{
-    collections::VecDeque,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use futures::stream::BoxStream;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, RwLock};
+use tokio::sync::Notify;
 use tokio::time::Instant;
-use tokio::{
-    sync::{RwLock, mpsc},
-    time::{Sleep, sleep_until},
-};
-use tokio_stream::wrappers::ReceiverStream;
+use tokio::time::sleep_until;
 use zksync_os_types::{
     IndexedInteropRoot, InteropRoot, InteropRootsLogIndex, SystemTxEnvelope, SystemTxType,
     ZkTransaction,
@@ -18,146 +11,106 @@ use zksync_os_types::{
 
 #[derive(Clone)]
 pub struct InteropRootsSubpool {
+    /// Consistent state of pending roots shared between all clones of this subpool.
     inner: Arc<RwLock<Inner>>,
-    channel_size: usize,
+    notify: Arc<Notify>,
+    interop_roots_per_tx: usize,
+}
+
+/// Holds all **pending** interop roots, i.e. those that have been received but not included in the
+/// canonical chain yet. Note that some prefix might have already been executed in sequencer (as
+/// they were returned from [`InteropRootsSubpool::interop_transactions_with_delay`]).
+struct Inner {
+    pending_roots: BTreeMap<InteropRootsLogIndex, InteropRoot>,
 }
 
 impl InteropRootsSubpool {
-    pub fn new(interop_roots_per_tx: usize, channel_size: usize) -> Self {
+    pub fn new(interop_roots_per_tx: usize) -> Self {
         Self {
             inner: Arc::new(RwLock::new(Inner {
-                interop_roots_per_tx,
-                sender: None,
-                pending_roots: VecDeque::new(),
+                pending_roots: BTreeMap::new(),
             })),
-            channel_size,
+            notify: Arc::new(Notify::new()),
+            interop_roots_per_tx,
         }
     }
-}
 
-impl InteropRootsSubpool {
     pub async fn interop_transactions_with_delay(
         &self,
         next_tx_allowed_after: Instant,
-    ) -> InteropRootsTransactionsStream {
-        self.inner
-            .write()
-            .await
-            .interop_transactions_with_delay(next_tx_allowed_after, self.channel_size)
+    ) -> BoxStream<ZkTransaction> {
+        Box::pin(futures::stream::unfold(
+            (
+                self.inner.clone(),
+                self.notify.clone(),
+                InteropRootsLogIndex::default(),
+                VecDeque::default(),
+            ),
+            move |(inner, notify, mut cursor, mut buffer)| async move {
+                sleep_until(next_tx_allowed_after).await;
+                loop {
+                    // Subscribe BEFORE reading — avoids the race where an insert
+                    // happens between our read and our .notified().await.
+                    let notified = notify.notified();
+
+                    {
+                        let inner = inner.read().unwrap();
+                        for (id, root) in inner.pending_roots.range(&cursor..) {
+                            cursor = InteropRootsLogIndex {
+                                block_number: id.block_number,
+                                index_in_block: id.index_in_block + 1,
+                            };
+                            buffer.push_front(root.clone());
+                        }
+                    }
+
+                    if !buffer.is_empty() {
+                        let amount_of_roots_to_take = buffer.len().min(self.interop_roots_per_tx);
+                        let starting_index = buffer.len() - amount_of_roots_to_take;
+
+                        let roots_to_consume = buffer
+                            .drain(starting_index..)
+                            .rev() // reversing iterator as last element is the one received earliest
+                            .collect::<Vec<_>>();
+
+                        let envelope = SystemTxEnvelope::import_interop_roots(roots_to_consume);
+                        drop(notified);
+                        return Some((envelope.into(), (inner, notify, cursor, buffer)));
+                    }
+
+                    // Nothing new yet — wait for an insert, then retry.
+                    notified.await;
+                }
+            },
+        ))
     }
 
     pub async fn add_root(&mut self, root: IndexedInteropRoot) {
-        self.inner.write().await.add_root(root).await;
+        self.inner
+            .write()
+            .unwrap()
+            .pending_roots
+            .insert(root.log_index, root.root);
+        self.notify.notify_waiters();
     }
 
-    pub async fn on_canonical_state_change(
-        &self,
-        txs: Vec<&SystemTxEnvelope>,
-    ) -> Option<InteropRootsLogIndex> {
-        self.inner.write().await.on_canonical_state_change(txs)
-    }
-}
-
-/// New root are added to `Inner` as well as it's used to create `InteropRootsTransactionsStream`.
-/// `sender` is used to submit new roots to the active stream.
-/// If there is no active stream, then sender will be dropped on the next access; root is inserted to `pending_txs` anyway.
-#[derive(Clone)]
-struct Inner {
-    interop_roots_per_tx: usize,
-    sender: Option<mpsc::Sender<InteropRoot>>,
-    pending_roots: VecDeque<IndexedInteropRoot>,
-}
-
-pub struct InteropRootsTransactionsStream {
-    receiver: ReceiverStream<InteropRoot>,
-    pending_roots: VecDeque<InteropRoot>,
-    interop_roots_per_tx: usize,
-    sleep: Option<Pin<Box<Sleep>>>,
-}
-
-impl Stream for InteropRootsTransactionsStream {
-    type Item = ZkTransaction;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(sleep) = self.sleep.as_mut() {
-            ready!(sleep.as_mut().poll(cx));
-            self.sleep = None;
-        }
-
+    async fn pop_wait(&self) -> (InteropRootsLogIndex, InteropRoot) {
         loop {
-            if let Some(envelope) = self.take_tx(false) {
-                return Poll::Ready(Some(envelope.into()));
-            }
-
-            match self.receiver.poll_next_unpin(cx) {
-                Poll::Ready(Some(root)) => {
-                    self.pending_roots.push_front(root);
-                    continue;
+            let notified = self.notify.notified();
+            {
+                let mut inner = self.inner.write().unwrap();
+                if let Some((id, root)) = inner.pending_roots.pop_first() {
+                    return (id, root);
                 }
-                Poll::Pending => {
-                    if let Some(tx) = self.take_tx(true) {
-                        return Poll::Ready(Some(tx.into()));
-                    }
-                    return Poll::Pending;
-                }
-                Poll::Ready(_) => return Poll::Ready(None),
             }
+            notified.await;
         }
-    }
-}
-
-impl InteropRootsTransactionsStream {
-    /// Take a transaction from pending roots(not depending on the amount)
-    fn take_tx(&mut self, allowed_to_take_remainder: bool) -> Option<SystemTxEnvelope> {
-        if self.pending_roots.is_empty()
-            || (self.pending_roots.len() < self.interop_roots_per_tx && !allowed_to_take_remainder)
-        {
-            None
-        } else {
-            let amount_of_roots_to_take = self.pending_roots.len().min(self.interop_roots_per_tx);
-            let starting_index = self.pending_roots.len() - amount_of_roots_to_take;
-
-            let roots_to_consume = self
-                .pending_roots
-                .drain(starting_index..)
-                .rev() // reversing iterator as last element is the one received earliest
-                .collect::<Vec<_>>();
-
-            Some(SystemTxEnvelope::import_interop_roots(roots_to_consume))
-        }
-    }
-}
-
-impl Inner {
-    fn interop_transactions_with_delay(
-        &mut self,
-        next_tx_allowed_after: Instant,
-        channel_size: usize,
-    ) -> InteropRootsTransactionsStream {
-        let (sender, receiver) = mpsc::channel(channel_size);
-        self.sender = Some(sender);
-        InteropRootsTransactionsStream {
-            receiver: ReceiverStream::new(receiver),
-            pending_roots: self.pending_roots.iter().map(|r| r.root.clone()).collect(),
-            interop_roots_per_tx: self.interop_roots_per_tx,
-            sleep: Some(Box::pin(sleep_until(next_tx_allowed_after))),
-        }
-    }
-
-    async fn add_root(&mut self, root: IndexedInteropRoot) {
-        if let Some(sender) = &self.sender {
-            // If the receiver has been dropped, we should stop sending transactions and clear the sender to avoid unnecessary work.
-            if sender.send(root.root.clone()).await.is_err() {
-                self.sender.take();
-            }
-        }
-        self.pending_roots.push_front(root);
     }
 
     /// Cleans up the stream and removes all roots that were sent in transactions
     /// Returns the last log index of executed interop root
-    fn on_canonical_state_change(
-        &mut self,
+    pub async fn on_canonical_state_change(
+        &self,
         txs: Vec<&SystemTxEnvelope>,
     ) -> Option<InteropRootsLogIndex> {
         if txs.is_empty() {
@@ -171,19 +124,13 @@ impl Inner {
                 continue;
             };
 
-            // todo: wait for more if `pending_roots.len() < roots_count`
-            let starting_index = self.pending_roots.len() - roots_count as usize;
-
-            let roots = self
-                .pending_roots
-                .drain(starting_index..)
-                .rev()
-                .collect::<Vec<_>>();
-
-            let envelope = SystemTxEnvelope::import_interop_roots(
-                roots.iter().map(|r| r.root.clone()).collect(),
-            );
-            log_index = roots.last().unwrap().log_index.clone();
+            let mut roots = Vec::with_capacity(roots_count as usize);
+            for _ in 0..roots_count {
+                let (id, root) = self.pop_wait().await;
+                roots.push(root);
+                log_index = id;
+            }
+            let envelope = SystemTxEnvelope::import_interop_roots(roots);
 
             assert_eq!(&envelope, tx);
         }

--- a/lib/types/src/transaction/system/mod.rs
+++ b/lib/types/src/transaction/system/mod.rs
@@ -141,7 +141,7 @@ mod tx_serde {
 }
 
 /// A helper struct to store the block number and index in block of published interop roots event.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, PartialOrd)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct InteropRootsLogIndex {
     /// Block number from which event was published.
     pub block_number: u64,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -431,7 +431,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let sl_chain_id_subpool = SlChainIdSubpool::default();
     let interop_roots_subpool = InteropRootsSubpool::new(
         // todo: change to config.sequencer_config.interop_roots_per_tx when contracts are updated
-        1, 10,
+        1,
     );
 
     // If we start from the very first block, we should start by sending upgrade tx for genesis.


### PR DESCRIPTION
## Summary

Continuation of #910. I think this works out a bit cleaner. No more manual `Stream` implementation which is another bonus IMHO

Similar refactoring can be performed for all other subpools as well.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

