### PR TITLE
fix(batch_verification): remove blocks only when processing the next request

### DIFF
--- a/lib/batch_verification/src/client/block_cache.rs
+++ b/lib/batch_verification/src/client/block_cache.rs
@@ -1,26 +1,23 @@
 use std::collections::HashMap;
-use zksync_os_storage_api::ReadFinality;
 
 use super::metrics::BATCH_VERIFICATION_CLIENT_METRICS;
 
-/// Cache of blocks that are to be used for batch verification
-/// Accepts blocks only in ascending order. Old blocks are evicted when not
-/// needed through a call to remove_lower_then.
+/// Cache of blocks that are to be used for batch verification.
+/// Accepts blocks only in ascending order. Old blocks are evicted via
+/// [`remove_lower_then`] after each verification request is handled.
 ///
 /// This may be optimized by using a ring buffer for data storage instead.
-pub(super) struct BlockCache<Finality, Data> {
+pub(super) struct BlockCache<Data> {
     data: HashMap<u64, Data>,
     /// Range of cached data. Range is inclusive of both bounds.
     range: Option<(u64, u64)>,
-    finality: Finality,
 }
 
-impl<Finality: ReadFinality, Data> BlockCache<Finality, Data> {
-    pub fn new(finality: Finality) -> Self {
+impl<Data> BlockCache<Data> {
+    pub fn new() -> Self {
         Self {
             data: HashMap::new(),
             range: None,
-            finality,
         }
     }
 
@@ -35,9 +32,6 @@ impl<Finality: ReadFinality, Data> BlockCache<Finality, Data> {
             self.range = Some((block_number, block_number));
         }
         self.data.insert(block_number, block);
-
-        // evict block for committed batches
-        self.remove_lower_then(self.finality.get_finality_status().last_committed_block + 1);
 
         if let Some((start, end)) = self.range {
             BATCH_VERIFICATION_CLIENT_METRICS.update_cache_range(start, end);
@@ -72,16 +66,11 @@ impl<Finality: ReadFinality, Data> BlockCache<Finality, Data> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::DummyFinality;
-
     use super::*;
-
-    // We use everywhere zero finality to trigger no automatic evictions in tests.
 
     #[test]
     fn insert_updates_range_and_data_for_sequential_blocks() {
-        let finality = DummyFinality::zero();
-        let mut cache = BlockCache::<_, u64>::new(finality);
+        let mut cache = BlockCache::<u64>::new();
 
         cache.insert(1, 1).unwrap();
         assert_eq!(cache.range, Some((1, 1)));
@@ -97,8 +86,7 @@ mod tests {
 
     #[test]
     fn insert_rejects_out_of_order_blocks() {
-        let finality = DummyFinality::zero();
-        let mut cache = BlockCache::new(finality);
+        let mut cache = BlockCache::new();
 
         cache.insert(1, 1).unwrap();
         cache.insert(2, 2).unwrap();
@@ -124,8 +112,7 @@ mod tests {
 
     #[test]
     fn remove_lower_then_evicts_and_updates_range() {
-        let finality = DummyFinality::zero();
-        let mut cache = BlockCache::new(finality);
+        let mut cache = BlockCache::new();
 
         for n in 1u64..=5 {
             cache.insert(n, n).unwrap();

--- a/lib/batch_verification/src/client/mod.rs
+++ b/lib/batch_verification/src/client/mod.rs
@@ -38,20 +38,20 @@ use zksync_os_observability::ComponentStateReporter;
 use zksync_os_observability::GenericComponentState;
 use zksync_os_observability::StateLabel;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
-use zksync_os_storage_api::{ReadFinality, ReadStateHistory};
+use zksync_os_storage_api::ReadStateHistory;
 use zksync_os_storage_api::{ReplayRecord, StateError, read_multichain_root};
 
 mod block_cache;
 mod metrics;
 
 /// Client that connects to the main sequencer for batch verification
-pub struct BatchVerificationClient<Finality, ReadState> {
+pub struct BatchVerificationClient<ReadState> {
     chain_id: u64,
     diamond_proxy_sl: Address,
     server_address: String,
     l1_state: L1State,
     signer: PrivateKeySigner,
-    block_cache: BlockCache<Finality, (BlockOutput, ReplayRecord, BlockMerkleTreeData)>,
+    block_cache: BlockCache<(BlockOutput, ReplayRecord, BlockMerkleTreeData)>,
     read_state: ReadState,
 }
 
@@ -69,15 +69,12 @@ enum BatchVerificationError {
 
 type VerificationInput = (BlockOutput, ReplayRecord, BlockMerkleTreeData);
 
-impl<Finality: ReadFinality, ReadState: ReadStateHistory>
-    BatchVerificationClient<Finality, ReadState>
-{
+impl<ReadState: ReadStateHistory> BatchVerificationClient<ReadState> {
     pub fn new(
         chain_id: u64,
         diamond_proxy_sl: Address,
         server_address: String,
         private_key: SecretString,
-        finality: Finality,
         l1_state: L1State,
         read_state: ReadState,
     ) -> Self {
@@ -98,7 +95,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
             server_address,
             l1_state,
             signer,
-            block_cache: BlockCache::new(finality),
+            block_cache: BlockCache::new(),
             read_state,
         }
     }
@@ -186,7 +183,14 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
 
                             let batch_number = message.batch_number;
                             let request_id = message.request_id;
+                            let first_block = message.first_block_number;
                             let verification_result = self.handle_verification_request(message).await;
+
+                            // Evict blocks from previous batches. We use the request's first_block rather than the finality
+                            // watch channel because after a restart the L1CommitWatcher can advance last_committed_block
+                            // past a batch whose L1 tx was still pending at startup, while the server's static
+                            // last_committed_batch_number hasn't caught up yet.
+                            self.block_cache.remove_lower_then(first_block);
 
                             latency_tracker.enter_state(BatchVerificationClientState::WaitingSend);
                             match verification_result {
@@ -330,9 +334,7 @@ impl StateLabel for BatchVerificationClientState {
 }
 
 #[async_trait]
-impl<Finality: ReadFinality, ReadState: ReadStateHistory> PipelineComponent
-    for BatchVerificationClient<Finality, ReadState>
-{
+impl<ReadState: ReadStateHistory> PipelineComponent for BatchVerificationClient<ReadState> {
     type Input = VerificationInput;
     type Output = ();
 

--- a/lib/batch_verification/src/tests/mod.rs
+++ b/lib/batch_verification/src/tests/mod.rs
@@ -1,40 +1,9 @@
 use alloy::primitives::{Address, B256};
 /// This module is for sharing various testing utilities and helpers.
-use tokio::sync::watch;
 use zksync_os_batch_types::BatchInfo;
 use zksync_os_contract_interface::models::{CommitBatchInfo, DACommitmentScheme, StoredBatchInfo};
 use zksync_os_l1_sender::batcher_model::{BatchEnvelope, BatchMetadata, MissingSignature};
-use zksync_os_storage_api::{FinalityStatus, ReadFinality};
 use zksync_os_types::ProtocolSemanticVersion;
-
-pub struct DummyFinality {
-    status: FinalityStatus,
-    rx: watch::Receiver<FinalityStatus>,
-}
-
-impl DummyFinality {
-    pub fn zero() -> Self {
-        let status = FinalityStatus {
-            last_committed_block: 0,
-            last_committed_batch: 0,
-            last_executed_block: 0,
-            last_executed_batch: 0,
-        };
-        let (tx, rx) = watch::channel(status.clone());
-        let _ = tx;
-        Self { status, rx }
-    }
-}
-
-impl ReadFinality for DummyFinality {
-    fn get_finality_status(&self) -> FinalityStatus {
-        self.status.clone()
-    }
-
-    fn subscribe(&self) -> watch::Receiver<FinalityStatus> {
-        self.rx.clone()
-    }
-}
 
 pub fn dummy_commit_batch_info(batch_number: u64, from: u64, to: u64) -> CommitBatchInfo {
     CommitBatchInfo {

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1188,7 +1188,6 @@ async fn run_en_pipeline(
                 node_state_on_startup.l1_state.diamond_proxy_address_sl(),
                 config.batch_verification_config.connect_address.clone(),
                 config.batch_verification_config.signing_key.clone(),
-                finality.clone(),
                 node_state_on_startup.l1_state.clone(),
                 state.clone(),
             ),


### PR DESCRIPTION
## Summary

After a restart, the server's last_committed_batch_number is captured from L1 state at startup and never updates. Meanwhile, L1CommitWatcher starts concurrently and can observe a batch commitment whose L1 tx was still pending at startup. This advances last_committed_block (via the finality watch channel) past a batch the server still considers uncommitted.
That leads to the removal of blocks needed for the validation of the current batch from the cache. 

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

