### PR TITLE
fix: upgrade lz4_flex to 0.12.1 to address RUSTSEC-2026-0041

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,9 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"


### PR DESCRIPTION
## Summary

- Upgrades `lz4_flex` from `0.12.0` to `0.12.1` to fix a memory information disclosure vulnerability
- `lz4_flex 0.12.0` was yanked from crates.io due to [RUSTSEC-2026-0041](https://rustsec.org/advisories/RUSTSEC-2026-0041) / CVE-2026-32829: decompressing invalid LZ4 data via the block API could leak data from uninitialized memory or from a previously reused output buffer
- This was causing `cargo-audit` and `cargo-deny` CI checks to fail as of today (advisory published 2026-03-17)

## Test plan

- CI `cargo-audit` and `cargo-deny` checks should pass
- No code changes — only `Cargo.lock` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)