### PR TITLE
fix(rpc): map client errors to -32602, keep server errors at -32603

### DIFF
--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -60,11 +60,8 @@ impl<Ok> ToRpcResult<Ok, DebugError> for Result<Ok, DebugError> {
         self.map_err(|err| match err {
             DebugError::UnsupportedDefaultTracer
             | DebugError::UnsupportedTracer(_)
-            | DebugError::UnsupportedTxIndex => rpc_error_with_code(
-                jsonrpsee::types::error::METHOD_NOT_FOUND_CODE,
-                err.to_string(),
-            ),
-            DebugError::InvalidTracerConfig
+            | DebugError::UnsupportedTxIndex
+            | DebugError::InvalidTracerConfig
             | DebugError::TransactionNotFound
             | DebugError::BlockNotFound => invalid_params_rpc_err(err.to_string()),
             DebugError::InternalError | DebugError::Repository(_) | DebugError::State(_) => {


### PR DESCRIPTION
## Summary

The blanket `impl_to_rpc_result!` macro was mapping all RPC handler errors to `-32603` (Internal error), including errors that are clearly the client's fault. This makes the `errors` metric noisy and misleading — client mistakes inflate the internal error rate.

Currently it look like this:
<img width="1527" height="258" alt="Screenshot 2026-04-02 at 14 31 47" src="https://github.com/user-attachments/assets/f8aa11e5-9f48-4a41-8bec-9aaedea31a90" />
Which makes it look like we have a lot of internal errors and something is going wrong.
After I check the logs - I see that most of those are legitimate client errors.
Examples:
* Wrong nonce
* Scan range over limit
* Asking for logs from a non-existing block


This PR replaces the macro with per-type implementations that match on each variant:

- **`-32602` (Invalid params):** bad block ids, invalid filter ranges, malformed transactions, bad signatures, unsupported tracer options, etc. — anything the client can fix by changing their request
- **`-32603` (Internal error):** storage failures, repository errors, VM state errors — genuine server-side problems

Affected error types: `EthFilterError`, `EthError`, `DebugError`, `EthSendRawTransactionError`.

`ZksError` and `UnstableError` are left on the macro — their variants are mostly server-side conditions (pruned data, batch indexing lag) that correctly belong in `-32603`.

No tests added — this is a mapping change with no behavioural logic; the existing integration tests exercise the affected code paths.