### PR TITLE
feat(revm-consistency-checker): Add metrics with last divergence timestamp

### DIFF
--- a/lib/revm_consistency_checker/src/lib.rs
+++ b/lib/revm_consistency_checker/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytecode_hash;
 pub mod helpers;
+pub mod metrics;
 pub mod node;
 pub mod revm_state_provider;
 pub mod storage_diff_comp;

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -1,0 +1,27 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use vise::{Gauge, Metrics};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "revm_consistency_checker")]
+pub(crate) struct RevmConsistencyCheckerMetrics {
+    /// Unix timestamp of the most recent detected inconsistency.
+    pub last_inconsistency_timestamp: Gauge<u64>,
+    /// Block number of the most recent detected inconsistency.
+    pub last_inconsistent_block_number: Gauge<u64>,
+}
+
+#[vise::register]
+pub(crate) static METRICS: vise::Global<RevmConsistencyCheckerMetrics> = vise::Global::new();
+
+impl RevmConsistencyCheckerMetrics {
+    pub fn record_inconsistency(&self, block_number: u64) {
+        self.last_inconsistent_block_number.set(block_number);
+        self.last_inconsistency_timestamp.set(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+    }
+}

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -4,7 +4,7 @@ use vise::{Gauge, Metrics, Unit};
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "revm_consistency_checker")]
-pub(crate) struct RevmConsistencyCheckerMetrics {
+pub struct RevmConsistencyCheckerMetrics {
     /// Unix timestamp of the most recent detection -- used for alerts
     #[metrics(unit = Unit::Seconds)]
     pub last_inconsistency_timestamp: Gauge<u64>,
@@ -13,7 +13,7 @@ pub(crate) struct RevmConsistencyCheckerMetrics {
 }
 
 #[vise::register]
-pub(crate) static METRICS: vise::Global<RevmConsistencyCheckerMetrics> = vise::Global::new();
+pub static METRICS: vise::Global<RevmConsistencyCheckerMetrics> = vise::Global::new();
 
 impl RevmConsistencyCheckerMetrics {
     pub fn record_inconsistency(&self, block_number: u64) {

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use vise::{Gauge, Metrics};
+use vise::{Gauge, Metrics, Unit};
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "revm_consistency_checker")]

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -6,6 +6,7 @@ use vise::{Gauge, Metrics};
 #[metrics(prefix = "revm_consistency_checker")]
 pub(crate) struct RevmConsistencyCheckerMetrics {
     /// Unix timestamp of the most recent detection -- used for alerts
+    #[metrics(unit = Unit::Seconds)]
     pub last_inconsistency_timestamp: Gauge<u64>,
     /// Block number of the most recent detected inconsistency.
     pub last_inconsistent_block_number: Gauge<u64>,

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -5,7 +5,7 @@ use vise::{Gauge, Metrics};
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "revm_consistency_checker")]
 pub(crate) struct RevmConsistencyCheckerMetrics {
-    /// Unix timestamp of the most recent detected inconsistency.
+    /// Unix timestamp of the most recent detection -- used for alerts
     pub last_inconsistency_timestamp: Gauge<u64>,
     /// Block number of the most recent detected inconsistency.
     pub last_inconsistent_block_number: Gauge<u64>,

--- a/lib/revm_consistency_checker/src/metrics.rs
+++ b/lib/revm_consistency_checker/src/metrics.rs
@@ -1,24 +1,28 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use vise::{Gauge, Metrics, Unit};
+use vise::{EncodeLabelValue, Gauge, LabeledFamily, Metrics, Unit};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(label = "outcome", rename_all = "snake_case")]
+pub enum RevmDivergenceOutcome {
+    Accepted,
+    Reverted,
+}
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "revm_consistency_checker")]
 pub struct RevmConsistencyCheckerMetrics {
-    /// Unix timestamp of the most recent detection -- used for alerts
-    #[metrics(unit = Unit::Seconds)]
-    pub last_inconsistency_timestamp: Gauge<u64>,
-    /// Block number of the most recent detected inconsistency.
-    pub last_inconsistent_block_number: Gauge<u64>,
+    /// Unix timestamp of the most recent divergence by outcome -- used for alerts.
+    #[metrics(unit = Unit::Seconds, labels = ["outcome"])]
+    pub last_divergence_timestamp: LabeledFamily<RevmDivergenceOutcome, Gauge<u64>>,
 }
 
 #[vise::register]
 pub static METRICS: vise::Global<RevmConsistencyCheckerMetrics> = vise::Global::new();
 
 impl RevmConsistencyCheckerMetrics {
-    pub fn record_inconsistency(&self, block_number: u64) {
-        self.last_inconsistent_block_number.set(block_number);
-        self.last_inconsistency_timestamp.set(
+    pub fn record_divergence(&self, outcome: RevmDivergenceOutcome) {
+        self.last_divergence_timestamp[&outcome].set(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -57,11 +57,24 @@ where
         report: &CompareReport,
     ) -> anyhow::Result<()> {
         report.log_tracing(20);
-        if !report.is_empty() {
-            let block_number = replay_record.block_context.block_number;
-            METRICS.record_inconsistency(block_number);
+        if report.is_empty() {
+            return Ok(());
         }
-        if self.revert_enabled && !report.is_empty() {
+
+        let block_number = replay_record.block_context.block_number;
+        METRICS.record_inconsistency(block_number);
+        let message = format!(
+            "REVM consistency check failed for block number {}, block hash {}",
+            replay_record.block_context.block_number,
+            block_output.header.hash(),
+        );
+        tracing::info!(
+            block_number = replay_record.block_context.block_number,
+            "Sleeping for {}s before reverting after REVM inconsistency so metrics can propagate",
+            METRICS_PROPAGATION_DELAY.as_secs(),
+        );
+
+        if self.revert_enabled {
             let mut config = self.internal_config_manager.read_config()?;
             config.failing_block = Some(replay_record.block_context.block_number);
 
@@ -75,21 +88,12 @@ where
                 new_blacklist_size - initial_blacklist_size
             );
 
-            let message = format!(
-                "REVM consistency check failed for block number {}, block hash {}",
-                replay_record.block_context.block_number,
-                block_output.header.hash(),
-            );
-            tracing::warn!(
-                delay = ?METRICS_PROPAGATION_DELAY,
-                block_number = replay_record.block_context.block_number,
-                "Sleeping before reverting after REVM inconsistency so metrics can propagate"
-            );
             thread::sleep(METRICS_PROPAGATION_DELAY);
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;
+        } else {
+            tracing::warn!(message);
         }
-
         Ok(())
     }
 }

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -68,11 +68,6 @@ where
             replay_record.block_context.block_number,
             block_output.header.hash(),
         );
-        tracing::info!(
-            block_number = replay_record.block_context.block_number,
-            "Sleeping for {}s before reverting after REVM inconsistency so metrics can propagate",
-            METRICS_PROPAGATION_DELAY.as_secs(),
-        );
 
         if self.revert_enabled {
             let mut config = self.internal_config_manager.read_config()?;
@@ -88,6 +83,11 @@ where
                 new_blacklist_size - initial_blacklist_size
             );
 
+            tracing::info!(
+                block_number = replay_record.block_context.block_number,
+                "Sleeping for {}s before reverting after REVM inconsistency so metrics can propagate",
+                METRICS_PROPAGATION_DELAY.as_secs(),
+            );
             thread::sleep(METRICS_PROPAGATION_DELAY);
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -14,7 +14,7 @@ use zksync_os_storage_api::{ReadStateHistory, ReplayRecord};
 use zksync_os_types::ExecutionVersion;
 
 use crate::helpers::{zk_spec_version, zk_tx_into_revm_tx};
-use crate::metrics::METRICS;
+use crate::metrics::{METRICS, RevmDivergenceOutcome};
 use crate::revm_state_provider::RevmStateProvider;
 use crate::storage_diff_comp::CompareReport;
 
@@ -54,8 +54,6 @@ where
             return Ok(());
         }
 
-        let block_number = replay_record.block_context.block_number;
-        METRICS.record_inconsistency(block_number);
         let message = format!(
             "REVM consistency check failed for block number {}, block hash {}",
             replay_record.block_context.block_number,
@@ -73,13 +71,15 @@ where
             }
             let new_blacklist_size = config.l2_signer_blacklist.len();
             tracing::info!(
-                "Adding {} new addresses to L2 signer blacklist due to REVM inconsistency",
+                "Adding {} new addresses to L2 signer blacklist due to REVM divergence",
                 new_blacklist_size - initial_blacklist_size
             );
 
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;
         }
+
+        METRICS.record_divergence(RevmDivergenceOutcome::Accepted);
         Ok(())
     }
 }

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -4,6 +4,8 @@ use reth_revm::ExecuteCommitEvm;
 use reth_revm::context::{Context, ContextTr};
 use reth_revm::db::CacheDB;
 use std::collections::HashSet;
