### PR TITLE
feat(config): generate declarative config validation

### DIFF
--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -43,6 +43,11 @@ struct Cli {
 
     #[command(subcommand)]
     cmd: Option<CliCommand>,
+
+    /// Makes the node to stop before calling `run` method.
+    /// It is used to catch issues with configuration.
+    #[arg(long)]
+    no_run: bool,
 }
 
 fn load_config_defaults(config_sources: &mut ConfigSources, config_paths: Option<Vec<String>>) {
@@ -151,6 +156,12 @@ pub async fn main() {
     tracing::info!(?config, "Loaded config");
     load_internal_config(&mut config);
     config.validate().await.expect("invalid config");
+
+    if opt.no_run {
+        tracing::info!("Node config was loaded successfully, exiting due to --no-run flag");
+        return;
+    }
+
     // ======= Run tasks ===========
     let ephemeral_enabled = config.general_config.ephemeral;
     let _ephemeral_guard = ephemeral_enabled.then(|| enable_ephemeral_mode(&mut config));


### PR DESCRIPTION
## Summary
- add a proc-macro-based config validation system that generates `Config::validate()` from field annotations
- move main/external node config requirements next to the relevant fields and support async field validation
- recurse into subconfigs by default for `*_config` fields and `#[config(nest)]`, with an explicit opt-out

## Testing
- cargo test -p zksync_os_server config::tests::
- cargo clippy --all-targets --all-features --workspace -- -D warnings