### PR TITLE
fix: EN preimage persisting before block saved

### DIFF
--- a/lib/state/src/lib.rs
+++ b/lib/state/src/lib.rs
@@ -148,7 +148,7 @@ impl WriteState for StateHandle {
         // As such, preimages might be missing for a short period (not yet written to disk, but purged from overlay).
         //
         // TODO: The right fix here would be to have `block_range_available()` depend on both storage & preimages being written.
-        // 
+        //
         // We intentionally defer the proper fix for now.
         // Whilst we prefer the above, it requires tracking preimages progress for persistent state across restarts.
         // That implies extra metadata and migration / compatibility work.


### PR DESCRIPTION
Previously, we advanced storage-side `latest_block` before saving preimages. This rarely caused any sort of issues, but we had this race condition where block_executor could start on a block before preimages were saved. `OverlayBuffer` uses `latest_block` to decide which blocks it can purge. As such, there is a window in which the `preimages` are not in base, but also not in `OverlayBuffer`.

This issue was not observed before, because:
1. most storage we use is fast
2. we haven't recently synced a node from scratch on slow storage
3. the pipeline was mostly serialized flow, but with introduction of async processing of `BlockExecutor` and `BlockApplier`, this issue becomes more likely to happen

