### PR TITLE
fix: Make L1/SL Provider Configurable to Avoid 429 During EN Sync

### DIFF
--- a/integration-tests/src/config.rs
+++ b/integration-tests/src/config.rs
@@ -145,6 +145,7 @@ fn load_config_from_path(config_path: &Path) -> Config {
     Config {
         genesis_config,
         l1_sender_config: config_repo.single().unwrap().parse().unwrap(),
+        provider_config: Default::default(),
         general_config: config_repo.single().unwrap().parse().unwrap(),
         network_config: Default::default(),
         rpc_config: Default::default(),

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -367,6 +367,7 @@ impl Tester {
             tx_validator_config: Default::default(),
             sequencer_config,
             l1_sender_config: default_config.l1_sender_config.clone(),
+            provider_config: Default::default(),
             l1_watcher_config: Default::default(),
             batcher_config: Default::default(),
             prover_input_generator_config: ProverInputGeneratorConfig {


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->
2FA Nodes and ENs can rely on an RPC with stricter rate limits. This PR adds `ProviderConfig` with two fiels:
- `provider_max_retries`
- `provider_retry_backoff`

Setting these fields properly makes syncing more accessible, less bug prone and faster(less restarts). In my tests frequent restarts are a real problem for syncing speed(even more so after fixing priority tree bug).

I want to add more functionality here:
- rotating between several RPCs
- timeout layer

This could be done in this PR or another one.
<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

