### PR TITLE
feat: add settleBatchesSharedBridge support for priority mode

### DIFF
--- a/docs/settle-mode-e2e-test.md
+++ b/docs/settle-mode-e2e-test.md
@@ -67,6 +67,18 @@ In permissionless mode, the server uses `settleBatchesSharedBridge` on the `Perm
 
 The `PermissionlessValidator` contract is already deployed (its address is in the L1 state). We need to add it to the diamond proxy's validators mapping so it can call commit/prove/execute.
 
+> **Why `anvil_setStorageAt` instead of the real activation flow?**
+>
+> In production, priority mode is activated through a multi-step L1 process:
+> `makePermanentRollup()` → `permanentlyAllowPriorityMode()` → wait 4 days → `activatePriorityMode()`.
+> We skip this in the E2E test for several reasons:
+> 1. The diamond proxy admin key isn't in our test wallets (would need `anvil_impersonateAccount`)
+> 2. The flow has complex prerequisites (valid DA validator pair, a priority tx with timestamp)
+> 3. `activatePriorityMode()` reverts all non-executed batches, complicating test setup ordering
+> 4. We're testing the *server's* permissionless mode behavior, not the contract activation logic
+>
+> Direct storage manipulation is deterministic, fast, and isolates what we're actually testing.
+
 8. **Find the PermissionlessValidator address** from `contracts.yaml`:
    ```bash
    # For v31.0, it's at:


### PR DESCRIPTION
Add a `settle_mode` config flag that, when enabled, uses `settleBatchesSharedBridge` on the PermissionlessValidator contract to atomically commit+prove+execute batches in a single L1 transaction.

In settle mode, the commit and prove L1Senders pass through without sending to L1 (the prove passthrough stores the SNARK proof in the batch envelope). The execute L1Sender constructs the combined settle calldata and sends it to the PermissionlessValidator contract.

Key changes:
- Add IPermissionlessValidator Solidity interface
- Add snark_proof/commit_blob_sidecar fields to BatchMetadata
- Extend SendToL1 trait with settle passthrough support
- Add run_settle_passthrough function for commit/prove passthrough
- Add settle calldata generation to ExecuteCommand
- Add settle_mode/settle_contract_address config options
- Support decoding settleBatchesSharedBridge calldata in L1 watcher
- Add E2E test documentation

## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

