### PR TITLE
fix(ci): remove workflow_dispatch from Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,6 @@
 name: Docker build and release
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "Tag of an image to build."
-        type: string
-        required: true
   push:
     branches:
       - main
@@ -59,7 +53,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.component }}
           tags: |
-            type=raw,value=${{ inputs.tag_name }},enable=${{ inputs.tag_name != '' }}
             type=ref,event=tag
             type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=sha,format=short,prefix=,suffix=-{{date 'x'}},enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Problem

The `workflow_dispatch` trigger allowed callers to pass an arbitrary `tag_name` string as the Docker image tag. However, the workflow always checked out the default branch (`main`) regardless of the tag provided. This meant a caller could push an image tagged as any version while the actual built artifact came from `main` — decoupling the image tag from the source commit it claims to represent.

## Fix

Remove the `workflow_dispatch` trigger entirely. Docker images can now only be built and pushed via:
- Push to `main` → tagged `latest` + `<sha>-<timestamp>`
- Push of a `v**` git tag → tagged with that version

In both cases, the checkout is pinned to the exact commit that triggered the workflow, so image tags are guaranteed to reflect their true source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)