### PR TITLE
feat(multivm): use in-memory app bins for PIG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,24 +2170,6 @@ dependencies = [
 [[package]]
 name = "basic_bootloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "arrayvec",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "paste",
- "ruint",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
-]
-
-[[package]]
-name = "basic_bootloader"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "arrayvec",
@@ -2201,6 +2183,24 @@ dependencies = [
  "strum_macros",
  "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+]
+
+[[package]]
+name = "basic_bootloader"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "arrayvec",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "cfg-if",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -2277,32 +2277,6 @@ dependencies = [
 [[package]]
 name = "basic_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "arrayvec",
- "cfg-if",
- "const-hex",
- "const_for",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "either",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "num-bigint",
- "num-traits",
- "paste",
- "rand 0.9.2",
- "ruint",
- "serde",
- "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "strum_macros",
- "zerocopy",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
-]
-
-[[package]]
-name = "basic_system"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "arrayvec",
@@ -2320,6 +2294,32 @@ dependencies = [
  "strum_macros",
  "zerocopy",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+]
+
+[[package]]
+name = "basic_system"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "const-hex",
+ "const_for",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "either",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "modexp 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rand 0.9.2",
+ "ruint",
+ "serde",
+ "storage_models 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "strum_macros",
+ "zerocopy",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -2865,23 +2865,6 @@ dependencies = [
 [[package]]
 name = "callable_oracles"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "alloy-consensus",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "c-kzg",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "num-bigint",
- "num-traits",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
-]
-
-[[package]]
-name = "callable_oracles"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "alloy-consensus",
@@ -2894,6 +2877,23 @@ dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "ruint",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+]
+
+[[package]]
+name = "callable_oracles"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "alloy-consensus",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "c-kzg",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "num-bigint",
+ "num-traits",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "ruint",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3556,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3717,12 +3717,12 @@ source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.2-interface-v0.0
 [[package]]
 name = "cycle_marker"
 version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 
 [[package]]
 name = "cycle_marker"
 version = "0.0.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 
 [[package]]
 name = "darling"
@@ -4396,22 +4396,6 @@ dependencies = [
 [[package]]
 name = "evm_interpreter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "arrayvec",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "either",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "evm_interpreter"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "arrayvec",
@@ -4422,6 +4406,22 @@ dependencies = [
  "ruint",
  "strum_macros",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "zksync_os_evm_errors",
+]
+
+[[package]]
+name = "evm_interpreter"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "arrayvec",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "either",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_evm_errors",
 ]
 
