### PR TITLE
fix(en): restart on sync stall when main node disconnects

### DIFF
--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::collections::HashSet;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_raft::{ConsensusRole, LeadershipSignal};
@@ -195,7 +196,30 @@ impl PipelineComponent for ExternalNodeCommandSource {
         _input: PeekableReceiver<()>,
         output: mpsc::Sender<BlockCommand>,
     ) -> anyhow::Result<()> {
-        while let Some(record) = self.replays_for_sequencer.recv().await {
+        // If no block arrives within this window the P2P stream is considered stalled.
+        // Returning Err triggers `pipeline segment failed` → container restart via
+        // the `unless-stopped` Docker policy, automatically recovering connectivity.
+        // 5 minutes is conservative: the network produces a block every ~1-2 seconds
+        // even at the chain head.
+        const STALL_TIMEOUT: Duration = Duration::from_secs(300);
+
+        loop {
+            let record = match tokio::time::timeout(
+                STALL_TIMEOUT,
+                self.replays_for_sequencer.recv(),
+            )
+            .await
+            {
+                Ok(Some(record)) => record,
+                Ok(None) => break, // channel closed — normal shutdown
+                Err(_elapsed) => {
+                    anyhow::bail!(
+                        "no block received from main node for {STALL_TIMEOUT:?}; \
+                         the P2P connection is likely stalled — triggering restart to recover"
+                    );
+                }
+            };
+
             let block_number = record.block_context.block_number;
             let command = BlockCommand::Replay(Box::new(record));
             tracing::info!(?command, "Received block command from main node");


### PR DESCRIPTION
## Summary

- When the main-node P2P connection drops, `run_en_connection` exits and stops sending to the replay channel, but `ExternalNodeCommandSource` blocks on `recv()` indefinitely — the channel never closes because other `replay_sender` clones remain alive
- The node appeared fully healthy (L1 watcher, RPC, DB all running) but silently stopped processing L2 blocks with zero errors logged, making this extremely hard to detect
- Fix adds a 5-minute stall timeout to the `recv()` loop in `ExternalNodeCommandSource`; on expiry it returns `Err` which hits `res.expect("pipeline segment failed")` in the pipeline builder, triggering a container restart via the `unless-stopped` Docker policy — the shared `starting_block` Arc ensures the restarted node resumes from the correct block

## Root cause (observed in production)

EN on the genlayer testnet stalled at block **4,182,956** for **~40 hours** after the main node went offline on April 5 at ~20:39 UTC. Diagnosis via RocksDB `block_replay_wal` stats dumps confirmed the stall precisely:

| 10-min interval | DB writes | Status |
|---|---|---|
| 20:28–20:38 | 300 | Syncing normally |
| 20:38–20:48 | 25 | Sharp drop |
| 20:48–20:58 | **0** | Stalled |
| every 10 min after | 0 | Stalled for 40+ hours |

The main node came back online but the EN never resumed — only a manual container restart fixed it.

## Why the node doesn't self-recover

When the P2P connection drops and reconnects, both the v1 and v2 protocol handlers share the same `replay_sender` and `starting_block` Arc. They can race to send the same block on reconnect, causing the `assert_eq!(block_number, expected_next_block)` in `run_en_connection` to panic in the second sender, breaking that connection — leading to an unstable retry loop that never makes progress.

## The fix

**`node/bin/src/command_source.rs`** — `ExternalNodeCommandSource::run()`

Wraps `self.replays_for_sequencer.recv()` in a `tokio::time::timeout(300s, ...)`. When the timeout fires, `anyhow::bail!` propagates an error through the pipeline's `res.expect("pipeline segment failed")`, causing the critical task to panic and the container to exit and auto-restart.

The 5-minute window is conservative — the network produces a block every ~1-2 seconds so legitimate waits at chain head are at most a few seconds. The resulting log message makes the cause of the restart immediately obvious in the container logs.
