### PR TITLE
fix: fix legacy batch processing in persist batch watcher

### DIFF
--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -252,6 +252,11 @@ impl<BatchStorage: WriteBatch, Finality: WriteFinality> ProcessRawEvents
                                 log.block_number.expect("Missing block number in log"),
                             ),
                         });
+                    } else if self.last_processed_commit_batch == self.last_persisted_batch_on_start
+                    {
+                        // No `ReportCommittedBatchRangeZKsyncOS` event was processed yet, it is very likely that the batch is legacy
+                        // i.e. block range was not reported for it. Skip this batch.
+                        tracing::info!("assuming batch #{batch_number} is legacy and skipping it");
                     } else {
                         return Err(L1WatcherError::Other(anyhow::anyhow!(
                             "discovered executed batch #{batch_number} was not previously discovered as committed"


### PR DESCRIPTION
## Summary

Fix legacy batch processing in persist batch watcher. If there is a batch that doesn't have ReportCommittedBatchRangeZKsyncOS then it currently fails with "discovered executed batch #{batch_number} was not previously discovered as committed"

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

