### PR TITLE
ci: reduce eth spec test frequency and add docker build retry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,26 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build docker image
+        id: build-docker
+        continue-on-error: true
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          load: true
+          file: ./Dockerfile
+          build-args: |
+            SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage
+            SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com
+            SCCACHE_GCS_RW_MODE=READ_WRITE
+            RUSTC_WRAPPER=sccache
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: 'type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}:buildcache'
+          cache-to: ${{ steps.set-cache-to.outputs.cache-to }}
+
+      - name: Build docker image (retry)
+        if: steps.build-docker.outcome == 'failure'
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .

--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -1,9 +1,12 @@
 name: Eth spec tests
 
-# Run tests every day or by manual request
+# Run tests every 6 hours or on push to main or by manual request
 on:
   schedule:
-    - cron: '0 */3 * * *' # every 3 hours
+    - cron: '0 */6 * * *' # every 6 hours
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 # Set default permissions


### PR DESCRIPTION
Based on CI analysis of the last 4 weeks.

## Changes

### Eth spec tests (`spec-tests.yaml`)
- Reduce schedule from every 3h to every 6h — saves ~150 runner-hours/week with minimal signal loss (the workflow had only 3 transient failures in 4 weeks at 1.4% failure rate)
- Also trigger on push to main, so the test suite runs immediately after every merge rather than waiting up to 6h for the next scheduled run

### Docker build (`docker.yml`)
- Add a retry step for the "Build docker image" step using `continue-on-error` + conditional retry pattern
- Two main-branch Docker failures in 4 weeks were both transient (network/cache issues) and self-healed on the next run — a single retry catches these without adding new action dependencies

## Test plan
- [ ] Verify `spec-tests.yaml` triggers on next push to main
- [ ] Verify `spec-tests.yaml` scheduled runs occur at 6h intervals
- [ ] Docker workflow behavior unchanged on success; retry step skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)