@@ -4799,31 +4799,6 @@ dependencies = [
 [[package]]
 name = "forward_system"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "alloy",
- "arrayvec",
- "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "bincode 1.3.3",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "hex",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "paste",
- "ruint",
- "serde",
- "strum_macros",
- "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "zksync_os_evm_errors",
- "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
-]
-
-[[package]]
-name = "forward_system"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "alloy",
@@ -4844,6 +4819,31 @@ dependencies = [
  "zksync_os_evm_errors",
  "zksync_os_interface",
  "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+]
+
+[[package]]
+name = "forward_system"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "alloy",
+ "arrayvec",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "bincode 1.3.3",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "hex",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "paste",
+ "ruint",
+ "serde",
+ "strum_macros",
+ "system_hooks 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "zksync_os_evm_errors",
+ "zksync_os_interface",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -6765,12 +6765,12 @@ source = "git+https://github.com/matter-labs/zksync-os?tag=v0.1.2-interface-v0.0
 [[package]]
 name = "modexp"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 
 [[package]]
 name = "modexp"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 
 [[package]]
 name = "modular-bitfield"
@@ -7455,19 +7455,19 @@ dependencies = [
 [[package]]
 name = "oracle_provider"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
 ]
 
 [[package]]
 name = "oracle_provider"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -11299,19 +11299,19 @@ dependencies = [
 [[package]]
 name = "storage_models"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
 ]
 
 [[package]]
 name = "storage_models"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 dependencies = [
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -11525,20 +11525,6 @@ dependencies = [
 [[package]]
 name = "system_hooks"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "arrayvec",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "paste",
- "ruint",
- "strum_macros",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
-]
-
-[[package]]
-name = "system_hooks"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "arrayvec",
@@ -11548,6 +11534,20 @@ dependencies = [
  "ruint",
  "strum_macros",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+]
+
+[[package]]
+name = "system_hooks"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "arrayvec",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -13892,23 +13892,6 @@ dependencies = [
 [[package]]
 name = "zk_ee"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
-dependencies = [
- "arrayvec",
- "bitflags 2.11.0",
- "cfg-if",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "paste",
- "ruint",
- "serde",
- "strum_macros",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "zk_ee"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
  "arrayvec",
@@ -13918,6 +13901,23 @@ dependencies = [
  "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
  "paste",
  "ruint",
+ "strum_macros",
+ "zksync_os_evm_errors",
+]
+
+[[package]]
+name = "zk_ee"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "paste",
+ "ruint",
+ "serde",
  "strum_macros",
  "zksync_os_evm_errors",
 ]
@@ -13935,20 +13935,20 @@ dependencies = [
 [[package]]
 name = "zksync_os_api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 dependencies = [
  "alloy",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
 ]
 
 [[package]]
@@ -13973,11 +13973,11 @@ name = "zksync_os_batch_types"
 version = "0.17.1"
 dependencies = [
  "alloy",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "blake2",
  "serde",
  "thiserror 2.0.17",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_contract_interface",
  "zksync_os_interface",
  "zksync_os_merkle_tree",
@@ -14106,7 +14106,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "blake2",
  "serde",
  "serde_json",
@@ -14127,7 +14127,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "flate2",
  "fs2",
  "futures",
@@ -14208,7 +14208,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "blake2",
  "futures",
  "itertools 0.14.0",
@@ -14221,7 +14221,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
  "zksync_os_interface",
@@ -14241,7 +14241,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "futures",
  "rangemap",
  "serde",
@@ -14290,10 +14290,10 @@ dependencies = [
  "alloy",
  "anyhow",
  "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "clap",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "insta",
  "leb128",
  "once_cell",
@@ -14308,7 +14308,7 @@ dependencies = [
  "tracing-subscriber 0.3.22",
  "vise",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_merkle_tree_api",
  "zksync_os_rocksdb",
 ]
@@ -14354,8 +14354,8 @@ dependencies = [
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.0.28-interface-v0.0.14)",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.1.2-interface-v0.0.14)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "reqwest",
  "tempfile",
  "test-casing",
@@ -14497,9 +14497,9 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "blake2",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "futures",
  "reth-execution-types",
  "reth-primitives",
@@ -14514,7 +14514,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync-os-revm",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -14548,12 +14548,12 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "blake2",
  "boa_engine",
  "boa_gc",
  "dashmap",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "futures",
  "hyper",
  "jsonrpsee",
@@ -14568,7 +14568,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_api",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
@@ -14638,9 +14638,9 @@ dependencies = [
 [[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14#f83156705c258b0349d66060ea31e817e599a026"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
 dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
@@ -14649,9 +14649,9 @@ dependencies = [
 [[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14#2815e823e67f1b558292ba57573fb4a6ca8a4c8e"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14#414c746e9c81392b8c0b75602c4a62097abdf066"
 dependencies = [
- "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-simulation-only-interface-v0.0.14)",
+ "cycle_marker 0.0.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "prover_examples 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
@@ -14664,8 +14664,8 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "futures",
  "num",
  "ruint",
@@ -14676,7 +14676,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_gas_adjuster",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -14698,14 +14698,14 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "bincode 2.0.1",
  "blake2",
  "clap",
  "execution_utils 0.1.0 (git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.5.2)",
  "flate2",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "full_statement_verifier",
  "futures",
  "http 1.3.1",
@@ -14731,7 +14731,7 @@ dependencies = [
  "tracing",
  "vise",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=dev-20260311)",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_base_token_adjuster",
  "zksync_os_batch_types",
  "zksync_os_batch_verification",
@@ -14775,12 +14775,12 @@ dependencies = [
  "alloy",
  "anyhow",
  "dashmap",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "ruint",
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -14793,12 +14793,12 @@ version = "0.17.1"
 dependencies = [
  "alloy",
  "anyhow",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "ruint",
  "tempfile",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -14845,7 +14845,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "auto_impl",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "futures",
  "pin-project 1.1.10",
  "semver 1.0.26",
@@ -14854,7 +14854,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.8-interface-v0.0.14)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.14)",
  "zksync_os_api",
  "zksync_os_batch_types",
  "zksync_os_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,14 +125,14 @@ zk_os_forward_system_0_2_8 = { package = "forward_system", git = "https://github
 #
 # When a new version is released this version gets downgraded to the "previous version" section above.
 
-zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.8-interface-v0.0.14", features = [
+zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.14", features = [
     "production",
     "no_print",
 ], default-features = false }
-zk_ee = { git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.8-interface-v0.0.14" }
-zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.8-interface-v0.0.14" }
-zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.8-interface-v0.0.14" }
-zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.8-interface-v0.0.14" }
+zk_ee = { git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.14" }
+zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.14" }
+zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.14" }
+zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.14" }
 execution_utils = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 full_statement_verifier = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -371,8 +371,11 @@ impl Tester {
         #[cfg(feature = "prover-tests")]
         if enable_prover {
             let base_url = format!("http://localhost:{}", prover_api_locked_port.port);
-            let app_bin_path =
-                zksync_os_multivm::apps::v6::multiblock_batch_path(&rocks_db_path.join("app_bins"));
+            let app_bin_path = utils::materialize_multiblock_batch_bin(
+                &tempdir.path().join("app_bins"),
+                "v6",
+                zksync_os_multivm::apps::v6::MULTIBLOCK_BATCH,
+            );
             let trusted_setup_file = std::env::var("COMPACT_CRS_FILE").unwrap();
             let output_dir = tempdir.path().join("outputs");
             std::fs::create_dir_all(&output_dir).unwrap();

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -56,3 +56,19 @@ impl Drop for LockedPort {
             .unwrap();
     }
 }
+
+#[cfg(feature = "prover-tests")]
+pub(crate) fn materialize_multiblock_batch_bin(
+    base_dir: &std::path::Path,
+    version: &str,
+    bytes: &[u8],
+) -> std::path::PathBuf {
+    let dir_path = base_dir.join(version);
+    std::fs::create_dir_all(&dir_path).unwrap();
+
+    let full_path = dir_path.join("multiblock_batch.bin");
+    if !full_path.exists() {
+        std::fs::write(&full_path, bytes).unwrap();
+    }
+    full_path
+}

--- a/lib/multivm/build.rs
+++ b/lib/multivm/build.rs
@@ -15,7 +15,7 @@ fn parse_git_tag(package_id: &PackageId) -> anyhow::Result<String> {
 
 fn proving_version_from_tag(tag: &str) -> Option<String> {
     match tag {
-        "v0.2.8-interface-v0.0.14" => Some(String::from("V6")),
+        "v0.2.9-interface-v0.0.14" => Some(String::from("V6")),
         "dev-20260311" => Some(String::from("V7")),
         _ => None,
     }

--- a/lib/multivm/src/apps/mod.rs
+++ b/lib/multivm/src/apps/mod.rs
@@ -1,117 +1,33 @@
-use std::path::{Path, PathBuf};
-
-fn materialize_app(base_dir: &Path, version: &str, file_name: &str, bytes: &[u8]) -> PathBuf {
-    let dir_path = base_dir.join(version);
-    std::fs::create_dir_all(&dir_path).unwrap();
-
-    let full_path = dir_path.join(file_name);
-    if !full_path.exists() {
-        std::fs::write(&full_path, bytes).unwrap();
-    }
-    full_path
-}
-
 pub mod v6 {
-    use std::path::{Path, PathBuf};
-
     pub const SINGLEBLOCK_BATCH_APP: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V6_SOURCE_PATH"),
         "/singleblock_batch.bin"
     ));
-
-    pub fn singleblock_batch_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(
-            base_dir,
-            "v6",
-            "singleblock_batch.bin",
-            SINGLEBLOCK_BATCH_APP,
-        )
-    }
 
     pub const SINGLEBLOCK_BATCH_LOGGING_ENABLED: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V6_SOURCE_PATH"),
         "/singleblock_batch_logging_enabled.bin"
     ));
 
-    pub fn singleblock_batch_logging_enabled_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(
-            base_dir,
-            "v6",
-            "singleblock_batch_logging_enabled.bin",
-            SINGLEBLOCK_BATCH_LOGGING_ENABLED,
-        )
-    }
-
     pub const MULTIBLOCK_BATCH: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V6_SOURCE_PATH"),
         "/multiblock_batch.bin"
     ));
-
-    pub fn multiblock_batch_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(base_dir, "v6", "multiblock_batch.bin", MULTIBLOCK_BATCH)
-    }
 }
 
 pub mod v7 {
-    use std::path::{Path, PathBuf};
-
     pub const SINGLEBLOCK_BATCH_APP: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V7_SOURCE_PATH"),
         "/singleblock_batch.bin"
     ));
-
-    pub fn singleblock_batch_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(
-            base_dir,
-            "v7",
-            "singleblock_batch.bin",
-            SINGLEBLOCK_BATCH_APP,
-        )
-    }
 
     pub const SINGLEBLOCK_BATCH_LOGGING_ENABLED: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V7_SOURCE_PATH"),
         "/singleblock_batch_logging_enabled.bin"
     ));
 
-    pub fn singleblock_batch_logging_enabled_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(
-            base_dir,
-            "v7",
-            "singleblock_batch_logging_enabled.bin",
-            SINGLEBLOCK_BATCH_LOGGING_ENABLED,
-        )
-    }
-
     pub const MULTIBLOCK_BATCH: &[u8] = include_bytes!(concat!(
         env!("ZKSYNC_OS_V7_SOURCE_PATH"),
         "/multiblock_batch.bin"
     ));
-
-    pub fn multiblock_batch_path(base_dir: &Path) -> PathBuf {
-        super::materialize_app(base_dir, "v7", "multiblock_batch.bin", MULTIBLOCK_BATCH)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::{Path, PathBuf};
-    use test_casing::test_casing;
-
-    const PATH_FNS: [fn(&Path) -> PathBuf; 2] = [
-        super::v6::singleblock_batch_path,
-        super::v7::singleblock_batch_path,
-    ];
-
-    #[test_casing(2, PATH_FNS)]
-    fn app_paths_are_scoped_to_the_requested_base_dir(path_fn: fn(&Path) -> PathBuf) {
-        let dir_a = tempfile::tempdir().unwrap();
-        let dir_b = tempfile::tempdir().unwrap();
-
-        let path_a = path_fn(dir_a.path());
-        let path_b = path_fn(dir_b.path());
-        assert_ne!(path_a, path_b);
-        assert!(path_a.exists());
-        assert!(path_b.exists());
-    }
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1012,7 +1012,6 @@ async fn run_main_node_pipeline(
             maximum_in_flight_blocks: config
                 .prover_input_generator_config
                 .maximum_in_flight_blocks,
-            app_bin_base_path: config.general_config.rocks_db_path.join("app_bins").clone(),
             read_state: state.clone(),
             pubdata_mode,
         })

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use std::collections::VecDeque;
-use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -23,7 +22,6 @@ use zksync_os_types::{ProvingVersion, PubdataMode, ZksyncOsEncode};
 pub struct ProverInputGenerator<ReadState> {
     pub enable_logging: bool,
     pub maximum_in_flight_blocks: usize,
-    pub app_bin_base_path: PathBuf,
     pub read_state: ReadState,
     pub pubdata_mode: PubdataMode,
 }
@@ -53,7 +51,6 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
         let read_state = self.read_state;
         let pubdata_mode = self.pubdata_mode;
         let enable_logging = self.enable_logging;
-        let app_bin_base_path = self.app_bin_base_path;
         let maximum_in_flight_blocks = self.maximum_in_flight_blocks;
 
         let mut input = input.into_inner();
@@ -79,7 +76,6 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                     replay_record.transactions.len(),
                 );
                 let read_state_clone = read_state.clone();