+use std::thread;
+use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_internal_config::InternalConfigManager;
@@ -14,8 +16,11 @@ use zksync_os_storage_api::{ReadStateHistory, ReplayRecord};
 use zksync_os_types::ExecutionVersion;
 
 use crate::helpers::{zk_spec_version, zk_tx_into_revm_tx};
+use crate::metrics::METRICS;
 use crate::revm_state_provider::RevmStateProvider;
 use crate::storage_diff_comp::CompareReport;
+
+const METRICS_PROPAGATION_DELAY: Duration = Duration::from_secs(5);
 
 pub struct RevmConsistencyChecker<State>
 where
@@ -49,6 +54,10 @@ where
         report: &CompareReport,
     ) -> anyhow::Result<()> {
         report.log_tracing(20);
+        if !report.is_empty() {
+            let block_number = replay_record.block_context.block_number;
+            METRICS.record_inconsistency(block_number);
+        }
         if self.revert_enabled && !report.is_empty() {
             let mut config = self.internal_config_manager.read_config()?;
             config.failing_block = Some(replay_record.block_context.block_number);
@@ -68,6 +77,12 @@ where
                 replay_record.block_context.block_number,
                 block_output.header.hash(),
             );
+            tracing::warn!(
+                delay = ?METRICS_PROPAGATION_DELAY,
+                block_number = replay_record.block_context.block_number,
+                "Sleeping before reverting after REVM inconsistency so metrics can propagate"
+            );
+            thread::sleep(METRICS_PROPAGATION_DELAY);
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;
         }

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -20,7 +20,10 @@ use crate::metrics::METRICS;
 use crate::revm_state_provider::RevmStateProvider;
 use crate::storage_diff_comp::CompareReport;
 
