### PR TITLE
feat: load test CI and regressions monitoring

### DIFF
--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -104,6 +104,7 @@ jobs:
             --branch "${{ github.head_ref || github.ref_name }}" \
             --start-point main \
             --err \
+            --ci-only-thresholds \
             --github-actions "${{ secrets.GITHUB_TOKEN }}" \
             --file "${LOADBASE_OUT_DIR}/bencher.json"
 
@@ -111,6 +112,7 @@ jobs:
         run: |
           SUMMARY_JSON="${LOADBASE_OUT_DIR}/summary.json"
           REPORT_MD="${LOADBASE_OUT_DIR}/report.md"
+          PR_COMMENT_MD="${LOADBASE_OUT_DIR}/pr-comment.md"
           if [ ! -f "${SUMMARY_JSON}" ]; then
             echo "summary.json is missing" >&2
             exit 1
@@ -124,18 +126,24 @@ jobs:
           RECEIPT_TIMEOUTS=$(jq -r '.summary.receipt_timeouts // 0' "${SUMMARY_JSON}")
           RECEIPT_ERRORS=$(jq -r '.summary.receipt_errors // 0' "${SUMMARY_JSON}")
 
+          cat > "${PR_COMMENT_MD}" <<EOF
+          ## Loadbase Benchmark
+
+          | Metric | Value |
+          |---|---:|
+          | Samples | ${SAMPLE_COUNT} |
+          | Median TPS10 | ${MEDIAN_TPS10} |
+          | P95 TPS10 | ${P95_TPS10} |
+          | Median include p50 10s (s) | ${MEDIAN_INC_P50} |
+          | Final included | ${FINAL_INCLUDED} |
+          | Receipt timeouts | ${RECEIPT_TIMEOUTS} |
+          | Receipt errors | ${RECEIPT_ERRORS} |
+
+          [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · Full markdown report is available in the workflow artifacts.
+          EOF
+
           {
-            echo "## Loadbase Benchmark"
-            echo
-            echo "| Metric | Value |"
-            echo "|---|---:|"
-            echo "| Samples | ${SAMPLE_COUNT} |"
-            echo "| Median TPS10 | ${MEDIAN_TPS10} |"
-            echo "| P95 TPS10 | ${P95_TPS10} |"
-            echo "| Median include p50 10s (s) | ${MEDIAN_INC_P50} |"
-            echo "| Final included | ${FINAL_INCLUDED} |"
-            echo "| Receipt timeouts | ${RECEIPT_TIMEOUTS} |"
-            echo "| Receipt errors | ${RECEIPT_ERRORS} |"
+            cat "${PR_COMMENT_MD}"
             echo
             if [ -f "${REPORT_MD}" ]; then
               echo "<details><summary>Full report</summary>"
@@ -145,6 +153,13 @@ jobs:
               echo "</details>"
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Update PR benchmark comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: loadbase-benchmark
+          path: ${{ env.LOADBASE_OUT_DIR }}/pr-comment.md
 
       - name: Upload benchmark artifacts
         if: always() && !cancelled()
@@ -156,6 +171,7 @@ jobs:
             ${{ env.LOADBASE_LOGFILE }}
             ${{ env.LOADBASE_OUT_DIR }}/summary.json
             ${{ env.LOADBASE_OUT_DIR }}/report.md
+            ${{ env.LOADBASE_OUT_DIR }}/pr-comment.md
             ${{ env.LOADBASE_OUT_DIR }}/metrics.json
             ${{ env.LOADBASE_OUT_DIR }}/metrics.csv
             ${{ env.LOADBASE_OUT_DIR }}/bencher.json

--- a/docs/src/guides/loadtest_regression_monitoring.md
+++ b/docs/src/guides/loadtest_regression_monitoring.md
@@ -62,7 +62,7 @@ In CI:
 - `bencher.json` is uploaded to bencher.dev
 - all of the above are uploaded as GitHub artifacts for debugging and post-run inspection
 
-For the local usage guide and file format overview, see [loadbase/README.md](/Users/abalias/projects/matter-labs/zksync-os-server/loadbase/README.md).
+For the local usage guide and file format overview, see [loadbase/README.md](https://github.com/matter-labs/zksync-os-server/blob/main/loadbase/README.md).
 
 ## Bencher.dev Tracking
 


### PR DESCRIPTION
## Summary

This PR moves the `loadbase` benchmark workflow off the old artifact-based regression approach and onto bencher.dev, while also hardening the benchmark client and CI profile.

## Example sticky comment in each PR

| Metric | Value |
|---|---:|
| Samples | 92 |
| Median TPS10 | 34.7 |
| P95 TPS10 | 38.4 |
| Median include p50 10s (s) | 0.406 |
| Final included | 3032 |
| Receipt timeouts | 0 |
| Receipt errors | 0 |

[Workflow run](https://github.com/matter-labs/zksync-os-server/actions/runs/22902406162) · Full markdown report is available in the workflow artifacts.

<!-- Sticky Pull Request Commentloadbase-benchmark -->

## What changed

- added structured benchmark outputs from `loadbase`
  - `summary.json`
  - `report.md`
  - `metrics.json`
  - `metrics.csv`
  - `bencher.json`
- added Bencher Metric Format export in `loadbase`
- updated the loadtest workflow to:
  - run `loadbase` in CI
  - upload `bencher.json` to bencher.dev
  - keep artifacts only for debugging / inspection
- removed custom artifact-based regression comparison from the active workflow path
- tuned the CI benchmark profile to a more stable setting
- run the server in `general_ephemeral=true` mode in CI to avoid stale local DB state
- improved `loadbase` reliability under load
  - added gas price headroom to avoid base-fee-related stalls
  - improved nonce / dropped-tx handling
  - improved worker / metrics / output handling
- refreshed benchmark documentation
  - `loadbase/README.md`
  - docs guide for loadtest regression monitoring

## Bencher metrics

The workflow now uploads these benchmarks to bencher.dev:

- `sequencer/tps10_median` as `throughput`
- `sequencer/tps10_p95` as `throughput`
- `sequencer/include_latency_p50` as `seconds`
- `sequencer/receipt_timeouts` as `count`
- `sequencer/receipt_errors` as `count`

## CI profile

Current benchmark profiles:

- PR runs:
  - `--duration 90s`
  - `--wallets 20`
  - `--max-in-flight 15`
- `main` / manual runs:
  - `--duration 3m`
  - `--wallets 30`
  - `--max-in-flight 25`

These are intentionally lower than aggressive local stress settings to improve repeatability and reduce CI hangs.

## Notes

- GitHub artifacts are still uploaded, but they are no longer used as the regression baseline source.
- Regression tracking is now Bencher-only.
- Bencher thresholds must be configured in bencher.dev for alerting / PR comments to become useful.

## Verification

- `cargo test --manifest-path loadbase/Cargo.toml output::tests -- --nocapture`
- local `loadbase` run against ephemeral server with successful bencher upload
