### PR TITLE
feat(l1): Make retry layer configurable, add fallback and timeout layers

### DIFF
--- a/node/bin/src/provider.rs
+++ b/node/bin/src/provider.rs
@@ -2,11 +2,21 @@ use crate::config::ProviderConfig;
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{Provider, ProviderBuilder, WalletProvider};
-use alloy::rpc::client::RpcClient;
+use alloy::rpc::client::{BuiltInConnectionString, RpcClient};
 use alloy::signers::local::PrivateKeySigner;
-use alloy::transports::layers::{RateLimitRetryPolicy, RetryBackoffLayer, RetryPolicy};
-use alloy::transports::{TransportError, TransportErrorKind};
+use alloy::transports::http::Http;
+use alloy::transports::layers::{
+    FallbackLayer, RateLimitRetryPolicy, RetryBackoffLayer, RetryPolicy,
+};
+use alloy::transports::{BoxTransport, TransportConnect, TransportError, TransportErrorKind};
+use futures::future::try_join_all;
+use std::num::NonZeroUsize;
 use std::time::Duration;
+use tower::{Layer, ServiceBuilder};
+
+/// It should practically never take this long for a request,
+/// so if it does it's better to return an error than keep hanging
+const RPC_TIMEOUT_BEFORE_RETRY: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Copy, Clone, Default)]
 struct OptimisticRetryPolicy(RateLimitRetryPolicy);
@@ -41,25 +51,58 @@ impl RetryPolicy for OptimisticRetryPolicy {
     }
 }
 
+/// Build BoxTransport from a url, adds a timeout
+/// see `RPC_TIMEOUT_BEFORE_RETRY`
+async fn transport_for_url(rpc_url: &str) -> Result<BoxTransport, TransportError> {
+    let connection = rpc_url.parse::<BuiltInConnectionString>()?;
+
+    match connection {
+        BuiltInConnectionString::Http(url) => {
+            let client = reqwest::Client::builder()
+                .timeout(RPC_TIMEOUT_BEFORE_RETRY)
+                .build()
+                .map_err(TransportErrorKind::custom)?;
+            Ok(BoxTransport::new(Http::with_client(client, url)))
+        }
+        _ => connection.get_transport().await,
+    }
+}
+
+/// Creates a provider from list of RPC URLs
+/// The provider can change the endpoint used based on stability and latency
 pub async fn build_node_provider(
-    rpc_url: &str,
-    provider_config: &ProviderConfig,
-) -> FillProvider<
-    impl TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
-    impl Provider<Ethereum> + Clone + 'static,
+    rpc_urls: &[String],
+    provider_config: ProviderConfig,
+) -> Result<
+    FillProvider<
+        impl TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
+        impl Provider<Ethereum> + Clone + 'static,
+    >,
+    TransportError,
 > {
+    assert!(
+        !rpc_urls.is_empty(),
+        "at least one RPC URL must be configured to build a provider"
+    );
+
     let retry_layer = RetryBackoffLayer::new_with_policy(
-        provider_config.max_retries,
-        provider_config.retry_backoff.as_millis() as u64,
+        provider_config.retry_attempt_limit,
+        provider_config.retry_backoff_period.as_millis() as u64,
         u64::MAX, // compute units per second, considering it unlimited for now
         OptimisticRetryPolicy::default(),
     );
-    let client = RpcClient::builder()
+
+    let transports =
+        try_join_all(rpc_urls.iter().map(|rpc_url| transport_for_url(rpc_url))).await?;
+
+    let fallback_layer = FallbackLayer::default()
+        .with_active_transport_count(NonZeroUsize::new(1).expect("1 is non-zero"));
+    let transport = ServiceBuilder::new()
         .layer(retry_layer)
-        .connect(rpc_url)
-        .await
-        .expect("failed to connect to L1 api");
-    ProviderBuilder::new()
+        .service(fallback_layer.layer(transports));
+    let client = RpcClient::new(transport, false);
+
+    Ok(ProviderBuilder::new()
         .wallet(EthereumWallet::new(PrivateKeySigner::random()))
-        .connect_client(client)
+        .connect_client(client))
 }


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->
This makes syncing more accessible, less bug prone and faster(less restarts). In my tests frequent restarts are a real problem for syncing speed(even more so after fixing priority tree bug).

l1_rpc_url and gateway_rpc_url now can accept comma separated lists of RPC URLs.
2FA Nodes and ENs can rely on an RPC with stricter rate limits. This PR adds `ProviderConfig` with two fiels:
- `provider_max_retries`
- `provider_retry_backoff`
Fallback Layer is added: this layer can take several RPC URLs and choose one based on latency and stability.
Timeout layer added just in case(only for http to avoid bloat, adding a proper layer would require a lot of boilerplate).

I'm still not sure about naming, and whether we should use the same config params for multiple RPCs. I also haven't looked into CI changes carefully, for now I want to identify if there are problems with the approach itself. I'll also test it more if the current solution is fine.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

