### PR TITLE
fix: support 0x-prefixed hex in all config fields

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cli::ConfigArgs;
-use self::util::SigningKeyDeserializer;
+use self::util::{SecretKeyDeserializer, SigningKeyDeserializer};
 use crate::{command_source::RebuildOptions, default_protocol_version::DEFAULT_ROCKS_DB_PATH};
 use alloy::primitives::{Address, Bytes, U128};
 use alloy::signers::k256::ecdsa::SigningKey;
@@ -242,7 +242,7 @@ pub struct NetworkConfig {
     /// The node's secret key (256-bit ECDSA), from which the node's identity is derived. Used during
     /// initial RLPx handshake.
     #[config(secret)]
-    #[config(default, with = Serde![str])]
+    #[config(default, with = SecretKeyDeserializer)]
     pub secret_key: Option<SecretKey>,
     /// IPv4 address to use for Node Discovery Protocol v5 (discv5) and RLPx Transport Protocol (rlpx).
     #[config(default_t = Ipv4Addr::UNSPECIFIED, with = Serde![str])]

--- a/node/bin/src/config/util.rs
+++ b/node/bin/src/config/util.rs
@@ -5,8 +5,11 @@ use serde_json::Value;
 use smart_config::ErrorWithOrigin;
 use smart_config::de::{DeserializeContext, DeserializeParam};
 use smart_config::metadata::{BasicTypes, ParamMetadata};
+use zksync_os_network::SecretKey;
 
 /// Custom deserializer for `ecdsa::SigningKey`.
+///
+/// Accepts hex strings both with and without `0x` prefix.
 #[derive(Debug)]
 pub struct SigningKeyDeserializer;
 
@@ -26,6 +29,33 @@ impl DeserializeParam<SigningKey> for SigningKeyDeserializer {
 
     fn serialize_param(&self, param: &SigningKey) -> Value {
         let bytes = B256::from_slice(param.to_bytes().as_slice());
+        serde_json::to_value(bytes).expect("failed serializing to JSON")
+    }
+}
+
+/// Custom deserializer for `secp256k1::SecretKey`.
+///
+/// Accepts hex strings both with and without `0x` prefix.
+/// The built-in `secp256k1` string parser does not support the `0x` prefix,
+/// so we go through `B256` (which uses `const-hex` and strips the prefix automatically).
+#[derive(Debug)]
+pub struct SecretKeyDeserializer;
+
+impl DeserializeParam<SecretKey> for SecretKeyDeserializer {
+    const EXPECTING: BasicTypes = BasicTypes::STRING;
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<SecretKey, ErrorWithOrigin> {
+        let deserializer = ctx.current_value_deserializer(param.name)?;
+        let b256 = B256::deserialize(deserializer)?;
+        SecretKey::from_slice(b256.as_slice()).map_err(ErrorWithOrigin::custom)
+    }
+
+    fn serialize_param(&self, param: &SecretKey) -> Value {
+        let bytes = B256::from_slice(&param.secret_bytes());
         serde_json::to_value(bytes).expect("failed serializing to JSON")
     }
 }


### PR DESCRIPTION
## Summary

- secp256k1 SecretKey::from_str does not strip the 0x prefix, so network_secret_key values with the prefix were rejected
- All other hex config fields (operator_commit_sk, operator_prove_sk, operator_execute_sk, token_multiplier_setter_sk, Address fields) use alloy-primitives / const-hex which already strips 0x automatically
- Add SecretKeyDeserializer in config/util.rs that parses via B256 first (picking up const-hex prefix stripping) then converts to SecretKey::from_slice — the same pattern as the existing SigningKeyDeserializer
- Switch NetworkConfig::secret_key from Serde![str] to with = SecretKeyDeserializer

## Test plan

- [x] network_secret_key=0x9cc842... (with prefix) starts successfully
- [x] network_secret_key=9cc842... (no prefix) continues to work

Generated with [Claude Code](https://claude.com/claude-code)