### PR TITLE
fix(rpc): reject low-fee L2 transactions at RPC layer before mempool

### DIFF
--- a/integration-tests/tests/api.rs
+++ b/integration-tests/tests/api.rs
@@ -1,6 +1,6 @@
 use alloy::eips::Encodable2718;
 use alloy::network::{ReceiptResponse, TransactionBuilder, TxSigner};
-use alloy::primitives::{TxHash, U128, U256, address};
+use alloy::primitives::{Address, TxHash, U128, U256, address};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use regex::Regex;
@@ -230,6 +230,52 @@ async fn estimate_gas_with_high_prices() -> anyhow::Result<()> {
         .expect_successful_receipt()
         .await?;
     tracing::info!("Got receipt, gas used: {}", receipt.gas_used);
+
+    Ok(())
+}
+
+/// A transaction with maxFeePerGas below the chain's base fee should be rejected
+/// by the RPC with a clear error, not silently accepted into the mempool.
+#[test_log::test(tokio::test)]
+async fn send_raw_transaction_low_fee_rejected() -> anyhow::Result<()> {
+    let known_base_fee: u128 = 100_000_000; // 100M wei = 0.1 gwei
+    let fee_config = FeeConfig {
+        native_price_usd: 3e-9,
+        base_fee_override: Some(U128::from(known_base_fee)),
+        native_per_gas: 100,
+        pubdata_price_override: Some(U128::from(1_000_000u64)),
+        native_price_override: Some(U128::from(1_000_000u64)),
+        pubdata_price_cap: None,
+    };
+    let tester = Tester::builder().fee_config(fee_config).build().await?;
+
+    let chain_id = tester.l2_provider.get_chain_id().await?;
+    let alice = tester.l2_wallet.default_signer().address();
+    let nonce = tester.l2_provider.get_transaction_count(alice).await?;
+
+    // Build a tx with maxFeePerGas=7, far below the 100M base fee.
+    let low_fee_tx = TransactionRequest::default()
+        .with_to(Address::random())
+        .with_value(U256::from(1))
+        .with_nonce(nonce)
+        .with_gas_limit(21_000)
+        .with_max_fee_per_gas(7)
+        .with_max_priority_fee_per_gas(0)
+        .with_chain_id(chain_id);
+    let envelope = low_fee_tx.build(&tester.l2_wallet).await?;
+    let encoded = envelope.encoded_2718();
+
+    let error = tester
+        .l2_provider
+        .send_raw_transaction(&encoded)
+        .await
+        .expect_err("low-fee tx should be rejected by RPC");
+    assert!(
+        error
+            .to_string()
+            .contains("max fee per gas less than block base fee"),
+        "expected basefee error, got: {error}",
+    );
 
     Ok(())
 }

