### PR TITLE
fix: fix batch storage in revert case

### DIFF
--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -98,17 +98,18 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
     ) -> Result<(), L1WatcherError> {
         let batch_number = report.batchNumber;
         let latest_processed_batch = self.last_processed_commit_batch;
-        if batch_number <= latest_processed_batch {
+        let stored_batch = self
+            .batch_storage
+            .get_batch_by_number(batch_number)
+            .map_err(L1WatcherError::Other)?;
+        if batch_number <= latest_processed_batch
+            && let Some(stored_batch) = stored_batch
+        {
             tracing::debug!(
                 batch_number,
                 "discovered already processed batch, validating"
             );
             let committed_batch = self.parse_committed_batch(report, log).await?;
-            let stored_batch = self
-                .batch_storage
-                .get_batch_by_number(batch_number)
-                .map_err(L1WatcherError::Other)?
-                .expect("persisted batch not found in DB");
             if stored_batch.committed_batch != committed_batch {
                 tracing::error!(
                     ?stored_batch,
@@ -142,6 +143,11 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                     );
                     return Ok(());
                 }
+            } else if batch_number <= latest_processed_batch {
+                tracing::warn!(
+                    "Found already committed batch #{batch_number}, but it is not present in batch storage; \
+                    assuming previous operation was reverted and overwriting data"
+                );
             }
             tracing::debug!(batch_number, "discovered committed batch");
             let committed_batch = self.parse_committed_batch(report, log).await?;


### PR DESCRIPTION
## Summary

Fix batch storage in revert case. It should overwrite in-memory batch data in this case 

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

