### PR TITLE
refactor(multivm): introduce ExecutionPlugin trait for V6 dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ members = [
     "lib/base_token_adjuster",
     "lib/reth_compat",
     "lib/operator_signer",
+    "lib/plugin-api",
+    "lib/plugin-v6",
 ]
 resolver = "3"
 default-members = ["node/bin"]
@@ -267,6 +269,8 @@ zksync_os_external_price_api = { version = "=0.16.0", path = "lib/external_price
 zksync_os_base_token_adjuster = { version = "=0.16.0", path = "lib/base_token_adjuster" }
 zksync_os_reth_compat = { version = "=0.16.0", path = "lib/reth_compat" }
 zksync_os_operator_signer = { version = "=0.16.0", path = "lib/operator_signer" }
+zksync_os_plugin_api = { version = "=0.16.0", path = "lib/plugin-api" }
+zksync_os_plugin_v6 = { version = "=0.16.0", path = "lib/plugin-v6" }
 
 zksync_os_server = { version = "=0.16.0", path = "node/bin" }
 

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -13,11 +13,12 @@ build = "build.rs"
 
 [dependencies]
 zksync_os_interface.workspace = true
+zksync_os_plugin_api.workspace = true
+zksync_os_plugin_v6.workspace = true
 zk_os_forward_system.workspace = true
 zk_os_forward_system_0_1_2.workspace = true
 zk_os_forward_system_0_0_28.workspace = true
 zk_os_forward_system_0_2_8.workspace = true
-zk_os_forward_system_dev.workspace = true
 anyhow.workspace = true
 zksync_os_types.workspace = true
 alloy = { workspace = true, default-features = false, features = [

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -1,12 +1,15 @@
 //! This module provides a unified interface for running blocks and simulating transactions.
-//! When adding new ZKsync OS execution version, make sure it is handled in `run_block` and `simulate_tx` methods.
-//! Also, update the `LATEST_EXECUTION_VERSION` constant accordingly.
+//!
+//! New execution versions should implement [`zksync_os_plugin_api::ExecutionPlugin`] in their own
+//! crate (see `plugin-v6` for an example) and be registered in this module's dispatch functions.
+//!
+//! Legacy versions (V1–V5) are frozen and dispatched directly to their respective
+//! `forward_system` crates without going through the plugin trait.
 
 use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV5Running;
 use zk_os_forward_system_0_0_28::run::RunBlockForward as RunBlockForwardV3;
 use zk_os_forward_system_0_1_2::run::RunBlockForward as RunBlockForwardV4;
 use zk_os_forward_system_0_2_8::run::RunBlockForward as RunBlockForwardV5Simulation;
-use zk_os_forward_system_dev::run::RunBlockForward as RunBlockForwardV6;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{AnyTracer, NopValidator};
 use zksync_os_interface::traits::{
@@ -14,12 +17,15 @@ use zksync_os_interface::traits::{
 };
 use zksync_os_interface::types::BlockContext;
 use zksync_os_interface::types::{BlockOutput, TxOutput};
+use zksync_os_plugin_api::ExecutionPlugin;
 
 mod adapter;
 pub mod apps;
 
 pub use adapter::AbiTxSource;
 use zksync_os_types::ExecutionVersion;
+
+static PLUGIN_V6: zksync_os_plugin_v6::PluginV6 = zksync_os_plugin_v6::PluginV6;
 
 pub fn run_block<
     Storage: ReadStorage,
@@ -40,6 +46,7 @@ pub fn run_block<
         .try_into()
         .expect("Unsupported ZKsync OS execution version");
     match execution_version {
+        // Legacy versions — frozen, dispatched directly to their forward_system crates.
         ExecutionVersion::V1 | ExecutionVersion::V2 | ExecutionVersion::V3 => {
             let object = RunBlockForwardV3 {};
             object
@@ -91,21 +98,15 @@ pub fn run_block<
                 )
                 .map_err(|err| anyhow::anyhow!(err))
         }
-        ExecutionVersion::V6 => {
-            let object = RunBlockForwardV6 {};
-            object
-                .run_block(
-                    (),
-                    block_context,
-                    storage,
-                    preimage_source,
-                    tx_source,
-                    tx_result_callback,
-                    tracer,
-                    &mut NopValidator,
-                )
-                .map_err(|err| anyhow::anyhow!(err))
-        }
+        // V6+ — dispatched through the ExecutionPlugin trait.
+        ExecutionVersion::V6 => PLUGIN_V6.run_block(
+            block_context,
+            storage,
+            preimage_source,
+            tx_source,
+            tx_result_callback,
+            tracer,
+        ),
     }
 }
 
@@ -121,6 +122,7 @@ pub fn simulate_tx<Storage: ReadStorage, PreimgSrc: PreimageSource, Tracer: AnyT
         .try_into()
         .expect("Unsupported ZKsync OS execution version");
     match execution_version {
+        // Legacy versions — frozen, dispatched directly to their forward_system crates.
         ExecutionVersion::V1 | ExecutionVersion::V2 | ExecutionVersion::V3 => {
             let object = RunBlockForwardV3 {};
             object
@@ -169,19 +171,9 @@ pub fn simulate_tx<Storage: ReadStorage, PreimgSrc: PreimageSource, Tracer: AnyT
                 )
                 .map_err(|err| anyhow::anyhow!(err))
         }
+        // V6+ — dispatched through the ExecutionPlugin trait.
         ExecutionVersion::V6 => {
-            let object = RunBlockForwardV6 {};
-            object
-                .simulate_tx(
-                    (),
-                    transaction,
-                    block_context,
-                    storage,
-                    preimage_source,
-                    tracer,
-                    &mut NopValidator,
-                )
-                .map_err(|err| anyhow::anyhow!(err))
+            PLUGIN_V6.simulate_tx(transaction, block_context, storage, preimage_source, tracer)
         }
     }
 }

