### PR TITLE
Fix integration tests command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Format**: `cargo fmt --all -- --check`
 - **Lint**: `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -- -D warnings`
 - **Unit tests**: `cargo nextest run --workspace --exclude zksync_os_integration_tests`
-- **Integration tests**: `cargo nextest run --profile ci -p zksync_os_integration_tests`
+- **Integration tests**: `cargo nextest run -p zksync_os_integration_tests` (no live anvil needed — each test manages its own L1/node)
 
 ### Local Development Setup
 1. Run script: `./run_local.sh ./local-chains/v30.2/default`


### PR DESCRIPTION
## Summary
- Fixed the integration tests command in CLAUDE.md: removed non-existent `--profile ci` nextest profile (only `default`, `fast`, and `coverage` profiles exist in `.config/nextest.toml`)
- Added clarification that tests manage their own anvil/L1 instances — no live anvil needed

## Task prompt
> The info about running integration tests in claude.md/agents.md is invalid. First, it doesn't require live anvil, but the tests manage anvil. Second, the command for running the integration tests doesn't work, fix that

## Test plan
- [ ] Verify `cargo nextest run -p zksync_os_integration_tests` runs successfully without a separate anvil instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)