### PR TITLE
fix: Compare block hash during block replay

### DIFF
--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -428,7 +428,7 @@ impl WriteReplay for BlockReplayStorage {
             let old_record = self
                 .get_replay_record(block_context.block_number)
                 .expect("Old record must exist");
-            if old_record.block_output_hash != block_record.block_output_hash {
+            if &old_record != block_record {
                 let old_record_hash = self.get_canonical_block_hash(block_context.block_number);
                 let old_record_hash_hex = alloy::hex::encode_prefixed(old_record_hash.0);
                 tracing::warn!(

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -28,7 +28,7 @@ pub struct StoredTxData {
 }
 
 /// Full data needed to replay a block - assuming storage is already in the correct state.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReplayRecord {
     pub block_context: BlockContext,
     /// L1 transaction serial id (0-based) expected at the beginning of this block.
@@ -40,18 +40,35 @@ pub struct ReplayRecord {
     /// Will be moved to the BlockContext at some point
     pub previous_block_timestamp: u64,
     /// Version of the node that created this replay record.
+    /// NOTE: Excluded from equality check, different node versions can produce identical blocks.
     pub node_version: semver::Version,
     /// Version of the protocol that was used to create this replay record.
     pub protocol_version: ProtocolSemanticVersion,
     /// Extension of traditional block hash (see hash_block_output)
     /// Used to confirm that we executed the replay correctly
     /// We need this because our header is missing a few important fields
+    // TODO: We may want to add more information about block_output_hash (currently tracks only output, but different input can result in same output)
     pub block_output_hash: B256,
     /// Forced preimages to be included before the block execution.
     pub force_preimages: Vec<(B256, Vec<u8>)>,
     /// Event index(block number and index in block) of the interop root tx executed first in the block
     /// If there is no interop root tx in the block, equals to the previous block's value
     pub starting_interop_event_index: InteropRootsLogIndex,
+}
+
+impl PartialEq for ReplayRecord {
+    fn eq(&self, other: &Self) -> bool {
+        // Same as #[derive(PartialEq)], but without `node_version`.
+        // During replay, we care about block identity, node_version is binary metadata.
+        self.block_context == other.block_context
+            && self.starting_l1_priority_id == other.starting_l1_priority_id
+            && self.transactions == other.transactions
+            && self.previous_block_timestamp == other.previous_block_timestamp
+            && self.protocol_version == other.protocol_version
+            && self.block_output_hash == other.block_output_hash
+            && self.force_preimages == other.force_preimages
+            && self.starting_interop_event_index == other.starting_interop_event_index
+    }
 }
 
 impl ReplayRecord {


### PR DESCRIPTION
Current block replay struct comparison includes all fields (such as metadata, like `NodeVersion`. This means that any node sent over the wire on old node version will fail comparison (if it was not also committed) after Main Node reboot. This is exactly what happened on stage-rollup (that is currently crash looping).

```bash
# EN have:
node_version: Version { major: 0, minor: 14, patch: 2 }
# But are receiving from MN:
node_version: Version { major: 0, minor: 15, patch: 1 }
```

As such, comparison fails, even though the block is exactly the same.

This PR checks whether the block is the same or not by comparing `block_output_hash` alone.