### PR TITLE
fix: make block executor wait for block applier

### DIFF
--- a/lib/sequencer/src/execution/block_applier.rs
+++ b/lib/sequencer/src/execution/block_applier.rs
@@ -2,7 +2,7 @@ use crate::config::SequencerConfig;
 use crate::model::blocks::BlockCommandType;
 use alloy::consensus::Sealed;
 use async_trait::async_trait;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_storage_api::{ReplayRecord, WriteReplay, WriteRepository, WriteState};
@@ -19,6 +19,7 @@ where
     pub replay: Replay,
     pub repositories: Repo,
     pub config: SequencerConfig,
+    pub applied_block_number_sender: watch::Sender<u64>,
 }
 
 #[async_trait]
@@ -74,6 +75,8 @@ where
             self.repositories
                 .populate(block_output.clone(), executed_replay.transactions.clone())
                 .await?;
+
+            self.applied_block_number_sender.send_replace(block_number);
 
             if output.send((block_output, executed_replay)).await.is_err() {
                 tracing::info!("outbound channel closed");

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -103,6 +103,10 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
         }
     }
 
+    pub fn next_block_number(&self) -> u64 {
+        self.next_block_number
+    }
+
     pub async fn prepare_command(
         &mut self,
         block_command: BlockCommand,

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -33,6 +33,11 @@ where
     /// Controls transaction acceptance state.
     /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
     pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
+    /// TEMPORARY: `BlockExecutor` waits for `BlockApplier` to apply block `N`
+    /// before starting block `N + 1`. This works around an `OverlayBuffer` bug
+    /// that reproduces during rebuilds when the runtime truncates base state.
+    /// Once that bug is fixed, this wait can be removed.
+    pub applied_block_number_receiver: watch::Receiver<u64>,
 }
 
 #[async_trait]
@@ -72,7 +77,6 @@ where
         // `BlockExecutor` doesn't persist/update state after block execution.
         // Instead, we keep the diff in memory - and apply it on top of the last persisted block
         let mut state_overlay_buffer = OverlayBuffer::default();
-
         loop {
             latency_tracker.enter_state(SequencerState::WaitingForCommand);
 
@@ -82,6 +86,11 @@ where
             };
             tracing::info!("Command {cmd} received by BlockExecutor");
             let cmd_type = cmd.command_type();
+            wait_for_block_applier(
+                &mut self.applied_block_number_receiver,
+                self.block_context_provider.next_block_number() - 1,
+            )
+            .await?;
 
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
             if matches!(cmd, BlockCommand::Produce(_))
@@ -180,6 +189,40 @@ where
             }
         }
     }
+}
+
+async fn wait_for_block_applier(
+    applied_block_number_receiver: &mut watch::Receiver<u64>,
+    required_block_number: u64,
+) -> anyhow::Result<()> {
+    let applied_block_number = *applied_block_number_receiver.borrow_and_update();
+    if applied_block_number >= required_block_number {
+        tracing::debug!(
+            applied_block_number,
+            required_block_number,
+            "BlockExecutor does not need to wait for BlockApplier"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        applied_block_number,
+        required_block_number,
+        "BlockExecutor waiting for BlockApplier to catch up"
+    );
+
+    let reached_block_number = applied_block_number_receiver
+        .wait_for(|block_number| *block_number >= required_block_number)
+        .await
+        .context("block applier progress watch closed while executor was waiting")?
+        .to_owned();
+
+    tracing::debug!(
+        reached_block_number,
+        required_block_number,
+        "BlockExecutor resumed after BlockApplier caught up"
+    );
+    Ok(())
 }
 
 /// Checks if block production limit has been reached.

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -842,6 +842,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             node_startup_state,
             block_replay_storage.clone(),
             runtime,
+            starting_block,
             block_context_provider,
             state.clone(),
             tree_db,
@@ -926,6 +927,8 @@ async fn run_main_node_pipeline(
     );
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::channel(8);
+    let (applied_block_number_sender, applied_block_number_receiver) =
+        watch::channel(starting_block - 1);
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ConsensusNodeCommandSource {
@@ -944,6 +947,7 @@ async fn run_main_node_pipeline(
             state: state.clone(),
             config: config.into(),
             tx_acceptance_state_sender,
+            applied_block_number_receiver,
         })
         .pipe(BlockCanonizer {
             consensus: canonization_engine,
@@ -954,6 +958,7 @@ async fn run_main_node_pipeline(
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
+            applied_block_number_sender,
         })
         .pipe_opt(
             config
@@ -1097,6 +1102,7 @@ async fn run_en_pipeline(
     node_state_on_startup: NodeStateOnStartup,
     block_replay_storage: impl WriteReplay + Clone,
     runtime: &Runtime,
+    starting_block: u64,
     block_context_provider: BlockContextProvider<impl L2Subpool>,
     state: impl ReadStateHistory + WriteState + Clone,
     tree: MerkleTree<RocksDBWrapper>,
@@ -1111,6 +1117,8 @@ async fn run_en_pipeline(
             .rocks_db_path
             .join(INTERNAL_CONFIG_FILE_NAME),
     );
+    let (applied_block_number_sender, applied_block_number_receiver) =
+        watch::channel(starting_block - 1);
 
     Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
@@ -1122,12 +1130,14 @@ async fn run_en_pipeline(
             state: state.clone(),
             config: config.into(),
             tx_acceptance_state_sender,
+            applied_block_number_receiver,
         })
         .pipe(BlockApplier {
             state: state.clone(),
             replay: block_replay_storage.clone(),
             repositories: repositories.clone(),
             config: config.into(),
+            applied_block_number_sender,
         })
         .pipe_opt(
             config


### PR DESCRIPTION
## Summary
Wait for the previous block to be fully applied before executing the next one, using the startup block boundary as intial value

## Why
This removes a race between BlockExecutor and BlockApplier during replay and rebuild.

This fix is necessary for #1107 to succeed.

## Validation
- the targeted rebuild integration test in #1107 passes with this fix in place