### PR TITLE
chore: use reth fork for discv5 shutdown fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,7 +3834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4281,7 +4281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5641,7 +5641,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -8212,7 +8212,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8249,9 +8249,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8599,7 +8599,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-chain-state"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8650,7 +8650,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8680,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8693,7 +8693,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -8720,7 +8720,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8764,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8789,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8813,7 +8813,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8888,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8899,7 +8899,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8947,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8965,7 +8965,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9020,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9055,7 +9055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9073,7 +9073,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9099,7 +9099,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures",
  "metrics",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9129,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9143,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9199,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9246,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -9273,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9290,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9337,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9389,7 +9389,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9433,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9461,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9546,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9560,7 +9560,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -9574,7 +9574,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9598,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9615,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9643,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "clap",
  "eyre",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9756,7 +9756,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "zstd",
 ]
@@ -10303,7 +10303,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13014,7 +13014,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,24 +225,24 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-appender-tracing = "0.31.1"
 
 # Reth dependencies
-reth-db-models = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
+reth-db-models = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-evm-ethereum = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-chainspec = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-trie-common = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives-traits = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-revm = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-storage-api = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-transaction-pool = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-execution-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network-peers = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-net-nat = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-eth-wire = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-discv5 = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-provider = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-rpc-eth-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-tasks = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
 
 zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.4" }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,7 +16,7 @@ use anyhow::Context;
 use backon::ConstantBuilder;
 use backon::Retryable;
 use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
@@ -114,6 +114,8 @@ pub const BATCH_VERIFICATION_KEYS: [&str; 2] = [
 /// shutdown. We put 60s here until zksync-os v0.4.0 which will get rid of RISC-V simulator and
 /// allow async/abortable prover input generation.
 const NODE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+const NETWORK_PORT_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+const NETWORK_PORT_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Set of addresses (i.e. public keys) expected by batch verification. Derived from [`BATCH_VERIFICATION_KEYS`].
 static BATCH_VERIFICATION_ADDRESSES: LazyLock<Vec<String>> = LazyLock::new(|| {
     BATCH_VERIFICATION_KEYS
@@ -146,6 +148,7 @@ pub struct Tester {
 
     // Needed to be able to connect external nodes
     node_record: NodeRecord,
+    network_port: u16,
     l2_rpc_address: String,
     batch_verification_url: String,
     gateway_rpc_url: Option<String>,
@@ -250,11 +253,14 @@ impl Tester {
             l1,
             tempdir,
             chain_layout,
+            network_port,
             ..
         } = self;
         if !runtime.graceful_shutdown_with_timeout(NODE_SHUTDOWN_TIMEOUT) {
             panic!("node failed to shutdown in time");
         }
+        drop(runtime);
+        wait_for_network_port_release(network_port).await;
         Self::launch_node_inner(l1, false, None::<fn(&mut Config)>, tempdir, chain_layout).await
     }
 
@@ -532,12 +538,43 @@ impl Tester {
             gateway_rpc_url,
             sl_provider,
             node_record,
+            network_port: network_locked_port.port,
             tempdir: tempdir.clone(),
             chain_layout,
             supporting_nodes: Vec::new(),
         })
     }
 }
+
+async fn wait_for_network_port_release(port: u16) {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let deadline = tokio::time::Instant::now() + NETWORK_PORT_RELEASE_TIMEOUT;
+    loop {
+        if network_port_is_reusable(addr) {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "network port {port} did not become reusable within {NETWORK_PORT_RELEASE_TIMEOUT:?}"
+        );
+        tokio::time::sleep(NETWORK_PORT_RELEASE_POLL_INTERVAL).await;
+    }
+}
+
+fn network_port_is_reusable(addr: SocketAddr) -> bool {
+    let tcp = match TcpListener::bind(addr) {
+        Ok(listener) => listener,
+        Err(_) => return false,
+    };
+    let udp = match UdpSocket::bind(addr) {
+        Ok(socket) => socket,
+        Err(_) => return false,
+    };
+    drop(udp);
+    drop(tcp);
+    true
+}
+
 
 async fn ensure_test_wallet_funded(
     l1: &AnvilL1,


### PR DESCRIPTION
## Summary

- Switches to a reth fork that includes a fix for discv5 port not being released on node shutdown
- Adds `wait_for_network_port_release` helper in integration tests to wait for the network port to become reusable before restarting the node (addresses flaky restart tests caused by the same discv5 issue)

## Test plan

- [ ] Run integration tests: `cargo nextest run -p zksync_os_integration_tests`
- [ ] Verify node restart tests no longer flake due to port-in-use errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)