### PR TITLE
test: tag integration test node logs

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::config::{ChainLayout, load_chain_config};
 use crate::dyn_wallet_provider::EthDynProvider;
 use crate::network::Zksync;
+use crate::node_log::NodeLogState;
 use crate::prover_tester::ProverTester;
 use crate::provider::{ZksyncApi, ZksyncTestingProvider};
 use crate::utils::LockedPort;
@@ -22,6 +23,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::runtime::Handle;
+use tracing::Instrument;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -45,6 +47,7 @@ pub mod config;
 pub mod contracts;
 pub mod dyn_wallet_provider;
 mod network;
+mod node_log;
 mod prover_tester;
 pub mod provider;
 pub mod upgrade;
@@ -150,6 +153,7 @@ pub struct Tester {
     batch_verification_url: String,
     gateway_rpc_url: Option<String>,
     sl_provider: EthDynProvider,
+    log_state: NodeLogState,
     chain_layout: ChainLayout<'static>,
     supporting_nodes: Vec<Tester>,
 }
@@ -158,6 +162,7 @@ pub struct Tester {
 pub struct StoppedTester {
     l1: AnvilL1,
     tempdir: Arc<tempfile::TempDir>,
+    log_state: NodeLogState,
     chain_layout: ChainLayout<'static>,
 }
 
@@ -266,6 +271,7 @@ impl Tester {
             runtime,
             l1,
             tempdir,
+            log_state,
             chain_layout,
             ..
         } = self;
@@ -275,6 +281,7 @@ impl Tester {
         Ok(StoppedTester {
             l1,
             tempdir,
+            log_state,
             chain_layout,
         })
     }
@@ -300,7 +307,15 @@ impl Tester {
         chain_layout: ChainLayout<'static>,
     ) -> anyhow::Result<Self> {
         let tempdir = Arc::new(tempfile::tempdir()?);
-        Self::launch_node_inner(l1, enable_prover, config_overrides, tempdir, chain_layout).await
+        Self::launch_node_inner(
+            l1,
+            enable_prover,
+            config_overrides,
+            tempdir,
+            None,
+            chain_layout,
+        )
+        .await
     }
 
     async fn launch_node_inner(
@@ -308,6 +323,7 @@ impl Tester {
         enable_prover: bool,
         config_overrides: Option<impl FnOnce(&mut Config)>,
         tempdir: Arc<TempDir>,
+        log_state: Option<NodeLogState>,
         chain_layout: ChainLayout<'static>,
     ) -> anyhow::Result<Self> {
         // Initialize and **hold** locked ports for the duration of node initialization.
@@ -430,12 +446,23 @@ impl Tester {
         if let Some(f) = config_overrides {
             f(&mut config)
         }
+        let node_role = config.general_config.node_role;
+        let log_state = log_state.unwrap_or_else(|| NodeLogState::fresh(node_role));
+        let log_tag = log_state.tag();
         let gateway_rpc_url = config.general_config.gateway_rpc_url.clone();
 
         let runtime = RuntimeBuilder::new(RuntimeConfig::with_existing_handle(Handle::current()))
             .build()
             .expect("failed to build runtime");
-        zksync_os_server::run::<FullDiffsState>(&runtime, config).await;
+        let node_span = tracing::info_span!(
+            "node",
+            node = %log_tag,
+            role = %node_role,
+        );
+        tracing::info!(parent: &node_span, "Launching test node");
+        zksync_os_server::run::<FullDiffsState>(&runtime, config)
+            .instrument(node_span)
+            .await;
 
         #[cfg(feature = "prover-tests")]
         if enable_prover {
@@ -567,6 +594,7 @@ impl Tester {
             gateway_rpc_url,
             sl_provider,
             node_record,
+            log_state,
             tempdir: tempdir.clone(),
             chain_layout,
             supporting_nodes: Vec::new(),
@@ -593,6 +621,7 @@ impl StoppedTester {
             false,
             None::<fn(&mut Config)>,
             self.tempdir,
+            Some(self.log_state.restarted()),
             self.chain_layout,
         )
         .await
@@ -607,6 +636,7 @@ impl StoppedTester {
             false,
             Some(config_overrides),
             self.tempdir,
+            Some(self.log_state.restarted()),
             self.chain_layout,
         )
         .await

--- a/integration-tests/src/node_log.rs
+++ b/integration-tests/src/node_log.rs
@@ -1,0 +1,83 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use zksync_os_types::NodeRole;
+
+static NODE_LOG_COUNTERS: NodeLogCounters = NodeLogCounters::new();
+
+pub(crate) struct NodeLogCounters {
+    next_main_node_id: AtomicUsize,
+    next_external_node_id: AtomicUsize,
+}
+
+impl NodeLogCounters {
+    pub(crate) const fn new() -> Self {
+        Self {
+            next_main_node_id: AtomicUsize::new(1),
+            next_external_node_id: AtomicUsize::new(1),
+        }
+    }
+
+    pub(crate) fn next_base_tag(&self, role: NodeRole) -> String {
+        let (prefix, counter) = match role {
+            NodeRole::MainNode => ("mn", &self.next_main_node_id),
+            NodeRole::ExternalNode => ("en", &self.next_external_node_id),
+        };
+        let id = counter.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{id}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NodeLogState {
+    base_tag: String,
+    restart_count: usize,
+}
+
+impl NodeLogState {
+    pub(crate) fn fresh(role: NodeRole) -> Self {
+        Self {
+            base_tag: NODE_LOG_COUNTERS.next_base_tag(role),
+            restart_count: 0,
+        }
+    }
+
+    pub(crate) fn restarted(mut self) -> Self {
+        self.restart_count += 1;
+        self
+    }
+
+    pub(crate) fn tag(&self) -> String {
+        if self.restart_count == 0 {
+            self.base_tag.clone()
+        } else {
+            format!("{}-restarted-{}", self.base_tag, self.restart_count)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NodeLogCounters, NodeLogState};
+    use zksync_os_types::NodeRole;
+
+    #[test]
+    fn node_log_counters_are_separate_per_role() {
+        let counters = NodeLogCounters::new();
+
+        assert_eq!(counters.next_base_tag(NodeRole::MainNode), "mn-1");
+        assert_eq!(counters.next_base_tag(NodeRole::ExternalNode), "en-1");
+        assert_eq!(counters.next_base_tag(NodeRole::MainNode), "mn-2");
+        assert_eq!(counters.next_base_tag(NodeRole::ExternalNode), "en-2");
+    }
+
+    #[test]
+    fn restart_tag_reuses_base_tag_and_increments_suffix() {
+        let base = NodeLogState {
+            base_tag: "mn-1".to_owned(),
+            restart_count: 0,
+        };
+
+        assert_eq!(base.tag(), "mn-1");
+        assert_eq!(base.clone().restarted().tag(), "mn-1-restarted-1");
+        assert_eq!(base.restarted().restarted().tag(), "mn-1-restarted-2");
+    }
+}


### PR DESCRIPTION
## Summary
- add a per-node log tag for integration-test launched nodes
- wrap each launched node in a root tracing span carrying `node`, `role`, and `rpc_addr`
- make interleaved `external_node.rs` logs attributable to the emitting node

## Validation
- cargo test -p zksync_os_integration_tests --no-run
- cargo test -p zksync_os_integration_tests --test suite external_node::transaction_replay::current_to_l1 -- --nocapture