### PR TITLE
feat: use log id for interop root indexing

### DIFF
--- a/integration-tests/src/upgrade/tester.rs
+++ b/integration-tests/src/upgrade/tester.rs
@@ -402,7 +402,7 @@ impl UpgradeTester {
     pub async fn generic_l2_upgrade_target(&self) -> anyhow::Result<(Address, Bytes)> {
         // HACK: right now we need to call an account with bytecode to make the upgrade work.
         // So we deploy a event emitter contract and use it as a delegate.
-        let event_emitter =
+        let event_emitter: crate::contracts::EventEmitter::EventEmitterInstance<EthDynProvider> =
             crate::contracts::EventEmitter::deploy(self.tester.l2_provider.clone()).await?;
         let event_emitter_calldata = event_emitter
             .emitEvent(U256::from(42u64))

--- a/integration-tests/tests/node/restart.rs
+++ b/integration-tests/tests/node/restart.rs
@@ -55,6 +55,7 @@ fn load_operator_private_key(layout: ChainLayout<'_>, chain_id: u64) -> anyhow::
 }
 
 fn make_commit_only_config(config: &mut Config) {
+    config.prover_input_generator_config.enable_input_generation = true;
     config.prover_api_config.fake_fri_provers.enabled = true;
     config.prover_api_config.fake_fri_provers.compute_time = Duration::from_millis(200);
     config.prover_api_config.fake_fri_provers.min_age = Duration::ZERO;
@@ -62,6 +63,7 @@ fn make_commit_only_config(config: &mut Config) {
 }
 
 fn disable_commits_config(config: &mut Config) {
+    config.prover_input_generator_config.enable_input_generation = true;
     config.prover_api_config.fake_fri_provers.enabled = false;
     config.prover_api_config.fake_snark_provers.enabled = false;
 }

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -7,6 +7,7 @@ use crate::IBridgehub::{
     IBridgehubInstance, L2TransactionRequestDirect, L2TransactionRequestTwoBridgesOuter,
     requestL2TransactionDirectCall, requestL2TransactionTwoBridgesCall,
 };
+use crate::IMessageRoot::IMessageRootInstance;
 use crate::IMultisigCommitter::IMultisigCommitterInstance;
 use crate::IZKChain::IZKChainInstance;
 use alloy::contract::SolCallBuilder;
@@ -91,6 +92,8 @@ alloy::sol! {
         );
 
         function addInteropRootsInBatch(InteropRoot[] calldata interopRootsInput);
+
+        uint256 public totalPublishedInteropRoots;
 
         function getChainTree(uint256 chainId) public view returns (Bytes32PushTree);
 
@@ -428,6 +431,46 @@ alloy::sol! {
     #[sol(rpc)]
     interface IERC20 {
         function decimals() external view returns (uint8);
+    }
+}
+
+pub struct MessageRoot<P: Provider> {
+    instance: IMessageRootInstance<P, Ethereum>,
+    address: Address,
+}
+
+impl<P: Provider> MessageRoot<P> {
+    pub fn new(address: Address, provider: P) -> Self {
+        let instance = IMessageRoot::new(address, provider);
+        Self { instance, address }
+    }
+
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    pub fn provider(&self) -> &P {
+        self.instance.provider()
+    }
+
+    pub async fn total_published_interop_roots(&self, block_id: BlockId) -> Result<u64> {
+        self.instance
+            .totalPublishedInteropRoots()
+            .block(block_id)
+            .call()
+            .await
+            .map(|n| n.saturating_to())
+            .enrich("totalPublishedInteropRoots", Some(block_id))
+    }
+
+    pub async fn code_exists_at_block(&self, block_id: BlockId) -> alloy::contract::Result<bool> {
+        let code = self
+            .provider()
+            .get_code_at(*self.address())
+            .block_id(block_id)
+            .await?;
+
+        Ok(!code.0.is_empty())
     }
 }
 

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
 
+use alloy::primitives::ruint::FromUintError;
 use alloy::rpc::types::{Log, Topic, ValueOrArray};
 use alloy::sol_types::SolEvent;
 use alloy::{primitives::Address, providers::DynProvider};
 use zksync_os_contract_interface::IMessageRoot::NewInteropRoot;
 use zksync_os_contract_interface::{Bridgehub, InteropRoot};
 use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
-use zksync_os_types::{IndexedInteropRoot, InteropRootsLogIndex};
+use zksync_os_types::IndexedInteropRoot;
 
+use crate::util::find_l1_block_by_interop_root_id;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessRawEvents};
 
 pub struct InteropWatcher {
     contract_address: Address,
-    starting_interop_event_index: InteropRootsLogIndex,
+    starting_interop_root_id: u64,
     interop_roots_subpool: InteropRootsSubpool,
 }
 
@@ -21,7 +23,7 @@ impl InteropWatcher {
     pub async fn create_watcher(
         bridgehub: Bridgehub<DynProvider>,
         config: L1WatcherConfig,
-        starting_interop_event_index: InteropRootsLogIndex,
+        starting_interop_root_id: u64,
         interop_roots_subpool: InteropRootsSubpool,
         l1_chain_id: u64,
     ) -> anyhow::Result<L1Watcher> {
@@ -29,19 +31,22 @@ impl InteropWatcher {
 
         tracing::info!(
             contract_address = ?contract_address,
-            starting_interop_event_index = ?starting_interop_event_index,
+            starting_interop_root_id,
             "initializing interop watcher"
         );
 
+        let next_l1_block =
+            find_l1_block_by_interop_root_id(bridgehub.clone(), starting_interop_root_id).await?;
+
         let this = Self {
             contract_address,
-            starting_interop_event_index,
+            starting_interop_root_id,
             interop_roots_subpool,
         };
 
         let l1_watcher = L1Watcher::new(
             bridgehub.provider().clone(),
-            this.starting_interop_event_index.block_number,
+            next_l1_block,
             config.max_blocks_to_process,
             config.confirmations,
             l1_chain_id,
@@ -73,10 +78,14 @@ impl ProcessRawEvents for InteropWatcher {
         let mut indexes = HashMap::new();
 
         for log in logs {
-            let sol_event = NewInteropRoot::decode_log(&log.inner)
-                .expect("failed to decode log")
-                .data;
-            indexes.insert(sol_event.blockNumber, log);
+            let event = match NewInteropRoot::decode_log(&log.inner) {
+                Ok(event) => event.data,
+                Err(err) => {
+                    tracing::error!(?log, error = ?err, "failed to decode interop root log");
+                    continue;
+                }
+            };
+            indexes.insert(event.logId, log);
         }
 
         indexes.into_values().collect()
@@ -85,16 +94,16 @@ impl ProcessRawEvents for InteropWatcher {
     async fn process_raw_event(&mut self, log: Log) -> Result<(), L1WatcherError> {
         let event = NewInteropRoot::decode_log(&log.inner)?.data;
 
-        let event_log_index = InteropRootsLogIndex {
-            block_number: log.block_number.unwrap(),
-            index_in_block: log.log_index.unwrap(),
-        };
+        let log_id: u64 = event
+            .logId
+            .try_into()
+            .map_err(|e: FromUintError<u64>| L1WatcherError::Other(e.into()))?;
 
-        if event_log_index < self.starting_interop_event_index {
+        if log_id < self.starting_interop_root_id {
             tracing::debug!(
-                log_id = ?event.logId,
-                starting_interop_event_index = ?self.starting_interop_event_index,
-                "skipping interop root event before starting index",
+                log_id,
+                starting_interop_root_id = self.starting_interop_root_id,
+                "skipping interop root event before starting id",
             );
             return Ok(());
         }
@@ -106,7 +115,7 @@ impl ProcessRawEvents for InteropWatcher {
 
         self.interop_roots_subpool
             .add_root(IndexedInteropRoot {
-                log_index: event_log_index,
+                log_id,
                 root: interop_root,
             })
             .await;

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -14,7 +14,7 @@ use zksync_os_batch_types::{BatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
 use zksync_os_contract_interface::models::CommitBatchInfo;
-use zksync_os_contract_interface::{IExecutor, ZkChain};
+use zksync_os_contract_interface::{Bridgehub, IExecutor, MessageRoot, ZkChain};
 use zksync_os_types::ProtocolSemanticVersion;
 
 pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
@@ -273,6 +273,62 @@ pub async fn find_l1_execute_block_by_batch_number(
         Ok(res >= batch_number)
     })
     .await
+}
+
+/// Finds the first L1 block where `totalPublishedInteropRoots >= next_interop_root_id`.
+/// Uses binary search for efficiency.
+pub async fn find_l1_block_by_interop_root_id(
+    bridgehub: Bridgehub<DynProvider>,
+    next_interop_root_id: u64,
+) -> anyhow::Result<BlockNumber> {
+    if next_interop_root_id == 0 {
+        return Ok(0);
+    }
+
+    // Binary search via `eth_call` with historical block IDs is not supported on Anvil with
+    // `--load-state`. Fall back to block 0 so the watcher starts from genesis and catches up
+    // via `eth_getLogs`, which Anvil does support.
+    if bridgehub.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
+        return Ok(0);
+    }
+
+    let message_root_address = bridgehub.message_root_address().await?;
+    let message_root = Arc::new(MessageRoot::new(
+        message_root_address,
+        bridgehub.provider().clone(),
+    ));
+
+    let latest = message_root.provider().get_block_number().await?;
+
+    let guarded_predicate =
+        async |message_root: Arc<MessageRoot<DynProvider>>, block: u64| -> anyhow::Result<bool> {
+            if !message_root.code_exists_at_block(block.into()).await? {
+                return Ok(false);
+            }
+            let res = message_root
+                .total_published_interop_roots(block.into())
+                .await?;
+            Ok(res >= next_interop_root_id)
+        };
+
+    if !guarded_predicate(message_root.clone(), latest).await? {
+        anyhow::bail!(
+            "Condition not satisfied up to latest block: contract not deployed yet \
+             or target not reached.",
+        );
+    }
+
+    let (mut lo, mut hi) = (0, latest);
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        if guarded_predicate(message_root.clone(), mid).await? {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+
+    Ok(lo)
 }
 
 /// Fetches and decodes stored batch data for batch `batch_number` that is expected to have been

--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -15,9 +15,7 @@ use reth_transaction_pool::{CanonicalStateUpdate, PoolUpdateKind};
 use tokio::time::Instant;
 use zksync_os_interface::types::AccountDiff;
 use zksync_os_storage_api::ReplayRecord;
-use zksync_os_types::{
-    InteropRootsLogIndex, L1TxSerialId, SystemTxType, UpgradeMetadata, ZkEnvelope, ZkTransaction,
-};
+use zksync_os_types::{L1TxSerialId, SystemTxType, UpgradeMetadata, ZkEnvelope, ZkTransaction};
 
 /// General pool that provides unified access to all transaction sources in the system.
 ///
@@ -213,7 +211,7 @@ impl<T: L2Subpool> Pool<T> {
         self.upgrade_subpool
             .on_canonical_state_change(&replay_record.protocol_version, upgrade_txs)
             .await;
-        let last_interop_log_index = self
+        let last_interop_log_id = self
             .interop_roots_subpool
             .on_canonical_state_change(interop_txs)
             .await;
@@ -254,7 +252,7 @@ impl<T: L2Subpool> Pool<T> {
             });
 
         StateChangeOutcome {
-            last_interop_log_index,
+            last_interop_log_id,
             last_l1_priority_id,
             last_migration_number,
             last_interop_fee_number,
@@ -273,8 +271,8 @@ pub struct StreamOutcome<'a> {
 
 #[derive(Debug, Default)]
 pub struct StateChangeOutcome {
-    /// Last interop log index that was imported after canonical state change.
-    pub last_interop_log_index: Option<InteropRootsLogIndex>,
+    /// Last interop log_id that was imported after canonical state change.
+    pub last_interop_log_id: Option<u64>,
     /// Last L1 priority ID that was executed after canonical state change.
     pub last_l1_priority_id: Option<L1TxSerialId>,
     /// Last migration number that was executed after canonical state change.

--- a/lib/mempool/src/subpools/interop_roots.rs
+++ b/lib/mempool/src/subpools/interop_roots.rs
@@ -5,8 +5,7 @@ use tokio::sync::Notify;
 use tokio::time::Instant;
 use tokio::time::sleep_until;
 use zksync_os_types::{
-    IndexedInteropRoot, InteropRoot, InteropRootsLogIndex, SystemTxEnvelope, SystemTxType,
-    ZkTransaction,
+    IndexedInteropRoot, InteropRoot, SystemTxEnvelope, SystemTxType, ZkTransaction,
 };
 
 #[derive(Clone)]
@@ -21,7 +20,7 @@ pub struct InteropRootsSubpool {
 /// canonical chain yet. Note that some prefix might have already been executed in sequencer (as
 /// they were returned from [`InteropRootsSubpool::interop_transactions_with_delay`]).
 struct Inner {
-    pending_roots: BTreeMap<InteropRootsLogIndex, InteropRoot>,
+    pending_roots: BTreeMap<u64, InteropRoot>,
 }
 
 impl InteropRootsSubpool {
@@ -43,8 +42,8 @@ impl InteropRootsSubpool {
             (
                 self.inner.clone(),
                 self.notify.clone(),
-                InteropRootsLogIndex::default(),
-                VecDeque::default(),
+                0u64,
+                VecDeque::<(u64, InteropRoot)>::default(),
             ),
             move |(inner, notify, mut cursor, mut buffer)| async move {
                 sleep_until(next_tx_allowed_after).await;
@@ -55,12 +54,9 @@ impl InteropRootsSubpool {
 
                     {
                         let inner = inner.read().unwrap();
-                        for (id, root) in inner.pending_roots.range(&cursor..) {
-                            cursor = InteropRootsLogIndex {
-                                block_number: id.block_number,
-                                index_in_block: id.index_in_block + 1,
-                            };
-                            buffer.push_front(root.clone());
+                        for (id, root) in inner.pending_roots.range(cursor..) {
+                            cursor = id + 1;
+                            buffer.push_front((*id, root.clone()));
                         }
                     }
 
@@ -68,12 +64,18 @@ impl InteropRootsSubpool {
                         let amount_of_roots_to_take = buffer.len().min(self.interop_roots_per_tx);
                         let starting_index = buffer.len() - amount_of_roots_to_take;
 
-                        let roots_to_consume = buffer
+                        let roots_to_consume: Vec<(u64, InteropRoot)> = buffer
                             .drain(starting_index..)
                             .rev() // reversing iterator as last element is the one received earliest
-                            .collect::<Vec<_>>();
+                            .collect();
 
-                        let envelope = SystemTxEnvelope::import_interop_roots(roots_to_consume);
+                        // Use the log_id of the last (largest) root as the salt for uniqueness.
+                        let last_log_id = roots_to_consume
+                            .last()
+                            .expect("roots_to_consume is non-empty")
+                            .0;
+                        let roots = roots_to_consume.into_iter().map(|(_, r)| r).collect();
+                        let envelope = SystemTxEnvelope::import_interop_roots(roots, last_log_id);
                         drop(notified);
                         return Some((envelope.into(), (inner, notify, cursor, buffer)));
                     }
@@ -90,11 +92,11 @@ impl InteropRootsSubpool {
             .write()
             .unwrap()
             .pending_roots
-            .insert(root.log_index, root.root);
+            .insert(root.log_id, root.root);
         self.notify.notify_waiters();
     }
 
-    async fn pop_wait(&self) -> (InteropRootsLogIndex, InteropRoot) {
+    async fn pop_wait(&self) -> (u64, InteropRoot) {
         loop {
             let notified = self.notify.notified();
             {
@@ -107,17 +109,14 @@ impl InteropRootsSubpool {
         }
     }
 
-    /// Cleans up the stream and removes all roots that were sent in transactions
-    /// Returns the last log index of executed interop root
-    pub async fn on_canonical_state_change(
-        &self,
-        txs: Vec<&SystemTxEnvelope>,
-    ) -> Option<InteropRootsLogIndex> {
+    /// Cleans up the stream and removes all roots that were sent in transactions.
+    /// Returns the last log_id of the executed interop root.
+    pub async fn on_canonical_state_change(&self, txs: Vec<&SystemTxEnvelope>) -> Option<u64> {
         if txs.is_empty() {
             return None;
         }
 
-        let mut log_index = InteropRootsLogIndex::default();
+        let mut last_log_id = None;
 
         for tx in txs {
             let SystemTxType::ImportInteropRoots(roots_count) = *tx.system_subtype() else {
@@ -125,16 +124,21 @@ impl InteropRootsSubpool {
             };
 
             let mut roots = Vec::with_capacity(roots_count as usize);
+            let mut tx_last_log_id = None;
             for _ in 0..roots_count {
                 let (id, root) = self.pop_wait().await;
                 roots.push(root);
-                log_index = id;
+                tx_last_log_id = Some(id);
             }
-            let envelope = SystemTxEnvelope::import_interop_roots(roots);
+            last_log_id = tx_last_log_id;
+            let envelope = SystemTxEnvelope::import_interop_roots(
+                roots,
+                tx_last_log_id.expect("roots_count > 0"),
+            );
 
             assert_eq!(&envelope, tx);
         }
 
-        Some(log_index)
+        last_log_id
     }
 }

--- a/lib/network/src/version.rs
+++ b/lib/network/src/version.rs
@@ -1,7 +1,7 @@
 //! Support for representing the version of the `zks` protocol
 
 use crate::wire::message::ZksMessageId;
-use crate::wire::replays::{WireReplayRecord, v0, v1, v2};
+use crate::wire::replays::{WireReplayRecord, v0, v1, v2, v3};
 use alloy::primitives::bytes::BufMut;
 use alloy::rlp::{Decodable, Encodable, Error as RlpError};
 use std::fmt::Debug;
@@ -36,8 +36,7 @@ impl AnyZksProtocolVersion for ZksProtocolV1 {
     const VERSION: ZksVersion = ZksVersion::Zks1;
 }
 
-/// Protocol version 1 is the initial implementation that supports `GetBlockReplays` and `BlockReplays`
-/// message types.
+/// Protocol version 2 updates replay records to use indexes for new watchers.
 #[derive(Debug, Clone)]
 pub struct ZksProtocolV2;
 
@@ -45,6 +44,17 @@ impl AnyZksProtocolVersion for ZksProtocolV2 {
     type Record = v2::ReplayRecord;
 
     const VERSION: ZksVersion = ZksVersion::Zks2;
+}
+
+/// Protocol version 3 replaces `starting_interop_event_index: InteropRootsLogIndex` with
+/// `starting_interop_root_id: u64`.
+#[derive(Debug, Clone)]
+pub struct ZksProtocolV3;
+
+impl AnyZksProtocolVersion for ZksProtocolV3 {
+    type Record = v3::ReplayRecord;
+
+    const VERSION: ZksVersion = ZksVersion::Zks3;
 }
 
 /// Error thrown when failed to parse a valid [`ZksVersion`].
@@ -62,14 +72,16 @@ pub enum ZksVersion {
     Zks1 = 1,
     /// The `zks` protocol version 2.
     Zks2 = 2,
+    /// The `zks` protocol version 3.
+    Zks3 = 3,
 }
 
 impl ZksVersion {
     /// The latest known zks version
-    pub const LATEST: Self = Self::Zks1;
+    pub const LATEST: Self = Self::Zks3;
 
     /// All known zks versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Zks0, Self::Zks1];
+    pub const ALL_VERSIONS: &'static [Self] = &[Self::Zks0, Self::Zks1, Self::Zks2, Self::Zks3];
 
     /// Returns the max message id for the given version.
     const fn max_message_id(&self) -> u8 {
@@ -77,6 +89,7 @@ impl ZksVersion {
             ZksVersion::Zks0 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks1 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks2 => ZksMessageId::BlockReplays as u8,
+            ZksVersion::Zks3 => ZksMessageId::BlockReplays as u8,
         }
     }
 
@@ -124,6 +137,7 @@ impl TryFrom<u8> for ZksVersion {
             0 => Ok(Self::Zks0),
             1 => Ok(Self::Zks1),
             2 => Ok(Self::Zks2),
+            3 => Ok(Self::Zks3),
             _ => Err(ParseVersionError(u.to_string())),
         }
     }
@@ -143,6 +157,7 @@ impl From<ZksVersion> for &'static str {
             ZksVersion::Zks0 => "0",
             ZksVersion::Zks1 => "1",
             ZksVersion::Zks2 => "2",
+            ZksVersion::Zks3 => "3",
         }
     }
 }
@@ -156,7 +171,7 @@ mod tests {
     #[test]
     fn test_zks_version_rlp_encode() {
         // Version 0 is purposefully left out as it encodes to 0x80 (prefix for 0-length string)
-        let versions = [ZksVersion::Zks1, ZksVersion::Zks2];
+        let versions = [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3];
 
         for version in versions {
             let mut encoded = BytesMut::new();
@@ -173,7 +188,8 @@ mod tests {
             (0_u8, Ok(ZksVersion::Zks0)),
             (1_u8, Ok(ZksVersion::Zks1)),
             (2_u8, Ok(ZksVersion::Zks2)),
-            (3_u8, Err(RlpError::Custom("invalid zks version"))),
+            (3_u8, Ok(ZksVersion::Zks3)),
+            (4_u8, Err(RlpError::Custom("invalid zks version"))),
         ];
 
         for (input, expected) in test_cases {

--- a/lib/network/src/wire/replays/impls.rs
+++ b/lib/network/src/wire/replays/impls.rs
@@ -3,7 +3,7 @@
 //! Note that this file is allowed to change as traits can evolve over time and hence can the
 //! surrounding logic.
 
-use crate::wire::replays::{WireReplayRecord, v0, v1, v2};
+use crate::wire::replays::{WireReplayRecord, v0, v1, v2, v3};
 use crate::wire::{BlockHashes, ForcedPreimage};
 use alloy::consensus::crypto::RecoveryError;
 use alloy::primitives::{BlockNumber, Bytes};
@@ -11,6 +11,7 @@ use zksync_os_interface::types::BlockContext as InterfaceBlockContext;
 use zksync_os_interface::types::BlockHashes as InterfaceBlockHashes;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_storage_api::ReplayRecord as StorageReplayRecord;
+use zksync_os_types::InteropRootsLogIndex;
 use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
 
 // ==================================================
@@ -103,7 +104,8 @@ impl From<StorageReplayRecord> for v1::ReplayRecord {
                     preimage: Bytes::from(preimage),
                 })
                 .collect(),
-            starting_interop_event_index: value.starting_cursors.interop_event_index,
+            // v1 format uses InteropRootsLogIndex; default it since log_id is not recoverable
+            starting_interop_event_index: InteropRootsLogIndex::default(),
         }
     }
 }
@@ -151,7 +153,8 @@ impl TryFrom<v1::ReplayRecord> for StorageReplayRecord {
                 .collect(),
             starting_cursors: BlockStartCursors {
                 l1_priority_id: value.starting_l1_priority_id,
-                interop_event_index: value.starting_interop_event_index,
+                // v1 format has InteropRootsLogIndex; map to 0 since block/index is not the log_id
+                interop_root_id: 0,
                 migration_number: 0,
                 interop_fee_number: 0,
             },
@@ -189,6 +192,26 @@ impl From<InterfaceBlockContext> for v2::BlockContext {
     }
 }
 
+impl From<v2::BlockContext> for InterfaceBlockContext {
+    fn from(value: v2::BlockContext) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            block_number: value.block_number,
+            block_hashes: InterfaceBlockHashes(value.block_hashes.0),
+            timestamp: value.timestamp,
+            eip1559_basefee: value.eip1559_basefee,
+            pubdata_price: value.pubdata_price,
+            native_price: value.native_price,
+            coinbase: value.coinbase,
+            gas_limit: value.gas_limit,
+            pubdata_limit: value.pubdata_limit,
+            mix_hash: value.mix_hash,
+            execution_version: value.execution_version,
+            blob_fee: value.blob_fee,
+        }
+    }
+}
+
 impl From<StorageReplayRecord> for v2::ReplayRecord {
     fn from(value: StorageReplayRecord) -> Self {
         Self {
@@ -210,29 +233,10 @@ impl From<StorageReplayRecord> for v2::ReplayRecord {
                     preimage: Bytes::from(preimage),
                 })
                 .collect(),
-            starting_interop_event_index: value.starting_cursors.interop_event_index,
+            // v2 format uses InteropRootsLogIndex; log_id is not recoverable from it
+            starting_interop_event_index: InteropRootsLogIndex::default(),
             starting_migration_number: value.starting_cursors.migration_number,
             starting_interop_fee_number: value.starting_cursors.interop_fee_number,
-        }
-    }
-}
-
-impl From<v2::BlockContext> for InterfaceBlockContext {
-    fn from(value: v2::BlockContext) -> Self {
-        Self {
-            chain_id: value.chain_id,
-            block_number: value.block_number,
-            block_hashes: InterfaceBlockHashes(value.block_hashes.0),
-            timestamp: value.timestamp,
-            eip1559_basefee: value.eip1559_basefee,
-            pubdata_price: value.pubdata_price,
-            native_price: value.native_price,
-            coinbase: value.coinbase,
-            gas_limit: value.gas_limit,
-            pubdata_limit: value.pubdata_limit,
-            mix_hash: value.mix_hash,
-            execution_version: value.execution_version,
-            blob_fee: value.blob_fee,
         }
     }
 }
@@ -260,7 +264,117 @@ impl TryFrom<v2::ReplayRecord> for StorageReplayRecord {
                 .collect(),
             starting_cursors: BlockStartCursors {
                 l1_priority_id: value.starting_l1_priority_id,
-                interop_event_index: value.starting_interop_event_index,
+                // v2 format has InteropRootsLogIndex; map to 0 since block/index is not the log_id
+                interop_root_id: 0,
+                migration_number: value.starting_migration_number,
+                interop_fee_number: value.starting_interop_fee_number,
+            },
+        })
+    }
+}
+
+// ==========================================
+// | Implementations for protocol version 3 |
+// ==========================================
+
+impl WireReplayRecord for v3::ReplayRecord {
+    fn block_number(&self) -> BlockNumber {
+        self.block_context.block_number
+    }
+}
+
+impl From<InterfaceBlockContext> for v3::BlockContext {
+    fn from(value: InterfaceBlockContext) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            block_number: value.block_number,
+            block_hashes: BlockHashes(value.block_hashes.0),
+            timestamp: value.timestamp,
+            eip1559_basefee: value.eip1559_basefee,
+            pubdata_price: value.pubdata_price,
+            native_price: value.native_price,
+            coinbase: value.coinbase,
+            gas_limit: value.gas_limit,
+            pubdata_limit: value.pubdata_limit,
+            mix_hash: value.mix_hash,
+            execution_version: value.execution_version,
+            blob_fee: value.blob_fee,
+        }
+    }
+}
+
+impl From<v3::BlockContext> for InterfaceBlockContext {
+    fn from(value: v3::BlockContext) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            block_number: value.block_number,
+            block_hashes: InterfaceBlockHashes(value.block_hashes.0),
+            timestamp: value.timestamp,
+            eip1559_basefee: value.eip1559_basefee,
+            pubdata_price: value.pubdata_price,
+            native_price: value.native_price,
+            coinbase: value.coinbase,
+            gas_limit: value.gas_limit,
+            pubdata_limit: value.pubdata_limit,
+            mix_hash: value.mix_hash,
+            execution_version: value.execution_version,
+            blob_fee: value.blob_fee,
+        }
+    }
+}
+
+impl From<StorageReplayRecord> for v3::ReplayRecord {
+    fn from(value: StorageReplayRecord) -> Self {
+        Self {
+            block_context: value.block_context.into(),
+            starting_l1_priority_id: value.starting_cursors.l1_priority_id,
+            transactions: value
+                .transactions
+                .into_iter()
+                .map(|tx| tx.into_envelope())
+                .collect(),
+            previous_block_timestamp: value.previous_block_timestamp,
+            protocol_version: value.protocol_version,
+            block_output_hash: value.block_output_hash,
+            force_preimages: value
+                .force_preimages
+                .into_iter()
+                .map(|(hash, preimage)| ForcedPreimage {
+                    hash,
+                    preimage: Bytes::from(preimage),
+                })
+                .collect(),
+            starting_interop_root_id: value.starting_cursors.interop_root_id,
+            starting_migration_number: value.starting_cursors.migration_number,
+            starting_interop_fee_number: value.starting_cursors.interop_fee_number,
+        }
+    }
+}
+
+impl TryFrom<v3::ReplayRecord> for StorageReplayRecord {
+    type Error = RecoveryError;
+
+    fn try_from(value: v3::ReplayRecord) -> Result<Self, Self::Error> {
+        Ok(Self {
+            block_context: value.block_context.into(),
+            transactions: value
+                .transactions
+                .into_iter()
+                .map(|tx| tx.try_into_recovered())
+                .collect::<Result<Vec<_>, _>>()?,
+            previous_block_timestamp: value.previous_block_timestamp,
+            // Stamp replay record with this node's version
+            node_version: NODE_SEMVER_VERSION.clone(),
+            protocol_version: value.protocol_version,
+            block_output_hash: value.block_output_hash,
+            force_preimages: value
+                .force_preimages
+                .into_iter()
+                .map(|p| (p.hash, p.preimage.into()))
+                .collect(),
+            starting_cursors: BlockStartCursors {
+                l1_priority_id: value.starting_l1_priority_id,
+                interop_root_id: value.starting_interop_root_id,
                 migration_number: value.starting_migration_number,
                 interop_fee_number: value.starting_interop_fee_number,
             },

--- a/lib/network/src/wire/replays/mod.rs
+++ b/lib/network/src/wire/replays/mod.rs
@@ -6,6 +6,7 @@
 pub mod v0;
 pub mod v1;
 pub mod v2;
+pub mod v3;
 
 mod impls;
 

--- a/lib/network/src/wire/replays/v3.rs
+++ b/lib/network/src/wire/replays/v3.rs
@@ -1,0 +1,40 @@
+//! Do not change this file under any circumstances. Copy it instead. May be deleted when obsolete.
+
+// Difference from v2:
+// - Replaced `starting_interop_event_index: InteropRootsLogIndex` with `starting_interop_root_id: u64`.
+
+use crate::wire::{BlockHashes, ForcedPreimage};
+use alloy::primitives::{Address, B256, U256};
+use alloy_rlp::{RlpDecodable, RlpEncodable};
+use zksync_os_types::{L1TxSerialId, ProtocolSemanticVersion, ZkEnvelope};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+pub struct ReplayRecord {
+    pub block_context: BlockContext,
+    pub starting_l1_priority_id: L1TxSerialId,
+    pub transactions: Vec<ZkEnvelope>,
+    pub previous_block_timestamp: u64,
+    pub protocol_version: ProtocolSemanticVersion,
+    pub block_output_hash: B256,
+    pub force_preimages: Vec<ForcedPreimage>,
+    pub starting_interop_root_id: u64,
+    pub starting_migration_number: u64,
+    pub starting_interop_fee_number: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable)]
+pub struct BlockContext {
+    pub chain_id: u64,
+    pub block_number: u64,
+    pub block_hashes: BlockHashes,
+    pub timestamp: u64,
+    pub eip1559_basefee: U256,
+    pub pubdata_price: U256,
+    pub native_price: U256,
+    pub coinbase: Address,
+    pub gas_limit: u64,
+    pub pubdata_limit: u64,
+    pub mix_hash: U256,
+    pub execution_version: u32,
+    pub blob_fee: U256,
+}

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -12,10 +12,10 @@ use zksync_os_interface::types::BlockContext;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_network::protocol::{ProtocolEvent, ProtocolState, ZksProtocolHandler};
 use zksync_os_network::version::{
-    AnyZksProtocolVersion, ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksVersion,
+    AnyZksProtocolVersion, ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksVersion,
 };
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};
-use zksync_os_types::{BlockStartCursors, InteropRootsLogIndex, NodeRole, ProtocolSemanticVersion};
+use zksync_os_types::{BlockStartCursors, NodeRole, ProtocolSemanticVersion};
 
 #[derive(Debug, Clone, Default)]
 struct InMemReplay(HashMap<BlockNumber, ReplayRecord>);
@@ -57,7 +57,7 @@ fn dummy_record<P: AnyZksProtocolVersion>(block_number: BlockNumber) -> ReplayRe
         vec![],
         BlockStartCursors {
             l1_priority_id: 42,
-            interop_event_index: InteropRootsLogIndex::default(),
+            interop_root_id: 0,
             migration_number: 123,
             interop_fee_number: 456,
         },
@@ -110,7 +110,7 @@ where
     }
 }
 
-#[test_casing(2, [ZksVersion::Zks1, ZksVersion::Zks2])]
+#[test_casing(3, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3])]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn send_replay_record_matching_version(version: ZksVersion) {
     // Run two peers that both communicate on exactly one matching zks protocol and successfully
@@ -151,10 +151,11 @@ async fn send_replay_record_matching_version(version: ZksVersion) {
         ZksVersion::Zks0 => unreachable!(),
         ZksVersion::Zks1 => test_inner::<ZksProtocolV1>().await,
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
+        ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
     }
 }
 
-#[test_casing(2, [ZksVersion::Zks1, ZksVersion::Zks2])]
+#[test_casing(3, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3])]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn send_replay_record_different_versions(version: ZksVersion) {
     // Run two peers where peer0 can communicate on zks protocol v0 AND v1, while peer1 can only
@@ -211,6 +212,7 @@ async fn send_replay_record_different_versions(version: ZksVersion) {
         ZksVersion::Zks0 => unreachable!(),
         ZksVersion::Zks1 => test_inner::<ZksProtocolV1>().await,
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
+        ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
     }
 }
 

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -11,8 +11,8 @@ use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_mempool::{MarkingTxStream, Pool};
 use zksync_os_storage_api::ReplayRecord;
 use zksync_os_types::{
-    BlockStartCursors, ExecutionVersion, InteropRootsLogIndex, ProtocolSemanticVersion,
-    SystemTxEnvelope, SystemTxType, ZkEnvelope, ZkTransaction,
+    BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion, SystemTxEnvelope, SystemTxType,
+    ZkEnvelope, ZkTransaction,
 };
 
 /// Component that turns `BlockCommand`s into `PreparedBlockCommand`s.
@@ -401,12 +401,9 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                 .next_l1_priority_id
                 .set(self.next_cursors.l1_priority_id);
         }
-        if let Some(last_interop_log_index) = outcome.last_interop_log_index {
+        if let Some(last_interop_log_id) = outcome.last_interop_log_id {
             self.next_interop_tx_allowed_after = Instant::now() + self.service_block_delay;
-            self.next_cursors.interop_event_index = InteropRootsLogIndex {
-                block_number: last_interop_log_index.block_number,
-                index_in_block: last_interop_log_index.index_in_block + 1,
-            };
+            self.next_cursors.interop_root_id = last_interop_log_id + 1;
         }
 
         if let Some(last_migration_number) = outcome.last_migration_number {

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -10,7 +10,7 @@ use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::{NamedColumnFamily, WriteBatch};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay};
-use zksync_os_types::{BlockStartCursors, InteropRootsLogIndex, ProtocolSemanticVersion};
+use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
 
 /// A write-ahead log storing [`ReplayRecord`]s.
 ///
@@ -48,7 +48,7 @@ pub enum BlockReplayColumnFamily {
     ProtocolVersion,
     ForcePreimages,
     BlockOutputHash,
-    StartingInteropEventIndex,
+    StartingInteropRootId,
     StartingMigrationNumber,
     StartingInteropFeeNumber,
     /// Mapping from block_number to block hash.
@@ -67,7 +67,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
         BlockReplayColumnFamily::ProtocolVersion,
         BlockReplayColumnFamily::BlockOutputHash,
         BlockReplayColumnFamily::ForcePreimages,
-        BlockReplayColumnFamily::StartingInteropEventIndex,
+        BlockReplayColumnFamily::StartingInteropRootId,
         BlockReplayColumnFamily::StartingMigrationNumber,
         BlockReplayColumnFamily::StartingInteropFeeNumber,
         BlockReplayColumnFamily::CanonicalHash,
@@ -83,7 +83,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
             BlockReplayColumnFamily::ProtocolVersion => "protocol_version",
             BlockReplayColumnFamily::BlockOutputHash => "block_output_hash",
             BlockReplayColumnFamily::ForcePreimages => "force_preimages",
-            BlockReplayColumnFamily::StartingInteropEventIndex => "starting_interop_event_index",
+            BlockReplayColumnFamily::StartingInteropRootId => "starting_interop_root_id",
             BlockReplayColumnFamily::StartingMigrationNumber => "starting_migration_number",
             BlockReplayColumnFamily::StartingInteropFeeNumber => "starting_interop_fee_number",
             BlockReplayColumnFamily::CanonicalHash => "canonical_hash",
@@ -198,15 +198,15 @@ impl BlockReplayStorage {
             &force_preimages_value,
         );
 
-        let starting_interop_event_index_value = bincode::serde::encode_to_vec(
-            &record.starting_cursors.interop_event_index,
+        let starting_interop_root_id_value = bincode::serde::encode_to_vec(
+            record.starting_cursors.interop_root_id,
             bincode::config::standard(),
         )
-        .expect("Failed to serialize record.starting_cursors.interop_event_index");
+        .expect("Failed to serialize record.starting_cursors.interop_root_id");
         batch.put_cf(
-            BlockReplayColumnFamily::StartingInteropEventIndex,
+            BlockReplayColumnFamily::StartingInteropRootId,
             &db_key,
-            &starting_interop_event_index_value,
+            &starting_interop_root_id_value,
         );
 
         let starting_migration_number_value = bincode::serde::encode_to_vec(
@@ -387,20 +387,20 @@ impl ReadReplay for BlockReplayStorage {
             .expect("Failed to read from BlockOutputHash CF")
             .expect("BlockOutputHash must be written atomically with Context");
 
-        let starting_interop_event_index = if let Some(starting_interop_event_index) = self
+        let starting_interop_root_id = if let Some(starting_interop_root_id) = self
             .db
-            .get_cf(BlockReplayColumnFamily::StartingInteropEventIndex, &key)
-            .expect("Failed to read from StartingInteropEventIndex CF")
+            .get_cf(BlockReplayColumnFamily::StartingInteropRootId, &key)
+            .expect("Failed to read from StartingInteropRootId CF")
         {
-            let stored: InteropRootsLogIndex = bincode::serde::decode_from_slice(
-                &starting_interop_event_index,
+            let stored: u64 = bincode::serde::decode_from_slice(
+                &starting_interop_root_id,
                 bincode::config::standard(),
             )
-            .expect("Failed to deserialize starting interop event index")
+            .expect("Failed to deserialize starting interop root id")
             .0;
             stored
         } else {
-            InteropRootsLogIndex::default()
+            0
         };
 
         let starting_migration_number = if let Some(starting_migration_number) = self
@@ -462,7 +462,7 @@ impl ReadReplay for BlockReplayStorage {
                 )
                 .expect("Failed to deserialize starting_l1_priority_id")
                 .0,
-                interop_event_index: starting_interop_event_index,
+                interop_root_id: starting_interop_root_id,
                 migration_number: starting_migration_number,
                 interop_fee_number: starting_interop_fee_number,
             },

--- a/lib/types/src/block_start_cursors.rs
+++ b/lib/types/src/block_start_cursors.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{InteropRootsLogIndex, L1TxSerialId};
+use crate::L1TxSerialId;
 
 /// Starting positions for the L1-backed inputs consumed while building a block.
 ///
@@ -11,9 +11,9 @@ pub struct BlockStartCursors {
     /// Next expected L1 priority transaction serial id (0-based).
     #[serde(rename = "starting_l1_priority_id")]
     pub l1_priority_id: L1TxSerialId,
-    /// Position of the next interop root event to consume.
-    #[serde(rename = "starting_interop_event_index")]
-    pub interop_event_index: InteropRootsLogIndex,
+    /// Log id of the next interop root event to consume.
+    #[serde(rename = "starting_interop_root_id")]
+    pub interop_root_id: u64,
     /// Next migration event number to consume.
     #[serde(rename = "starting_migration_number")]
     pub migration_number: u64,

--- a/lib/types/src/transaction/system/mod.rs
+++ b/lib/types/src/transaction/system/mod.rs
@@ -40,9 +40,21 @@ impl PartialEq for SystemTxEnvelope {
 }
 
 impl SystemTxEnvelope {
-    /// A constructor for system transaction that imports interop roots
-    pub fn import_interop_roots(roots: Vec<InteropRoot>) -> Self {
-        Self::create_from_input(SystemTxInput::ImportInteropRoots(roots))
+    /// A constructor for system transaction that imports interop roots.
+    /// `latest_log_id` is used as the transaction salt to ensure uniqueness.
+    pub fn import_interop_roots(roots: Vec<InteropRoot>, latest_log_id: u64) -> Self {
+        let tx_input = SystemTxInput::ImportInteropRoots(roots);
+        let (calldata, _) = tx_input.encode_data();
+        let transaction = SystemTx {
+            to: tx_input.to_address(),
+            input: Bytes::from(calldata),
+            salt: latest_log_id,
+        };
+        Self {
+            hash: transaction.calculate_hash(),
+            inner: transaction,
+            subtype: OnceLock::new(),
+        }
     }
 
     /// A constructor for system transaction that sets the settlement layer chain id
@@ -66,7 +78,6 @@ impl SystemTxEnvelope {
             input: Bytes::from(calldata),
             salt,
         };
-
         Self {
             hash: transaction.calculate_hash(),
             inner: transaction,
@@ -142,7 +153,7 @@ impl SystemTxEnvelope {
 
 #[derive(Clone, Debug)]
 pub struct IndexedInteropRoot {
-    pub log_index: InteropRootsLogIndex,
+    pub log_id: u64,
     pub root: InteropRoot,
 }
 
@@ -202,7 +213,8 @@ mod tx_serde {
 }
 
 /// A helper struct to store the block number and index in block of published interop roots event.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord)]
+/// Kept for backward-compatibility with the v1 and v2 network wire formats.
+#[derive(Default, Debug, Clone, Hash, Eq, PartialEq)]
 pub struct InteropRootsLogIndex {
     /// Block number from which event was published.
     pub block_number: u64,
@@ -384,11 +396,14 @@ mod tests {
     /// See https://ethereum.github.io/execution-apis/api-documentation/
     #[test]
     fn interop_roots_tx_serialization() {
-        let tx = SystemTxEnvelope::import_interop_roots(vec![InteropRoot {
-            chainId: Uint::from(1),
-            blockOrBatchNumber: Uint::from(1),
-            sides: vec![B256::ZERO],
-        }]);
+        let tx = SystemTxEnvelope::import_interop_roots(
+            vec![InteropRoot {
+                chainId: Uint::from(1),
+                blockOrBatchNumber: Uint::from(1),
+                sides: vec![B256::ZERO],
+            }],
+            0,
+        );
 
         assert_eq!(
             serde_json::to_string_pretty(&tx).unwrap(),

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -547,7 +547,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 InteropWatcher::create_watcher(
                     node_startup_state.l1_state.bridgehub_sl.clone(),
                     config.l1_watcher_config.clone().into(),
-                    next_cursors.interop_event_index.clone(),
+                    next_cursors.interop_root_id,
                     interop_roots_subpool.clone(),
                     node_startup_state.l1_state.l1_chain_id,
                 )


### PR DESCRIPTION
## Summary

Replaces the compound `InteropRootsLogIndex` (block number + index-in-block) with a plain `u64` log ID (`totalPublishedInteropRoots` counter from the `IMessageRoot` contract) everywhere interop root indexing was used.

- `InteropRootsLogIndex` is removed from all live codepaths (mempool, sequencer, storage, block context provider, interop watcher). It is kept only for backward-compat with the v1 and v2 network wire format.
- The interop watcher now uses a binary search over `MessageRoot.totalPublishedInteropRoots` to find the correct starting L1 block, replacing the previous approach of storing the block number directly.
- `SystemTxEnvelope::import_interop_roots` now takes `log_id` as an explicit salt to ensure transaction uniqueness.
- The RocksDB WAL column family is renamed from `starting_interop_event_index` to `starting_interop_root_id` (note: existing DBs will not have this column and will fall back to `0`).

This PR is the clean rebased replacement for the outdated merge-follow-up flow from #1092 / #1142.

## Testing

- `cargo nextest run --workspace --exclude zksync_os_integration_tests`
- `PATH="$HOME/.foundry/bin:$PATH" cargo nextest run -p zksync_os_integration_tests --profile no-pig`
