### PR TITLE
feat: add pre-push skill for Claude Code

### DIFF
--- a/.claude/hooks/guard-push.sh
+++ b/.claude/hooks/guard-push.sh
@@ -22,6 +22,6 @@ if [ -f "$FLAG_FILE" ]; then
   fi
 fi
 
-# Block the push
-echo "BLOCKED: Run /pre-push before pushing. Pre-push checks (format, lint, unit tests, integration tests) must all pass first." >&2
+# Block the push — including force pushes
+echo "BLOCKED: Run /pre-push before pushing. All pre-push checks (format, lint, unit tests, integration tests) must pass first. Do NOT bypass this by using --force or --force-with-lease without running /pre-push." >&2
 exit 2

--- a/.claude/skills/pre-push.md
+++ b/.claude/skills/pre-push.md
@@ -6,7 +6,13 @@ user_invocable: true
 
 # Pre-Push Checks
 
-Run **all** of the following checks before every `git push`. Do not skip any step. Do not push if any check fails — fix the issue first and re-run all checks.
+## MANDATORY — NO EXCEPTIONS
+
+Every check below **must** be executed before every `git push`, regardless of what was changed. Even if the change is documentation-only, config-only, or a single-line fix — **run every check anyway**. There are no exemptions.
+
+**Do NOT bypass this process by using `git push --force`, `git push --no-verify`, or any other flag that skips hooks or validation.** Force push (`--force` or `--force-with-lease`) is only permitted for rebases, and only AFTER all checks below have passed and the `.pre-push-passed` flag has been created.
+
+If a tool (like `cargo`) is not available in the environment, **stop and tell the user** — do not silently skip the check or proceed with the push.
 
 ## 1. Format
 
@@ -71,3 +77,4 @@ If any check fails:
 2. Re-run **all** checks from the beginning (not just the one that failed).
 3. Do **not** create the `.pre-push-passed` flag until every check passes.
 4. Only push once every check passes.
+5. **NEVER** bypass a failed check by force-pushing or skipping the hook.


### PR DESCRIPTION
## Summary
- Extracts pre-push validation instructions from CLAUDE.md into a reusable Claude Code skill at `.claude/skills/pre-push.md`
- The skill can be invoked with `/pre-push` before every `git push`, ensuring all required checks pass: formatting, linting, unit tests, integration tests, test coverage assessment, and wire format immutability verification
- Includes a failure protocol requiring all checks to be re-run from scratch after any fix

## Task prompt
> now claude.md has multiple instructions what to do before push to main, please take those instructions from there and turn them into a skill. The skill should tell AI which actions it must do before each push of code

## Test plan
- [ ] Verify `/pre-push` skill is recognized by Claude Code
- [ ] Run `/pre-push` and confirm all 6 checks execute in order
- [ ] Confirm a formatting failure stops the push and triggers the failure protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)