### PR TITLE
fix: detect Git LFS pointers early and document LFS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The ZKsync OS Server design optimizes for throughput, low latency, and a seamles
 
 ## Quickstart
 
+> **Note:** This repo uses Git LFS. Install it **before** cloning: `brew install git-lfs && git lfs install` (macOS) or `sudo apt-get install -y git-lfs && git lfs install` (Linux). If you already cloned without it, run `git lfs pull`.
+
 To run server locally with in-memory L1 node and dummy proofs, run the following commands:
 ```bash
 # Launch zksync-os-server on the default port 3050

--- a/docs/src/setup/prerequisites.md
+++ b/docs/src/setup/prerequisites.md
@@ -2,8 +2,34 @@
 
 This project requires:
 
+* **Git LFS** (this repo uses Git Large File Storage for chain state files)
 * The **Foundry nightly toolchain**
 * The **Rust toolchain**
+
+### Install Git LFS
+
+This repository uses [Git LFS](https://git-lfs.com) to store large chain state files (`*.json.gz`, `*.tar.gz`).
+You **must** install and initialize Git LFS before cloning, otherwise you'll get small pointer files instead of the actual data.
+
+```bash
+# macOS
+brew install git-lfs
+
+# Ubuntu/Debian
+sudo apt-get install -y git-lfs
+```
+
+Then run the one-time global setup:
+
+```bash
+git lfs install
+```
+
+After this, `git clone` will automatically fetch LFS files. If you already cloned without LFS, run:
+
+```bash
+git lfs pull
+```
 
 ### Install Foundry (v1.5.1)
 

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -37,6 +37,14 @@ fn decompress_l1_states() {
         let compressed = std::fs::read(&gz_path)
             .unwrap_or_else(|e| panic!("failed to read {}: {e}", gz_path.display()));
 
+        assert!(
+            !compressed.starts_with(b"version https://git-lfs"),
+            "{} is a Git LFS pointer, not the actual file.\n\
+             Install git-lfs and run `git lfs pull` to fetch the real content.\n\
+             See: https://git-lfs.com",
+            gz_path.display()
+        );
+
         let hash = Sha256::digest(&compressed);
         let hex_hash = format!("{hash:x}");
 

--- a/run_local.sh
+++ b/run_local.sh
@@ -114,6 +114,13 @@ if [ ! -f "$L1_STATE_FILE_GZ" ]; then
     exit 1
 fi
 
+# Detect Git LFS pointer instead of actual file
+if head -c 40 "$L1_STATE_FILE_GZ" | grep -q "version https://git-lfs"; then
+    echo -e "${RED}Error: '$L1_STATE_FILE_GZ' is a Git LFS pointer, not the actual file.${NC}"
+    echo -e "${RED}Run: git lfs install && git lfs pull${NC}"
+    exit 1
+fi
+
 # Decompress L1 state file into temporary directory
 gzip -d < "$L1_STATE_FILE_GZ" > "$TEMP_DIR/l1-state.json"
 


### PR DESCRIPTION
## Summary

After the Git LFS migration, users cloning without `git-lfs` installed silently get pointer files instead of actual chain state data, leading to cryptic "invalid gzip header" build failures.

- Add early LFS pointer detection in `integration-tests/build.rs` and `run_local.sh` with a clear error message and fix instructions
- Add Git LFS as the first prerequisite in `docs/src/setup/prerequisites.md` with install instructions for macOS and Linux
- Add a note in the README Quickstart section

No tests added — the detection is exercised by any build that encounters a pointer file.