### PR TITLE
feat(revm-consistency-checker): Add metrics for alerts

### DIFF
--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -4,8 +4,6 @@ use reth_revm::ExecuteCommitEvm;
 use reth_revm::context::{Context, ContextTr};
 use reth_revm::db::CacheDB;
 use std::collections::HashSet;
-use std::thread;
-use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_internal_config::InternalConfigManager;


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->
Adds two metrics to revm_consistency_checker:
- Unix timestamp of the most recent detection of inconsistency.
- Block number of the most recent detected inconsistency.
I also changed the code to print the log with block number even if not reverting.

Timestamp will be used to setup alerts, block number is just for UX, currently you can
<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