-const METRICS_PROPAGATION_DELAY: Duration = Duration::from_secs(5);
+/// In case of revert we need metric to be pulled before crashing.
+/// We would still find out without this, because SLIs would break.
+/// But this way we get the alert earlier.
+const METRICS_PROPAGATION_DELAY: Duration = Duration::from_secs(30);
 
 pub struct RevmConsistencyChecker<State>
 where

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -20,11 +20,6 @@ use crate::metrics::METRICS;
 use crate::revm_state_provider::RevmStateProvider;
 use crate::storage_diff_comp::CompareReport;
 
-/// In case of revert we need metric to be pulled before crashing.
-/// We would still find out without this, because SLIs would break.
-/// But this way we get the alert earlier.
-const METRICS_PROPAGATION_DELAY: Duration = Duration::from_secs(30);
-
 pub struct RevmConsistencyChecker<State>
 where
     State: ReadStateHistory + Clone + Send + 'static,
@@ -68,6 +63,7 @@ where
             replay_record.block_context.block_number,
             block_output.header.hash(),
         );
+        tracing::warn!(message);
 
         if self.revert_enabled {
             let mut config = self.internal_config_manager.read_config()?;
@@ -83,16 +79,8 @@ where
                 new_blacklist_size - initial_blacklist_size
             );
 
-            tracing::info!(
-                block_number = replay_record.block_context.block_number,
-                "Sleeping for {}s before reverting after REVM inconsistency so metrics can propagate",
-                METRICS_PROPAGATION_DELAY.as_secs(),
-            );
-            thread::sleep(METRICS_PROPAGATION_DELAY);
             self.internal_config_manager
                 .write_config_and_panic(&config, &message)?;
