### PR TITLE
ci: move git-lfs setup into runner-setup action

### DIFF
--- a/.github/actions/runner-setup/action.yaml
+++ b/.github/actions/runner-setup/action.yaml
@@ -45,7 +45,8 @@ runs:
         if command -v sudo >/dev/null 2>&1; then
           SUDO=sudo
         fi
-        ${SUDO} apt update && ${SUDO} apt install -y libclang-dev wget jq libssl-dev pkg-config
+        ${SUDO} apt update && ${SUDO} apt install -y libclang-dev wget jq libssl-dev pkg-config git-lfs
+        git lfs install
 
     - name: Add cuda to path
       shell: 'bash -ex {0}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,8 @@ jobs:
     env:
       ZKSYNC_USE_CUDA_STUBS: true
     steps:
-      - name: Install git-lfs
-        run: sudo apt-get install -y git-lfs && git lfs install
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup
@@ -85,13 +80,8 @@ jobs:
   test:
     runs-on: matterlabs-ci-runner-high-performance
     steps:
-      - name: Install git-lfs
-        run: sudo apt-get install -y git-lfs && git lfs install
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup
@@ -181,13 +171,8 @@ jobs:
   build-prover-tests:
     runs-on: matterlabs-ci-runner-ultra-performance
     steps:
-      - name: Install git-lfs
-        run: sudo apt-get install -y git-lfs && git lfs install
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup
@@ -222,13 +207,8 @@ jobs:
     runs-on: [matterlabs-ci-hetzner-rtx6000-gpu]
     needs: build-prover-tests
     steps:
-      - name: Install git-lfs
-        run: sudo apt-get install -y git-lfs && git lfs install
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup
@@ -280,8 +260,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          lfs: true
 
       - name: Setup runner
         uses: ./.github/actions/runner-setup


### PR DESCRIPTION
## Summary

- Move `git-lfs` installation and `git lfs pull` into `.github/actions/runner-setup` so all jobs that use the shared action get LFS support automatically
- Remove per-job `Install git-lfs` steps and `lfs: true` checkout options from `ci.yml` (5 jobs cleaned up)

This addresses the PR review feedback on #1084 about introducing boilerplate in individual jobs.