### PR TITLE
feat(rpc): add HTTP-level response time histogram

### DIFF
--- a/lib/rpc/src/http_timing_layer.rs
+++ b/lib/rpc/src/http_timing_layer.rs
@@ -1,0 +1,49 @@
+use crate::metrics::HTTP_METRICS;
+use hyper::body::Body;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct HttpTimingLayer;
+
+impl<S> Layer<S> for HttpTimingLayer {
+    type Service = HttpTimingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpTimingService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct HttpTimingService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<hyper::Request<ReqBody>> for HttpTimingService<S>
+where
+    S: Service<hyper::Request<ReqBody>, Response = hyper::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    ReqBody: Body + Send + 'static,
+    ResBody: Body + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: hyper::Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        Box::pin(async move {
+            let started = Instant::now();
+            let response = inner.call(req).await;
+            HTTP_METRICS.response_time.observe(started.elapsed());
+            response
+        })
+    }
+}

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 pub use config::RpcConfig;
 use std::sync::Arc;
 use tokio::sync::watch;
+use tower::ServiceBuilder;
 
 mod eth_call_handler;
 pub use eth_call_handler::EthCallHandler;
@@ -17,6 +18,7 @@ mod result;
 mod rpc_storage;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
+mod http_timing_layer;
 pub mod js_tracer;
 mod log_proof_utils;
 mod monitoring_middleware;
@@ -32,6 +34,7 @@ use crate::debug_impl::DebugNamespace;
 use crate::eth_filter_impl::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
+use crate::http_timing_layer::HttpTimingLayer;
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
@@ -127,7 +130,7 @@ pub async fn run_jsonrpsee_server<RpcStorage: ReadRpcStorage, Mempool: L2Subpool
         // Allow requests from any origin
         .allow_origin(Any)
         .allow_headers([hyper::header::CONTENT_TYPE]);
-    let middleware = tower::ServiceBuilder::new().layer(cors);
+    let middleware = ServiceBuilder::new().layer(HttpTimingLayer).layer(cors);
 
     let max_response_size_bytes = config.max_response_size_bytes();
     let rpc_middleware = RpcServiceBuilder::new()

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use vise::{Buckets, Histogram, LabeledFamily, Metrics, Unit};
 
-const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
+const LATENCIES: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
 const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1B .. 10MB
 
@@ -9,7 +9,7 @@ const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1
 pub struct ApiMetrics {
     #[metrics(labels = ["method"], buckets = BLOCK_COUNTS)]
     pub get_logs_scanned_blocks: LabeledFamily<&'static str, Histogram<u64>>,
-    #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]
+    #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES)]
     pub response_time: LabeledFamily<String, Histogram<Duration>>,
     #[metrics(unit = Unit::Bytes, labels = ["method"], buckets = BYTES_BUCKETS)]
     pub request_size: LabeledFamily<String, Histogram<usize>>,
@@ -19,5 +19,16 @@ pub struct ApiMetrics {
     pub requests_in_batch_count: LabeledFamily<String, Histogram<u64>>,
 }
 
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "http")]
+pub struct HttpMetrics {
+    /// Full HTTP request-response time, including TLS, parsing, serialization.
+    #[metrics(unit = Unit::Seconds, buckets = LATENCIES)]
+    pub response_time: Histogram<Duration>,
+}
+
 #[vise::register]
 pub static API_METRICS: vise::Global<ApiMetrics> = vise::Global::new();
+
+#[vise::register]
+pub static HTTP_METRICS: vise::Global<HttpMetrics> = vise::Global::new();


### PR DESCRIPTION
## Summary
- Adds `http_response_time_seconds` histogram measuring the full HTTP request-response lifecycle (tower layer wrapping the entire middleware stack)
- Complements the existing `response_time_seconds` which only measures RPC handler execution
- Renames `LATENCIES_FAST` → `LATENCIES` (no other variant exists)

## Motivation
Load testing from Frankfurt showed **67ms p50** client-side vs **~1ms p50** server-side (`response_time_seconds`). The server metric excludes JSON-RPC parsing, response serialization, and everything outside the handler. This new metric lets us measure how much overhead sits between the HTTP layer and the RPC handler, and by comparing with external client latency, isolate the LB/TLS/network contribution.

## Test plan
- [x] `cargo check -p zksync_os_rpc` passes
- [ ] Deploy to staging and compare `http_response_time_seconds` vs `response_time_seconds` under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)