### PR TITLE
fix: retry on pending commit tx in L1 watcher instead of panicking

### DIFF
--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -398,7 +398,7 @@ pub async fn fetch_commit_calldata(
                 "commit tx {tx_hash} has no block number (still pending)"
             ))
         })?;
-        Ok(tx)
+        Ok::<_, L1WatcherError>(tx)
     })
     .retry(
         ConstantBuilder::default()


### PR DESCRIPTION
## Summary

- Fix race condition in `fetch_commit_calldata` (`lib/l1_watcher/src/util.rs`) where fetching a commit transaction by hash could return a pending tx (no block number), causing a panic
- Replace panicking `.expect("mined transaction has no block number")` with retry logic (200ms × 50 = 10s budget)
- Resolves the pre-existing `// todo: retry-backoff logic in case tx is missing` comment

The panic was observed in `batch_verification_works` integration test:
```
thread 'batch_verification_works' panicked at lib/l1_watcher/src/util.rs:398:14:
    mined transaction has no block number
```

## Test plan
- [ ] Verify `batch_verification_works` no longer panics
- [ ] Run full integration test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)