### PR TITLE
refactor(rpc): decompose eth_filter_impl into focused submodules

### DIFF
--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -7,7 +7,6 @@ use pending::{FullTransactionsReceiver, PendingTransactionKind, PendingTransacti
 mod registry;
 use registry::{FilterKind, FilterRegistry};
 mod scan;
-use scan::scan_logs;
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::{B256, BlockNumber};
 use alloy::rpc::types::{
@@ -16,7 +15,7 @@ use alloy::rpc::types::{
 };
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
-use std::time::Instant;
+use scan::scan_logs;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_rpc_api::filter::EthFilterApiServer;
 use zksync_os_storage_api::RepositoryError;
@@ -144,15 +143,9 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
         )
     }
 
-    /// Endless future that calls [`Self::clear_stale_filters`] every `stale_filter_ttl` interval.
+    /// Endless future that evicts stale filters every `stale_filter_ttl` interval.
     pub(crate) async fn watch_and_clear_stale_filters(&self) {
         self.registry.watch_and_clear_stale().await
-    }
-
-    /// Clears all filters that have not been polled for longer than the configured
-    /// `stale_filter_ttl` at the given instant.
-    pub async fn clear_stale_filters(&self, now: Instant) {
-        self.registry.clear_stale(now)
     }
 
     fn resolve_range(

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -26,7 +26,11 @@ pub(crate) fn scan_logs(
             return Err(EthFilterError::BlockNotFound(number.into()));
         };
         if filter.matches_bloom(block.header.logs_bloom) {
-            tracing::trace!(number, ?filter, "Block matches bloom filter, scanning receipts");
+            tracing::trace!(
+                number,
+                ?filter,
+                "Block matches bloom filter, scanning receipts"
+            );
             let stored_txs = get_block_transactions(repo, block, number)?;
             let logs_before = logs.len();
             collect_matching_logs(filter, stored_txs, &mut logs);


### PR DESCRIPTION
## Summary

`eth_filter_impl.rs` was a 500-line file mixing RPC dispatch, filter lifecycle management, pending transaction subscriptions, and log scan logic. This PR breaks it apart into focused modules and fixes a silent bug in the scan loop.

This is not just housekeeping — we are planning to replace the naive O(block_range) bloom scan in `scan.rs` with an Erigon-style inverted index. Having the scan logic isolated in its own module with a clean `&dyn ReadRepository` interface means the index implementation will be a contained change to one file, and the two approaches can be benchmarked and tested independently without touching RPC plumbing.

**Bug fix**
- `eth_getLogs` previously silently skipped blocks that were missing from storage. Now returns an error, matching expected RPC behaviour.

**Structural changes**
- `eth_filter_impl.rs` → `eth_filter/` module directory (pure rename, no logic change)
- `eth_filter/pending.rs` — pending transaction receivers (`PendingTransactionsReceiver`, `FullTransactionsReceiver`)
- `eth_filter/registry.rs` — `FilterRegistry`: owns the `DashMap` of active filters, install/advance/uninstall/eviction logic
- `eth_filter/scan.rs` — bloom scan business logic, decoupled from RPC types; this is the file the index will replace
- `eth_filter/mod.rs` — RPC dispatch only: resolves block tags, enforces config limits, delegates to registry and scan

**Other improvements**
- `BlockScanStats` RAII guard observes Prometheus metrics on all exit paths, including early returns
- `filter_logs_impl` simplified via `FilterKind::as_log_filter()`
- Removed dead `clear_stale_filters` wrapper (became unreachable after registry extraction)

## Test plan

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [ ] `cargo nextest run --release --workspace --exclude zksync_os_integration_tests` passes
- [ ] `cargo nextest run -p zksync_os_integration_tests` passes

_No new tests added — this is a pure refactor. The bug fix (missing block error) has no existing test coverage to extend._

🤖 Generated with [Claude Code](https://claude.com/claude-code)