### PR TITLE
feat: add trace logs to estimate gas with exec results

### DIFF
--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -456,7 +456,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         block_context: BlockContext,
         mut storage_view: V,
     ) -> Result<U256, EthCallError> {
-        tracing::trace!(?block_context, "Estimating gas");
+        tracing::trace!("Estimating gas with block context {block_context:?}");
         // Rest of the flow was heavily borrowed from reth, which in turn closely follows the
         // original geth logic. Source:
         // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -526,9 +526,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             .map_err(EthCallError::ForwardSubsystemError)?
             .map_err(EthCallError::InvalidTransaction)?;
         tracing::trace!(
-            gas_limit = tx.gas_limit(),
-            ?res,
-            "Executed tx in estimate_gas with highest gas limit"
+            "Executed tx in estimate_gas with highest gas limit {}, result {res:?}",
+            tx.gas_limit(),
         );
         match res.execution_result {
             ExecutionResult::Success(_) => {
@@ -569,9 +568,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 .map_err(EthCallError::ForwardSubsystemError)?
                 .map_err(EthCallError::InvalidTransaction)?;
             tracing::trace!(
-                gas_limit = tx.gas_limit(),
-                ?res,
-                "Executed tx in estimate_gas with optimistic gas limit"
+                "Executed tx in estimate_gas with optimistic gas limit {}, result {res:?}",
+                tx.gas_limit()
             );
 
             // Update the gas used based on the new result.
@@ -613,8 +611,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             let mut mid_tx = tx.clone();
             set_gas_limit(&mut mid_tx, mid_gas_limit);
             tracing::trace!(
-                gas_limit = mid_tx.gas_limit(),
-                "trying to simulate transaction"
+                "trying to simulate transaction with gas_limit {}",
+                mid_tx.gas_limit()
             );
 
             // Execute transaction and handle potential gas errors, adjusting limits accordingly.
@@ -638,9 +636,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     // Unpack the result and environment if the transaction was successful.
                     res = ethres.map_err(EthCallError::InvalidTransaction)?;
                     tracing::trace!(
-                        gas_limit = tx.gas_limit(),
-                        ?res,
-                        "Executed tx in estimate_gas with gas limit"
+                        "Executed tx in estimate_gas with gas limit {}, result {res:?}",
+                        tx.gas_limit(),
                     );
                     // Update the estimated gas range based on the transaction result.
                     update_estimated_gas_range(
@@ -655,6 +652,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             // New midpoint
             mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
         }
+        tracing::trace!("Estimated gas limit: {highest_gas_limit}");
 
         Ok(U256::from(highest_gas_limit))
     }


### PR DESCRIPTION
## Summary

Checking executions result can help to get more details about tx fee, result includes these fields:
```
    /// Amount of native resource used in the entire transaction for computation.
    pub computational_native_used: u64,
    /// Total amount of native resource used in the entire transaction (includes spent on pubdata)
    pub native_used: u64,
    /// Amount of pubdata used in the entire transaction.
    pub pubdata_used: u64,
```
We already have a similar log with result in sequencer:
```
tracing::debug!(
                            block_number=command.block_context.block_number,
                            output=?res,
                            "Transaction executed"
                        );
```

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

