### PR TITLE
test: try fix flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: ./.github/actions/runner-setup
 
       - name: Run tests
-        run: cargo nextest run --release --workspace --stress-count 20 upgrade_to_v31_with_deployments
+        run: cargo nextest run --release --workspace ${NEXTEST_ITERATIONS}
 
       - name: Upload test results
         if: always() && !cancelled()


### PR DESCRIPTION
## Summary

Try to fix flaky upgrade test.
Why it was flaky: we test v30->v31 upgrade but we don't do full upgrade, only necessary part; so after the test upgrade l1->l2 txs don't work and we're ok with it. Most likely when we spawn external node in the test then deposit is sent in `ensure_test_wallet_funded` because EN reads balance at the moment node is still processing old blocks.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

