### PR TITLE
fix(rpc): lower eth_getLogs default limits to match industry standard

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -410,11 +410,11 @@ pub struct RpcConfig {
     pub max_response_size: u32,
 
     /// Maximum number of blocks that could be scanned per filter
-    #[config(default_t = 100_000)]
+    #[config(default_t = 10_000)]
     pub max_blocks_per_filter: u64,
 
     /// Maximum number of logs that can be returned in a response
-    #[config(default_t = 20_000)]
+    #[config(default_t = 10_000)]
     pub max_logs_per_response: usize,
 
     /// Duration since the last filter poll, after which the filter is considered stale


### PR DESCRIPTION
## Summary
- Reduce `max_blocks_per_filter` default: 100,000 → 10,000
- Reduce `max_logs_per_response` default: 20,000 → 10,000
- Aligns with industry standard limits

## Industry comparison

| Provider | Max block range | Max logs per response |
|---|---|---|
| Alchemy | 2,000 (unlimited logs) OR any range (10K logs cap) | 10,000 |
| QuickNode | 10,000 | — |
| Infura | 10,000 | 10,000 |
| Chainstack | 10,000 | — |
| **zksync-os (before)** | **100,000** | **20,000** |
| **zksync-os (after)** | **10,000** | **10,000** |

## Context
Users report slow RPC responses under load. Testing against genlayer testnet (recent blocks) shows:

| Block range | Time | Response |
|---|---|---|
| 1 | 0.29s | 7 KB |
| 10 | 0.21s | 30 KB |
| 100 | 0.36s | 321 KB |
| 1,000 | 0.58s | 2.8 MB |
| 10,000 | 0.61s | error: max logs exceeded |
| 100,000 | 1.08s | error: max logs exceeded |

Even with the current 20k logs limit, scanning 100k blocks takes >1s just for the iteration. Existing deployments can restore old limits via env vars (`rpc_max_blocks_per_filter=100000`, `rpc_max_logs_per_response=20000`) if needed.

## Test plan
- No tests added — config default change only
- Tested manually against genlayer testnet
- Verified compilation with `cargo check -p zksync_os_server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)