### PR TITLE
fix(batch_types): explicitly declare required alloy features

### DIFF
--- a/lib/batch_types/Cargo.toml
+++ b/lib/batch_types/Cargo.toml
@@ -20,7 +20,7 @@ zksync_os_interface.workspace = true
 zk_os_basic_system.workspace = true
 zk_ee.workspace = true
 
-alloy.workspace = true
+alloy = { workspace = true, default-features = false, features = ["consensus", "kzg", "signer-local"] }
 thiserror.workspace = true
 serde.workspace = true
 blake2.workspace = true


### PR DESCRIPTION
## Summary

- `zksync_os_batch_types` uses `alloy::signers` and `SidecarBuilder` but declared `alloy.workspace = true` with no extra features
- It compiled in full workspace builds because `l1_sender` and `operator_signer` contributed `signer-local`/`kzg` via Cargo feature unification
- Isolated builds (`cargo check -p zksync_os_batch_types`) failed with 4 errors since those features were absent

## Test plan

- `cargo check -p zksync_os_batch_types` now passes in isolation
- Full workspace build unaffected

No tests added — this is a dependency declaration fix with no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)