### PR TITLE
feat: use logId for interop roots persistence instead of block/event …

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -7,6 +7,7 @@ use crate::IBridgehub::{
     IBridgehubInstance, L2TransactionRequestDirect, L2TransactionRequestTwoBridgesOuter,
     requestL2TransactionDirectCall, requestL2TransactionTwoBridgesCall,
 };
+use crate::IMessageRoot::IMessageRootInstance;
 use crate::IMultisigCommitter::IMultisigCommitterInstance;
 use crate::IZKChain::IZKChainInstance;
 use alloy::contract::SolCallBuilder;
@@ -81,6 +82,8 @@ alloy::sol! {
         );
 
         function addInteropRootsInBatch(InteropRoot[] calldata interopRootsInput);
+
+        uint256 public totalPublishedInteropRoots;
 
         function getChainTree(uint256 chainId) public view returns (Bytes32PushTree);
 
@@ -411,6 +414,46 @@ alloy::sol! {
     #[sol(rpc)]
     interface IERC20 {
         function decimals() external view returns (uint8);
+    }
+}
+
+pub struct MessageRoot<P: Provider> {
+    instance: IMessageRootInstance<P, Ethereum>,
+    address: Address,
+}
+
+impl<P: Provider> MessageRoot<P> {
+    pub fn new(address: Address, provider: P) -> Self {
+        let instance = IMessageRoot::new(address, provider);
+        Self { instance, address }
+    }
+
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    pub fn provider(&self) -> &P {
+        self.instance.provider()
+    }
+
+    pub async fn total_published_interop_roots(&self, block_id: BlockId) -> Result<u64> {
+        self.instance
+            .totalPublishedInteropRoots()
+            .block(block_id)
+            .call()
+            .await
+            .map(|n| n.saturating_to())
+            .enrich("totalPublishedInteropRoots", Some(block_id))
+    }
+
+    pub async fn code_exists_at_block(&self, block_id: BlockId) -> alloy::contract::Result<bool> {
+        let code = self
+            .provider()
+            .get_code_at(*self.address())
+            .block_id(block_id)
+            .await?;
+
+        Ok(!code.0.is_empty())
     }
 }
 

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
 
+use alloy::primitives::ruint::FromUintError;
 use alloy::rpc::types::{Log, Topic, ValueOrArray};
 use alloy::sol_types::SolEvent;
 use alloy::{primitives::Address, providers::DynProvider};
 use zksync_os_contract_interface::IMessageRoot::NewInteropRoot;
 use zksync_os_contract_interface::{Bridgehub, InteropRoot};
 use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
-use zksync_os_types::{IndexedInteropRoot, InteropRootsLogIndex};
+use zksync_os_types::IndexedInteropRoot;
 
+use crate::util::find_l1_block_by_interop_root_id;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessRawEvents};
 
 pub struct InteropWatcher {
     contract_address: Address,
-    starting_interop_event_index: InteropRootsLogIndex,
+    starting_interop_root_id: u64,
     interop_roots_subpool: InteropRootsSubpool,
 }
 
@@ -21,32 +23,33 @@ impl InteropWatcher {
     pub async fn create_watcher(
         bridgehub: Bridgehub<DynProvider>,
         config: L1WatcherConfig,
-        starting_interop_event_index: InteropRootsLogIndex,
+        starting_interop_root_id: u64,
         interop_roots_subpool: InteropRootsSubpool,
     ) -> anyhow::Result<L1Watcher> {
         let contract_address = bridgehub.message_root_address().await?;
 
         tracing::info!(
             contract_address = ?contract_address,
-            starting_interop_event_index = ?starting_interop_event_index,
+            starting_interop_root_id,
             "initializing interop watcher"
         );
 
+        let next_l1_block =
+            find_l1_block_by_interop_root_id(bridgehub.clone(), starting_interop_root_id).await?;
+
         let this = Self {
             contract_address,
-            starting_interop_event_index,
+            starting_interop_root_id,
             interop_roots_subpool,
         };
 
-        let l1_watcher = L1Watcher::new(
+        Ok(L1Watcher::new(
             bridgehub.provider().clone(),
-            this.starting_interop_event_index.block_number,
+            next_l1_block,
             config.max_blocks_to_process,
             config.poll_interval,
             Box::new(this),
-        );
-
-        Ok(l1_watcher)
+        ))
     }
 }
 
@@ -72,7 +75,7 @@ impl ProcessRawEvents for InteropWatcher {
             let sol_event = NewInteropRoot::decode_log(&log.inner)
                 .expect("failed to decode log")
                 .data;
-            indexes.insert(sol_event.blockNumber, log);
+            indexes.insert(sol_event.logId, log);
         }
 
         indexes.into_values().collect()
