### PR TITLE
chore: auth download with retry for zksync-os bins

### DIFF
--- a/lib/multivm/build.rs
+++ b/lib/multivm/build.rs
@@ -1,4 +1,7 @@
 use cargo_metadata::{MetadataCommand, PackageId};
+use reqwest::StatusCode;
+use reqwest::blocking::Client;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use url::Url;
 
 fn parse_git_tag(package_id: &PackageId) -> anyhow::Result<String> {
@@ -17,9 +20,83 @@ fn proving_version_from_tag(tag: &str) -> Option<String> {
     }
 }
 
+const DOWNLOAD_MAX_ATTEMPTS: usize = 5;
+const DOWNLOAD_TIMEOUT_SECS: u64 = 60;
+const DOWNLOAD_BASE_BACKOFF_MS: u64 = 500;
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS
+}
+
+fn new_http_client() -> anyhow::Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static("zksync-os-build-script/1.0"),
+    );
+
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        let bearer = format!("Bearer {}", token.trim());
+        match HeaderValue::from_str(&bearer) {
+            Ok(value) => {
+                headers.insert(AUTHORIZATION, value);
+            }
+            Err(err) => {
+                println!("cargo:warning=Ignoring invalid GITHUB_TOKEN format: {err}");
+            }
+        }
+    }
+
+    Ok(Client::builder()
+        .default_headers(headers)
+        .timeout(std::time::Duration::from_secs(DOWNLOAD_TIMEOUT_SECS))
+        .build()?)
+}
+
+fn download_with_retry(client: &Client, url: &str, path: &str) -> anyhow::Result<()> {
+    for attempt in 1..=DOWNLOAD_MAX_ATTEMPTS {
+        let response = client.get(url).send();
+        match response {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    let body = response.bytes()?;
+                    std::fs::write(path, body.as_ref())?;
+                    return Ok(());
+                }
+
+                if is_retryable_status(status) && attempt < DOWNLOAD_MAX_ATTEMPTS {
+                    let delay_ms = DOWNLOAD_BASE_BACKOFF_MS * attempt as u64;
+                    println!(
+                        "cargo:warning=download attempt {attempt}/{DOWNLOAD_MAX_ATTEMPTS} failed with status {status} for {url}; retrying in {delay_ms}ms"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                    continue;
+                }
+
+                anyhow::bail!("download failed with status {status} for {url}");
+            }
+            Err(err) => {
+                if attempt < DOWNLOAD_MAX_ATTEMPTS {
+                    let delay_ms = DOWNLOAD_BASE_BACKOFF_MS * attempt as u64;
+                    println!(
+                        "cargo:warning=download attempt {attempt}/{DOWNLOAD_MAX_ATTEMPTS} failed for {url}: {err}; retrying in {delay_ms}ms"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                    continue;
+                }
+
+                anyhow::bail!("download request failed for {url}: {err}");
+            }
+        }
+    }
+    unreachable!("loop always returns on success or final attempt");
+}
+
 fn main() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let metadata = MetadataCommand::new().exec().unwrap();
+    let client = new_http_client().expect("failed to create HTTP client");
 
     // Find forward_system crate and expose its path to the directory containing `app*.bin` files.
     for package in &metadata.packages {
@@ -49,9 +126,7 @@ fn main() {
                 if std::fs::exists(&path).expect("failed to check file existence") {
                     continue;
                 }
-                let resp = reqwest::blocking::get(url).expect("failed to download");
-                let body = resp.bytes().expect("failed to read response body").to_vec();
-                std::fs::write(path, body).expect("failed to write file");
+                download_with_retry(&client, &url, &path).expect("failed to download");
             }
 
             println!("cargo:rustc-env=ZKSYNC_OS_{proving_version}_SOURCE_PATH={dir}");


### PR DESCRIPTION
## Summary

* [x] auth download with retry for zksync-os bins

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