--- a/integration-tests/tests/mempool.rs
+++ b/integration-tests/tests/mempool.rs
@@ -113,15 +113,15 @@ async fn sensitive_to_balance_changes() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A transaction with maxFeePerGas below the chain's base fee must not stall
-/// block production for other senders.
+/// A rejected low-fee tx must not stall block production for other senders.
+/// The RPC rejects the low-fee tx (maxFeePerGas < basefee), then we verify
+/// that a legitimate tx from an independent sender still gets mined promptly.
 #[test_log::test(tokio::test)]
 async fn low_fee_tx_does_not_hang_block_executor() -> anyhow::Result<()> {
-    // Use a deterministic base fee so the "low fee" value is unambiguous.
-    let known_base_fee: u128 = 100_000_000; // 100M wei = 0.1 gwei
+    let initial_base_fee: u128 = 100_000_000; // 100M wei = 0.1 gwei
     let fee_config = FeeConfig {
         native_price_usd: 3e-9,
-        base_fee_override: Some(U128::from(known_base_fee)),
+        base_fee_override: Some(U128::from(initial_base_fee)),
         native_per_gas: 100,
         pubdata_price_override: Some(U128::from(1_000_000u64)),
         native_price_override: Some(U128::from(1_000_000u64)),
@@ -164,15 +164,15 @@ async fn low_fee_tx_does_not_hang_block_executor() -> anyhow::Result<()> {
         .expect_successful_receipt()
         .await?;
 
-    // Step 3: Submit a low-fee tx from Alice with maxFeePerGas=7 (far below base fee of 100M).
-    // Uses build() + send_raw_transaction() to bypass provider fee estimation.
+    // Step 3: Submit a low-fee tx from Alice (maxFeePerGas=7, far below 100M base fee).
+    // The RPC rejects it due to base fee validation — we ignore the error.
     let nonce = tester.l2_provider.get_transaction_count(alice).await?;
     let poison_tx = TransactionRequest::default()
         .with_to(Address::random())
         .with_value(U256::from(1))
         .with_nonce(nonce)
         .with_gas_limit(21_000)
-        .with_max_fee_per_gas(7) // Above Reth MIN_PROTOCOL_BASE_FEE, far below actual base fee
+        .with_max_fee_per_gas(7)
         .with_max_priority_fee_per_gas(0)
         .with_chain_id(chain_id);
     let poison_envelope = poison_tx.build(&tester.l2_wallet).await?;
@@ -180,10 +180,7 @@ async fn low_fee_tx_does_not_hang_block_executor() -> anyhow::Result<()> {
     let _ = tester
         .l2_provider
         .send_raw_transaction(&poison_encoded)
-        .await?;
-
-    // Give the block executor time to pick up the low-fee tx
-    tokio::time::sleep(Duration::from_secs(2)).await;
+        .await;
 
     // Step 4: Send a legitimate follow-up from Bob (independent sender, no nonce dependency).
     let follow_up_tx = TransactionRequest::default()
@@ -203,7 +200,7 @@ async fn low_fee_tx_does_not_hang_block_executor() -> anyhow::Result<()> {
 
     match result {
         Ok(Ok(_receipt)) => {
-            // Block executor handled the low-fee tx gracefully — test passes
+            // Block executor handled everything gracefully — test passes
         }
         Ok(Err(e)) => {
             panic!("Follow-up transaction failed unexpectedly: {e:#}");
@@ -211,8 +208,7 @@ async fn low_fee_tx_does_not_hang_block_executor() -> anyhow::Result<()> {
         Err(_elapsed) => {
             panic!(
                 "Follow-up transaction not mined within 30s. \
-                 The low-fee tx (maxFeePerGas=7, baseFee={known_base_fee}) \
-                 appears to have stalled block production for other senders."
+                 Block production appears to have stalled."
             );
         }
     }

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -1,5 +1,6 @@
 use crate::eth_impl::build_api_receipt;
 use crate::{ReadRpcStorage, RpcConfig};
+use alloy::consensus::Transaction;
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::{B256, Bytes, U256};
@@ -57,6 +58,18 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
         let l2_tx: L2Transaction = transaction
             .try_into_recovered()
             .map_err(|_| EthSendRawTransactionError::InvalidTransactionSignature)?;
+        // Validate tx fee against current basefee
+        let latest_block = self.storage.repository().get_latest_block();
+        if let Some(block_context) = self.storage.replay_storage().get_context(latest_block) {
+            let base_fee: u128 = block_context
+                .eip1559_basefee
+                .try_into()
+                .unwrap_or(u128::MAX);
+            if l2_tx.max_fee_per_gas() < base_fee {
+                return Err(EthSendRawTransactionError::MaxFeePerGasTooLow);
+            }
+        }
+
         let hash = *l2_tx.hash();
         if self.config.l2_signer_blacklist.contains(&l2_tx.signer()) {
             return Err(EthSendRawTransactionError::BlacklistedSigner);
@@ -154,6 +167,8 @@ pub enum EthSendRawTransactionError {
     ForwardError(#[from] RpcError<TransportErrorKind>),
     #[error("Signer is blacklisted")]
     BlacklistedSigner,
+    #[error("max fee per gas less than block base fee")]
+    MaxFeePerGasTooLow,
 }
 
 /// Error types returned by `eth_sendRawTransactionSync` implementation


### PR DESCRIPTION
- Add `maxFeePerGas` vs block basefee validation to `eth_sendRawTransaction`, rejecting underpriced transactions immediately with a clear error instead of silently accepting them into the mempool where they'd never get mined
- Add integration test `send_raw_transaction_low_fee_rejected` in `api.rs` to verify the new validation
- Update existing `low_fee_tx_does_not_hang_block_executor` test in `mempool.rs` to account for the new early rejection

## Context

Previously, `eth_sendRawTransaction` performed zero gas price validation — it decoded the tx, checked the signature, and added it straight to the mempool. The Reth mempool also had fee checks explicitly disabled (`set_tx_fee_cap(0)`). This meant a transaction with `maxFeePerGas=7` against a basefee of 100,000,000 wei would be accepted, return a tx hash to the user, and then silently fail `BaseFeeGreaterThanMaxFee` validation in the VM every block forever.

The user got no indication their transaction would never mine. The tx stayed in the pool as a `Skip` rejection (not `Purge`, since basefee can theoretically change), retried and rejected every block.

This is a standard check that geth, reth, and other Ethereum clients perform at pool admission time. The fix validates `maxFeePerGas >= current basefee` in the RPC handler before adding to the mempool. If the block context isn't available yet (e.g. pre-genesis), the check is skipped gracefully.

## Changes

### `lib/rpc/src/tx_handler.rs`
- Added `MaxFeePerGasTooLow` variant to `EthSendRawTransactionError`
- Added basefee validation in `send_raw_transaction_impl` after tx decoding/recovery, before mempool admission
- Uses `alloy::consensus::Transaction::max_fee_per_gas()` which works uniformly for both legacy (`gas_price`) and EIP-1559 transactions

### `integration-tests/tests/api.rs`
- **New test `send_raw_transaction_low_fee_rejected`**: submits a tx with `maxFeePerGas=7` against a 100M basefee, asserts the RPC returns `"max fee per gas less than block base fee"`

### `integration-tests/tests/mempool.rs`
- **Updated `low_fee_tx_does_not_hang_block_executor`**: the poison tx is now rejected at the RPC layer (result ignored); test still verifies Bob's legitimate tx gets mined promptly