@@ -81,19 +84,20 @@ impl ProcessRawEvents for InteropWatcher {
     async fn process_raw_event(&mut self, log: Log) -> Result<(), L1WatcherError> {
         let event = NewInteropRoot::decode_log(&log.inner)?.data;
 
-        let event_log_index = InteropRootsLogIndex {
-            block_number: log.block_number.unwrap(),
-            index_in_block: log.log_index.unwrap(),
-        };
+        let log_id: u64 = event
+            .logId
+            .try_into()
+            .map_err(|e: FromUintError<u64>| L1WatcherError::Other(e.into()))?;
 
-        if event_log_index < self.starting_interop_event_index {
+        if log_id < self.starting_interop_root_id {
             tracing::debug!(
-                log_id = ?event.logId,
-                starting_interop_event_index = ?self.starting_interop_event_index,
-                "skipping interop root event before starting index",
+                log_id,
+                starting_interop_root_id = self.starting_interop_root_id,
+                "skipping interop root event before starting id",
             );
             return Ok(());
         }
+
         let interop_root = InteropRoot {
             chainId: event.chainId,
             blockOrBatchNumber: event.blockNumber,
@@ -102,7 +106,7 @@ impl ProcessRawEvents for InteropWatcher {
 
         self.interop_roots_subpool
             .add_root(IndexedInteropRoot {
-                log_index: event_log_index,
+                log_id,
                 root: interop_root,
             })
             .await;

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -14,7 +14,7 @@ use zksync_os_batch_types::{BatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
 use zksync_os_contract_interface::models::CommitBatchInfo;
-use zksync_os_contract_interface::{IExecutor, ZkChain};
+use zksync_os_contract_interface::{Bridgehub, IExecutor, MessageRoot, ZkChain};
 use zksync_os_types::ProtocolSemanticVersion;
 
 pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
@@ -276,6 +276,55 @@ pub async fn find_l1_execute_block_by_batch_number(
         Ok(res >= batch_number)
     })
     .await
+}
+
+/// Finds the first L1 block where `totalPublishedInteropRoots >= next_interop_root_id`.
+/// Uses binary search for efficiency.
+pub async fn find_l1_block_by_interop_root_id(
+    bridgehub: Bridgehub<DynProvider>,
+    next_interop_root_id: u64,
+) -> anyhow::Result<BlockNumber> {
+    if next_interop_root_id == 0 {
+        return Ok(0);
+    }
+
+    let message_root_address = bridgehub.message_root_address().await?;
+    let message_root = Arc::new(MessageRoot::new(
+        message_root_address,
+        bridgehub.provider().clone(),
+    ));
+
+    let latest = message_root.provider().get_block_number().await?;
+
+    let guarded_predicate =
+        async |message_root: Arc<MessageRoot<DynProvider>>, block: u64| -> anyhow::Result<bool> {
+            if !message_root.code_exists_at_block(block.into()).await? {
+                return Ok(false);
+            }
+            let res = message_root
+                .total_published_interop_roots(block.into())
+                .await?;
+            Ok(res >= next_interop_root_id)
+        };
+
+    if !guarded_predicate(message_root.clone(), latest).await? {
+        anyhow::bail!(
+            "Condition not satisfied up to latest block: contract not deployed yet \
+             or target not reached.",
+        );
+    }
+
+    let (mut lo, mut hi) = (0, latest);
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        if guarded_predicate(message_root.clone(), mid).await? {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+
+    Ok(lo)
 }
 
 /// Fetches and decodes stored batch data for batch `batch_number` that is expected to have been

--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -14,8 +14,7 @@ use tokio::time::Instant;
 use zksync_os_interface::types::AccountDiff;
 use zksync_os_storage_api::ReplayRecord;
 use zksync_os_types::{
-    InteropRootsLogIndex, L1TxSerialId, L2Envelope, SystemTxType, UpgradeMetadata, ZkEnvelope,
-    ZkTransaction,
+    L1TxSerialId, L2Envelope, SystemTxType, UpgradeMetadata, ZkEnvelope, ZkTransaction,
 };
 
 /// General pool that provides unified access to all transaction sources in the system.
@@ -247,8 +246,8 @@ pub struct StreamOutcome<'a> {
 
 #[derive(Debug, Default)]
 pub struct StateChangeOutcome {
-    /// Last interop log index that was imported after canonical state change.
-    pub last_interop_log_index: Option<InteropRootsLogIndex>,
+    /// Last interop log_id that was imported after canonical state change.
+    pub last_interop_log_index: Option<u64>,
     /// Last L1 priority ID that was executed after canonical state change.
     pub last_l1_priority_id: Option<L1TxSerialId>,
 }

--- a/lib/mempool/src/subpools/interop_roots.rs
+++ b/lib/mempool/src/subpools/interop_roots.rs
@@ -5,8 +5,7 @@ use tokio::sync::Notify;
 use tokio::time::Instant;
 use tokio::time::sleep_until;
 use zksync_os_types::{
-    IndexedInteropRoot, InteropRoot, InteropRootsLogIndex, SystemTxEnvelope, SystemTxType,
-    ZkTransaction,
+    IndexedInteropRoot, InteropRoot, SystemTxEnvelope, SystemTxType, ZkTransaction,
 };
 
 #[derive(Clone)]
@@ -21,7 +20,7 @@ pub struct InteropRootsSubpool {
 /// canonical chain yet. Note that some prefix might have already been executed in sequencer (as
 /// they were returned from [`InteropRootsSubpool::interop_transactions_with_delay`]).
 struct Inner {
-    pending_roots: BTreeMap<InteropRootsLogIndex, InteropRoot>,
+    pending_roots: BTreeMap<u64, InteropRoot>,
 }
 
 impl InteropRootsSubpool {
@@ -43,8 +42,8 @@ impl InteropRootsSubpool {
             (
                 self.inner.clone(),
                 self.notify.clone(),
-                InteropRootsLogIndex::default(),
-                VecDeque::default(),
+                0u64,
+                VecDeque::<(u64, InteropRoot)>::default(),
             ),
             move |(inner, notify, mut cursor, mut buffer)| async move {
                 sleep_until(next_tx_allowed_after).await;
@@ -55,12 +54,9 @@ impl InteropRootsSubpool {
 
                     {
                         let inner = inner.read().unwrap();
-                        for (id, root) in inner.pending_roots.range(&cursor..) {
-                            cursor = InteropRootsLogIndex {
-                                block_number: id.block_number,
-                                index_in_block: id.index_in_block + 1,
-                            };
-                            buffer.push_front(root.clone());
+                        for (id, root) in inner.pending_roots.range(cursor..) {
+                            cursor = id + 1;
+                            buffer.push_front((*id, root.clone()));
                         }
                     }
 
@@ -68,12 +64,15 @@ impl InteropRootsSubpool {
                         let amount_of_roots_to_take = buffer.len().min(self.interop_roots_per_tx);
                         let starting_index = buffer.len() - amount_of_roots_to_take;
 
-                        let roots_to_consume = buffer
+                        let roots_to_consume: Vec<(u64, InteropRoot)> = buffer
                             .drain(starting_index..)
                             .rev() // reversing iterator as last element is the one received earliest
-                            .collect::<Vec<_>>();
+                            .collect();
 
-                        let envelope = SystemTxEnvelope::import_interop_roots(roots_to_consume);
+                        // Use the log_id of the first (smallest) root as the salt for uniqueness.
+                        let first_log_id = roots_to_consume[0].0;
+                        let roots = roots_to_consume.into_iter().map(|(_, r)| r).collect();
+                        let envelope = SystemTxEnvelope::import_interop_roots(roots, first_log_id);
                         drop(notified);
                         return Some((envelope.into(), (inner, notify, cursor, buffer)));
                     }
@@ -90,11 +89,11 @@ impl InteropRootsSubpool {
             .write()
             .unwrap()
             .pending_roots
-            .insert(root.log_index, root.root);
+            .insert(root.log_id, root.root);
         self.notify.notify_waiters();
     }
 
-    async fn pop_wait(&self) -> (InteropRootsLogIndex, InteropRoot) {
+    async fn pop_wait(&self) -> (u64, InteropRoot) {
         loop {
             let notified = self.notify.notified();
             {
@@ -107,17 +106,14 @@ impl InteropRootsSubpool {
         }
     }
 
-    /// Cleans up the stream and removes all roots that were sent in transactions
-    /// Returns the last log index of executed interop root
-    pub async fn on_canonical_state_change(
-        &self,
-        txs: Vec<&SystemTxEnvelope>,
-    ) -> Option<InteropRootsLogIndex> {
+    /// Cleans up the stream and removes all roots that were sent in transactions.
+    /// Returns the last log_id of the executed interop root.
+    pub async fn on_canonical_state_change(&self, txs: Vec<&SystemTxEnvelope>) -> Option<u64> {
         if txs.is_empty() {
             return None;
         }
 
-        let mut log_index = InteropRootsLogIndex::default();
+        let mut last_log_id = None;
 
         for tx in txs {
             let SystemTxType::ImportInteropRoots(roots_count) = *tx.system_subtype() else {
@@ -125,16 +121,23 @@ impl InteropRootsSubpool {
             };
 
             let mut roots = Vec::with_capacity(roots_count as usize);
+            let mut first_log_id = None;
             for _ in 0..roots_count {
                 let (id, root) = self.pop_wait().await;
+                if first_log_id.is_none() {
+                    first_log_id = Some(id);
+                }
                 roots.push(root);
-                log_index = id;
+                last_log_id = Some(id);
             }
-            let envelope = SystemTxEnvelope::import_interop_roots(roots);
+            let envelope = SystemTxEnvelope::import_interop_roots(
+                roots,
+                first_log_id.expect("roots_count > 0"),
+            );
 
             assert_eq!(&envelope, tx);
         }
 
-        Some(log_index)
+        last_log_id
     }
 }

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -1,6 +1,6 @@
 use crate::config::NetworkConfig;
 use crate::protocol::{ProtocolEvent, ProtocolState, ZksProtocolHandler};
-use crate::version::ZksProtocolV1;
+use crate::version::ZksProtocolV2;
 use crate::wire::replays::RecordOverride;
 use alloy::primitives::BlockNumber;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
@@ -113,7 +113,7 @@ impl NetworkService {
             .network_id(Some(client.chain_spec().chain_id()))
             // Add latest version of `zks` subprotocol. In the future this can be extended so that
             // several versions are registered here.
-            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV1, _> {
+            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV2, _> {
                 replay,
                 node_role,
                 starting_block: Arc::new(RwLock::new(starting_block)),

--- a/lib/network/src/version.rs
+++ b/lib/network/src/version.rs
@@ -1,7 +1,7 @@
 //! Support for representing the version of the `zks` protocol
 
 use crate::wire::message::ZksMessageId;
-use crate::wire::replays::{WireReplayRecord, v0, v1};
+use crate::wire::replays::{WireReplayRecord, v0, v1, v2};
 use alloy::primitives::bytes::BufMut;
 use alloy::rlp::{Decodable, Encodable, Error as RlpError};
 use std::fmt::Debug;
@@ -36,6 +36,16 @@ impl AnyZksProtocolVersion for ZksProtocolV1 {
     const VERSION: ZksVersion = ZksVersion::Zks1;
 }
 
+/// Protocol version 2 updates interop root indexing to use log IDs instead of block/event indexes.
+#[derive(Debug, Clone)]
+pub struct ZksProtocolV2;
+
+impl AnyZksProtocolVersion for ZksProtocolV2 {
+    type Record = v2::ReplayRecord;
+
+    const VERSION: ZksVersion = ZksVersion::Zks2;
+}
+
 /// Error thrown when failed to parse a valid [`ZksVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("Unknown zks protocol version: {0}")]
@@ -49,20 +59,23 @@ pub enum ZksVersion {
     Zks0 = 0,
     /// The `zks` protocol version 1.
     Zks1 = 1,
+    /// The `zks` protocol version 2. Uses log IDs for interop root indexing.
+    Zks2 = 2,
 }
 
 impl ZksVersion {
     /// The latest known zks version
-    pub const LATEST: Self = Self::Zks1;
+    pub const LATEST: Self = Self::Zks2;
 
     /// All known zks versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Zks0, Self::Zks1];
+    pub const ALL_VERSIONS: &'static [Self] = &[Self::Zks0, Self::Zks1, Self::Zks2];
 
     /// Returns the max message id for the given version.
     const fn max_message_id(&self) -> u8 {
         match self {
             ZksVersion::Zks0 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks1 => ZksMessageId::BlockReplays as u8,
+            ZksVersion::Zks2 => ZksMessageId::BlockReplays as u8,
         }
     }
 
@@ -109,6 +122,7 @@ impl TryFrom<u8> for ZksVersion {
         match u {
             0 => Ok(Self::Zks0),
             1 => Ok(Self::Zks1),
+            2 => Ok(Self::Zks2),
             _ => Err(ParseVersionError(u.to_string())),
         }
     }
@@ -127,6 +141,7 @@ impl From<ZksVersion> for &'static str {
         match v {
             ZksVersion::Zks0 => "0",
             ZksVersion::Zks1 => "1",
+            ZksVersion::Zks2 => "2",
         }
     }
 }
@@ -156,7 +171,8 @@ mod tests {
         let test_cases = [
             (0_u8, Ok(ZksVersion::Zks0)),
             (1_u8, Ok(ZksVersion::Zks1)),
-            (2_u8, Err(RlpError::Custom("invalid zks version"))),
+            (2_u8, Ok(ZksVersion::Zks2)),
+            (3_u8, Err(RlpError::Custom("invalid zks version"))),
         ];
 
         for (input, expected) in test_cases {

--- a/lib/network/src/wire/replays/impls.rs
+++ b/lib/network/src/wire/replays/impls.rs
@@ -3,7 +3,7 @@
 //! Note that this file is allowed to change as traits can evolve over time and hence can the
 //! surrounding logic.
 
-use crate::wire::replays::{WireReplayRecord, v0, v1};
+use crate::wire::replays::{WireReplayRecord, v0, v1, v2};
 use crate::wire::{BlockHashes, ForcedPreimage};
 use alloy::consensus::crypto::RecoveryError;
 use alloy::primitives::{BlockNumber, Bytes};
@@ -48,7 +48,7 @@ impl TryFrom<v0::ReplayRecord> for StorageReplayRecord {
             protocol_version: ProtocolSemanticVersion::new(0, 0, 0),
             block_output_hash: Default::default(),
             force_preimages: vec![],
-            starting_interop_event_index: InteropRootsLogIndex::default(),
+            starting_interop_root_id: 0,
         })
     }
 }
@@ -104,7 +104,8 @@ impl From<StorageReplayRecord> for v1::ReplayRecord {
                     preimage: Bytes::from(preimage),
                 })
                 .collect(),
-            starting_interop_event_index: value.starting_interop_event_index,
+            // v1 format uses InteropRootsLogIndex; default it since log_id is not recoverable
+            starting_interop_event_index: InteropRootsLogIndex::default(),
         }
     }
 }
@@ -151,7 +152,110 @@ impl TryFrom<v1::ReplayRecord> for StorageReplayRecord {
                 .into_iter()
                 .map(|p| (p.hash, p.preimage.into()))
                 .collect(),
-            starting_interop_event_index: value.starting_interop_event_index,
+            // v1 format has InteropRootsLogIndex; map to 0 since block/index is not the log_id
+            starting_interop_root_id: 0,
+        })
+    }
+}
+
+// ==========================================
+// | Implementations for protocol version 2 |
+// ==========================================
+
+impl WireReplayRecord for v2::ReplayRecord {
+    fn block_number(&self) -> BlockNumber {
+        self.block_context.block_number
+    }
+}
+
+impl From<InterfaceBlockContext> for v2::BlockContext {
+    fn from(value: InterfaceBlockContext) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            block_number: value.block_number,
+            block_hashes: BlockHashes(value.block_hashes.0),
+            timestamp: value.timestamp,
+            eip1559_basefee: value.eip1559_basefee,
+            pubdata_price: value.pubdata_price,
+            native_price: value.native_price,
+            coinbase: value.coinbase,
+            gas_limit: value.gas_limit,
+            pubdata_limit: value.pubdata_limit,
+            mix_hash: value.mix_hash,
+            execution_version: value.execution_version,
+            blob_fee: value.blob_fee,
+        }
+    }
+}
+
+impl From<v2::BlockContext> for InterfaceBlockContext {
+    fn from(value: v2::BlockContext) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            block_number: value.block_number,
+            block_hashes: InterfaceBlockHashes(value.block_hashes.0),
+            timestamp: value.timestamp,
+            eip1559_basefee: value.eip1559_basefee,
+            pubdata_price: value.pubdata_price,
+            native_price: value.native_price,
+            coinbase: value.coinbase,
+            gas_limit: value.gas_limit,
+            pubdata_limit: value.pubdata_limit,
+            mix_hash: value.mix_hash,
+            execution_version: value.execution_version,
+            blob_fee: value.blob_fee,
+        }
+    }
+}
+
+impl From<StorageReplayRecord> for v2::ReplayRecord {
+    fn from(value: StorageReplayRecord) -> Self {
+        Self {
+            block_context: value.block_context.into(),
+            starting_l1_priority_id: value.starting_l1_priority_id,
+            transactions: value
+                .transactions
+                .into_iter()
+                .map(|tx| tx.into_envelope())
+                .collect(),
+            previous_block_timestamp: value.previous_block_timestamp,
+            protocol_version: value.protocol_version,
+            block_output_hash: value.block_output_hash,
+            force_preimages: value
+                .force_preimages
+                .into_iter()
+                .map(|(hash, preimage)| ForcedPreimage {
+                    hash,
+                    preimage: Bytes::from(preimage),
+                })
+                .collect(),
+            starting_interop_root_id: value.starting_interop_root_id,
+        }
+    }
+}
+
+impl TryFrom<v2::ReplayRecord> for StorageReplayRecord {
+    type Error = RecoveryError;
+
+    fn try_from(value: v2::ReplayRecord) -> Result<Self, Self::Error> {
+        Ok(Self {
+            block_context: value.block_context.into(),
+            starting_l1_priority_id: value.starting_l1_priority_id,
+            transactions: value
+                .transactions
+                .into_iter()
+                .map(|tx| tx.try_into_recovered())
+                .collect::<Result<Vec<_>, _>>()?,
+            previous_block_timestamp: value.previous_block_timestamp,
+            node_version: NODE_SEMVER_VERSION.clone(),
+            protocol_version: value.protocol_version,
+            block_output_hash: value.block_output_hash,
+            force_preimages: value
+                .force_preimages
+                .into_iter()
+                .map(|p| (p.hash, p.preimage.into()))
+                .collect(),
+            starting_interop_root_id: value.starting_interop_root_id,
         })
     }
 }

--- a/lib/network/src/wire/replays/mod.rs
+++ b/lib/network/src/wire/replays/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod v0;
 pub mod v1;
+pub mod v2;
 
 mod impls;
 

--- a/lib/network/src/wire/replays/v2.rs
+++ b/lib/network/src/wire/replays/v2.rs
@@ -1,0 +1,40 @@
+//! Wire format version 2.
+//!
+//! Changes from v1: replaced `starting_interop_event_index: InteropRootsLogIndex`
+//! with `starting_interop_root_id: u64`.
+//!
+//! Do not change this file under any circumstances. Copy it instead. May be deleted when obsolete.
+
+use crate::wire::{BlockHashes, ForcedPreimage};
+use alloy::primitives::{Address, B256, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use zksync_os_types::{L1TxSerialId, ProtocolSemanticVersion, ZkEnvelope};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+pub struct ReplayRecord {
+    pub block_context: BlockContext,
+    pub starting_l1_priority_id: L1TxSerialId,
+    pub transactions: Vec<ZkEnvelope>,
+    pub previous_block_timestamp: u64,
+    pub protocol_version: ProtocolSemanticVersion,
+    pub block_output_hash: B256,
+    pub force_preimages: Vec<ForcedPreimage>,
+    pub starting_interop_root_id: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+pub struct BlockContext {
+    pub chain_id: u64,
+    pub block_number: u64,
+    pub block_hashes: BlockHashes,
+    pub timestamp: u64,
+    pub eip1559_basefee: U256,
+    pub pubdata_price: U256,
+    pub native_price: U256,
+    pub coinbase: Address,
+    pub gas_limit: u64,
+    pub pubdata_limit: u64,
+    pub mix_hash: U256,
+    pub execution_version: u32,
+    pub blob_fee: U256,
+}

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -12,7 +12,7 @@ use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_network::protocol::{ProtocolEvent, ProtocolState, ZksProtocolHandler};
 use zksync_os_network::version::{AnyZksProtocolVersion, ZksProtocolV0, ZksProtocolV1};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};
-use zksync_os_types::{InteropRootsLogIndex, NodeRole, ProtocolSemanticVersion};
+use zksync_os_types::{NodeRole, ProtocolSemanticVersion};
 
 #[derive(Debug, Clone, Default)]
 struct InMemReplay(HashMap<BlockNumber, ReplayRecord>);
@@ -50,7 +50,7 @@ fn dummy_record(block_number: BlockNumber) -> ReplayRecord {
         ProtocolSemanticVersion::new(4, 5, 6),
         B256::random(),
         vec![],
-        InteropRootsLogIndex::default(),
+        0,
     )
 }
 

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -9,9 +9,7 @@ use zksync_os_interface::types::{BlockContext, BlockHashes, BlockOutput};
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_mempool::{MarkingTxStream, Pool};
 use zksync_os_storage_api::ReplayRecord;
-use zksync_os_types::{
-    ExecutionVersion, InteropRootsLogIndex, ProtocolSemanticVersion, ZkEnvelope,
-};
+use zksync_os_types::{ExecutionVersion, ProtocolSemanticVersion, ZkEnvelope};
 
 /// Component that turns `BlockCommand`s into `PreparedBlockCommand`s.
 /// Last step in the stream where `Produce` and `Replay` are differentiated.
@@ -25,7 +23,7 @@ use zksync_os_types::{
 ///  this is easily fixable if needed.
 pub struct BlockContextProvider<Subpool> {
     next_l1_priority_id: u64,
-    next_interop_event_index: InteropRootsLogIndex,
+    next_interop_root_id: u64,
     pool: Pool<Subpool>,
     block_hashes_for_next_block: BlockHashes,
     previous_block_timestamp: u64,
@@ -47,7 +45,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         next_l1_priority_id: u64,
-        next_interop_event_index: InteropRootsLogIndex,
+        next_interop_root_id: u64,
         pool: Pool<Subpool>,
         block_hashes_for_next_block: BlockHashes,
         previous_block_timestamp: u64,
@@ -63,7 +61,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
     ) -> Self {
         Self {
             next_l1_priority_id,
-            next_interop_event_index,
+            next_interop_root_id,
             pool,
             block_hashes_for_next_block,
             previous_block_timestamp,
@@ -169,7 +167,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                     expected_block_output_hash: None,
                     previous_block_timestamp: self.previous_block_timestamp,
                     force_preimages,
-                    starting_interop_event_index: self.next_interop_event_index.clone(),
+                    starting_interop_root_id: self.next_interop_root_id,
                     interop_roots_per_block: self.interop_roots_per_block,
                 }
             }
@@ -201,7 +199,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                     expected_block_output_hash: Some(record.block_output_hash),
                     previous_block_timestamp: self.previous_block_timestamp,
                     force_preimages: record.force_preimages,
-                    starting_interop_event_index: record.starting_interop_event_index.clone(),
+                    starting_interop_root_id: record.starting_interop_root_id,
                     interop_roots_per_block: self.interop_roots_per_block,
                 }
             }
@@ -282,7 +280,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                     expected_block_output_hash: None,
                     previous_block_timestamp: self.previous_block_timestamp,
                     force_preimages: rebuild.replay_record.force_preimages,
-                    starting_interop_event_index: self.next_interop_event_index.clone(),
+                    starting_interop_root_id: self.next_interop_root_id,
                     interop_roots_per_block: self.interop_roots_per_block,
                 }
             }
@@ -314,12 +312,9 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                 .next_l1_priority_id
                 .set(self.next_l1_priority_id);
         }
-        if let Some(last_interop_log_index) = outcome.last_interop_log_index {
+        if let Some(last_interop_log_id) = outcome.last_interop_log_index {
             self.next_interop_tx_allowed_after = Instant::now() + self.service_block_delay;
-            self.next_interop_event_index = InteropRootsLogIndex {
-                block_number: last_interop_log_index.block_number,
-                index_in_block: last_interop_log_index.index_in_block + 1,
-            };
+            self.next_interop_root_id = last_interop_log_id + 1;
         }
 
         // We update protocol version here, so that we take into account replay records with protocol version bumps.

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -372,7 +372,7 @@ pub async fn execute_block<R: ReadStateHistory + WriteState>(
             command.protocol_version,
             block_hash_output,
             command.force_preimages,
-            command.starting_interop_event_index,
+            command.starting_interop_root_id,
         ),
         purged_txs,
     ))

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use zksync_os_interface::types::BlockContext;
 use zksync_os_mempool::MarkingTxStream;
 use zksync_os_storage_api::ReplayRecord;
