### PR TITLE
test: move deployment filter integration test under rpc

### DIFF
--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -50,7 +50,7 @@ async fn setup() -> Result<(GatewayTester, Address)> {
 async fn unauthorized_address_deploy_is_rejected() -> Result<()> {
     let (mc, unauthorized) = setup().await?;
 
-    // Rejected during block execution (FilteredByValidator → Purge).
+    // Rejected during block execution (FilteredByValidator -> Purge).
     let pending = EventEmitter::deploy_builder(mc.chain(0).l2_provider.clone())
         .from(unauthorized)
         .send()

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 mod call;
 mod debug;
+mod deployment_filter;
 mod filter;
 mod pubsub;
 mod storage_proof;


### PR DESCRIPTION
## Summary
- move `integration-tests/tests/deployment_filter.rs` into the `integration-tests/tests/rpc/` module tree
- register the moved test in `integration-tests/tests/rpc/mod.rs`
- keep the test covered by the existing `suite` integration target instead of a standalone test target

## Verification
- `cargo fmt --all --check`
- `cargo metadata --format-version 1 --no-deps | grep -o '"name":"[^"]*"' | grep 'deployment_filter\|suite' | sort -u`