### PR TITLE
fix(loadbase): Increase max-in-flight from 10 to 1000 in loadbase

### DIFF
--- a/loadbase/src/main.rs
+++ b/loadbase/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     mnemonic: String,
     #[arg(long, default_value_t = 10)] wallets: u32,
     #[arg(long)] duration: humantime::Duration,
-    #[arg(long, default_value_t = 10)] max_in_flight: u32,
+    #[arg(long, default_value_t = 1000)] max_in_flight: u32,
     #[arg(long, default_value = "100000000000000")] amount_fund: String,
     #[arg(long)] estimate_gas: bool,
     #[arg(long, value_enum, default_value_t = DestMode::Wallet)] dest: DestMode,


### PR DESCRIPTION
## Summary

10 in-flight transactions is too little to reach our TPS limits. 
It used to be OK before when this limit was per-wallet. But now as it's global - 1000 is a better number which reaches 2.5k+ TPS in local tests