-use zksync_os_types::{InteropRootsLogIndex, L1TxSerialId, ProtocolSemanticVersion};
+use zksync_os_types::{L1TxSerialId, ProtocolSemanticVersion};
 
 /// `BlockCommand`s drive the sequencer execution.
 /// Produced by `CommandProducer` - first blocks are `Replay`ed from block replay storage
@@ -94,7 +94,7 @@ pub struct PreparedBlockCommand<'a> {
     /// Contract preimages to be included before the block execution.
     /// Can be non-empty e.g. when processing upgrade transactions.
     pub force_preimages: Vec<(B256, Vec<u8>)>,
-    pub starting_interop_event_index: InteropRootsLogIndex,
+    pub starting_interop_root_id: u64,
     pub interop_roots_per_block: u64,
 }
 

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -10,7 +10,7 @@ use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::{NamedColumnFamily, WriteBatch};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay};
-use zksync_os_types::{InteropRootsLogIndex, ProtocolSemanticVersion};
+use zksync_os_types::ProtocolSemanticVersion;
 
 /// A write-ahead log storing [`ReplayRecord`]s.
 ///
@@ -43,7 +43,7 @@ pub enum BlockReplayColumnFamily {
     ProtocolVersion,
     ForcePreimages,
     BlockOutputHash,
-    StartingInteropEventIndex,
+    StartingInteropRootId,
     /// Mapping from block_number to block hash.
     CanonicalHash,
     /// Stores the latest appended block number under a fixed key.
@@ -60,7 +60,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
         BlockReplayColumnFamily::ProtocolVersion,
         BlockReplayColumnFamily::BlockOutputHash,
         BlockReplayColumnFamily::ForcePreimages,
-        BlockReplayColumnFamily::StartingInteropEventIndex,
+        BlockReplayColumnFamily::StartingInteropRootId,
         BlockReplayColumnFamily::CanonicalHash,
         BlockReplayColumnFamily::Latest,
     ];
