### PR TITLE
fix: Use warn for server disconnects

### DIFF
--- a/lib/batch_verification/src/client/mod.rs
+++ b/lib/batch_verification/src/client/mod.rs
@@ -205,7 +205,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
                         }
                         Some(Err(parsing_err)) =>
                         {
-                            tracing::error!("Error parsing verification request message. Ignoring: {}", parsing_err);
+                            tracing::warn!("Error parsing verification request message. Ignoring: {}", parsing_err);
                         }
                         None => {
                             anyhow::bail!("Server has disconnected verification client");


### PR DESCRIPTION
Due to infra, such disconnects are expected. Marking them as error might confuse users into believing this is a problem. In reality, given it's HTTP, such "errors" can happen. This PR marks them properly for UX.