### PR TITLE
docs: add AI reviewer guide for zksync-os-server

### DIFF
--- a/agents/ai_reviewer_guide.md
+++ b/agents/ai_reviewer_guide.md
@@ -1,6 +1,6 @@
 # AI Code Review Guide for zksync-os-server
 
-*Synthesized from observed review patterns in zksync-era and tailored to this codebase. This guide covers the conventions, idioms, and correctness expectations that apply specifically to zksync-os-server.*
+*This guide covers the conventions, idioms, and correctness expectations that apply to zksync-os-server.*
 
 ---
 
@@ -8,7 +8,7 @@
 
 ### 1.1 Pipeline Component Discipline
 
-This codebase uses a custom pipeline framework (`lib/pipeline/`) rather than a node-framework task registry. Components implement `PipelineComponent` and are chained via `Pipeline::pipe()`. Tasks are collected into a `JoinSet<()>` in `run()`.
+This codebase uses a custom pipeline framework (`lib/pipeline/`). Components implement `PipelineComponent` and are chained via `Pipeline::pipe()`. Tasks are collected into a `JoinSet<()>` in `run()`.
 
 **What to flag:**
 - `tokio::spawn` in library crates — background work must go through the pipeline framework or be explicitly registered into the `JoinSet` in `node/bin/src/lib.rs`
@@ -189,7 +189,7 @@ Every redundant clone is worth flagging:
 
 ### 3.1 RocksDB Usage
 
-This codebase uses RocksDB (not Postgres) via column families defined with `NamedColumnFamily`. RocksDB handles are cheap to clone; there are no "connection pools" or SQL transaction isolation levels.
+This codebase uses RocksDB via column families defined with `NamedColumnFamily`. RocksDB handles are cheap to clone; there are no connection pools or SQL transaction isolation levels.
 
 **What to flag:**
 - Operations that must be atomic but are split across two separate `WriteBatch` commits — use a single batch


### PR DESCRIPTION
## Summary

- Adds `agents/ai_reviewer_guide.md`: a code review style guide for AI agents reviewing PRs in this repository
- Adapted from Alex Ostrovski's review patterns in zksync-era, with all sections rewritten to reflect zksync-os-server's actual conventions

## What changed vs the zksync-era guide

The original guide was written for a codebase that uses: a node-framework task registry, Postgres with connection pools, protobuf configs, and zksync-era-specific type wrappers. This guide is rewritten around zksync-os-server's actual stack:

- **Pipeline framework** (`PipelineComponent` / `JoinSet`) instead of `impl Task for X` + framework registration
- **`smart-config`** with `DescribeConfig`/`DeserializeConfig` instead of protobuf
- **RocksDB column families** instead of Postgres — different atomicity model, no connection pool concerns
- **Alloy primitives** and project-specific wrappers (`L1TxSerialId`, `ProtocolSemanticVersion`, `NodeRole`) instead of era-specific types
- **`vise` metrics** with `#[derive(Metrics)]` instead of era's metrics macros
- **Historical VM versioning** constraints (`zk_os_forward_system_*`) — specific to this repo
- **`backon`** for retries, **`insta`** for snapshot tests, **`DashMap`** for concurrent maps — all in workspace deps

## Test plan

- [ ] Read through the guide and verify section references (file paths, crate names, trait names) match the actual codebase
- [ ] Confirm the `PipelineComponent` code example compiles against `lib/pipeline/src/traits.rs`
- [ ] Confirm the `smart-config` example matches patterns in `node/bin/src/config/mod.rs`
- [ ] Confirm the `vise` metrics example matches patterns in e.g. `lib/l1_watcher/src/metrics.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)