### PR TITLE
refactor(l1_watcher): Remove Anvil-specific hacks from L1 watcher

### DIFF
--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::factory_deps::load_factory_deps;
-use crate::util::ANVIL_L1_CHAIN_ID;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::dyn_abi::SolType;
@@ -31,7 +30,6 @@ const UPGRADE_DATA_LOOKBEHIND_BLOCKS: u64 = 2_500_000;
 pub struct L1UpgradeTxWatcher {
     admin_contract_l1: Address,
 
-    provider_l1: DynProvider,
     provider_sl: DynProvider,
     /// Address of the bytecode supplier contract (used to detect published bytecode preimages)
     #[allow(dead_code)] // TODO: enable once bytecode supplier integration is ready
@@ -72,14 +70,12 @@ impl L1UpgradeTxWatcher {
         let last_l1_block = find_l1_block_by_protocol_version(zk_chain_l1.clone(), current_protocol_version.clone())
             .await
             .or_else(|err| {
-                // This may error on Anvil with `--load-state` - as it doesn't support `eth_call` even for recent blocks.
-                // We default to `0` in this case - `eth_getLogs` are still supported.
-                // Assert that we don't fallback on longer chains (e.g. Sepolia)
                 if current_l1_block > INITIAL_LOOKBEHIND_BLOCKS {
                     anyhow::bail!(
                         "Binary search failed with {err}. Cannot default starting block to zero for a long chain. Current L1 block number: {current_l1_block}. Limit: {INITIAL_LOOKBEHIND_BLOCKS}."
                     );
                 } else {
+                    tracing::warn!("Binary search for protocol version failed with {err}. Defaulting to block 0.");
                     Ok(0)
                 }
             })?;
@@ -98,7 +94,6 @@ impl L1UpgradeTxWatcher {
 
         let this = Self {
             admin_contract_l1: admin_l1,
-            provider_l1: zk_chain_l1.provider().clone(),
             provider_sl: zk_chain_sl.provider().clone(),
             bytecode_supplier_address,
             ctm_sl,
@@ -293,20 +288,11 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
             return Ok(());
         }
 
-        // In localhost environment, we may want to test upgrades to non-live versions, but
-        // we don't want to allow them anywhere else.
         if !request.protocol_version.is_live() {
             tracing::warn!(
                 ?request.protocol_version,
                 "received a protocol version that is not marked as live"
             );
-            // Only allow non-live versions in localhost environment.
-            if self.provider_l1.get_chain_id().await? != ANVIL_L1_CHAIN_ID {
-                panic!(
-                    "Received an upgrade to a non-live protocol version: {:?}",
-                    request.protocol_version
-                );
-            }
         }
 
         let upgrade_info = self

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -17,8 +17,6 @@ use zksync_os_contract_interface::models::CommitBatchInfo;
 use zksync_os_contract_interface::{IExecutor, ZkChain};
 use zksync_os_types::ProtocolSemanticVersion;
 
-pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
-
 /// Maximum number of L1 blocks that we can scan in a reasonable amount of time.
 ///
 /// Rough calculations: 10min * 10 req/s * 1000 blocks/req = 600 * 10 * 1000 = 6_000_000
@@ -29,13 +27,6 @@ pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool
     start_block_number: BlockNumber,
     predicate: impl Fn(Arc<ZkChain<DynProvider>>, u64) -> Fut,
 ) -> anyhow::Result<BlockNumber> {
-    if zk_chain.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
-        // Binary search may error on Anvil with `--load-state` - as it doesn't support `eth_call`
-        // even for recent blocks. We default to `start_block_number` in this case - `eth_getLogs`
-        // are still supported.
-        return Ok(start_block_number);
-    }
-
     let latest = zk_chain.provider().get_block_number().await?;
 
     let guarded_predicate =
@@ -173,27 +164,6 @@ pub async fn find_l1_commit_block_by_batch_number(
     batch_number: u64,
     max_l1_blocks_to_scan: u64,
 ) -> anyhow::Result<BlockNumber> {
-    if zk_chain.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
-        // Binary search may error on Anvil with `--load-state` - as it doesn't support `eth_call`
-        // for historical blocks. We run linear search as a fallback.
-        if batch_number == 0 {
-            // For genesis we must return L1 block where `zk_chain` got deployed. For Anvil it's okay
-            // to return 0 here as the chain should not be long anyway.
-            return Ok(0);
-        }
-        return find_last_matching_event::<ReportCommittedBatchRangeZKsyncOS>(
-            *zk_chain.address(),
-            zk_chain.provider(),
-            0,
-            max_l1_blocks_to_scan,
-            |e| e.batchNumber == batch_number,
-        )
-        .await?
-        .with_context(|| {
-            format!("linear search failed to find where batch {batch_number} was committed")
-        });
-    }
-
     let is_batch_committed = move |zk: Arc<ZkChain<DynProvider>>, block: BlockNumber| async move {
         let res = zk.get_total_batches_committed(block.into()).await?;
         Ok(res >= batch_number)


### PR DESCRIPTION
## Summary

- Removed `ANVIL_L1_CHAIN_ID` chain-ID check that bypassed binary search in `find_l1_block_by_predicate` and replaced it with linear event-log search in `find_l1_commit_block_by_batch_number`
- Removed the `panic!` on non-live protocol versions that only fired on non-Anvil chains; now just logs a warning
- Removed the `provider_l1` field from `L1UpgradeTxWatcher` (it was only used for the chain-ID check)
- The `.or_else` fallback in `upgrade_tx_watcher` is kept as a chain-agnostic safety net: if binary search fails on a short chain (< 100k blocks), we default to block 0 and log a warning

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `cargo nextest run -p zksync_os_integration_tests` — 68/70 pass; the 2 failures (`l1_withdraw::next_to_gateway`, `erc20_withdrawal::next_to_gateway`) reproduce identically on upstream `main` and are unrelated to this change

No tests added — the behavior is already covered by existing integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)