### PR TITLE
Guard overlay buffer against regressing base tip

### DIFF
--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -17,6 +17,7 @@ pub struct BlockOverlay {
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {
     overlays: Arc<BTreeMap<BlockNumber, BlockOverlay>>,
+    max_base_latest_seen: Option<BlockNumber>,
 }
 
 impl OverlayBuffer {
@@ -37,12 +38,24 @@ impl OverlayBuffer {
     where
         S: ReadStateHistory + 'a,
     {
-        let base_latest = *base.block_range_available().end();
+        let observed_base_latest = *base.block_range_available().end();
+        let base_latest = match self.max_base_latest_seen {
+            Some(previous) if observed_base_latest < previous => {
+                tracing::warn!(
+                    observed_base_latest,
+                    previous,
+                    "Base state latest block regressed while syncing overlay buffer; using the highest value seen so far"
+                );
+                previous
+            }
+            _ => observed_base_latest,
+        };
+        self.max_base_latest_seen = Some(base_latest);
         self.purge_already_persisted_blocks(base_latest)?;
         let first_overlay = self.overlays.keys().next().copied();
         let last_overlay = self.overlays.keys().next_back().copied();
         tracing::debug!(
-            "Synced overlay buffer with base (base_latest={base_latest}, overlays_len={}, overlays_range={first_overlay:?}..={last_overlay:?}). \
+            "Synced overlay buffer with base (observed_base_latest={observed_base_latest}, effective_base_latest={base_latest}, overlays_len={}, overlays_range={first_overlay:?}..={last_overlay:?}). \
             Preparing storage view to execute block {block_number_to_execute}.",
             self.overlays.len(),
         );


### PR DESCRIPTION
## Summary

Guard `OverlayBuffer` against a regressing observed base tip during block rebuild.

This targets the failure:

`Cannot clean tail: base_latest 102283 is behind overlay tail 102286`

## Changes

- track the highest `base_latest` seen by `OverlayBuffer`
- if a later read of `base.block_range_available().end()` regresses, keep using the highest seen value
- log when this regression is observed

## Motivation

The rebuild failure suggests the executor can observe a lower persisted state tip than it had already seen while its in-memory overlay has advanced past that point. In that case, overlay cleanup fails even though the executor had already progressed further.

This patch keeps the base tip monotonic from the overlay buffer's perspective.

## Notes

- intentionally scoped to `overlay_buffer` only
- not tested yet
- this is still a suspected fix based on the observed `base_latest 102283` / `overlay tail 102286` failure
