### PR TITLE
fix(l1-watcher): add missing logic for discovery of already commited batches on L1

### DIFF
--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -43,10 +43,16 @@ impl CommittedBatchProvider {
         }
         // todo: this can take a while and should ideally happen in the background
         // Ignore genesis here as it was handled above
+        let mut prefer_sl = l1_state.l1_chain_id != l1_state.sl_chain_id;
         for batch_number in l1_state.last_executed_batch.max(1)..=l1_state.last_committed_batch {
-            let discovered_batch =
-                discover_committed_batch_for_startup(l1_state, batch_number, max_l1_blocks_to_scan)
-                    .await?;
+            let (discovered_batch, found_on_sl) = discover_committed_batch_for_startup(
+                l1_state,
+                batch_number,
+                max_l1_blocks_to_scan,
+                prefer_sl,
+            )
+            .await?;
+            prefer_sl = found_on_sl;
             tracing::info!(
                 batch_number = discovered_batch.number(),
                 "discovered committed batch on startup"
@@ -88,64 +94,71 @@ impl Inner {
 }
 
 /// For chains that migrated from L1 settlement to a gateway, pre-migration commit events are on
-/// `diamond_proxy_l1`; post-migration commits are on `diamond_proxy_sl`.
+/// `diamond_proxy_l1`; post-migration commits are on `diamond_proxy_sl`. The chain can migrate
+/// back and forth, so `prefer_sl` tracks where the previous batch was found: the next batch is
+/// likely on the same source.
+///
+/// Returns `(batch, found_on_sl)` so the caller can feed `found_on_sl` back as `prefer_sl`.
 async fn discover_committed_batch_for_startup(
     l1_state: &L1State,
     batch_number: u64,
     max_l1_blocks_to_scan: u64,
-) -> anyhow::Result<DiscoveredCommittedBatch> {
-    // Same diamond address can appear on L1 and on the gateway L2; use chain IDs, not addresses.
-    let settle_on_l1 = l1_state.l1_chain_id == l1_state.sl_chain_id;
-    if settle_on_l1 {
-        let block = util::find_l1_commit_block_by_batch_number(
-            l1_state.diamond_proxy_sl.clone(),
-            batch_number,
-            max_l1_blocks_to_scan,
+    prefer_sl: bool,
+) -> anyhow::Result<(DiscoveredCommittedBatch, bool)> {
+    let (primary, fallback, primary_is_sl) = if prefer_sl {
+        (&l1_state.diamond_proxy_sl, &l1_state.diamond_proxy_l1, true)
+    } else {
+        (
+            &l1_state.diamond_proxy_l1,
+            &l1_state.diamond_proxy_sl,
+            false,
         )
-        .await?;
-        let discovered =
-            util::fetch_stored_batch_data(&l1_state.diamond_proxy_sl, block, batch_number)
-                .await?
-                .with_context(|| format!("failed to find committed batch {batch_number} on L1"))?;
-        return Ok(discovered);
-    }
+    };
+    let source_name = |is_sl: bool| if is_sl { "SL" } else { "L1" };
+
+    // Try the preferred source first.
     match util::find_l1_commit_block_by_batch_number(
-        l1_state.diamond_proxy_l1.clone(),
+        primary.clone(),
         batch_number,
         max_l1_blocks_to_scan,
     )
     .await
     {
         Ok(block) => {
-            if let Some(batch) =
-                util::fetch_stored_batch_data(&l1_state.diamond_proxy_l1, block, batch_number)
-                    .await?
+            if let Some(batch) = util::fetch_stored_batch_data(primary, block, batch_number).await?
             {
-                tracing::debug!(batch_number, "found committed batch on L1 diamond proxy");
-                return Ok(batch);
+                tracing::debug!(
+                    "found committed batch {batch_number} on {source} at block {block}",
+                    source = source_name(primary_is_sl),
+                );
+                return Ok((batch, primary_is_sl));
             }
         }
         Err(err) => {
-            tracing::warn!(
-                batch_number,
-                ?err,
-                "failed to find commit block on L1 diamond proxy, falling back to settlement layer"
+            tracing::debug!(
+                "batch {batch_number} not found on {source}: {err:#}, trying fallback",
+                source = source_name(primary_is_sl),
             );
         }
     }
+
+    // Fall back to the other source.
     let block = util::find_l1_commit_block_by_batch_number(
-        l1_state.diamond_proxy_sl.clone(),
+        fallback.clone(),
         batch_number,
         max_l1_blocks_to_scan,
     )
     .await?;
-    let batch = util::fetch_stored_batch_data(&l1_state.diamond_proxy_sl, block, batch_number)
+    let batch = util::fetch_stored_batch_data(fallback, block, batch_number)
         .await?
         .with_context(|| {
             format!(
-                "failed to find committed batch {batch_number} on L1 diamond or settlement-layer chain"
+                "failed to find committed batch {batch_number} on either L1 or settlement layer"
             )
         })?;
-    tracing::debug!(batch_number, "found committed batch on settlement layer");
-    Ok(batch)
+    tracing::debug!(
+        "found committed batch {batch_number} on {source} at block {block}",
+        source = source_name(!primary_is_sl),
+    );
+    Ok((batch, !primary_is_sl))
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the server cannot start when it already committed some batches to L1 and then was migrated on top of Gateway

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