-        } else {
-            tracing::warn!(message);
         }
         Ok(())
     }

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -4,8 +4,6 @@ use reth_revm::ExecuteCommitEvm;
 use reth_revm::context::{Context, ContextTr};
 use reth_revm::db::CacheDB;
 use std::collections::HashSet;
-use std::thread;
-use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use zksync_os_interface::types::BlockOutput;
 use zksync_os_internal_config::InternalConfigManager;

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -9,7 +9,6 @@ use tokio::signal::unix::{SignalKind, signal};
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_metadata::NODE_VERSION;
 use zksync_os_observability::prometheus::PrometheusExporterConfig;
-use zksync_os_revm_consistency_checker::metrics::RevmDivergenceOutcome;
 use zksync_os_server::config::{
     BaseTokenPriceUpdaterConfig, BatchVerificationConfig, BatcherConfig, Config, ConfigArgs,
     ExternalPriceApiClientConfig, FeeConfig, GasAdjusterConfig, GeneralConfig, GenesisConfig,

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -483,6 +483,7 @@ fn load_internal_config(config: &mut Config) {
         .l2_signer_blacklist
         .extend(internal_config.l2_signer_blacklist);
     if let Some(failing_block) = internal_config.failing_block {
+        zksync_os_revm_consistency_checker::metrics::METRICS.record_inconsistency(42);
         if config.sequencer_config.block_rebuild.is_some() {
             panic!(
                 "External config specifies block rebuild: {:?} and internal config specifies failing block: {}. \

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -9,6 +9,7 @@ use tokio::signal::unix::{SignalKind, signal};
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_metadata::NODE_VERSION;
 use zksync_os_observability::prometheus::PrometheusExporterConfig;
+use zksync_os_revm_consistency_checker::metrics::RevmDivergenceOutcome;
 use zksync_os_server::config::{
     BaseTokenPriceUpdaterConfig, BatchVerificationConfig, BatcherConfig, Config, ConfigArgs,
     ExternalPriceApiClientConfig, FeeConfig, GasAdjusterConfig, GeneralConfig, GenesisConfig,
@@ -483,7 +484,8 @@ fn load_internal_config(config: &mut Config) {
         .l2_signer_blacklist
         .extend(internal_config.l2_signer_blacklist);
     if let Some(failing_block) = internal_config.failing_block {
-        zksync_os_revm_consistency_checker::metrics::METRICS.record_inconsistency(42);
+        zksync_os_revm_consistency_checker::metrics::METRICS
+            .record_divergence(RevmDivergenceOutcome::Reverted);
         if config.sequencer_config.block_rebuild.is_some() {
             panic!(
                 "External config specifies block rebuild: {:?} and internal config specifies failing block: {}. \

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -484,8 +484,6 @@ fn load_internal_config(config: &mut Config) {
         .l2_signer_blacklist
         .extend(internal_config.l2_signer_blacklist);
     if let Some(failing_block) = internal_config.failing_block {
-        zksync_os_revm_consistency_checker::metrics::METRICS
-            .record_divergence(RevmDivergenceOutcome::Reverted);
         if config.sequencer_config.block_rebuild.is_some() {
             panic!(
                 "External config specifies block rebuild: {:?} and internal config specifies failing block: {}. \


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->
Add a 2 metrics with timestamps of last divergent block: 1 for case where the block is rebuilt and one for case where it's not.

I use LabeledFamily, becuase it has lazy initialization. Otherwise the metric would be reset to zero which is misleading. Becuase it's reported rarely we'll still need to use `last_over_time`

Alert condition would be something like
```

      watchdog_transfer_failing_or_missing:
        promql: '(max(last_over_time(revm_consistency_checker_last_divergence_timestamp_seconds{namespace="{{ .Release.Namespace }}"}[7d])) or vector(0))'
        compare: ">"
        thresholds:
          P3: 0
        duration: 1m
        annotations:
          description: "REVM divergence detected"
          summary: "REVM divergence detected"
          runbook_url: "..."
        labels:
          owner: zksync-os-team
```

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

