### PR TITLE
fix: restart node on unexpected l1 commit

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -25,6 +25,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
 use zksync_os_observability::{ComponentStateHandle, ComponentStateReporter};
 use zksync_os_operator_signer::SignerConfig;
 use zksync_os_pipeline::PeekableReceiver;
@@ -71,6 +72,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
     >,
     config: L1SenderConfig<Input>,
     gateway: bool,
+    commit_submitted_tx: Option<watch::Sender<u64>>,
 ) -> anyhow::Result<()> {
     let latency_tracker =
         ComponentStateReporter::global().handle_for(Input::NAME, L1SenderState::WaitingRecv);
@@ -200,6 +202,24 @@ pub async fn run_l1_sender<Input: SendToL1>(
                         "{command_name}: L1 transaction submitted for {range}. Hash: {tx_hash:?} Waiting for inclusion...",
                     );
                     let receipt_fut = pending_tx.get_receipt().boxed();
+
+                    // Notify CommitWatcher: this batch number has been submitted to L1.
+                    if let Some(sender) = &commit_submitted_tx {
+                        let batch_number = cmd
+                            .as_ref()
+                            .last()
+                            .expect("commands is non-empty after recv_many")
+                            .batch_number();
+                        sender.send_if_modified(|current| {
+                            if batch_number > *current {
+                                *current = batch_number;
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                    }
+
                     cmd.as_mut()
                         .iter_mut()
                         .for_each(|envelope| envelope.set_stage(Input::SENT_STAGE));

--- a/lib/l1_sender/src/pipeline_component.rs
+++ b/lib/l1_sender/src/pipeline_component.rs
@@ -8,6 +8,7 @@ use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{Provider, WalletProvider};
 use async_trait::async_trait;
 use tokio::sync::mpsc;
+use tokio::sync::watch;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 
 /// Generic L1 Sender pipeline component
@@ -17,6 +18,7 @@ pub struct L1Sender<F: TxFiller<Ethereum>, P: Provider<Ethereum>, C> {
     pub config: L1SenderConfig<C>,
     pub to_address: Address,
     pub gateway: bool,
+    pub commit_submitted_tx: Option<watch::Sender<u64>>,
 }
 
 #[async_trait]
@@ -44,6 +46,7 @@ where
             self.provider,
             self.config,
             self.gateway,
+            self.commit_submitted_tx,
         )
         .await
     }

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -4,6 +4,7 @@ use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::primitives::Address;
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::Log;
+use tokio::sync::watch;
 use zksync_os_batch_types::{BatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::ZkChain;
@@ -18,6 +19,7 @@ pub struct L1CommitWatcher<Finality> {
     startup_last_committed_batch: u64,
     committed_batch_provider: CommittedBatchProvider,
     finality: Finality,
+    commit_submitted_rx: Option<watch::Receiver<u64>>,
 }
 
 impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
@@ -27,6 +29,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         l1_chain_id: u64,
+        commit_submitted_rx: Option<watch::Receiver<u64>>,
     ) -> anyhow::Result<L1Watcher> {
         let current_l1_block = zk_chain.provider().get_block_number().await?;
         let last_committed_batch = finality.get_finality_status().last_committed_batch;
@@ -53,6 +56,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
             startup_last_committed_batch: last_committed_batch,
             committed_batch_provider,
             finality,
+            commit_submitted_rx,
         };
         let l1_watcher = L1Watcher::new(
             zk_chain.provider().clone(),
@@ -106,6 +110,12 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
         } else if batch_number < self.next_batch_number {
             tracing::debug!(batch_number, "skipping already processed committed batch");
         } else {
+            // Fast-fail if this batch was committed by a prior crashed session's pending tx.
+            if should_restart_for_unexpected_commit(batch_number, self.commit_submitted_rx.as_ref())
+            {
+                return Err(L1WatcherError::UnexpectedCommit(batch_number));
+            }
+
             tracing::debug!(batch_number, "discovered committed batch");
             let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
             let committed_batch = util::fetch_commit_calldata(&self.zk_chain, tx_hash).await?;
@@ -143,6 +153,15 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
     }
 }
 
+/// Returns true if the commit event is for a batch that this session's pipeline has not yet
+/// submitted to L1 — indicating a pending tx from a prior crashed session just landed.
+fn should_restart_for_unexpected_commit(
+    batch_number: u64,
+    commit_submitted_rx: Option<&watch::Receiver<u64>>,
+) -> bool {
+    commit_submitted_rx.is_some_and(|rx| batch_number > *rx.borrow())
+}
+
 /// Returns true if the commit event belongs to startup catch-up range and is above the startup
 /// committed frontier.
 fn should_skip_historical_commit(
@@ -158,7 +177,9 @@ fn should_skip_historical_commit(
 
 #[cfg(test)]
 mod tests {
+    use super::should_restart_for_unexpected_commit;
     use super::should_skip_historical_commit;
+    use tokio::sync::watch;
 
     #[test]
     fn skips_historical_batch_above_startup_frontier() {
@@ -180,5 +201,35 @@ mod tests {
     #[test]
     fn does_not_skip_when_log_has_no_block_number() {
         assert!(!should_skip_historical_commit(100, 10, 11, None));
+    }
+
+    #[test]
+    fn restarts_when_batch_exceeds_submitted() {
+        let (_tx, rx) = watch::channel(5u64);
+        assert!(should_restart_for_unexpected_commit(6, Some(&rx)));
+    }
+
+    #[test]
+    fn no_restart_when_batch_equals_submitted() {
+        let (_tx, rx) = watch::channel(5u64);
+        assert!(!should_restart_for_unexpected_commit(5, Some(&rx)));
+    }
+
+    #[test]
+    fn no_restart_when_batch_below_submitted() {
+        let (_tx, rx) = watch::channel(5u64);
+        assert!(!should_restart_for_unexpected_commit(4, Some(&rx)));
+    }
+
+    #[test]
+    fn no_restart_when_rx_is_none() {
+        assert!(!should_restart_for_unexpected_commit(100, None));
+    }
+
+    #[test]
+    fn no_restart_after_pipeline_updates_submitted() {
+        let (tx, rx) = watch::channel(5u64);
+        tx.send(6).unwrap();
+        assert!(!should_restart_for_unexpected_commit(6, Some(&rx)));
     }
 }

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -48,7 +48,10 @@ impl L1Watcher {
         let mut timer = tokio::time::interval(self.poll_interval);
         loop {
             timer.tick().await;
-            self.poll().await.expect("watcher failed");
+            if let Err(e) = self.poll().await {
+                tracing::error!("l1 watcher fatal error: {e}");
+                panic!("watcher failed: {e}");
+            }
         }
     }
 
@@ -137,6 +140,10 @@ pub enum L1WatcherError {
     Contract(#[from] zksync_os_contract_interface::Error),
     #[error(transparent)]
     Other(anyhow::Error),
+    #[error(
+        "batch {0} was committed on L1 but not submitted by this session; likely a pending tx from a prior crash"
+    )]
+    UnexpectedCommit(u64),
     #[error("output has been closed")]
     OutputClosed,
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -439,6 +439,12 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         );
     }
 
+    // Channel from L1Sender<CommitCommand> to L1CommitWatcher.
+    // Initialized to startup's last_committed_batch so any commit above that value
+    // which the pipeline didn't submit in this session triggers a restart.
+    let (commit_submitted_tx, commit_submitted_rx) =
+        watch::channel(node_startup_state.l1_state.last_committed_batch);
+
     tracing::info!("Initializing L1 Watchers");
     runtime.spawn_critical_task(
         "l1 commit watcher",
@@ -448,6 +454,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             committed_batch_provider.clone(),
             finality_storage.clone(),
             node_startup_state.l1_state.l1_chain_id,
+            node_role.is_main().then_some(commit_submitted_rx),
         )
         .await
         .expect("failed to start L1 commit watcher")
@@ -835,6 +842,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             committed_batch_provider.clone(),
             canonization_engine,
             leadership,
+            commit_submitted_tx,
         )
         .await;
     } else {
@@ -917,6 +925,7 @@ async fn run_main_node_pipeline(
     committed_batch_provider: CommittedBatchProvider,
     canonization_engine: BlockCanonizationEngine,
     leadership: LeadershipSignal,
+    commit_submitted_tx: watch::Sender<u64>,
 ) {
     let pubdata_mode = config
         .l1_sender_config
@@ -1087,6 +1096,7 @@ async fn run_main_node_pipeline(
             config: config.l1_sender_config.clone().into(),
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: config.general_config.gateway_rpc_url.is_some(),
+            commit_submitted_tx: Some(commit_submitted_tx),
         })
         .pipe(snark_proving_step)
         .pipe(GaplessL1ProofSender::new(
@@ -1097,6 +1107,7 @@ async fn run_main_node_pipeline(
             config: config.l1_sender_config.clone().into(),
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: config.general_config.gateway_rpc_url.is_some(),
+            commit_submitted_tx: None,
         })
         .pipe(
             PriorityTreePipelineStep::new(
@@ -1112,6 +1123,7 @@ async fn run_main_node_pipeline(
             config: config.l1_sender_config.clone().into(),
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: config.general_config.gateway_rpc_url.is_some(),
+            commit_submitted_tx: None,
         })
         .pipe(BatchSink::new(internal_config_manager));
 


### PR DESCRIPTION
## Summary

* [x] crash-recovery mechanism to prevent state desync when a batch commit transaction from a prior crashed session lands on L1 after restart

## Why?

When the node crashes with a commit tx in-flight, the new session has no way to know that tx is pending.

If it lands on L1, the commit watcher would see a batch it didn't submit. This PR introduces a watch channel between `L1Sender<CommitCommand>` and `L1CommitWatcher`.

The sender updates the channel after each broadcast, and the watcher returns `UnexpectedCommit` if it sees a commit above the highest batch this session submitted - triggering a clean restart and L1 re-sync. This allows the main node and ENs to automatically re-sync.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