--- a/lib/plugin-api/Cargo.toml
+++ b/lib/plugin-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "zksync_os_plugin_api"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+zksync_os_interface.workspace = true
+anyhow.workspace = true

--- a/lib/plugin-api/src/lib.rs
+++ b/lib/plugin-api/src/lib.rs
@@ -1,0 +1,49 @@
+//! Stable trait definitions for multivm execution plugins.
+//!
+//! Each execution version of zksync-os implements [`ExecutionPlugin`] to provide
+//! block execution and transaction simulation capabilities. This crate deliberately
+//! has no dependency on any `forward_system` version — it only depends on the
+//! version-stable `zksync_os_interface`.
+
+use zksync_os_interface::error::InvalidTransaction;
+use zksync_os_interface::tracing::AnyTracer;
+use zksync_os_interface::traits::{
+    EncodedTx, PreimageSource, ReadStorage, TxResultCallback, TxSource,
+};
+use zksync_os_interface::types::{BlockContext, BlockOutput, TxOutput};
+
+/// Trait for block execution and transaction simulation, implemented by each
+/// version-specific plugin crate.
+///
+/// The trait uses generic parameters (not trait objects) to match the existing
+/// `zksync_os_interface` design and avoid boxing overhead in the hot path.
+pub trait ExecutionPlugin {
+    fn run_block<S, P, T, C, Tr>(
+        &self,
+        block_context: BlockContext,
+        storage: S,
+        preimage_source: P,
+        tx_source: T,
+        tx_result_callback: C,
+        tracer: &mut Tr,
+    ) -> Result<BlockOutput, anyhow::Error>
+    where
+        S: ReadStorage,
+        P: PreimageSource,
+        T: TxSource,
+        C: TxResultCallback,
+        Tr: AnyTracer;
+
+    fn simulate_tx<S, P, Tr>(
+        &self,
+        transaction: EncodedTx,
+        block_context: BlockContext,
+        storage: S,
+        preimage_source: P,
+        tracer: &mut Tr,
+    ) -> Result<Result<TxOutput, InvalidTransaction>, anyhow::Error>
+    where
+        S: ReadStorage,
+        P: PreimageSource,
+        Tr: AnyTracer;
+}

