### PR TITLE
feat(rpc): track mempool insertion and forwarding latency for eth_sendRawTransaction

### DIFF
--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -25,3 +25,18 @@ pub struct ApiMetrics {
 
 #[vise::register]
 pub static API_METRICS: vise::Global<ApiMetrics> = vise::Global::new();
+
+/// Metrics for the transaction submission pipeline.
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "tx_submission")]
+pub struct TxSubmissionMetrics {
+    /// Time spent validating and inserting a transaction into the local mempool.
+    #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
+    pub mempool_latency: Histogram<Duration>,
+    /// Time spent forwarding a transaction to the main node (external nodes only).
+    #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
+    pub forwarding_latency: Histogram<Duration>,
+}
+
+#[vise::register]
+pub static TX_SUBMISSION_METRICS: vise::Global<TxSubmissionMetrics> = vise::Global::new();

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -62,21 +62,22 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
         if self.config.l2_signer_blacklist.contains(&l2_tx.signer()) {
             return Err(EthSendRawTransactionError::BlacklistedSigner);
         }
-        let mut stats = TxSubmissionStats::new();
-        self.mempool.add_l2_transaction(l2_tx).await?;
-        stats.mempool_done();
+        {
+            let _guard = MempoolLatencyGuard::new();
+            self.mempool.add_l2_transaction(l2_tx).await?;
+        }
 
         if let Some(tx_forwarder) = self.tx_forwarder.as_ref() {
-            stats.start_forwarding();
-            match tx_forwarder.send_raw_transaction(&tx_bytes).await {
-                // We do not need to wait for pending transaction here, so it's safe to forget about it
-                Ok(_) => {}
-                Err(err) => {
-                    tracing::debug!(%err, "forwarding error from main node back to user");
-                    // Remove previously added transaction from local mempool
-                    self.mempool.remove_transactions(vec![hash]);
-                    return Err(err.into());
-                }
+            let forwarding_result = {
+                let _guard = ForwardingLatencyGuard::new();
+                tx_forwarder.send_raw_transaction(&tx_bytes).await
+            };
+            // We do not need to wait for pending transaction here, so it's safe to forget about it
+            if let Err(err) = forwarding_result {
+                tracing::debug!(%err, "forwarding error from main node back to user");
+                // Remove previously added transaction from local mempool
+                self.mempool.remove_transactions(vec![hash]);
+                return Err(err.into());
             }
         }
 
@@ -171,44 +172,36 @@ pub enum EthSendRawTransactionSyncError {
     Timeout(Duration),
 }
 
-/// Tracks latency of the transaction submission pipeline.
-/// Observes Prometheus metrics when dropped, ensuring they are recorded on all exit paths.
-struct TxSubmissionStats {
-    mempool_started: Instant,
-    mempool_elapsed: Option<Duration>,
-    forwarding_started: Option<Instant>,
-}
+/// Records mempool insertion latency on drop, capturing errors and async cancellations.
+struct MempoolLatencyGuard(Instant);
 
-impl TxSubmissionStats {
+impl MempoolLatencyGuard {
     fn new() -> Self {
-        Self {
-            mempool_started: Instant::now(),
-            mempool_elapsed: None,
-            forwarding_started: None,
-        }
-    }
-
-    fn mempool_done(&mut self) {
-        self.mempool_elapsed = Some(self.mempool_started.elapsed());
-    }
-
-    fn start_forwarding(&mut self) {
-        self.forwarding_started = Some(Instant::now());
+        Self(Instant::now())
     }
 }
 
-impl Drop for TxSubmissionStats {
+impl Drop for MempoolLatencyGuard {
     fn drop(&mut self) {
-        let mempool_elapsed = self
-            .mempool_elapsed
-            .unwrap_or_else(|| self.mempool_started.elapsed());
         TX_SUBMISSION_METRICS
             .mempool_latency
-            .observe(mempool_elapsed);
-        if let Some(started) = self.forwarding_started {
-            TX_SUBMISSION_METRICS
-                .forwarding_latency
-                .observe(started.elapsed());
-        }
+            .observe(self.0.elapsed());
+    }
+}
+
+/// Records forwarding latency on drop, capturing errors and async cancellations.
+struct ForwardingLatencyGuard(Instant);
+
+impl ForwardingLatencyGuard {
+    fn new() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl Drop for ForwardingLatencyGuard {
+    fn drop(&mut self) {
+        TX_SUBMISSION_METRICS
+            .forwarding_latency
+            .observe(self.0.elapsed());
     }
 }

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -1,11 +1,12 @@
 use crate::eth_impl::build_api_receipt;
+use crate::metrics::TX_SUBMISSION_METRICS;
 use crate::{ReadRpcStorage, RpcConfig};
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::{B256, Bytes, U256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::transports::{RpcError, TransportErrorKind};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use zksync_os_mempool::PoolError;
 use zksync_os_mempool::subpools::l2::L2Subpool;
@@ -61,9 +62,12 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
         if self.config.l2_signer_blacklist.contains(&l2_tx.signer()) {
             return Err(EthSendRawTransactionError::BlacklistedSigner);
         }
+        let mut stats = TxSubmissionStats::new();
         self.mempool.add_l2_transaction(l2_tx).await?;
+        stats.mempool_done();
 
         if let Some(tx_forwarder) = self.tx_forwarder.as_ref() {
+            stats.start_forwarding();
             match tx_forwarder.send_raw_transaction(&tx_bytes).await {
                 // We do not need to wait for pending transaction here, so it's safe to forget about it
                 Ok(_) => {}
@@ -165,4 +169,46 @@ pub enum EthSendRawTransactionSyncError {
     /// Timeout while waiting for transaction receipt.
     #[error("The transaction was added to the mempool but wasn't processed within {0:?}.")]
     Timeout(Duration),
+}
+
+/// Tracks latency of the transaction submission pipeline.
+/// Observes Prometheus metrics when dropped, ensuring they are recorded on all exit paths.
+struct TxSubmissionStats {
+    mempool_started: Instant,
+    mempool_elapsed: Option<Duration>,
+    forwarding_started: Option<Instant>,
+}
+
+impl TxSubmissionStats {
+    fn new() -> Self {
+        Self {
+            mempool_started: Instant::now(),
+            mempool_elapsed: None,
+            forwarding_started: None,
+        }
+    }
+
+    fn mempool_done(&mut self) {
+        self.mempool_elapsed = Some(self.mempool_started.elapsed());
+    }
+
+    fn start_forwarding(&mut self) {
+        self.forwarding_started = Some(Instant::now());
+    }
+}
+
+impl Drop for TxSubmissionStats {
+    fn drop(&mut self) {
+        let mempool_elapsed = self
+            .mempool_elapsed
+            .unwrap_or_else(|| self.mempool_started.elapsed());
+        TX_SUBMISSION_METRICS
+            .mempool_latency
+            .observe(mempool_elapsed);
+        if let Some(started) = self.forwarding_started {
+            TX_SUBMISSION_METRICS
+                .forwarding_latency
+                .observe(started.elapsed());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`eth_sendRawTransaction` can occasionally take multiple seconds. We have an end-to-end `response_time` histogram per method, but no visibility into which part of the handler is slow.

The handler does two async operations sequentially:

1. **Mempool insertion** — validates the transaction (nonce, balance, gas price) and inserts it into the reth pool. On the main node, this is the only async step. The most likely source of latency spikes here is write lock contention: `add_transaction` needs a write lock on the pool, and `on_canonical_state_change` (which runs on every block) also holds that lock while removing mined transactions and reordering subpools.

2. **Forwarding** (external nodes only) — forwards the raw transaction to the main node and waits for a response. Any latency in the main node's own mempool insertion propagates here, plus network round-trip.

This PR adds two histograms under the `tx_submission` prefix, modeled after `BlockScanStats` — a stats struct that records to Prometheus on drop, ensuring observations are recorded on all exit paths including early returns via `?`.

- `tx_submission_mempool_latency_seconds` — time spent inside `add_l2_transaction().await`
- `tx_submission_forwarding_latency_seconds` — time spent inside `send_raw_transaction().await` (only observed on external nodes, only when forwarding is attempted)

Both metrics use the same exponential bucket range as `response_time` (1µs–32s).

No tests added — these are observe-only metrics with no behavioural change.