@@ -74,7 +74,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
             BlockReplayColumnFamily::ProtocolVersion => "protocol_version",
             BlockReplayColumnFamily::BlockOutputHash => "block_output_hash",
             BlockReplayColumnFamily::ForcePreimages => "force_preimages",
-            BlockReplayColumnFamily::StartingInteropEventIndex => "starting_interop_event_index",
+            BlockReplayColumnFamily::StartingInteropRootId => "starting_interop_root_id",
             BlockReplayColumnFamily::CanonicalHash => "canonical_hash",
             BlockReplayColumnFamily::Latest => "latest",
         }
@@ -107,7 +107,7 @@ impl BlockReplayStorage {
                 protocol_version: genesis_tx.protocol_version.clone(),
                 block_output_hash: B256::ZERO,
                 force_preimages: genesis_tx.force_deploy_preimages.clone(),
-                starting_interop_event_index: InteropRootsLogIndex::default(),
+                starting_interop_root_id: 0,
             };
             this.write_replay_unchecked(Sealed::new_unchecked(genesis_record, genesis_hash), true);
         }
@@ -185,15 +185,15 @@ impl BlockReplayStorage {
             &force_preimages_value,
         );
 
-        let starting_interop_event_index_value = bincode::serde::encode_to_vec(
-            &record.starting_interop_event_index,
+        let starting_interop_root_id_value = bincode::serde::encode_to_vec(
+            record.starting_interop_root_id,
             bincode::config::standard(),
         )
-        .expect("Failed to serialize record.starting_interop_event_index");
+        .expect("Failed to serialize record.starting_interop_root_id");
         batch.put_cf(
-            BlockReplayColumnFamily::StartingInteropEventIndex,
+            BlockReplayColumnFamily::StartingInteropRootId,
             &db_key,
-            &starting_interop_event_index_value,
+            &starting_interop_root_id_value,
         );
 
         self.db
@@ -352,20 +352,20 @@ impl ReadReplay for BlockReplayStorage {
             .expect("Failed to read from BlockOutputHash CF")
             .expect("BlockOutputHash must be written atomically with Context");
 
-        let starting_interop_event_index = if let Some(starting_interop_event_index) = self
+        let starting_interop_root_id = if let Some(starting_interop_root_id) = self
             .db
-            .get_cf(BlockReplayColumnFamily::StartingInteropEventIndex, &key)
-            .expect("Failed to read from StartingInteropEventIndex CF")
+            .get_cf(BlockReplayColumnFamily::StartingInteropRootId, &key)
+            .expect("Failed to read from StartingInteropRootId CF")
         {
-            let stored: InteropRootsLogIndex = bincode::serde::decode_from_slice(
-                &starting_interop_event_index,
+            let stored: u64 = bincode::serde::decode_from_slice(
+                &starting_interop_root_id,
                 bincode::config::standard(),
             )
-            .expect("Failed to deserialize starting interop event index")
+            .expect("Failed to deserialize starting interop root id")
             .0;
             stored
         } else {
-            InteropRootsLogIndex::default()
+            0
         };
 
         Some(ReplayRecord {
@@ -392,7 +392,7 @@ impl ReadReplay for BlockReplayStorage {
             protocol_version,
             block_output_hash: B256::from_slice(&block_output_hash),
             force_preimages,
-            starting_interop_event_index,
+            starting_interop_root_id,
         })
     }
 

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -3,8 +3,7 @@ use alloy::rlp::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 use zksync_os_interface::types::BlockContext;
 use zksync_os_types::{
-    InteropRootsLogIndex, L1TxSerialId, ProtocolSemanticVersion, ZkEnvelope, ZkReceiptEnvelope,
-    ZkTransaction,
+    L1TxSerialId, ProtocolSemanticVersion, ZkEnvelope, ZkReceiptEnvelope, ZkTransaction,
 };
 
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
@@ -51,9 +50,9 @@ pub struct ReplayRecord {
     pub block_output_hash: B256,
     /// Forced preimages to be included before the block execution.
     pub force_preimages: Vec<(B256, Vec<u8>)>,
-    /// Event index(block number and index in block) of the interop root tx executed first in the block
-    /// If there is no interop root tx in the block, equals to the previous block's value
-    pub starting_interop_event_index: InteropRootsLogIndex,
+    /// Log id of the first interop root included in this block.
+    /// If there is no interop root tx in the block, equals to the previous block's value.
+    pub starting_interop_root_id: u64,
 }
 
 impl PartialEq for ReplayRecord {
@@ -67,7 +66,7 @@ impl PartialEq for ReplayRecord {
             && self.protocol_version == other.protocol_version
             && self.block_output_hash == other.block_output_hash
             && self.force_preimages == other.force_preimages
-            && self.starting_interop_event_index == other.starting_interop_event_index
+            && self.starting_interop_root_id == other.starting_interop_root_id
     }
 }
 
@@ -82,7 +81,7 @@ impl ReplayRecord {
         protocol_version: ProtocolSemanticVersion,
         block_output_hash: B256,
         force_preimages: Vec<(B256, Vec<u8>)>,
-        starting_interop_event_index: InteropRootsLogIndex,
+        starting_interop_root_id: u64,
     ) -> Self {
         let first_l1_tx_priority_id = transactions.iter().find_map(|tx| match tx.envelope() {
             ZkEnvelope::L1(l1_tx) => Some(l1_tx.priority_id()),
@@ -104,7 +103,7 @@ impl ReplayRecord {
             protocol_version,
             block_output_hash,
             force_preimages,
-            starting_interop_event_index,
+            starting_interop_root_id,
         }
     }
 }

--- a/lib/types/src/transaction/system/mod.rs
+++ b/lib/types/src/transaction/system/mod.rs
@@ -36,25 +36,30 @@ impl PartialEq for SystemTxEnvelope {
 }
 
 impl SystemTxEnvelope {
-    /// A constructor for system transaction that imports interop roots
-    pub fn import_interop_roots(roots: Vec<InteropRoot>) -> Self {
-        Self::create_from_input(SystemTxInput::ImportInteropRoots(roots))
+    /// A constructor for system transaction that imports interop roots.
+    /// `log_id` is used as the transaction salt to ensure uniqueness.
+    pub fn import_interop_roots(roots: Vec<InteropRoot>, log_id: u64) -> Self {
+        let tx_input = SystemTxInput::ImportInteropRoots(roots);
+        let transaction = SystemTx {
+            to: tx_input.to_address(),
+            input: Bytes::from(tx_input.abi_encode()),
+            salt: log_id,
+        };
+        Self {
+            hash: transaction.calculate_hash(),
+            inner: transaction,
+            subtype: OnceLock::new(),
+        }
     }
 
     /// A constructor for system transaction that sets the settlement layer chain id
     pub fn set_sl_chain_id(chain_id: ChainId) -> Self {
-        Self::create_from_input(SystemTxInput::SetSLChainId(chain_id))
-    }
-
-    fn create_from_input(tx_input: SystemTxInput) -> Self {
-        let calldata = tx_input.abi_encode();
-
+        let tx_input = SystemTxInput::SetSLChainId(chain_id);
         let transaction = SystemTx {
             to: tx_input.to_address(),
-            input: Bytes::from(calldata),
+            input: Bytes::from(tx_input.abi_encode()),
             salt: 0,
         };
-
         Self {
             hash: transaction.calculate_hash(),
             inner: transaction,
@@ -91,7 +96,7 @@ impl SystemTxEnvelope {
 
 #[derive(Clone, Debug)]
 pub struct IndexedInteropRoot {
-    pub log_index: InteropRootsLogIndex,
+    pub log_id: u64,
     pub root: InteropRoot,
 }
 
@@ -151,6 +156,7 @@ mod tx_serde {
 }
 
 /// A helper struct to store the block number and index in block of published interop roots event.
+/// Kept for backward-compatibility with the v1 network wire format.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct InteropRootsLogIndex {
     /// Block number from which event was published.
@@ -333,11 +339,14 @@ mod tests {
     /// See https://ethereum.github.io/execution-apis/api-documentation/
     #[test]
     fn interop_roots_tx_serialization() {
-        let tx = SystemTxEnvelope::import_interop_roots(vec![InteropRoot {
-            chainId: Uint::from(1),
-            blockOrBatchNumber: Uint::from(1),
-            sides: vec![B256::ZERO],
-        }]);
+        let tx = SystemTxEnvelope::import_interop_roots(
+            vec![InteropRoot {
+                chainId: Uint::from(1),
+                blockOrBatchNumber: Uint::from(1),
+                sides: vec![B256::ZERO],
+            }],
+            0,
+        );
 
         assert_eq!(
             serde_json::to_string_pretty(&tx).unwrap(),

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -97,8 +97,7 @@ use zksync_os_storage_api::{
     WriteReplay, WriteRepository, WriteState,
 };
 use zksync_os_types::{
-    InteropRootsLogIndex, ProtocolSemanticVersion, PubdataMode, TransactionAcceptanceState,
-    UpgradeInfo, UpgradeMetadata,
+    ProtocolSemanticVersion, PubdataMode, TransactionAcceptanceState, UpgradeInfo, UpgradeMetadata,
 };
 
 const BLOCK_REPLAY_WAL_DB_NAME: &str = "block_replay_wal";
@@ -450,11 +449,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         .as_ref()
         .map_or(0, |record| record.starting_l1_priority_id);
 
-    let next_interop_event_index = first_replay_record
+    let next_interop_root_id = first_replay_record
         .as_ref()
-        .map_or(InteropRootsLogIndex::default(), |record| {
-            record.starting_interop_event_index.clone()
-        });
+        .map_or(0u64, |record| record.starting_interop_root_id);
 
     let current_protocol_version = if let Some(record) = &first_replay_record {
         &record.protocol_version
@@ -490,7 +487,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             InteropWatcher::create_watcher(
                 node_startup_state.l1_state.bridgehub_sl.clone(), // TODO: what bridgehub to use here?
                 config.l1_watcher_config.clone().into(),
-                next_interop_event_index.clone(),
+                next_interop_root_id,
                 interop_roots_subpool.clone(),
             )
             .await
@@ -643,7 +640,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     );
     let block_context_provider = BlockContextProvider::new(
         next_l1_priority_id,
-        next_interop_event_index,
+        next_interop_root_id,
         pool,
         block_hashes_for_next_block,
         previous_block_timestamp,


### PR DESCRIPTION
## Summary

- Replaces `InteropRootsLogIndex` (`block_number + index_in_block` composite key) with a monotonic `logId: u64` from the `NewInteropRoot` L1 event for all interop root indexing and persistence.
- Uses `log_id` as the `salt` field of `SystemTxEnvelope::import_interop_roots` to ensure transaction uniqueness per batch of roots.
- Introduces wire format `v2` with `starting_interop_root_id: u64`; updates network service to use `ZksProtocolV2`. `v1` is kept frozen per project policy with zero-defaults for the new field.
- Adds `totalPublishedInteropRoots` to the `IMessageRoot` contract interface and a binary-search helper (`find_l1_block_by_interop_root_id`) so the interop watcher can determine the correct L1 starting block without storing `block_number`.
- `InteropRootsLogIndex` struct is retained (with a backward-compat note) since it is referenced by the frozen `v1` wire format.

## Changes

- **`lib/contract_interface`**: Added `totalPublishedInteropRoots` to `IMessageRoot` Solidity interface; added `MessageRoot<P>` wrapper with `total_published_interop_roots()` and `code_exists_at_block()` helpers.
- **`lib/types`**: `IndexedInteropRoot.log_id: u64` (was `log_index: InteropRootsLogIndex`); `import_interop_roots` takes `log_id: u64` as salt.
- **`lib/mempool`**: `InteropRootsSubpool` keyed by `u64`; `StateChangeOutcome.last_interop_log_index: Option<u64>`.
- **`lib/l1_watcher`**: `InteropWatcher` starts from `starting_interop_root_id: u64`; uses binary search on L1 to find the starting block; filters events by `logId`.
- **`lib/storage_api`**: `ReplayRecord.starting_interop_root_id: u64`.
- **`lib/storage`**: Column family renamed to `starting_interop_root_id`; serializes/deserializes `u64`.
- **`lib/sequencer`**: `PreparedBlockCommand.starting_interop_root_id: u64`; `BlockContextProvider` fields updated.
- **`lib/network`**: New `v2::ReplayRecord` with `starting_interop_root_id`; `ZksVersion::Zks2`; service uses `ZksProtocolV2`.
- **`node/bin`**: Passes `next_interop_root_id: u64` through to watcher and block context provider.

## Test plan

- [ ] Build passes: `cargo build`
- [ ] Clippy clean: `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [ ] All unit tests pass: `cargo nextest run --release --workspace --exclude zksync_os_integration_tests`
- [ ] Integration tests pass: `cargo nextest run -p zksync_os_integration_tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)