--- a/lib/plugin-v6/Cargo.toml
+++ b/lib/plugin-v6/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "zksync_os_plugin_v6"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+zksync_os_plugin_api.workspace = true
+zksync_os_interface.workspace = true
+zk_os_forward_system_dev.workspace = true
+anyhow.workspace = true

--- a/lib/plugin-v6/src/lib.rs
+++ b/lib/plugin-v6/src/lib.rs
@@ -1,0 +1,72 @@
+//! Execution plugin for zksync-os V6 (dev version).
+//!
+//! Wraps `zk_os_forward_system_dev` behind the stable [`ExecutionPlugin`] trait.
+
+use zk_os_forward_system_dev::run::RunBlockForward;
+use zksync_os_interface::error::InvalidTransaction;
+use zksync_os_interface::tracing::{AnyTracer, NopValidator};
+use zksync_os_interface::traits::{
+    EncodedTx, PreimageSource, ReadStorage, RunBlock, SimulateTx, TxResultCallback, TxSource,
+};
+use zksync_os_interface::types::{BlockContext, BlockOutput, TxOutput};
+use zksync_os_plugin_api::ExecutionPlugin;
+
+pub struct PluginV6;
+
+impl ExecutionPlugin for PluginV6 {
+    fn run_block<S, P, T, C, Tr>(
+        &self,
+        block_context: BlockContext,
+        storage: S,
+        preimage_source: P,
+        tx_source: T,
+        tx_result_callback: C,
+        tracer: &mut Tr,
+    ) -> Result<BlockOutput, anyhow::Error>
+    where
+        S: ReadStorage,
+        P: PreimageSource,
+        T: TxSource,
+        C: TxResultCallback,
+        Tr: AnyTracer,
+    {
+        RunBlockForward {}
+            .run_block(
+                (),
+                block_context,
+                storage,
+                preimage_source,
+                tx_source,
+                tx_result_callback,
+                tracer,
+                &mut NopValidator,
+            )
+            .map_err(|err| anyhow::anyhow!(err))
+    }
+
+    fn simulate_tx<S, P, Tr>(
+        &self,
+        transaction: EncodedTx,
+        block_context: BlockContext,
+        storage: S,
+        preimage_source: P,
+        tracer: &mut Tr,
+    ) -> Result<Result<TxOutput, InvalidTransaction>, anyhow::Error>
+    where
+        S: ReadStorage,
+        P: PreimageSource,
+        Tr: AnyTracer,
+    {
+        RunBlockForward {}
+            .simulate_tx(
+                (),
+                transaction,
+                block_context,
+                storage,
+                preimage_source,
+                tracer,
+                &mut NopValidator,
+            )
+            .map_err(|err| anyhow::anyhow!(err))
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces a `plugin-api` crate with a stable `ExecutionPlugin` trait that new execution versions implement
- Adds `plugin-v6` crate wrapping `zk_os_forward_system_dev` behind the trait
- Refactors `multivm` to dispatch V6 through the plugin while keeping frozen V1–V5 paths untouched
- Removes direct `zk_os_forward_system_dev` dependency from multivm (it is now only in plugin-v6)

This establishes the pattern for future versions: implement `ExecutionPlugin` in a new `plugin-vN` crate, register it in the multivm dispatcher. No changes needed to the multivm public API — callers (`sequencer`, `rpc`, etc.) are unaffected.

## Context

This is the first step toward simplifying multiVM per the plugin architecture proposal. The approach keeps legacy versions (V1–V5) frozen and untouched to avoid risk, and only routes V6+ through the new trait.

### Task prompt

> Implement steps 1-3 of the static plugin wrapper plan, keeping V1-V5 as-is:
> 1. Define `ExecutionPlugin` trait in a `plugin-api` crate
> 2. Create `plugin-v6` wrapper implementing the trait
> 3. Refactor multivm to use plugin-v6 for V6 dispatch

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --exclude zksync_os_integration_tests` — 149/149 tests pass

No new tests added — this is a pure refactor with no behavioral change. The existing test suite (including multivm's `app_paths_are_scoped_to_the_requested_base_dir` test) validates the unchanged functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)