### PR TITLE
feat: consensus integration 2/5: Consensus interface, raft dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14444,6 +14444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync_os_raft"
+version = "0.16.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "tokio",
+ "zksync_os_sequencer",
+ "zksync_os_storage_api",
+]
+
+[[package]]
 name = "zksync_os_reth_compat"
 version = "0.17.1"
 dependencies = [
@@ -14720,6 +14732,7 @@ dependencies = [
  "zksync_os_operator_signer",
  "zksync_os_pipeline",
  "zksync_os_priority_tree",
+ "zksync_os_raft",
  "zksync_os_reth_compat",
  "zksync_os_revm_consistency_checker",
  "zksync_os_rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "lib/base_token_adjuster",
     "lib/reth_compat",
     "lib/operator_signer",
+    "lib/raft",
 ]
 resolver = "3"
 default-members = ["node/bin"]
@@ -267,6 +268,7 @@ zksync_os_batch_types = { version = "=0.17.1", path = "lib/batch_types" }
 zksync_os_internal_config = { version = "=0.17.1", path = "lib/internal_config" }
 zksync_os_interop_fee_updater = { version = "=0.17.1", path = "lib/interop_fee_updater" }
 zksync_os_network = { version = "=0.17.1", path = "lib/network" }
+zksync_os_raft = { version = "=0.17.1", path = "lib/raft" }
 zksync_os_metadata = { version = "=0.17.1", path = "lib/metadata" }
 zksync_os_external_price_api = { version = "=0.17.1", path = "lib/external_price_api" }
 zksync_os_base_token_adjuster = { version = "=0.17.1", path = "lib/base_token_adjuster" }

--- a/lib/raft/Cargo.toml
+++ b/lib/raft/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "zksync_os_raft"
+description = "OpenRaft integration for ZKsync OS"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+zksync_os_sequencer.workspace = true
+zksync_os_storage_api.workspace = true

--- a/lib/raft/src/init.rs
+++ b/lib/raft/src/init.rs
@@ -1,0 +1,15 @@
+use crate::model::{
+    BlockCanonizationEngine, ConsensusBootstrapper, ConsensusNetworkProtocol,
+    ConsensusRuntimeParts, ConsensusStatusSource, LeadershipSignal,
+};
+use zksync_os_sequencer::execution::NoopCanonization;
+
+pub fn loopback_consensus() -> ConsensusRuntimeParts {
+    ConsensusRuntimeParts {
+        canonization_engine: BlockCanonizationEngine::Noop(NoopCanonization::new()),
+        leadership: LeadershipSignal::AlwaysLeader,
+        network_protocol: ConsensusNetworkProtocol::Disabled,
+        bootstrapper: ConsensusBootstrapper::Noop,
+        status: ConsensusStatusSource::None,
+    }
+}

--- a/lib/raft/src/lib.rs
+++ b/lib/raft/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod init;
+pub mod model;
+
+pub use init::loopback_consensus;
+pub use model::{
+    BlockCanonizationEngine, ConsensusBootstrapper, ConsensusNetworkProtocol, ConsensusRole,
+    ConsensusRuntimeParts, ConsensusStatusSource, LeadershipSignal,
+};

--- a/lib/raft/src/model.rs
+++ b/lib/raft/src/model.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+use futures::future;
+use tokio::sync::watch;
+use zksync_os_sequencer::execution::{BlockCanonization, NoopCanonization};
+use zksync_os_storage_api::ReplayRecord;
+
+pub struct ConsensusRuntimeParts {
+    pub canonization_engine: BlockCanonizationEngine,
+    pub leadership: LeadershipSignal,
+    pub network_protocol: ConsensusNetworkProtocol,
+    pub bootstrapper: ConsensusBootstrapper,
+    pub status: ConsensusStatusSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsensusRole {
+    Leader,
+    Replica,
+}
+
+pub enum BlockCanonizationEngine {
+    Noop(NoopCanonization),
+}
+
+#[async_trait]
+impl BlockCanonization for BlockCanonizationEngine {
+    async fn propose(&self, record: ReplayRecord) -> anyhow::Result<()> {
+        match self {
+            BlockCanonizationEngine::Noop(canonization) => canonization.propose(record).await,
+        }
+    }
+
+    async fn next_canonized(&mut self) -> anyhow::Result<ReplayRecord> {
+        match self {
+            BlockCanonizationEngine::Noop(canonization) => canonization.next_canonized().await,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum LeadershipSignal {
+    AlwaysLeader,
+    Watch(watch::Receiver<ConsensusRole>),
+}
+
+impl LeadershipSignal {
+    pub fn current_role(&self) -> ConsensusRole {
+        match self {
+            Self::AlwaysLeader => ConsensusRole::Leader,
+            Self::Watch(rx) => *rx.borrow(),
+        }
+    }
+
+    pub async fn wait_for_change(&mut self) -> Result<(), watch::error::RecvError> {
+        match self {
+            Self::AlwaysLeader => future::pending::<Result<(), watch::error::RecvError>>().await,
+            Self::Watch(rx) => rx.changed().await,
+        }
+    }
+}
+
+pub enum ConsensusNetworkProtocol {
+    Disabled,
+}
+
+pub enum ConsensusBootstrapper {
+    Noop,
+}
+
+pub enum ConsensusStatusSource {
+    None,
+}

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -46,6 +46,7 @@ zksync_os_state.workspace = true
 zksync_os_state_full_diffs.workspace = true
 zksync_os_merkle_tree.workspace = true
 zksync_os_interop_fee_updater.workspace = true
+zksync_os_raft.workspace = true
 
 zk_os_forward_system.workspace = true
 zk_ee.workspace = true

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -2,14 +2,15 @@ use async_trait::async_trait;
 use std::collections::HashSet;
 use tokio::sync::{mpsc, watch};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_raft::{ConsensusRole, LeadershipSignal};
 use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
 use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
 use zksync_os_storage_api::{ReadReplay, ReadReplayExt, ReplayRecord};
 
-/// Command source for Main Node.
-/// Replays local WAL starting from `starting_block` and then produces new blocks.
+/// Command source for consensus-enabled main node.
+/// Replays local WAL starting from `starting_block` and then produces new blocks when leader.
 #[derive(Debug)]
-pub struct MainNodeCommandSource<Replay> {
+pub struct ConsensusNodeCommandSource<Replay> {
     /// Local block replays (aka `WAL`).
     pub block_replay_storage: Replay,
     /// Block number to start replaying from.
@@ -19,6 +20,8 @@ pub struct MainNodeCommandSource<Replay> {
     pub rebuild_options: Option<RebuildOptions>,
     /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
     pub replays_to_execute: mpsc::Receiver<ReplayRecord>,
+    /// Current leadership status from consensus.
+    pub leadership: LeadershipSignal,
 }
 
 #[derive(Debug)]
@@ -36,11 +39,11 @@ pub struct ExternalNodeCommandSource {
 }
 
 #[async_trait]
-impl<Replay: ReadReplay> PipelineComponent for MainNodeCommandSource<Replay> {
+impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay> {
     type Input = ();
     type Output = BlockCommand;
 
-    const NAME: &'static str = "node_command_source";
+    const NAME: &'static str = "consensus_node_command_source";
     const OUTPUT_BUFFER_SIZE: usize = 1;
 
     async fn run(
@@ -94,23 +97,45 @@ impl<Replay: ReadReplay> PipelineComponent for MainNodeCommandSource<Replay> {
     }
 }
 
-impl<Replay: ReadReplay> MainNodeCommandSource<Replay> {
+impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
     /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
-    /// Produces `Produce` commands and errors if any replay records are received.
-    /// When consensus is integrated, this method will switch the mode from Replica to Leader.
+    /// Produces `Produce` commands only when the node is the leader.
     async fn run_loop(mut self, output: mpsc::Sender<BlockCommand>) -> anyhow::Result<()> {
+        let mut leadership = self.leadership.clone();
+        let mut role = leadership.current_role();
+        tracing::info!(?role, "Consensus role initialized");
+
         loop {
             tokio::select! {
+                res = leadership.wait_for_change() => {
+                    if res.is_err() {
+                        anyhow::bail!("leader watch channel closed");
+                    }
+                    let new_role = leadership.current_role();
+                    if new_role != role {
+                        tracing::info!(?role, ?new_role, "Consensus role changed");
+                        role = new_role;
+                    }
+                }
                 maybe_record = self.replays_to_execute.recv() => {
                     let Some(record) = maybe_record else {
                         anyhow::bail!("inbound replay channel closed");
                     };
-                    anyhow::bail!(
-                        "Leader node received block {} produced by someone else!",
-                        record.block_context.block_number,
+                    tracing::info!(
+                        block_number = record.block_context.block_number,
+                        role = ?role,
+                        "Received canonized block from consensus",
                     );
+                    if output
+                        .send(BlockCommand::Replay(Box::new(record)))
+                        .await
+                        .is_err()
+                    {
+                        tracing::warn!("Command output channel closed, stopping source");
+                        break;
+                    }
                 }
-                send_res = output.send(BlockCommand::Produce(ProduceCommand)) => {
+                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if role == ConsensusRole::Leader => {
                     if send_res.is_err() {
                         tracing::warn!("Command output channel closed, stopping source");
                         break;
@@ -119,7 +144,7 @@ impl<Replay: ReadReplay> MainNodeCommandSource<Replay> {
             }
         }
 
-        anyhow::bail!("Execution loop in MainNodeCommandSource ended unexpectedly");
+        anyhow::bail!("Execution loop in ConsensusNodeCommandSource ended unexpectedly");
     }
 
     async fn send_block_rebuilds(

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -18,7 +18,7 @@ pub mod util;
 
 use crate::batch_sink::{BatchSink, NoOpSink, clear_failing_block_config_task};
 use crate::batcher::{Batcher, BatcherStartupConfig, util::load_genesis_stored_batch_info};
-use crate::command_source::{ExternalNodeCommandSource, MainNodeCommandSource};
+use crate::command_source::{ConsensusNodeCommandSource, ExternalNodeCommandSource};
 use crate::config::{
     Config, ProverApiConfig, base_token_price_updater_config, gas_adjuster_config,
 };
@@ -84,13 +84,16 @@ use zksync_os_network::RecordOverride;
 use zksync_os_network::service::{NetworkService, ZksProtocolConfig};
 use zksync_os_observability::GENERAL_METRICS;
 use zksync_os_pipeline::Pipeline;
+use zksync_os_raft::{
+    BlockCanonizationEngine, ConsensusRuntimeParts, LeadershipSignal, loopback_consensus,
+};
 use zksync_os_reth_compat::provider::ZkProviderFactory;
 use zksync_os_revm_consistency_checker::node::RevmConsistencyChecker;
 use zksync_os_rpc::{EthCallHandler, RpcStorage, run_jsonrpsee_server};
 use zksync_os_rpc_api::eth::EthApiClient;
 use zksync_os_sequencer::execution::block_context_provider::BlockContextProvider;
 use zksync_os_sequencer::execution::{
-    BlockApplier, BlockCanonizer, BlockExecutor, FeeParams, FeeProvider, NoopCanonization,
+    BlockApplier, BlockCanonizer, BlockExecutor, FeeParams, FeeProvider,
 };
 use zksync_os_status_server::run_status_server;
 use zksync_os_storage::db::{BlockReplayStorage, ExecutedBatchStorage};
@@ -392,6 +395,12 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     // Channel between NetworkService and Sequencer
     let (replay_sender, replays_for_sequencer) = tokio::sync::mpsc::channel(128);
+
+    let ConsensusRuntimeParts {
+        canonization_engine,
+        leadership,
+        ..
+    } = loopback_consensus();
     if config.network_config.enabled {
         tracing::info!("initializing p2p networking");
 
@@ -834,6 +843,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             tx_acceptance_state_sender,
             sidecar_sender,
             committed_batch_provider.clone(),
+            canonization_engine,
+            leadership,
         )
         .await;
     } else {
@@ -913,11 +924,69 @@ async fn run_main_node_pipeline(
     tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     sidecar_sender: tokio::sync::mpsc::Sender<BlobTransactionSidecar>,
     committed_batch_provider: CommittedBatchProvider,
+    canonization_engine: BlockCanonizationEngine,
+    leadership: LeadershipSignal,
 ) {
     let pubdata_mode = config
         .l1_sender_config
         .pubdata_mode
         .expect("l1_sender_pubdata_mode must be set on the Main Node");
+    let priority_tree_db_path = config
+        .general_config
+        .rocks_db_path
+        .join(PRIORITY_TREE_DB_NAME);
+    let internal_config_manager = init_and_report_internal_config_manager(
+        config
+            .general_config
+            .rocks_db_path
+            .join(INTERNAL_CONFIG_FILE_NAME),
+    );
+
+    let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::channel(8);
+
+    let pipeline = Pipeline::new()
+        .pipe(ConsensusNodeCommandSource {
+            block_replay_storage: block_replay_storage.clone(),
+            starting_block,
+            rebuild_options: config
+                .sequencer_config
+                .block_rebuild
+                .clone()
+                .map(Into::into),
+            replays_to_execute,
+            leadership,
+        })
+        .pipe(BlockExecutor {
+            block_context_provider,
+            state: state.clone(),
+            config: config.into(),
+            tx_acceptance_state_sender,
+        })
+        .pipe(BlockCanonizer {
+            consensus: canonization_engine,
+            canonized_blocks_for_execution: replays_to_execute_sender,
+        })
+        .pipe(BlockApplier {
+            state: state.clone(),
+            replay: block_replay_storage.clone(),
+            repositories: repositories.clone(),
+            config: config.into(),
+        })
+        .pipe_opt(
+            config
+                .sequencer_config
+                .revm_consistency_checker_enabled
+                .then(|| {
+                    RevmConsistencyChecker::new(
+                        state.clone(),
+                        internal_config_manager.clone(),
+                        config
+                            .sequencer_config
+                            .revm_consistency_checker_revert_on_divergence,
+                    )
+                }),
+        )
+        .pipe(TreeManager { tree: tree.clone() });
     tracing::info!("Initializing ProofStorage");
     let proof_storage = ProofStorage::new(config.prover_api_config.proof_storage.clone())
         .await
@@ -957,61 +1026,7 @@ async fn run_main_node_pipeline(
         run_fake_snark_provers(&config.prover_api_config, tasks, snark_job_manager);
     }
 
-    let priority_tree_db_path = config
-        .general_config
-        .rocks_db_path
-        .join(PRIORITY_TREE_DB_NAME);
-    let internal_config_manager = init_and_report_internal_config_manager(
-        config
-            .general_config
-            .rocks_db_path
-            .join(INTERNAL_CONFIG_FILE_NAME),
-    );
-
-    let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::channel(8);
-
-    Pipeline::new()
-        .pipe(MainNodeCommandSource {
-            block_replay_storage: block_replay_storage.clone(),
-            starting_block,
-            rebuild_options: config
-                .sequencer_config
-                .block_rebuild
-                .clone()
-                .map(Into::into),
-            replays_to_execute,
-        })
-        .pipe(BlockExecutor {
-            block_context_provider,
-            state: state.clone(),
-            config: config.into(),
-            tx_acceptance_state_sender,
-        })
-        .pipe(BlockCanonizer {
-            consensus: NoopCanonization::new(),
-            canonized_blocks_for_execution: replays_to_execute_sender,
-        })
-        .pipe(BlockApplier {
-            state: state.clone(),
-            replay: block_replay_storage.clone(),
-            repositories: repositories.clone(),
-            config: config.into(),
-        })
-        .pipe_opt(
-            config
-                .sequencer_config
-                .revm_consistency_checker_enabled
-                .then(|| {
-                    RevmConsistencyChecker::new(
-                        state.clone(),
-                        internal_config_manager.clone(),
-                        config
-                            .sequencer_config
-                            .revm_consistency_checker_revert_on_divergence,
-                    )
-                }),
-        )
-        .pipe(TreeManager { tree: tree.clone() })
+    let pipeline = pipeline
         .pipe(ProverInputGenerator {
             enable_logging: config.prover_input_generator_config.logging_enabled,
             maximum_in_flight_blocks: config
@@ -1084,8 +1099,10 @@ async fn run_main_node_pipeline(
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: config.general_config.gateway_rpc_url.is_some(),
         })
-        .pipe(BatchSink::new(internal_config_manager))
-        .spawn(tasks);
+        .pipe(BatchSink::new(internal_config_manager));
+
+    tracing::info!("Launching pipeline");
+    pipeline.spawn(tasks);
 }
 
 /// Only for EN - we still populate channels destined for the batcher subsystem -


### PR DESCRIPTION
## Description
  This PR extracts the first, minimal slice of the consensus work.

  It introduces a shared consensus runtime boundary in zksync_os_raft and updates node wiring to use it, but keeps behavior single-node:

  - explicit consensus runtime parts
  - shared ConsensusRole / LeadershipSignal
  - loopback consensus initialization
  - local canonization / always-leader behavior
  - it also makes the batcher subsystem optional - but it's of course running by default

  What is intentionally not included yet:

  - OpenRaft transport over the network
  - cluster bootstrap / multi-node behavior
  - broader config, status, and test rollout

  The goal is to make the node consensus-aware first, without mixing that review with distributed networking.

