### PR TITLE
feat: add config option to `reset_timestamps` for rebuilt blocks

### DIFF
--- a/integration-tests/tests/node/rebuild.rs
+++ b/integration-tests/tests/node/rebuild.rs
@@ -116,6 +116,7 @@ async fn rebuild_after_emptying_historical_block_preserves_unrelated_l2_txs() ->
             config.sequencer_config.block_rebuild = Some(RebuildBlocksConfig {
                 from_block: block_to_empty,
                 blocks_to_empty: vec![block_to_empty],
+                reset_timestamps: false,
             });
         })
         .await?;

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -296,12 +296,17 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                     );
                 }
 
+                let timestamp = if rebuild.reset_timestamp {
+                    (millis_since_epoch() / 1000) as u64
+                } else {
+                    rebuild.replay_record.block_context.timestamp
+                };
                 let block_context = BlockContext {
                     eip1559_basefee: rebuild.replay_record.block_context.eip1559_basefee,
                     native_price: rebuild.replay_record.block_context.native_price,
                     pubdata_price: rebuild.replay_record.block_context.pubdata_price,
                     block_number,
-                    timestamp: rebuild.replay_record.block_context.timestamp,
+                    timestamp,
                     blob_fee: rebuild.replay_record.block_context.blob_fee,
                     chain_id: self.chain_id,
                     coinbase: self.fee_collector_address,

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -39,6 +39,7 @@ pub struct ProduceCommand;
 pub struct RebuildCommand {
     pub replay_record: ReplayRecord,
     pub make_empty: bool,
+    pub reset_timestamp: bool,
 }
 
 impl BlockCommand {

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -26,8 +26,9 @@ pub struct ConsensusNodeCommandSource<Replay> {
 
 #[derive(Debug)]
 pub struct RebuildOptions {
-    pub rebuild_from_block: u64,
+    pub from_block: u64,
     pub blocks_to_empty: HashSet<u64>,
+    pub reset_timestamps: bool,
 }
 
 /// External node command source.
@@ -54,18 +55,18 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 
         let replay_until = if let Some(rebuild_options) = &self.rebuild_options {
             assert!(
-                rebuild_options.rebuild_from_block >= self.starting_block,
+                rebuild_options.from_block >= self.starting_block,
                 "rebuild_from_block must be >= starting_block, got {} < {}",
-                rebuild_options.rebuild_from_block,
+                rebuild_options.from_block,
                 self.starting_block
             );
             assert!(
-                rebuild_options.rebuild_from_block <= last_block_in_wal,
+                rebuild_options.from_block <= last_block_in_wal,
                 "rebuild_from_block must be <= last_block_in_wal, got {} > {}",
-                rebuild_options.rebuild_from_block,
+                rebuild_options.from_block,
                 last_block_in_wal
             );
-            rebuild_options.rebuild_from_block - 1
+            rebuild_options.from_block - 1
         } else {
             last_block_in_wal
         };
@@ -156,7 +157,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         tracing::warn!(
             "Starting block rebuilds! {rebuild_options:?}, last_block_in_wal: {last_block_in_wal}"
         );
-        for block_number in rebuild_options.rebuild_from_block..=last_block_in_wal {
+        for block_number in rebuild_options.from_block..=last_block_in_wal {
             let replay_record = self
                 .block_replay_storage
                 .get_replay_record(block_number)
@@ -172,6 +173,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             let command = BlockCommand::Rebuild(Box::new(RebuildCommand {
                 replay_record,
                 make_empty,
+                reset_timestamp: rebuild_options.reset_timestamps,
             }));
             if output.send(command).await.is_err() {
                 tracing::warn!("Command output channel closed, stopping source");

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -550,6 +550,10 @@ pub struct RebuildBlocksConfig {
     /// List of blocks to empty (i.e., remove all transactions from).
     #[config(default, with = Delimited::new(","))]
     pub blocks_to_empty: Vec<u64>,
+    /// Whether to reset timestamps of rebuilt blocks to the current time.
+    /// If false, original timestamps are kept. If true then current time is used.
+    #[config(default_t = false)]
+    pub reset_timestamps: bool,
 }
 
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
@@ -1379,8 +1383,9 @@ impl From<MempoolTxValidatorConfig> for zksync_os_mempool::TxValidatorConfig {
 impl From<RebuildBlocksConfig> for RebuildOptions {
     fn from(c: RebuildBlocksConfig) -> Self {
         Self {
-            rebuild_from_block: c.from_block,
+            from_block: c.from_block,
             blocks_to_empty: c.blocks_to_empty.into_iter().collect(),
+            reset_timestamps: c.reset_timestamps,
         }
     }
 }

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -298,6 +298,7 @@ fn load_internal_config(config: &mut Config) {
             config.sequencer_config.block_rebuild = Some(RebuildBlocksConfig {
                 from_block: failing_block,
                 blocks_to_empty: vec![failing_block],
+                reset_timestamps: false,
             });
         }
     }


### PR DESCRIPTION
## Summary

Adds config option to `reset_timestamps` for rebuilt blocks. It's useful when blocks were not committed on L1 for a long time and L1 no longer accepts blocks with such an old timestamp.
Example usage
```yaml
sequencer:
   block_rebuild:
      from_block: 100
      reset_timestamps: true
```
or for env
```
sequencer_block_rebuild_from_block: "100"
sequencer_block_rebuild_reset_timestamps: "true"
```
After all blocks are rebuilt you should remove block_rebuild config. In case you remove it before timestamp are reset for all blocks, then it's likely that node will crash because timestamps won't be monotonic, to fix it just add config back and wait for all blocks before removing.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

