### PR TITLE
feat(rpc): track JSON-RPC error counts by method and error code

### DIFF
--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use vise::{Buckets, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{Buckets, Counter, Histogram, LabeledFamily, Metrics, Unit};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
@@ -17,6 +17,8 @@ pub struct ApiMetrics {
     pub response_size: LabeledFamily<String, Histogram<usize>>,
     #[metrics(labels = ["method"], buckets = Buckets::exponential(1.0..=1_000.0, 2.0))]
     pub requests_in_batch_count: LabeledFamily<String, Histogram<u64>>,
+    #[metrics(labels = ["method", "code"])]
+    pub errors: LabeledFamily<(String, i32), Counter, 2>,
 }
 
 #[vise::register]

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -50,6 +50,7 @@ impl RpcServiceT for Monitoring {
                 started.elapsed(),
                 request_size,
                 output_size,
+                out.as_error_code(),
             );
             out
         }
@@ -161,6 +162,7 @@ impl RpcServiceT for Monitoring {
                 started.elapsed(),
                 request_size,
                 output_size,
+                out.as_error_code(),
             );
             out
         }
@@ -199,10 +201,14 @@ fn log_and_report(
     elapsed: Duration,
     request_size: usize,
     output_size_bytes: usize,
+    error_code: Option<i32>,
 ) {
     API_METRICS.response_time[method].observe(elapsed);
     API_METRICS.request_size[method].observe(request_size);
     API_METRICS.response_size[method].observe(output_size_bytes);
+    if let Some(code) = error_code {
+        API_METRICS.errors[&(method.to_owned(), code)].inc();
+    }
 
     debug_dispatch!(
         targets: match method {


### PR DESCRIPTION
## Summary
- Previously, the only error rate visibility was HTTP 4xx/5xx counts from Traefik — leaving no way to diagnose elevated error rates reported by clients when HTTP-level metrics look clean
- Adds an `errors` Prometheus counter to `ApiMetrics` with `method` and `code` labels, incremented whenever a JSON-RPC error response is returned
- Enables querying error rates overall, per method, per error code, or any combination

**Example queries:**
```promql
rate(rpc_api_errors_total[5m])                    # total error rate
rate(rpc_api_errors_total[5m]) by (method)        # per method
rate(rpc_api_errors_total[5m]) by (code)          # per error code (-32603, -32602, 3, 4)
rate(rpc_api_errors_total[5m]) by (method, code)  # full breakdown
```

## Test plan
- [ ] Deploy to staging and verify `rpc_api_errors_total` appears in Prometheus with expected labels
- [ ] Trigger a known error (e.g. `eth_call` revert) and confirm the counter increments with `method="eth_call"` and `code=3`

No tests added — the logic is a single `counter.inc()` call gated on `as_error_code()` returning `Some`; no meaningful unit test can be written without reaching into the global Prometheus registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)