-                let app_bin_base_path_clone = app_bin_base_path.clone();
 
                 // we need to adapt pubdata mode depending on protocol version, to ensure automatic DA mode change during v30 upgrade
                 let da_commitment_scheme = pubdata_mode
@@ -92,7 +88,6 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                         read_state_clone,
                         tree.block_start.clone(),
                         da_commitment_scheme,
-                        app_bin_base_path_clone,
                         enable_logging,
                     );
                     (block_output, replay_record, prover_input, tree)
@@ -123,7 +118,6 @@ fn compute_prover_input(
     state_handle: impl ReadStateHistory,
     tree_view: MerkleTreeVersion<RocksDBWrapper>,
     da_commitment_scheme: DACommitmentScheme,
-    app_bin_base_path: PathBuf,
     enable_logging: bool,
 ) -> Vec<u32> {
     let block_number = replay_record.block_context.block_number;
@@ -152,7 +146,7 @@ fn compute_prover_input(
                 common_structs::ProofData, system::metadata::zk_metadata::BlockMetadataFromOracle,
             };
             use zk_os_forward_system::run::{
-                StorageCommitment, convert::FromInterface, generate_proof_input,
+                StorageCommitment, convert::FromInterface, generate_proof_input_from_bytes,
             };
 
             let initial_storage_commitment = StorageCommitment {
@@ -162,19 +156,17 @@ fn compute_prover_input(
 
             let list_source = TxListSource { transactions };
 
-            let bin_path = if enable_logging {
-                zksync_os_multivm::apps::v6::singleblock_batch_logging_enabled_path(
-                    &app_bin_base_path,
-                )
+            let bin_bytes = if enable_logging {
+                zksync_os_multivm::apps::v6::SINGLEBLOCK_BATCH_LOGGING_ENABLED
             } else {
-                zksync_os_multivm::apps::v6::singleblock_batch_path(&app_bin_base_path)
+                zksync_os_multivm::apps::v6::SINGLEBLOCK_BATCH_APP
             };
 
             let da_commitment_scheme = (da_commitment_scheme as u8)
                 .try_into()
                 .expect("Failed to convert DA commitment scheme");
-            generate_proof_input(
-                bin_path,
+            generate_proof_input_from_bytes(
+                bin_bytes,
                 BlockMetadataFromOracle::from_interface(replay_record.block_context),
                 ProofData {
                     state_root_view: initial_storage_commitment,
@@ -192,7 +184,7 @@ fn compute_prover_input(
                 common_structs::ProofData, system::metadata::zk_metadata::BlockMetadataFromOracle,
             };
             use zk_os_forward_system_dev::run::{
-                StorageCommitment, convert::FromInterface, generate_proof_input,
+                StorageCommitment, convert::FromInterface, generate_proof_input_from_bytes,
             };
 
             let initial_storage_commitment = StorageCommitment {
@@ -202,19 +194,17 @@ fn compute_prover_input(
 
             let list_source = TxListSource { transactions };
 
-            let bin_path = if enable_logging {
-                zksync_os_multivm::apps::v7::singleblock_batch_logging_enabled_path(
-                    &app_bin_base_path,
-                )
+            let bin_bytes = if enable_logging {
+                zksync_os_multivm::apps::v7::SINGLEBLOCK_BATCH_LOGGING_ENABLED
             } else {
-                zksync_os_multivm::apps::v7::singleblock_batch_path(&app_bin_base_path)
+                zksync_os_multivm::apps::v7::SINGLEBLOCK_BATCH_APP
             };
 
             let da_commitment_scheme = (da_commitment_scheme as u8)
                 .try_into()
                 .expect("Failed to convert DA commitment scheme");
-            generate_proof_input(
-                bin_path,
+            generate_proof_input_from_bytes(
+                bin_bytes,
                 BlockMetadataFromOracle::from_interface(replay_record.block_context),
                 ProofData {
                     state_root_view: initial_storage_commitment,


### PR DESCRIPTION
## Summary

Long-overdue removal of app.bin materiazliation that used to be needed for prover input generator (Claude abbreviates it as PIG, which I found to be quite funny so I'll start doing the same).

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

