### PR TITLE
fix: handle already reverted batches in commit watcher

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -12,6 +12,10 @@ use zksync_os_storage_api::WriteFinality;
 pub struct L1CommitWatcher<Finality> {
     zk_chain: ZkChain<DynProvider>,
     next_batch_number: u64,
+    // L1 tip observed at watcher startup. Used to identify historical events during catch-up.
+    startup_latest_l1_block: u64,
+    // Last committed batch as of startup. Historical commits above this value are stale.
+    startup_last_committed_batch: u64,
     committed_batch_provider: CommittedBatchProvider,
     finality: Finality,
 }
@@ -44,6 +48,8 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
         let this = Self {
             zk_chain: zk_chain.clone(),
             next_batch_number: last_committed_batch + 1,
+            startup_latest_l1_block: current_l1_block,
+            startup_last_committed_batch: last_committed_batch,
             committed_batch_provider,
             finality,
         };
@@ -78,7 +84,22 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let batch_number = report.batchNumber;
-        if batch_number < self.next_batch_number {
+        // Startup-only guard: skip historical commits that are above the startup committed frontier.
+        // This handles batches that were committed and reverted before the node started.
+        if should_skip_historical_commit(
+            self.startup_latest_l1_block,
+            self.startup_last_committed_batch,
+            batch_number,
+            log.block_number,
+        ) {
+            tracing::warn!(
+                batch_number,
+                log_block_number = ?log.block_number,
+                startup_latest_l1_block = self.startup_latest_l1_block,
+                startup_last_committed_batch = self.startup_last_committed_batch,
+                "skipping historical committed batch above startup frontier; likely reverted before startup",
+            );
+        } else if batch_number < self.next_batch_number {
             tracing::debug!(batch_number, "skipping already processed committed batch");
         } else {
             tracing::debug!(batch_number, "discovered committed batch");
@@ -115,5 +136,45 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
             self.committed_batch_provider.insert(committed_batch);
         }
         Ok(())
+    }
+}
+
+/// Returns true if the commit event belongs to startup catch-up range and is above the startup
+/// committed frontier.
+fn should_skip_historical_commit(
+    startup_latest_l1_block: u64,
+    startup_last_committed_batch: u64,
+    batch_number: u64,
+    log_block_number: Option<u64>,
+) -> bool {
+    log_block_number.is_some_and(|log_block_number| {
+        log_block_number <= startup_latest_l1_block && batch_number > startup_last_committed_batch
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_historical_commit;
+
+    #[test]
+    fn skips_historical_batch_above_startup_frontier() {
+        assert!(should_skip_historical_commit(100, 10, 11, Some(99)));
+        assert!(should_skip_historical_commit(100, 10, 11, Some(100)));
+    }
+
+    #[test]
+    fn does_not_skip_batch_after_startup_block() {
+        assert!(!should_skip_historical_commit(100, 10, 11, Some(101)));
+    }
+
+    #[test]
+    fn does_not_skip_batch_within_startup_committed_frontier() {
+        assert!(!should_skip_historical_commit(100, 10, 10, Some(50)));
+        assert!(!should_skip_historical_commit(100, 10, 9, Some(50)));
+    }
+
+    #[test]
+    fn does_not_skip_when_log_has_no_block_number() {
+        assert!(!should_skip_historical_commit(100, 10, 11, None));
     }
 }


### PR DESCRIPTION
## Summary

Handle pre-startup reverted commits in L1CommitWatcher catch-up.

This change adds a startup-only guard that skips historical ReportCommittedBatchRangeZKsyncOS events when they are above the committed frontier observed at startup (startup_last_committed_batch) and come from blocks at or before the startup L1 tip (startup_latest_l1_block). This prevents stale pre-startup commits (committed, then reverted before node launch) from being indexed and avoids non-monotonic commit assertions on recommit.


<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

