### PR TITLE
feat(rpc): log slow RPC requests at warn level

### DIFF
--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -204,6 +204,17 @@ fn log_and_report(
     API_METRICS.request_size[method].observe(request_size);
     API_METRICS.response_size[method].observe(output_size_bytes);
 
+    if elapsed > Duration::from_secs(1) {
+        tracing::warn!(
+            method,
+            ?kind,
+            ?elapsed,
+            request_size,
+            output_size_bytes,
+            "slow rpc request"
+        );
+    }
+
     debug_dispatch!(
         targets: match method {
             "eth_call" => "rpc::monitoring::eth::call",


### PR DESCRIPTION
## Summary
- Add a `warn!` log for any RPC request taking longer than 1 second
- Logs method name, elapsed time, request/response sizes
- Existing debug-level logging for all requests is unchanged

## Context
Users report 10s+ response times under load, but our per-request logging is at debug level (too noisy for production). This surfaces slow requests in production logs so we can see actual durations, not just histogram bucket counts.

## Test plan
- No tests added — this is a logging-only change with no behavioral impact
- Verified compilation with `cargo check -p zksync_os_rpc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)