### PR TITLE
Make BlockExecutor wait for BlockApplier

### DIFF
--- a/lib/sequencer/src/execution/block_applier.rs
+++ b/lib/sequencer/src/execution/block_applier.rs
@@ -2,7 +2,7 @@ use crate::config::SequencerConfig;
 use crate::model::blocks::BlockCommandType;
 use alloy::consensus::Sealed;
 use async_trait::async_trait;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_storage_api::{ReplayRecord, WriteReplay, WriteRepository, WriteState};
@@ -19,6 +19,7 @@ where
     pub replay: Replay,
     pub repositories: Repo,
     pub config: SequencerConfig,
+    pub applied_block_sender: watch::Sender<Option<u64>>,
 }
 
 #[async_trait]
@@ -74,6 +75,12 @@ where
             self.repositories
                 .populate(block_output.clone(), executed_replay.transactions.clone())
                 .await?;
+
+            self.applied_block_sender.send_replace(Some(block_number));
+            tracing::debug!(
+                block_number,
+                "BlockApplier updated applied block progress watch"
+            );
 
             if output.send((block_output, executed_replay)).await.is_err() {
                 tracing::info!("outbound channel closed");

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -103,6 +103,10 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
         }
     }
 
+    pub fn next_block_number(&self) -> u64 {
+        self.next_block_number
+    }
+
     pub async fn prepare_command(
         &mut self,
         block_command: BlockCommand,

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -33,6 +33,9 @@ where
     /// Controls transaction acceptance state.
     /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
     pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
+    /// Latest block number fully applied by `BlockApplier`.
+    /// `None` means the executor has not yet observed any local apply progress since startup.
+    pub applied_block_receiver: watch::Receiver<Option<u64>>,
 }
 
 #[async_trait]
@@ -72,6 +75,7 @@ where
         // `BlockExecutor` doesn't persist/update state after block execution.
         // Instead, we keep the diff in memory - and apply it on top of the last persisted block
         let mut state_overlay_buffer = OverlayBuffer::default();
+        let mut startup_bypass_used = false;
 
         loop {
             latency_tracker.enter_state(SequencerState::WaitingForCommand);
@@ -82,6 +86,18 @@ where
             };
             tracing::info!("Command {cmd} received by BlockExecutor");
             let cmd_type = cmd.command_type();
+            let block_number = match &cmd {
+                BlockCommand::Produce(_) => self.block_context_provider.next_block_number(),
+                BlockCommand::Replay(record) => record.block_context.block_number,
+                BlockCommand::Rebuild(command) => command.replay_record.block_context.block_number,
+            };
+
+            wait_for_block_applier(
+                &mut self.applied_block_receiver,
+                block_number.saturating_sub(1),
+                &mut startup_bypass_used,
+            )
+            .await?;
 
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
             if matches!(cmd, BlockCommand::Produce(_))
@@ -180,6 +196,50 @@ where
             }
         }
     }
+}
+
+async fn wait_for_block_applier(
+    applied_block_receiver: &mut watch::Receiver<Option<u64>>,
+    required_block_number: u64,
+    startup_bypass_used: &mut bool,
+) -> anyhow::Result<()> {
+    let applied_block_number = *applied_block_receiver.borrow_and_update();
+    if applied_block_number.is_none() && !*startup_bypass_used {
+        *startup_bypass_used = true;
+        tracing::debug!(
+            required_block_number,
+            "BlockExecutor does not need to wait for BlockApplier on startup"
+        );
+        return Ok(());
+    }
+
+    if applied_block_number.is_some_and(|block_number| block_number >= required_block_number) {
+        tracing::debug!(
+            applied_block_number,
+            required_block_number,
+            "BlockExecutor does not need to wait for BlockApplier"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        applied_block_number,
+        required_block_number,
+        "BlockExecutor waiting for BlockApplier to catch up"
+    );
+
+    let reached_block_number = applied_block_receiver
+        .wait_for(|value| value.is_some_and(|block_number| block_number >= required_block_number))
+        .await
+        .context("block applier progress watch closed while executor was waiting")?
+        .to_owned();
+
+    tracing::debug!(
+        reached_block_number,
+        required_block_number,
+        "BlockExecutor resumed after BlockApplier caught up"
+    );
+    Ok(())
 }
 
 /// Checks if block production limit has been reached.

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -926,6 +926,7 @@ async fn run_main_node_pipeline(
     );
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::channel(8);
+    let (applied_block_sender, applied_block_receiver) = watch::channel(None);
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ConsensusNodeCommandSource {
@@ -944,6 +945,7 @@ async fn run_main_node_pipeline(
             state: state.clone(),
             config: config.into(),
             tx_acceptance_state_sender,
+            applied_block_receiver,
         })
         .pipe(BlockCanonizer {
             consensus: canonization_engine,
@@ -954,6 +956,7 @@ async fn run_main_node_pipeline(
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
+            applied_block_sender,
         })
         .pipe_opt(
             config
@@ -1112,6 +1115,7 @@ async fn run_en_pipeline(
             .rocks_db_path
             .join(INTERNAL_CONFIG_FILE_NAME),
     );
+    let (applied_block_sender, applied_block_receiver) = watch::channel(None);
 
     Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
@@ -1123,12 +1127,14 @@ async fn run_en_pipeline(
             state: state.clone(),
             config: config.into(),
             tx_acceptance_state_sender,
+            applied_block_receiver,
         })
         .pipe(BlockApplier {
             state: state.clone(),
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
+            applied_block_sender,
         })
         .pipe_opt(
             config


### PR DESCRIPTION
## Summary
- make `BlockExecutor` wait until `BlockApplier` has processed block `N` before starting block `N+1`
- wire an applier-to-executor `watch<u64>` through the main-node and EN pipelines
- add debug logging around the executor wait path and applier watch updates

## Testing
- not run (opened PR without waiting for compilation)
