### PR TITLE
fix: Add more metrics for 2FA

### DIFF
--- a/lib/batch_verification/src/sequencer/component.rs
+++ b/lib/batch_verification/src/sequencer/component.rs
@@ -218,6 +218,13 @@ impl BatchVerifier {
         response_channels: ResponseChannelsMapArc,
         server: Arc<BatchVerificationServer>,
     ) -> Self {
+        BATCH_VERIFICATION_SEQUENCER_METRICS
+            .threshold
+            .set(component.threshold);
+        BATCH_VERIFICATION_SEQUENCER_METRICS
+            .validators_count
+            .set(component.validators.len());
+
         Self {
             config: component.config.clone(),
             accepted_signers: component.validators.clone(),
@@ -445,6 +452,7 @@ impl BatchVerifier {
                 result: BatchVerificationResult::Refused(reason),
                 ..
             } => {
+                BATCH_VERIFICATION_SEQUENCER_METRICS.failed_responses[&"refused"].inc();
                 tracing::info!(
                     batch_number = batch_envelope.batch_number(),
                     request_id = request_id,
@@ -462,6 +470,7 @@ impl BatchVerifier {
             self.multisig_committer,
             &batch_envelope.batch.protocol_version,
         ) else {
+            BATCH_VERIFICATION_SEQUENCER_METRICS.failed_responses[&"invalid_signature"].inc();
             tracing::warn!(
                 batch_number = batch_envelope.batch_number(),
                 request_id = request_id,
@@ -471,6 +480,7 @@ impl BatchVerifier {
         };
 
         if !self.accepted_signers.contains(validated_signature.signer()) {
+            BATCH_VERIFICATION_SEQUENCER_METRICS.failed_responses[&"unknown_signer"].inc();
             tracing::warn!(
                 batch_number = batch_envelope.batch_number(),
                 request_id = request_id,

--- a/lib/batch_verification/src/sequencer/metrics.rs
+++ b/lib/batch_verification/src/sequencer/metrics.rs
@@ -1,9 +1,15 @@
 use std::time::Duration;
-use vise::{Buckets, Gauge, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{Buckets, Counter, Gauge, Histogram, LabeledFamily, Metrics, Unit};
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "batch_verification_sequencer")]
 pub struct BatchVerificationSequencerMetrics {
+    /// Threshold chosen by the main node for batch verification.
+    pub threshold: Gauge<u64>,
+
+    /// Number of signer addresses chosen by the main node for batch verification.
+    pub validators_count: Gauge<usize>,
+
     /// Histogram of the attempt number on which batch verification succeeds. factor 1.3 -> 19 buckets
     #[metrics(buckets = Buckets::exponential(1.0..=128.0, 1.3))]
     pub attempts_to_success: Histogram<u64>,
@@ -20,6 +26,11 @@ pub struct BatchVerificationSequencerMetrics {
     /// retries where needed, all successes will be recorded.
     #[metrics(labels = ["signer"], buckets = Buckets::exponential(1.0..=128.0, 1.3))]
     pub successful_attempt_per_signer: LabeledFamily<String, Histogram<u64>>,
+
+    /// Total number of responses received by the main node that did not validate into
+    /// a usable signature set entry (e.g. refused, invalid, unknown signer).
+    #[metrics(labels = ["reason"])]
+    pub failed_responses: LabeledFamily<&'static str, Counter>,
 
     /// Latest request_id used for batch verification
     pub last_request_id: Gauge<u64>,


### PR DESCRIPTION
Currently, we don't know when 2FA nodes fail and what is the current configuration being ran by the server. This PR adds said metrics.

Note: 2FA metrics will be reworked as part of devp2p integration, but this gives us preliminary info to work with.