### PR TITLE
fix(l1_sender): fix bug in `parallel_transactions` metric

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -120,7 +120,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
         latency_tracker.enter_state(L1SenderState::SendingToL1);
         let range = Input::display_range(&commands); // Only for logging
         tracing::info!(command_name, range, "sending L1 transactions");
-        L1_SENDER_METRICS.parallel_transactions[&command_name].set(cmd_buffer.len() as u64);
+        L1_SENDER_METRICS.parallel_transactions[&command_name].set(commands.len() as u64);
         // It's important to preserve the order of commands -
         // so that we send them downstream also in order.
         // This holds true because l1 transactions are included in the order of sender nonce.


### PR DESCRIPTION

The metric was always reporting 0 because cmd_buffer is drained into commands before the metric is set. Fixed to use commands.len() which contains the actual number of parallel transactions being sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
