### PR TITLE
fix(l1-watcher): wait two L1 blocks before processing events

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -53,6 +53,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
             // one.
             last_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             this.into(),
         );

--- a/lib/l1_watcher/src/config.rs
+++ b/lib/l1_watcher/src/config.rs
@@ -6,6 +6,9 @@ pub struct L1WatcherConfig {
     /// Max number of L1 blocks to be processed at a time.
     pub max_blocks_to_process: u64,
 
+    /// Number of latest L1 blocks to leave unprocessed in order to reduce reorg risk.
+    pub confirmations: u64,
+
     /// How often to poll L1 for new priority requests.
     pub poll_interval: Duration,
 }

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -50,6 +50,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
             // one.
             last_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             this.into(),
         );

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -87,6 +87,7 @@ impl GatewayMigrationWatcher {
             zk_chain.provider().clone(),
             next_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             Box::new(this),
         ))

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -42,6 +42,7 @@ impl InteropWatcher {
             bridgehub.provider().clone(),
             this.starting_interop_event_index.block_number,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             Box::new(this),
         );

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -62,6 +62,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
             // one.
             last_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             Box::new(this),
         );

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -51,6 +51,7 @@ impl L1TxWatcher {
             zk_chain_l1.provider().clone(),
             next_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             this.into(),
         );

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -110,6 +110,7 @@ impl L1UpgradeTxWatcher {
             zk_chain_l1.provider().clone(),
             last_l1_block,
             config.max_blocks_to_process,
+            config.confirmations,
             config.poll_interval,
             this.into(),
         );

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -12,6 +12,7 @@ pub struct L1Watcher {
     provider: DynProvider,
     next_l1_block: BlockNumber,
     max_blocks_to_process: u64,
+    confirmations: BlockNumber,
     poll_interval: Duration,
     processor: Box<dyn ProcessRawEvents>,
 }
@@ -21,6 +22,7 @@ impl L1Watcher {
         provider: DynProvider,
         next_l1_block: BlockNumber,
         max_blocks_to_process: u64,
+        confirmations: BlockNumber,
         poll_interval: Duration,
         processor: Box<dyn ProcessRawEvents>,
     ) -> Self {
@@ -28,6 +30,7 @@ impl L1Watcher {
             provider,
             next_l1_block,
             max_blocks_to_process,
+            confirmations,
             poll_interval,
             processor,
         }
@@ -45,11 +48,12 @@ impl L1Watcher {
 
     async fn poll(&mut self) -> Result<(), L1WatcherError> {
         let latest_block = self.provider.get_block_number().await?;
+        let latest_confirmed_block = latest_block.saturating_sub(self.confirmations);
 
-        while self.next_l1_block <= latest_block {
+        while self.next_l1_block <= latest_confirmed_block {
             let from_block = self.next_l1_block;
             // Inspect up to `self.max_blocks_to_process` blocks at a time
-            let to_block = latest_block.min(from_block + self.max_blocks_to_process - 1);
+            let to_block = latest_confirmed_block.min(from_block + self.max_blocks_to_process - 1);
 
             let events = self
                 .extract_logs_from_l1_blocks(from_block, to_block)

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -563,6 +563,10 @@ pub struct L1WatcherConfig {
     #[config(default_t = 1000)]
     pub max_blocks_to_process: u64,
 
+    /// Number of latest L1 blocks to leave unprocessed in order to reduce reorg risk.
+    #[config(default_t = 2)]
+    pub confirmations: u64,
+
     /// How often to poll L1 for new priority requests.
     #[config(default_t = 100 * TimeUnit::Millis)]
     pub poll_interval: Duration,
@@ -1093,6 +1097,7 @@ impl From<L1WatcherConfig> for zksync_os_l1_watcher::L1WatcherConfig {
     fn from(c: L1WatcherConfig) -> Self {
         Self {
             max_blocks_to_process: c.max_blocks_to_process,
+            confirmations: c.confirmations,
             poll_interval: c.poll_interval,
         }
     }


### PR DESCRIPTION
## Summary
- leave the latest 2 L1 blocks unprocessed in the shared `L1Watcher`
- apply the lag uniformly to all watcher flavors that use the shared poll loop
- keep the implementation local to the shared watcher so no per-watcher changes are needed

## Testing
- cargo test -p zksync_os_l1_watcher --no-run
- cargo test -p zksync_os_l1_watcher