### PR TITLE
feat(storage): build RocksDB log index on block write/rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14835,6 +14835,7 @@ dependencies = [
  "dashmap",
  "roaring",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "vise",

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -17,7 +17,7 @@ use std::{
 
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor, DB, DBPinnableSlice, Direction,
-    IteratorMode, Options, PrefixRange, ReadOptions, WriteOptions, perf, properties,
+    IteratorMode, Options, PrefixRange, ReadOptions, SliceTransform, WriteOptions, perf, properties,
 };
 use thread_local::ThreadLocal;
 use vise::MetricsFamily;
@@ -44,6 +44,15 @@ pub trait NamedColumnFamily: 'static + Copy {
     /// of compaction / memtables.
     fn requires_tuning(&self) -> bool {
         false
+    }
+
+    /// Returns the byte length of the fixed-length key prefix to use as a RocksDB prefix extractor
+    /// for this CF, or `None` if no prefix extractor should be configured.
+    ///
+    /// When set, RocksDB builds per-prefix bloom filters that allow `range_iterator_cf` to skip
+    /// SST files that contain no keys with the requested prefix.
+    fn prefix_extractor_len(&self) -> Option<usize> {
+        None
     }
 }
 
@@ -397,7 +406,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
 
         let cfs_and_options: HashMap<_, _> = CF::ALL
             .iter()
-            .map(|cf| (cf.name(), cf.requires_tuning()))
+            .map(|cf| (cf.name(), (cf.requires_tuning(), cf.prefix_extractor_len())))
             .collect();
         let obsolete_cfs: Vec<_> = existing_cfs
             .iter()
@@ -423,8 +432,8 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         let cf_names = cfs_and_options.keys().copied().collect();
         let all_cfs_and_options = cfs_and_options
             .into_iter()
-            .chain(obsolete_cfs.into_iter().map(|name| (name, false)));
-        let cfs = all_cfs_and_options.map(|(cf_name, requires_tuning)| {
+            .chain(obsolete_cfs.into_iter().map(|name| (name, (false, None))));
+        let cfs = all_cfs_and_options.map(|(cf_name, (requires_tuning, prefix_extractor_len))| {
             let mut block_based_options = BlockBasedOptions::default();
             block_based_options.set_bloom_filter(10.0, false);
             if let Some(cache) = &caches.shared {
@@ -436,7 +445,10 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             }
 
             let memtable_capacity = options.large_memtable_capacity.filter(|_| requires_tuning);
-            let cf_options = Self::rocksdb_options(memtable_capacity, Some(block_based_options));
+            let mut cf_options = Self::rocksdb_options(memtable_capacity, Some(block_based_options));
+            if let Some(len) = prefix_extractor_len {
+                cf_options.set_prefix_extractor(SliceTransform::create_fixed_prefix(len));
+            }
             ColumnFamilyDescriptor::new(cf_name, cf_options)
         });
 
@@ -649,6 +661,31 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         self.inner
             .db
             .iterator_cf(cf, IteratorMode::From(keys.start, Direction::Forward))
+            .map(Result::unwrap)
+            .fuse()
+        // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.
+    }
+
+    /// Iterates over key-value pairs in `cf` in lexical order from `from` (inclusive) up to
+    /// `to` (exclusive).  When the column family has a prefix extractor configured and `from` and
+    /// `to` share the same extracted prefix, RocksDB uses prefix bloom filters to skip SST files
+    /// that contain no keys with that prefix.
+    pub fn range_iterator_cf<'a>(
+        &'a self,
+        cf: CF,
+        from: &'a [u8],
+        to: Vec<u8>,
+    ) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a {
+        let cf_handle = self.column_family(cf);
+        let mut options = ReadOptions::default();
+        options.set_iterate_upper_bound(to);
+        // When the CF has a prefix extractor configured, this tells RocksDB to use
+        // prefix bloom filters for the initial seek — checking each SST file only if
+        // it contains keys with the same prefix as the seek key.
+        options.set_prefix_same_as_start(true);
+        self.inner
+            .db
+            .iterator_cf_opt(cf_handle, options, IteratorMode::From(from, Direction::Forward))
             .map(Result::unwrap)
             .fuse()
         // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -668,9 +668,9 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.
     }
 
-    /// Iterates over key-value pairs in `cf` in lexical order from `from` (inclusive) up to
-    /// `to` (exclusive).  When the column family has a prefix extractor configured and `from` and
-    /// `to` share the same extracted prefix, RocksDB uses prefix bloom filters to skip SST files
+    /// Iterates over key-value pairs in `cf` in lexical order over `range` (start inclusive,
+    /// end exclusive).  When the column family has a prefix extractor configured and both bounds
+    /// share the same extracted prefix, RocksDB uses prefix bloom filters to skip SST files
     /// that contain no keys with that prefix.
     pub fn range_iterator_cf<'a>(
         &'a self,

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -5,7 +5,7 @@ use std::{
     fmt, iter,
     marker::PhantomData,
     num::NonZeroU32,
-    ops,
+    ops::{Range, RangeFrom, RangeToInclusive},
     path::Path,
     sync::{
         Arc, Condvar, Mutex, Weak,
@@ -84,7 +84,7 @@ impl<CF: NamedColumnFamily> WriteBatch<'_, CF> {
         self.inner.delete_cf(cf, key);
     }
 
-    pub fn delete_range_cf(&mut self, cf: CF, keys: ops::Range<&[u8]>) {
+    pub fn delete_range_cf(&mut self, cf: CF, keys: Range<&[u8]>) {
         let cf = self.db.column_family(cf);
         self.inner.delete_range_cf(cf, keys.start, keys.end);
     }
@@ -657,7 +657,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
     pub fn from_iterator_cf(
         &self,
         cf: CF,
-        keys: ops::RangeFrom<&[u8]>,
+        keys: RangeFrom<&[u8]>,
     ) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_ {
         let cf = self.column_family(cf);
         self.inner
@@ -675,12 +675,11 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
     pub fn range_iterator_cf<'a>(
         &'a self,
         cf: CF,
-        from: &'a [u8],
-        to: Vec<u8>,
+        range: Range<&'a [u8]>,
     ) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a {
         let cf_handle = self.column_family(cf);
         let mut options = ReadOptions::default();
-        options.set_iterate_upper_bound(to);
+        options.set_iterate_upper_bound(range.end.to_vec());
         // When the CF has a prefix extractor configured, this tells RocksDB to use
         // prefix bloom filters for the initial seek — checking each SST file only if
         // it contains keys with the same prefix as the seek key.
@@ -690,7 +689,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             .iterator_cf_opt(
                 cf_handle,
                 options,
-                IteratorMode::From(from, Direction::Forward),
+                IteratorMode::From(range.start, Direction::Forward),
             )
             .map(Result::unwrap)
             .fuse()
@@ -702,7 +701,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
     pub fn to_iterator_cf(
         &self,
         cf: CF,
-        keys: ops::RangeToInclusive<&[u8]>,
+        keys: RangeToInclusive<&[u8]>,
     ) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + '_ {
         let cf = self.column_family(cf);
         self.inner

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -17,7 +17,8 @@ use std::{
 
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor, DB, DBPinnableSlice, Direction,
-    IteratorMode, Options, PrefixRange, ReadOptions, SliceTransform, WriteOptions, perf, properties,
+    IteratorMode, Options, PrefixRange, ReadOptions, SliceTransform, WriteOptions, perf,
+    properties,
 };
 use thread_local::ThreadLocal;
 use vise::MetricsFamily;
@@ -445,7 +446,8 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             }
 
             let memtable_capacity = options.large_memtable_capacity.filter(|_| requires_tuning);
-            let mut cf_options = Self::rocksdb_options(memtable_capacity, Some(block_based_options));
+            let mut cf_options =
+                Self::rocksdb_options(memtable_capacity, Some(block_based_options));
             if let Some(len) = prefix_extractor_len {
                 cf_options.set_prefix_extractor(SliceTransform::create_fixed_prefix(len));
             }
@@ -685,7 +687,11 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         options.set_prefix_same_as_start(true);
         self.inner
             .db
-            .iterator_cf_opt(cf_handle, options, IteratorMode::From(from, Direction::Forward))
+            .iterator_cf_opt(
+                cf_handle,
+                options,
+                IteratorMode::From(from, Direction::Forward),
+            )
             .map(Result::unwrap)
             .fuse()
         // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -28,3 +28,6 @@ bincode.workspace = true
 anyhow.workspace = true
 serde_json.workspace = true
 roaring.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -6,7 +6,10 @@ use alloy::{
     primitives::{Address, BlockHash, BlockNumber, TxHash, TxNonce},
     rlp::{Decodable, Encodable},
 };
-use log_index::{chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage};
+use log_index::{
+    BitmapCache, chunk_start, deindex_logs, flush_bitmap_cache, index_logs, rollback_coverage,
+    update_coverage,
+};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,7 +24,7 @@ use zksync_os_types::{ZkEnvelope, ZkReceiptEnvelope, ZkTransaction};
 
 mod log_index;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RepositoryCF {
     // block hash => (block header, array of tx hashes)
     BlockData,
@@ -171,10 +174,19 @@ impl RepositoryDb {
         block.encode(&mut block_bytes);
         batch.put_cf(RepositoryCF::BlockData, block_hash.as_slice(), &block_bytes);
 
+        let mut bitmap_cache = BitmapCache::new();
         for tx in txs {
-            Self::add_tx_to_write_batch(db, &mut batch, tx, block_number_u32, chunk)
-                .expect("write batch failed");
+            Self::add_tx_to_write_batch(
+                db,
+                &mut batch,
+                &mut bitmap_cache,
+                tx,
+                block_number_u32,
+                chunk,
+            )
+            .expect("write batch failed");
         }
+        flush_bitmap_cache(bitmap_cache, &mut batch);
 
         let block_number_key = RepositoryCF::block_number_key();
         batch.put_cf(RepositoryCF::Meta, block_number_key, &block_number_bytes);
@@ -199,6 +211,7 @@ impl RepositoryDb {
     fn add_tx_to_write_batch(
         db: &RocksDB<RepositoryCF>,
         batch: &mut WriteBatch<RepositoryCF>,
+        bitmap_cache: &mut BitmapCache,
         tx: &StoredTxData,
         block_number: u32,
         chunk: u64,
@@ -227,7 +240,7 @@ impl RepositoryDb {
             tx_hash.as_slice(),
         );
 
-        index_logs(db, batch, block_number, chunk, tx.receipt.logs())?;
+        index_logs(db, bitmap_cache, block_number, chunk, tx.receipt.logs())?;
 
         Ok(())
     }
@@ -252,6 +265,12 @@ impl RepositoryDb {
                 block_number_key,
                 &last_block_to_keep_bytes,
             );
+
+            // Bitmap mutations for the log index are accumulated in a local cache so that
+            // successive removals within the same batch for the same bitmap key compose
+            // correctly (plain `with_chunk` always reads from the DB, so the last write
+            // would silently win and earlier removals would be lost).
+            let mut bitmap_cache = BitmapCache::new();
 
             for block_number in (last_block_to_keep + 1)..=latest_block_number {
                 let old_repo_block = self
@@ -283,7 +302,7 @@ impl RepositoryDb {
 
                     deindex_logs(
                         &self.db,
-                        &mut batch,
+                        &mut bitmap_cache,
                         block_number_u32,
                         chunk,
                         stored_tx.receipt.logs(),
@@ -292,6 +311,7 @@ impl RepositoryDb {
                 }
             }
 
+            flush_bitmap_cache(bitmap_cache, &mut batch);
             rollback_coverage(&mut batch, &last_block_to_keep_bytes);
 
             self.db.write(batch)?;

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -6,16 +6,20 @@ use alloy::{
     primitives::{Address, BlockHash, BlockNumber, TxHash, TxNonce},
     rlp::{Decodable, Encodable},
 };
+use log_index::{chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage};
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::watch;
 use zksync_os_genesis::Genesis;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::{NamedColumnFamily, WriteBatch};
 use zksync_os_storage_api::{
-    LogIndex, ReadRepository, RepositoryBlock, RepositoryResult, StoredTxData, TxMeta,
+    ReadRepository, RepositoryBlock, RepositoryResult, StoredTxData, TxMeta,
 };
 use zksync_os_types::{ZkEnvelope, ZkReceiptEnvelope, ZkTransaction};
+
+mod log_index;
 
 #[derive(Clone, Copy, Debug)]
 pub enum RepositoryCF {
@@ -31,13 +35,25 @@ pub enum RepositoryCF {
     TxMeta,
     // (initiator address, nonce) => tx hash
     InitiatorAndNonceToHash,
-    // meta fields: currently only latest block number
+    // meta fields: latest block number, log index first/last block
     Meta,
+    // (address[20] ++ chunk_start[8]) => roaring bitmap of block numbers containing logs from that address
+    LogBlocksByAddress,
+    // (topic[32] ++ chunk_start[8]) => roaring bitmap of block numbers containing logs with that topic
+    LogBlocksByTopic,
 }
 
 impl RepositoryCF {
     fn block_number_key() -> &'static [u8] {
         b"block_number"
+    }
+
+    fn log_index_first_block_key() -> &'static [u8] {
+        b"log_index_first_block"
+    }
+
+    fn log_index_last_block_key() -> &'static [u8] {
+        b"log_index_last_block"
     }
 }
 
@@ -51,6 +67,8 @@ impl NamedColumnFamily for RepositoryCF {
         RepositoryCF::TxMeta,
         RepositoryCF::InitiatorAndNonceToHash,
         RepositoryCF::Meta,
+        RepositoryCF::LogBlocksByAddress,
+        RepositoryCF::LogBlocksByTopic,
     ];
 
     fn name(&self) -> &'static str {
@@ -62,27 +80,38 @@ impl NamedColumnFamily for RepositoryCF {
             RepositoryCF::TxMeta => "tx_meta",
             RepositoryCF::InitiatorAndNonceToHash => "initiator_and_nonce_to_hash",
             RepositoryCF::Meta => "meta",
+            RepositoryCF::LogBlocksByAddress => "log_blocks_by_address",
+            RepositoryCF::LogBlocksByTopic => "log_blocks_by_topic",
         }
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct RepositoryDb {
-    db: RocksDB<RepositoryCF>,
+    pub(self) db: RocksDB<RepositoryCF>,
     /// Points to the latest block whose data has been persisted in `db`. There might be partial
     /// data written for the next block, in other words `db` is caught up to *AT LEAST* this number.
     latest_block_number: watch::Sender<u64>,
+    /// True once the log index coverage start marker has been written to the DB.
+    log_index_started: Arc<AtomicBool>,
 }
 
 impl RepositoryDb {
     pub async fn new(db_path: &Path, genesis: &Genesis) -> Self {
         let db = RocksDB::<RepositoryCF>::new(db_path).expect("Failed to open db");
-        let latest_block_number = db
+        let db_block_number = db
             .get_cf(RepositoryCF::Meta, RepositoryCF::block_number_key())
             .unwrap()
             .map(|v| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
-        let latest_block_number = if let Some(n) = latest_block_number {
-            n
+        let log_index_started_in_db = db
+            .get_cf(
+                RepositoryCF::Meta,
+                RepositoryCF::log_index_first_block_key(),
+            )
+            .unwrap()
+            .is_some();
+        let (latest_block_number, log_index_started) = if let Some(n) = db_block_number {
+            (n, log_index_started_in_db)
         } else {
             let (header, hash) = genesis.state().await.header.clone().into_parts();
             let block = Sealed::new_unchecked(
@@ -96,14 +125,14 @@ impl RepositoryDb {
                 },
                 hash,
             );
-            Self::write_block_inner(&db, &block, &[]);
-
-            0
+            Self::write_block_inner(&db, &block, &[], false);
+            (0, true)
         };
 
         Self {
             db,
             latest_block_number: watch::channel(latest_block_number).0,
+            log_index_started: Arc::new(AtomicBool::new(log_index_started)),
         }
     }
 
@@ -122,11 +151,14 @@ impl RepositoryDb {
         db: &RocksDB<RepositoryCF>,
         block: &Sealed<Block<TxHash>>,
         txs: &[Arc<StoredTxData>],
+        log_index_started: bool,
     ) {
         let block_number = block.number;
         let block_hash = block.hash();
         let block_number_bytes = block_number.to_be_bytes();
         let block_hash_bytes = block_hash.to_vec();
+        let block_number_u32 = block_number as u32;
+        let chunk = chunk_start(block_number);
 
         let mut batch = db.new_write_batch();
         batch.put_cf(
@@ -140,11 +172,13 @@ impl RepositoryDb {
         batch.put_cf(RepositoryCF::BlockData, block_hash.as_slice(), &block_bytes);
 
         for tx in txs {
-            Self::add_tx_to_write_batch(&mut batch, tx);
+            Self::add_tx_to_write_batch(db, &mut batch, tx, block_number_u32, chunk)
+                .expect("write batch failed");
         }
 
         let block_number_key = RepositoryCF::block_number_key();
         batch.put_cf(RepositoryCF::Meta, block_number_key, &block_number_bytes);
+        update_coverage(&mut batch, &block_number_bytes, log_index_started);
 
         REPOSITORIES_METRICS
             .block_data_size
@@ -156,11 +190,19 @@ impl RepositoryDb {
     }
 
     pub fn write_block(&self, block: &Sealed<Block<TxHash>>, txs: &[Arc<StoredTxData>]) {
-        Self::write_block_inner(&self.db, block, txs);
+        let log_index_started = self.log_index_started.load(Ordering::Relaxed);
+        Self::write_block_inner(&self.db, block, txs, log_index_started);
+        self.log_index_started.store(true, Ordering::Relaxed);
         self.latest_block_number.send_replace(block.number);
     }
 
-    fn add_tx_to_write_batch(batch: &mut WriteBatch<RepositoryCF>, tx: &StoredTxData) {
+    fn add_tx_to_write_batch(
+        db: &RocksDB<RepositoryCF>,
+        batch: &mut WriteBatch<RepositoryCF>,
+        tx: &StoredTxData,
+        block_number: u32,
+        chunk: u64,
+    ) -> RepositoryResult<()> {
         let tx_hash = tx.tx.hash();
         let mut tx_bytes = Vec::new();
         tx.tx.inner.encode_2718(&mut tx_bytes);
@@ -184,6 +226,10 @@ impl RepositoryDb {
             &initiator_and_nonce_key,
             tx_hash.as_slice(),
         );
+
+        index_logs(db, batch, block_number, chunk, tx.receipt.logs())?;
+
+        Ok(())
     }
 
     pub fn rollback(&self, last_block_to_keep: u64) -> RepositoryResult<()> {
@@ -215,16 +261,18 @@ impl RepositoryDb {
                 batch.delete_cf(RepositoryCF::BlockNumberToHash, &block_number_bytes);
                 batch.delete_cf(RepositoryCF::BlockData, &old_repo_block.hash().0);
 
+                let chunk = chunk_start(block_number);
+                let block_number_u32 = block_number as u32;
+
                 for tx_hash in &old_repo_block.body.transactions {
                     batch.delete_cf(RepositoryCF::Tx, &tx_hash.0);
-                    batch.delete_cf(RepositoryCF::TxReceipt, &tx_hash.0);
                     batch.delete_cf(RepositoryCF::TxMeta, &tx_hash.0);
 
-                    let tx = self
-                        .get_transaction(*tx_hash)?
+                    let stored_tx = self
+                        .get_stored_transaction(*tx_hash)?
                         .expect("tx to rollback must be present in DB");
-                    let initiator = tx.signer();
-                    let nonce = tx.inner.nonce();
+                    let initiator = stored_tx.tx.signer();
+                    let nonce = stored_tx.tx.inner.nonce();
                     let mut initiator_and_nonce_key = Vec::with_capacity(20 + 8);
                     initiator_and_nonce_key.extend_from_slice(initiator.as_slice());
                     initiator_and_nonce_key.extend_from_slice(&nonce.to_be_bytes());
@@ -232,8 +280,19 @@ impl RepositoryDb {
                         RepositoryCF::InitiatorAndNonceToHash,
                         &initiator_and_nonce_key,
                     );
+
+                    deindex_logs(
+                        &self.db,
+                        &mut batch,
+                        block_number_u32,
+                        chunk,
+                        stored_tx.receipt.logs(),
+                    )?;
+                    batch.delete_cf(RepositoryCF::TxReceipt, &tx_hash.0);
                 }
             }
+
+            rollback_coverage(&mut batch, &last_block_to_keep_bytes);
 
             self.db.write(batch)?;
             self.latest_block_number.send_replace(last_block_to_keep);
@@ -242,8 +301,6 @@ impl RepositoryDb {
         Ok(())
     }
 }
-
-impl LogIndex for RepositoryDb {}
 
 impl ReadRepository for RepositoryDb {
     fn get_block_by_number(

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -6,9 +6,7 @@ use alloy::{
     primitives::{Address, BlockHash, BlockNumber, TxHash, TxNonce},
     rlp::{Decodable, Encodable},
 };
-use log_index::{
-    BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage,
-};
+use log_index::{BitmapCache, deindex_logs, index_logs, rollback_coverage, update_coverage};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -157,8 +155,6 @@ impl RepositoryDb {
         let block_hash = block.hash();
         let block_number_bytes = block_number.to_be_bytes();
         let block_hash_bytes = block_hash.to_vec();
-        let chunk = chunk_start(block_number);
-        let block_offset = (block_number - chunk) as u32;
 
         let mut batch = db.new_write_batch();
         batch.put_cf(
@@ -173,7 +169,7 @@ impl RepositoryDb {
 
         let mut bitmap_cache = BitmapCache::default();
         for tx in txs {
-            Self::add_tx_to_write_batch(db, &mut batch, &mut bitmap_cache, tx, block_offset, chunk)
+            Self::add_tx_to_write_batch(db, &mut batch, &mut bitmap_cache, tx, block_number)
                 .expect("write batch failed");
         }
         bitmap_cache.flush(&mut batch);
@@ -201,8 +197,7 @@ impl RepositoryDb {
         batch: &mut WriteBatch<RepositoryCF>,
         bitmap_cache: &mut BitmapCache,
         tx: &StoredTxData,
-        block_offset: u32,
-        chunk: u64,
+        block_number: u64,
     ) -> RepositoryResult<()> {
         let tx_hash = tx.tx.hash();
         let mut tx_bytes = Vec::new();
@@ -228,7 +223,7 @@ impl RepositoryDb {
             tx_hash.as_slice(),
         );
 
-        index_logs(db, bitmap_cache, block_offset, chunk, tx.receipt.logs())?;
+        index_logs(db, bitmap_cache, block_number, tx.receipt.logs())?;
 
         Ok(())
     }
@@ -268,9 +263,6 @@ impl RepositoryDb {
                 batch.delete_cf(RepositoryCF::BlockNumberToHash, &block_number_bytes);
                 batch.delete_cf(RepositoryCF::BlockData, &old_repo_block.hash().0);
 
-                let chunk = chunk_start(block_number);
-                let block_offset = (block_number - chunk) as u32;
-
                 for tx_hash in &old_repo_block.body.transactions {
                     batch.delete_cf(RepositoryCF::Tx, &tx_hash.0);
                     batch.delete_cf(RepositoryCF::TxMeta, &tx_hash.0);
@@ -291,8 +283,7 @@ impl RepositoryDb {
                     deindex_logs(
                         &self.db,
                         &mut bitmap_cache,
-                        block_offset,
-                        chunk,
+                        block_number,
                         stored_tx.receipt.logs(),
                     )?;
                     batch.delete_cf(RepositoryCF::TxReceipt, &tx_hash.0);

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -6,7 +6,9 @@ use alloy::{
     primitives::{Address, BlockHash, BlockNumber, TxHash, TxNonce},
     rlp::{Decodable, Encodable},
 };
-use log_index::{BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage};
+use log_index::{
+    BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage,
+};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -161,15 +163,8 @@ impl RepositoryDb {
 
         let mut bitmap_cache = BitmapCache::default();
         for tx in txs {
-            Self::add_tx_to_write_batch(
-                db,
-                &mut batch,
-                &mut bitmap_cache,
-                tx,
-                block_offset,
-                chunk,
-            )
-            .expect("write batch failed");
+            Self::add_tx_to_write_batch(db, &mut batch, &mut bitmap_cache, tx, block_offset, chunk)
+                .expect("write batch failed");
         }
         bitmap_cache.flush(&mut batch);
 

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -145,8 +145,8 @@ impl RepositoryDb {
         let block_hash = block.hash();
         let block_number_bytes = block_number.to_be_bytes();
         let block_hash_bytes = block_hash.to_vec();
-        let block_number_u32 = block_number as u32;
         let chunk = chunk_start(block_number);
+        let block_offset = (block_number - chunk) as u32;
 
         let mut batch = db.new_write_batch();
         batch.put_cf(
@@ -166,7 +166,7 @@ impl RepositoryDb {
                 &mut batch,
                 &mut bitmap_cache,
                 tx,
-                block_number_u32,
+                block_offset,
                 chunk,
             )
             .expect("write batch failed");
@@ -196,7 +196,7 @@ impl RepositoryDb {
         batch: &mut WriteBatch<RepositoryCF>,
         bitmap_cache: &mut BitmapCache,
         tx: &StoredTxData,
-        block_number: u32,
+        block_offset: u32,
         chunk: u64,
     ) -> RepositoryResult<()> {
         let tx_hash = tx.tx.hash();
@@ -223,7 +223,7 @@ impl RepositoryDb {
             tx_hash.as_slice(),
         );
 
-        index_logs(db, bitmap_cache, block_number, chunk, tx.receipt.logs())?;
+        index_logs(db, bitmap_cache, block_offset, chunk, tx.receipt.logs())?;
 
         Ok(())
     }
@@ -264,7 +264,7 @@ impl RepositoryDb {
                 batch.delete_cf(RepositoryCF::BlockData, &old_repo_block.hash().0);
 
                 let chunk = chunk_start(block_number);
-                let block_number_u32 = block_number as u32;
+                let block_offset = (block_number - chunk) as u32;
 
                 for tx_hash in &old_repo_block.body.transactions {
                     batch.delete_cf(RepositoryCF::Tx, &tx_hash.0);
@@ -286,7 +286,7 @@ impl RepositoryDb {
                     deindex_logs(
                         &self.db,
                         &mut bitmap_cache,
-                        block_number_u32,
+                        block_offset,
                         chunk,
                         stored_tx.receipt.logs(),
                     )?;

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -7,8 +7,7 @@ use alloy::{
     rlp::{Decodable, Encodable},
 };
 use log_index::{
-    BitmapCache, chunk_start, deindex_logs, flush_bitmap_cache, index_logs, rollback_coverage,
-    update_coverage,
+    BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -24,7 +23,7 @@ use zksync_os_types::{ZkEnvelope, ZkReceiptEnvelope, ZkTransaction};
 
 mod log_index;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug)]
 pub enum RepositoryCF {
     // block hash => (block header, array of tx hashes)
     BlockData,
@@ -174,7 +173,7 @@ impl RepositoryDb {
         block.encode(&mut block_bytes);
         batch.put_cf(RepositoryCF::BlockData, block_hash.as_slice(), &block_bytes);
 
-        let mut bitmap_cache = BitmapCache::new();
+        let mut bitmap_cache = BitmapCache::default();
         for tx in txs {
             Self::add_tx_to_write_batch(
                 db,
@@ -186,7 +185,7 @@ impl RepositoryDb {
             )
             .expect("write batch failed");
         }
-        flush_bitmap_cache(bitmap_cache, &mut batch);
+        bitmap_cache.flush(&mut batch);
 
         let block_number_key = RepositoryCF::block_number_key();
         batch.put_cf(RepositoryCF::Meta, block_number_key, &block_number_bytes);
@@ -270,7 +269,7 @@ impl RepositoryDb {
             // successive removals within the same batch for the same bitmap key compose
             // correctly (plain `with_chunk` always reads from the DB, so the last write
             // would silently win and earlier removals would be lost).
-            let mut bitmap_cache = BitmapCache::new();
+            let mut bitmap_cache = BitmapCache::default();
 
             for block_number in (last_block_to_keep + 1)..=latest_block_number {
                 let old_repo_block = self
@@ -311,7 +310,7 @@ impl RepositoryDb {
                 }
             }
 
-            flush_bitmap_cache(bitmap_cache, &mut batch);
+            bitmap_cache.flush(&mut batch);
             rollback_coverage(&mut batch, &last_block_to_keep_bytes);
 
             self.db.write(batch)?;

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -6,12 +6,9 @@ use alloy::{
     primitives::{Address, BlockHash, BlockNumber, TxHash, TxNonce},
     rlp::{Decodable, Encodable},
 };
-use log_index::{
-    BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage,
-};
+use log_index::{BitmapCache, chunk_start, deindex_logs, index_logs, rollback_coverage, update_coverage};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::watch;
 use zksync_os_genesis::Genesis;
 use zksync_os_rocksdb::RocksDB;
@@ -94,8 +91,6 @@ pub struct RepositoryDb {
     /// Points to the latest block whose data has been persisted in `db`. There might be partial
     /// data written for the next block, in other words `db` is caught up to *AT LEAST* this number.
     latest_block_number: watch::Sender<u64>,
-    /// True once the log index coverage start marker has been written to the DB.
-    log_index_started: Arc<AtomicBool>,
 }
 
 impl RepositoryDb {
@@ -105,15 +100,8 @@ impl RepositoryDb {
             .get_cf(RepositoryCF::Meta, RepositoryCF::block_number_key())
             .unwrap()
             .map(|v| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
-        let log_index_started_in_db = db
-            .get_cf(
-                RepositoryCF::Meta,
-                RepositoryCF::log_index_first_block_key(),
-            )
-            .unwrap()
-            .is_some();
-        let (latest_block_number, log_index_started) = if let Some(n) = db_block_number {
-            (n, log_index_started_in_db)
+        let latest_block_number = if let Some(n) = db_block_number {
+            n
         } else {
             let (header, hash) = genesis.state().await.header.clone().into_parts();
             let block = Sealed::new_unchecked(
@@ -127,14 +115,13 @@ impl RepositoryDb {
                 },
                 hash,
             );
-            Self::write_block_inner(&db, &block, &[], false);
-            (0, true)
+            Self::write_block_inner(&db, &block, &[]);
+            0
         };
 
         Self {
             db,
             latest_block_number: watch::channel(latest_block_number).0,
-            log_index_started: Arc::new(AtomicBool::new(log_index_started)),
         }
     }
 
@@ -153,7 +140,6 @@ impl RepositoryDb {
         db: &RocksDB<RepositoryCF>,
         block: &Sealed<Block<TxHash>>,
         txs: &[Arc<StoredTxData>],
-        log_index_started: bool,
     ) {
         let block_number = block.number;
         let block_hash = block.hash();
@@ -189,7 +175,7 @@ impl RepositoryDb {
 
         let block_number_key = RepositoryCF::block_number_key();
         batch.put_cf(RepositoryCF::Meta, block_number_key, &block_number_bytes);
-        update_coverage(&mut batch, &block_number_bytes, log_index_started);
+        update_coverage(db, &mut batch, &block_number_bytes);
 
         REPOSITORIES_METRICS
             .block_data_size
@@ -201,9 +187,7 @@ impl RepositoryDb {
     }
 
     pub fn write_block(&self, block: &Sealed<Block<TxHash>>, txs: &[Arc<StoredTxData>]) {
-        let log_index_started = self.log_index_started.load(Ordering::Relaxed);
-        Self::write_block_inner(&self.db, block, txs, log_index_started);
-        self.log_index_started.store(true, Ordering::Relaxed);
+        Self::write_block_inner(&self.db, block, txs);
         self.latest_block_number.send_replace(block.number);
     }
 

--- a/lib/storage/src/db/repository.rs
+++ b/lib/storage/src/db/repository.rs
@@ -85,6 +85,16 @@ impl NamedColumnFamily for RepositoryCF {
             RepositoryCF::LogBlocksByTopic => "log_blocks_by_topic",
         }
     }
+
+    fn prefix_extractor_len(&self) -> Option<usize> {
+        match self {
+            // Keys are address[20] ++ chunk_start[8]; the prefix is the address.
+            RepositoryCF::LogBlocksByAddress => Some(20),
+            // Keys are topic[32] ++ chunk_start[8]; the prefix is the topic hash.
+            RepositoryCF::LogBlocksByTopic => Some(32),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -234,7 +234,8 @@ fn read_range(
     }
 
     // Mask to the requested range (block numbers fit in u32 given current chain sizes).
-    result &= RoaringBitmap::from_iter(range.start as u32..range.end as u32);
+    result.remove_range(..range.start as u32);
+    result.remove_range(range.end as u32..);
     Ok(result)
 }
 

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -6,7 +6,7 @@ use std::io::Cursor;
 use std::ops::Range;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::WriteBatch;
-use zksync_os_storage_api::{LogIndex, RepositoryError, RepositoryResult};
+use zksync_os_storage_api::{LogIndex, RepositoryResult};
 
 /// Chunk size for log index bitmaps. Equals 2^16 = 65536, which aligns with roaring32's
 /// internal container boundary: all block numbers within a chunk share the same high 16 bits,
@@ -41,9 +41,8 @@ fn serialize_bitmap(bitmap: &RoaringBitmap) -> Vec<u8> {
     buf
 }
 
-fn deserialize_bitmap(bytes: &[u8]) -> Result<RoaringBitmap, RepositoryError> {
-    RoaringBitmap::deserialize_from(Cursor::new(bytes))
-        .map_err(|e| RepositoryError::BitmapDeserialize(e.to_string()))
+fn deserialize_bitmap(bytes: &[u8]) -> RoaringBitmap {
+    RoaringBitmap::deserialize_from(Cursor::new(bytes)).expect("log index bitmap is corrupted")
 }
 
 /// In-memory cache of pending bitmap mutations for a single write batch.
@@ -92,7 +91,7 @@ fn with_chunk(
         bm
     } else {
         let bm = match db.get_cf(cf, key)? {
-            Some(bytes) => deserialize_bitmap(&bytes)?,
+            Some(bytes) => deserialize_bitmap(&bytes),
             None => RoaringBitmap::new(),
         };
         bitmaps.entry(key.to_vec()).or_insert(bm)
@@ -206,9 +205,9 @@ pub(super) fn deindex_logs<'a>(
 }
 
 fn read_u64_meta(db: &RocksDB<RepositoryCF>, key: &[u8]) -> RepositoryResult<Option<u64>> {
-    Ok(db
-        .get_cf(RepositoryCF::Meta, key)?
-        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap())))
+    Ok(db.get_cf(RepositoryCF::Meta, key)?.map(|v: Vec<u8>| {
+        u64::from_be_bytes(v.as_slice().try_into().expect("metadata must be 8 bytes"))
+    }))
 }
 
 /// Returns the index coverage as a half-open range, or `None` if the index is empty.
@@ -250,7 +249,7 @@ fn read_range(
             .try_into()
             .expect("chunk key suffix must be 8 bytes");
         let chunk_base = u64::from_be_bytes(chunk_bytes) as u32;
-        result |= deserialize_bitmap(&value)?
+        result |= deserialize_bitmap(&value)
             .into_iter()
             .map(|offset| chunk_base + offset)
             .collect::<RoaringBitmap>();

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -180,17 +180,16 @@ pub(super) fn deindex_logs<'a>(
     Ok(())
 }
 
+fn read_u64_meta(db: &RocksDB<RepositoryCF>, key: &[u8]) -> RepositoryResult<Option<u64>> {
+    Ok(db
+        .get_cf(RepositoryCF::Meta, key)?
+        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap())))
+}
+
 /// Returns the index coverage as a half-open range, or `None` if the index is empty.
 fn coverage(db: &RocksDB<RepositoryCF>) -> RepositoryResult<Option<Range<u64>>> {
-    let first = db
-        .get_cf(
-            RepositoryCF::Meta,
-            RepositoryCF::log_index_first_block_key(),
-        )?
-        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
-    let last = db
-        .get_cf(RepositoryCF::Meta, RepositoryCF::log_index_last_block_key())?
-        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
+    let first = read_u64_meta(db, RepositoryCF::log_index_first_block_key())?;
+    let last = read_u64_meta(db, RepositoryCF::log_index_last_block_key())?;
     Ok(first.zip(last).map(|(f, l)| f..l + 1))
 }
 

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -104,6 +104,10 @@ fn with_chunk(
 /// Updates the log index coverage metadata in `batch`.
 /// Writes `log_index_first_block` if it is not already present in the DB
 /// (it is only ever set once); always updates `log_index_last_block`.
+///
+/// Must be called at most once per `batch`: the first-block check reads from
+/// the DB, not the batch, so a second call within the same batch would
+/// overwrite the first-block key even though it was already set by the batch.
 pub(super) fn update_coverage(
     db: &RocksDB<RepositoryCF>,
     batch: &mut WriteBatch<RepositoryCF>,

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -241,7 +241,7 @@ fn read_range(
     to_key.extend_from_slice(&to_chunk_exclusive.to_be_bytes());
 
     let mut result = RoaringBitmap::new();
-    for (key, value) in db.range_iterator_cf(cf, &from_key, to_key) {
+    for (key, value) in db.range_iterator_cf(cf, from_key.as_slice()..to_key.as_slice()) {
         // Bitmaps store offsets relative to chunk_start; we need to recover the chunk base
         // from the key suffix to shift offsets back to absolute block numbers.
         let chunk_bytes: [u8; 8] = key[key_prefix.len()..]

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -138,16 +138,14 @@ pub(super) fn rollback_coverage(batch: &mut WriteBatch<RepositoryCF>, block_numb
 }
 
 /// Adds all logs from a single transaction to the bitmap cache.
-/// `block_offset` is the block number relative to `chunk` (i.e. `block_number - chunk`);
-/// storing offsets rather than absolute block numbers keeps values within `[0, CHUNK_SIZE)`
-/// so they can never overflow `u32` regardless of how large block numbers grow.
 pub(super) fn index_logs<'a>(
     db: &RocksDB<RepositoryCF>,
     cache: &mut BitmapCache,
-    block_offset: u32,
-    chunk: u64,
+    block_number: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
+    let chunk = chunk_start(block_number);
+    let block_offset = (block_number - chunk) as u32;
     for log in logs {
         with_chunk(
             db,
@@ -174,14 +172,14 @@ pub(super) fn index_logs<'a>(
 }
 
 /// Removes all logs from a single transaction from the bitmap cache.
-/// `block_offset` is the block number relative to `chunk` (i.e. `block_number - chunk`).
 pub(super) fn deindex_logs<'a>(
     db: &RocksDB<RepositoryCF>,
     cache: &mut BitmapCache,
-    block_offset: u32,
-    chunk: u64,
+    block_number: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
+    let chunk = chunk_start(block_number);
+    let block_offset = (block_number - chunk) as u32;
     for log in logs {
         with_chunk(
             db,
@@ -330,10 +328,9 @@ mod tests {
 
     /// Writes log index entries and coverage for `block_number` using the production functions.
     fn index_block(db: &RocksDB<RepositoryCF>, block_number: u64, logs: &[alloy::primitives::Log]) {
-        let chunk = chunk_start(block_number);
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
-        index_logs(db, &mut cache, (block_number - chunk) as u32, chunk, logs).unwrap();
+        index_logs(db, &mut cache, block_number, logs).unwrap();
         cache.flush(&mut batch);
         update_coverage(db, &mut batch, &block_number.to_be_bytes());
         db.write(batch).unwrap();
@@ -404,14 +401,7 @@ mod tests {
 
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
-        deindex_logs(
-            &db,
-            &mut cache,
-            1u32 - chunk_start(1) as u32,
-            chunk_start(1),
-            &[log],
-        )
-        .unwrap();
+        deindex_logs(&db, &mut cache, 1, &[log]).unwrap();
         cache.flush(&mut batch);
         rollback_coverage(&mut batch, &0u64.to_be_bytes());
         db.write(batch).unwrap();
@@ -513,15 +503,7 @@ mod tests {
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
         for block in 0u64..=2 {
-            let chunk = chunk_start(block);
-            deindex_logs(
-                &db,
-                &mut cache,
-                (block - chunk) as u32,
-                chunk,
-                &[make_log(addr, &[])],
-            )
-            .unwrap();
+            deindex_logs(&db, &mut cache, block, &[make_log(addr, &[])]).unwrap();
         }
         cache.flush(&mut batch);
         db.write(batch).unwrap();

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -130,10 +130,13 @@ pub(super) fn rollback_coverage(batch: &mut WriteBatch<RepositoryCF>, block_numb
 }
 
 /// Adds all logs from a single transaction to the bitmap cache.
+/// `block_offset` is the block number relative to `chunk` (i.e. `block_number - chunk`);
+/// storing offsets rather than absolute block numbers keeps values within `[0, CHUNK_SIZE)`
+/// so they can never overflow `u32` regardless of how large block numbers grow.
 pub(super) fn index_logs<'a>(
     db: &RocksDB<RepositoryCF>,
     cache: &mut BitmapCache,
-    block_number: u32,
+    block_offset: u32,
     chunk: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
@@ -144,7 +147,7 @@ pub(super) fn index_logs<'a>(
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
             |bm| {
-                bm.insert(block_number);
+                bm.insert(block_offset);
             },
         )?;
         for topic in log.topics() {
@@ -154,7 +157,7 @@ pub(super) fn index_logs<'a>(
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
                 |bm| {
-                    bm.insert(block_number);
+                    bm.insert(block_offset);
                 },
             )?;
         }
@@ -163,10 +166,11 @@ pub(super) fn index_logs<'a>(
 }
 
 /// Removes all logs from a single transaction from the bitmap cache.
+/// `block_offset` is the block number relative to `chunk` (i.e. `block_number - chunk`).
 pub(super) fn deindex_logs<'a>(
     db: &RocksDB<RepositoryCF>,
     cache: &mut BitmapCache,
-    block_number: u32,
+    block_offset: u32,
     chunk: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
@@ -177,7 +181,7 @@ pub(super) fn deindex_logs<'a>(
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
             |bm| {
-                bm.remove(block_number);
+                bm.remove(block_offset);
             },
         )?;
         for topic in log.topics() {
@@ -187,7 +191,7 @@ pub(super) fn deindex_logs<'a>(
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
                 |bm| {
-                    bm.remove(block_number);
+                    bm.remove(block_offset);
                 },
             )?;
         }
@@ -225,12 +229,16 @@ fn read_range(
         let mut key = key_prefix.to_vec();
         key.extend_from_slice(&chunk.to_be_bytes());
         if let Some(bytes) = db.get_cf(cf, &key)? {
-            result |= deserialize_bitmap(&bytes)?;
+            // Bitmaps store offsets relative to chunk_start; shift back to absolute block numbers.
+            let chunk_base = chunk as u32;
+            result |= deserialize_bitmap(&bytes)?
+                .into_iter()
+                .map(|offset| chunk_base + offset)
+                .collect::<RoaringBitmap>();
         }
         chunk += CHUNK_SIZE;
     }
 
-    // Mask to the requested range (block numbers fit in u32 given current chain sizes).
     result.remove_range(..range.start as u32);
     result.remove_range(range.end as u32..);
     Ok(result)
@@ -303,13 +311,14 @@ mod tests {
 
     /// Writes log index entries and coverage for `block_number` using the production functions.
     fn index_block(db: &RocksDB<RepositoryCF>, block_number: u64, logs: &[alloy::primitives::Log]) {
+        let chunk = chunk_start(block_number);
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
         index_logs(
             db,
             &mut cache,
-            block_number as u32,
-            chunk_start(block_number),
+            (block_number - chunk) as u32,
+            chunk,
             logs,
         )
         .unwrap();
@@ -383,7 +392,7 @@ mod tests {
 
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
-        deindex_logs(&db, &mut cache, 1u32, chunk_start(1), &[log]).unwrap();
+        deindex_logs(&db, &mut cache, 1u32 - chunk_start(1) as u32, chunk_start(1), &[log]).unwrap();
         cache.flush(&mut batch);
         rollback_coverage(&mut batch, &0u64.to_be_bytes());
         db.write(batch).unwrap();
@@ -485,11 +494,12 @@ mod tests {
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
         for block in 0u64..=2 {
+            let chunk = chunk_start(block);
             deindex_logs(
                 &db,
                 &mut cache,
-                block as u32,
-                chunk_start(block),
+                (block - chunk) as u32,
+                chunk,
                 &[make_log(addr, &[])],
             )
             .unwrap();

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -1,0 +1,454 @@
+use super::{RepositoryCF, RepositoryDb};
+use alloy::primitives::{Address, B256};
+use roaring::RoaringBitmap;
+use std::io::Cursor;
+use std::ops::Range;
+use zksync_os_rocksdb::RocksDB;
+use zksync_os_rocksdb::db::WriteBatch;
+use zksync_os_storage_api::{LogIndex, RepositoryError, RepositoryResult};
+
+/// Chunk size for log index bitmaps. Equals 2^16 = 65536, which aligns with roaring32's
+/// internal container boundary: all block numbers within a chunk share the same high 16 bits,
+/// so each chunk serializes to exactly one roaring container (max 8 KB).
+pub(super) const CHUNK_SIZE: u64 = 1 << 16;
+
+pub(super) fn chunk_start(block_number: u64) -> u64 {
+    // Round down to the nearest CHUNK_SIZE boundary (equivalent to
+    // `(block_number / CHUNK_SIZE) * CHUNK_SIZE` but without a division).
+    block_number & !(CHUNK_SIZE - 1)
+}
+
+pub(super) fn address_chunk_key(address: Address, chunk_start: u64) -> [u8; 28] {
+    let mut key = [0u8; 28];
+    key[..20].copy_from_slice(address.as_slice());
+    key[20..].copy_from_slice(&chunk_start.to_be_bytes());
+    key
+}
+
+pub(super) fn topic_chunk_key(topic: B256, chunk_start: u64) -> [u8; 40] {
+    let mut key = [0u8; 40];
+    key[..32].copy_from_slice(topic.as_slice());
+    key[32..].copy_from_slice(&chunk_start.to_be_bytes());
+    key
+}
+
+fn serialize_bitmap(bitmap: &RoaringBitmap) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(bitmap.serialized_size());
+    bitmap
+        .serialize_into(&mut buf)
+        .expect("Vec<u8> write cannot fail");
+    buf
+}
+
+fn deserialize_bitmap(bytes: &[u8]) -> Result<RoaringBitmap, RepositoryError> {
+    RoaringBitmap::deserialize_from(Cursor::new(bytes))
+        .map_err(|e| RepositoryError::BitmapDeserialize(e.to_string()))
+}
+
+/// Reads the bitmap for `key` from `cf`, sets `block_number`, writes back into `batch`.
+pub(super) fn update_chunk(
+    db: &RocksDB<RepositoryCF>,
+    batch: &mut WriteBatch<RepositoryCF>,
+    cf: RepositoryCF,
+    key: &[u8],
+    block_number: u32,
+) -> RepositoryResult<()> {
+    let mut bitmap = match db.get_cf(cf, key)? {
+        Some(bytes) => deserialize_bitmap(&bytes)?,
+        None => RoaringBitmap::new(),
+    };
+    bitmap.insert(block_number);
+    batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
+    Ok(())
+}
+
+/// Reads the bitmap for `key` from `cf`, removes `block_number`. Deletes the key if the
+/// bitmap becomes empty.
+pub(super) fn remove_from_chunk(
+    db: &RocksDB<RepositoryCF>,
+    batch: &mut WriteBatch<RepositoryCF>,
+    cf: RepositoryCF,
+    key: &[u8],
+    block_number: u32,
+) -> RepositoryResult<()> {
+    let Some(bytes) = db.get_cf(cf, key)? else {
+        return Ok(());
+    };
+    let mut bitmap = deserialize_bitmap(&bytes)?;
+    bitmap.remove(block_number);
+    if bitmap.is_empty() {
+        batch.delete_cf(cf, key);
+    } else {
+        batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
+    }
+    Ok(())
+}
+
+/// Updates the log index coverage metadata in `batch`.
+/// `log_index_started` indicates whether `log_index_first_block` is already set in the DB;
+/// if not, it is written now (it is only ever set once).
+pub(super) fn update_coverage(
+    batch: &mut WriteBatch<RepositoryCF>,
+    block_number_bytes: &[u8],
+    log_index_started: bool,
+) {
+    if !log_index_started {
+        batch.put_cf(
+            RepositoryCF::Meta,
+            RepositoryCF::log_index_first_block_key(),
+            block_number_bytes,
+        );
+    }
+    batch.put_cf(
+        RepositoryCF::Meta,
+        RepositoryCF::log_index_last_block_key(),
+        block_number_bytes,
+    );
+}
+
+/// Rolls back the log index last-block marker to `block_number_bytes`.
+pub(super) fn rollback_coverage(batch: &mut WriteBatch<RepositoryCF>, block_number_bytes: &[u8]) {
+    batch.put_cf(
+        RepositoryCF::Meta,
+        RepositoryCF::log_index_last_block_key(),
+        block_number_bytes,
+    );
+}
+
+/// Adds all logs from a single transaction to the log index write batch.
+pub(super) fn index_logs<'a>(
+    db: &RocksDB<RepositoryCF>,
+    batch: &mut WriteBatch<RepositoryCF>,
+    block_number: u32,
+    chunk: u64,
+    logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
+) -> RepositoryResult<()> {
+    for log in logs {
+        update_chunk(
+            db,
+            batch,
+            RepositoryCF::LogBlocksByAddress,
+            &address_chunk_key(log.address, chunk),
+            block_number,
+        )?;
+        for topic in log.topics() {
+            update_chunk(
+                db,
+                batch,
+                RepositoryCF::LogBlocksByTopic,
+                &topic_chunk_key(*topic, chunk),
+                block_number,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Removes all logs from a single transaction from the log index write batch.
+pub(super) fn deindex_logs<'a>(
+    db: &RocksDB<RepositoryCF>,
+    batch: &mut WriteBatch<RepositoryCF>,
+    block_number: u32,
+    chunk: u64,
+    logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
+) -> RepositoryResult<()> {
+    for log in logs {
+        remove_from_chunk(
+            db,
+            batch,
+            RepositoryCF::LogBlocksByAddress,
+            &address_chunk_key(log.address, chunk),
+            block_number,
+        )?;
+        for topic in log.topics() {
+            remove_from_chunk(
+                db,
+                batch,
+                RepositoryCF::LogBlocksByTopic,
+                &topic_chunk_key(*topic, chunk),
+                block_number,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Returns the index coverage as a half-open range, or `None` if the index is empty.
+fn coverage(db: &RocksDB<RepositoryCF>) -> RepositoryResult<Option<Range<u64>>> {
+    let first = db
+        .get_cf(
+            RepositoryCF::Meta,
+            RepositoryCF::log_index_first_block_key(),
+        )?
+        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
+    let last = db
+        .get_cf(RepositoryCF::Meta, RepositoryCF::log_index_last_block_key())?
+        .map(|v: Vec<u8>| u64::from_be_bytes(v.as_slice().try_into().unwrap()));
+    Ok(first.zip(last).map(|(f, l)| f..l + 1))
+}
+
+/// Reads all chunks overlapping `range` for `key_prefix` from `cf`, ORs them together,
+/// and masks to `range`.
+fn read_range(
+    db: &RocksDB<RepositoryCF>,
+    cf: RepositoryCF,
+    key_prefix: &[u8],
+    range: Range<u64>,
+) -> RepositoryResult<RoaringBitmap> {
+    let from_chunk = chunk_start(range.start);
+    let to_chunk = chunk_start(range.end.saturating_sub(1));
+
+    let mut result = RoaringBitmap::new();
+    let mut chunk = from_chunk;
+    while chunk <= to_chunk {
+        let mut key = key_prefix.to_vec();
+        key.extend_from_slice(&chunk.to_be_bytes());
+        if let Some(bytes) = db.get_cf(cf, &key)? {
+            result |= deserialize_bitmap(&bytes)?;
+        }
+        chunk += CHUNK_SIZE;
+    }
+
+    // Mask to the requested range (block numbers fit in u32 given current chain sizes).
+    result &= RoaringBitmap::from_iter(range.start as u32..range.end as u32);
+    Ok(result)
+}
+
+/// Intersects `range` with `coverage` and, if non-empty, reads the bitmap for `key_prefix`.
+pub(super) fn query(
+    db: &RocksDB<RepositoryCF>,
+    cf: RepositoryCF,
+    key_prefix: &[u8],
+    range: Range<u64>,
+) -> RepositoryResult<(RoaringBitmap, Range<u64>)> {
+    let Some(cov) = coverage(db)? else {
+        return Ok((RoaringBitmap::new(), 0..0));
+    };
+    let covered = range.start.max(cov.start)..range.end.min(cov.end);
+    if covered.is_empty() {
+        return Ok((RoaringBitmap::new(), 0..0));
+    }
+    let bitmap = read_range(db, cf, key_prefix, covered.clone())?;
+    Ok((bitmap, covered))
+}
+
+impl LogIndex for RepositoryDb {
+    fn blocks_for_address(
+        &self,
+        address: Address,
+        range: Range<u64>,
+    ) -> RepositoryResult<(RoaringBitmap, Range<u64>)> {
+        query(
+            &self.db,
+            RepositoryCF::LogBlocksByAddress,
+            address.as_slice(),
+            range,
+        )
+    }
+
+    fn blocks_for_topic(
+        &self,
+        topic: B256,
+        range: Range<u64>,
+    ) -> RepositoryResult<(RoaringBitmap, Range<u64>)> {
+        query(
+            &self.db,
+            RepositoryCF::LogBlocksByTopic,
+            topic.as_slice(),
+            range,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::LogData;
+    use tempfile::TempDir;
+
+    fn open_test_db() -> (RocksDB<RepositoryCF>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let db = RocksDB::<RepositoryCF>::new(dir.path()).unwrap();
+        (db, dir)
+    }
+
+    fn make_log(address: Address, topics: &[B256]) -> alloy::primitives::Log {
+        alloy::primitives::Log {
+            address,
+            data: LogData::new_unchecked(topics.to_vec(), Default::default()),
+        }
+    }
+
+    /// Writes log index entries and coverage for `block_number` using the production functions.
+    fn index_block(
+        db: &RocksDB<RepositoryCF>,
+        block_number: u64,
+        logs: &[alloy::primitives::Log],
+        log_index_started: bool,
+    ) {
+        let mut batch = db.new_write_batch();
+        index_logs(
+            db,
+            &mut batch,
+            block_number as u32,
+            chunk_start(block_number),
+            logs,
+        )
+        .unwrap();
+        update_coverage(&mut batch, &block_number.to_be_bytes(), log_index_started);
+        db.write(batch).unwrap();
+    }
+
+    #[test]
+    fn address_index_round_trip() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(0xAB);
+        let log = make_log(addr, &[]);
+
+        index_block(&db, 10, std::slice::from_ref(&log), false);
+        index_block(&db, 20, &[log], true);
+
+        let (bitmap, covered) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr.as_slice(),
+            0..100,
+        )
+        .unwrap();
+        assert_eq!(covered, 10..21);
+        assert!(bitmap.contains(10));
+        assert!(bitmap.contains(20));
+        assert!(!bitmap.contains(15));
+    }
+
+    #[test]
+    fn topic_index_round_trip() {
+        let (db, _dir) = open_test_db();
+        let topic = B256::repeat_byte(0x42);
+        let log = make_log(Address::ZERO, &[topic]);
+
+        index_block(&db, 5, &[log], false);
+
+        let (bitmap, covered) = query(
+            &db,
+            RepositoryCF::LogBlocksByTopic,
+            topic.as_slice(),
+            0..100,
+        )
+        .unwrap();
+        assert_eq!(covered, 5..6);
+        assert!(bitmap.contains(5));
+    }
+
+    #[test]
+    fn query_respects_requested_range() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(0x01);
+        let log = make_log(addr, &[]);
+
+        index_block(&db, 1, std::slice::from_ref(&log), false);
+        index_block(&db, 2, std::slice::from_ref(&log), true);
+        index_block(&db, 3, &[log], true);
+
+        // Request only blocks 2..=3 — block 1 must not appear.
+        let (bitmap, covered) =
+            query(&db, RepositoryCF::LogBlocksByAddress, addr.as_slice(), 2..4).unwrap();
+        assert_eq!(covered, 2..4);
+        assert!(!bitmap.contains(1));
+        assert!(bitmap.contains(2));
+        assert!(bitmap.contains(3));
+    }
+
+    #[test]
+    fn deindex_removes_block() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(0xCC);
+        let log = make_log(addr, &[]);
+
+        index_block(&db, 7, std::slice::from_ref(&log), false);
+        index_block(&db, 8, std::slice::from_ref(&log), true);
+
+        let mut batch = db.new_write_batch();
+        deindex_logs(&db, &mut batch, 8u32, chunk_start(8), &[log]).unwrap();
+        rollback_coverage(&mut batch, &7u64.to_be_bytes());
+        db.write(batch).unwrap();
+
+        let (bitmap, covered) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr.as_slice(),
+            0..100,
+        )
+        .unwrap();
+        assert_eq!(covered, 7..8);
+        assert!(bitmap.contains(7));
+        assert!(!bitmap.contains(8));
+    }
+
+    #[test]
+    fn no_index_returns_empty() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(0xFF);
+
+        let (bitmap, covered) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr.as_slice(),
+            0..1000,
+        )
+        .unwrap();
+        assert!(covered.is_empty());
+        assert!(bitmap.is_empty());
+    }
+
+    #[test]
+    fn different_addresses_do_not_interfere() {
+        let (db, _dir) = open_test_db();
+        let addr_a = Address::repeat_byte(0x0A);
+        let addr_b = Address::repeat_byte(0x0B);
+
+        index_block(&db, 10, &[make_log(addr_a, &[])], false);
+        index_block(&db, 11, &[make_log(addr_b, &[])], true);
+
+        let (bitmap_a, _) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr_a.as_slice(),
+            0..100,
+        )
+        .unwrap();
+        let (bitmap_b, _) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr_b.as_slice(),
+            0..100,
+        )
+        .unwrap();
+
+        assert!(bitmap_a.contains(10) && !bitmap_a.contains(11));
+        assert!(bitmap_b.contains(11) && !bitmap_b.contains(10));
+    }
+
+    #[test]
+    fn chunk_boundary_spanning_query() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(0x77);
+        let log = make_log(addr, &[]);
+
+        let last_in_chunk0 = CHUNK_SIZE - 1;
+        let first_in_chunk1 = CHUNK_SIZE;
+        index_block(&db, last_in_chunk0, std::slice::from_ref(&log), false);
+        index_block(&db, first_in_chunk1, &[log], true);
+
+        let (bitmap, covered) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr.as_slice(),
+            0..CHUNK_SIZE + 1,
+        )
+        .unwrap();
+        assert!(bitmap.contains(last_in_chunk0 as u32));
+        assert!(bitmap.contains(first_in_chunk1 as u32));
+        assert_eq!(covered, last_in_chunk0..first_in_chunk1 + 1);
+    }
+}

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -110,7 +110,11 @@ pub(super) fn update_coverage(
     block_number_bytes: &[u8],
 ) {
     let first_block_key = RepositoryCF::log_index_first_block_key();
-    if db.get_cf(RepositoryCF::Meta, first_block_key).unwrap().is_none() {
+    if db
+        .get_cf(RepositoryCF::Meta, first_block_key)
+        .unwrap()
+        .is_none()
+    {
         batch.put_cf(RepositoryCF::Meta, first_block_key, block_number_bytes);
     }
     batch.put_cf(
@@ -314,14 +318,7 @@ mod tests {
         let chunk = chunk_start(block_number);
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
-        index_logs(
-            db,
-            &mut cache,
-            (block_number - chunk) as u32,
-            chunk,
-            logs,
-        )
-        .unwrap();
+        index_logs(db, &mut cache, (block_number - chunk) as u32, chunk, logs).unwrap();
         cache.flush(&mut batch);
         update_coverage(db, &mut batch, &block_number.to_be_bytes());
         db.write(batch).unwrap();
@@ -392,7 +389,14 @@ mod tests {
 
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
-        deindex_logs(&db, &mut cache, 1u32 - chunk_start(1) as u32, chunk_start(1), &[log]).unwrap();
+        deindex_logs(
+            &db,
+            &mut cache,
+            1u32 - chunk_start(1) as u32,
+            chunk_start(1),
+            &[log],
+        )
+        .unwrap();
         cache.flush(&mut batch);
         rollback_coverage(&mut batch, &0u64.to_be_bytes());
         db.write(batch).unwrap();

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -256,6 +256,10 @@ fn read_range(
             .collect::<RoaringBitmap>();
     }
 
+    // Trim block numbers outside the requested range that leaked in from
+    // partially-overlapping boundary chunks. `remove_range` runs in
+    // O(containers removed) time rather than O(bits), so this is efficient
+    // even when the trimmed region is large.
     result.remove_range(..range.start as u32);
     result.remove_range(range.end as u32..);
     Ok(result)

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -48,42 +48,57 @@ fn deserialize_bitmap(bytes: &[u8]) -> Result<RoaringBitmap, RepositoryError> {
 
 /// In-memory cache of pending bitmap mutations for a single write batch.
 /// Reads fall through to the DB on first access; writes stay in the cache until
-/// `flush_bitmap_cache` copies them to the batch.  Using a cache means that
-/// multiple mutations to the same key within one batch compose correctly —
-/// without it, each read would see the pre-batch DB state and later writes
-/// would silently overwrite earlier ones.
-pub(super) type BitmapCache = HashMap<(RepositoryCF, Vec<u8>), RoaringBitmap>;
-
-fn with_chunk(
-    db: &RocksDB<RepositoryCF>,
-    cache: &mut BitmapCache,
-    cf: RepositoryCF,
-    key: &[u8],
-    f: impl FnOnce(&mut RoaringBitmap),
-) -> RepositoryResult<()> {
-    let cache_key = (cf, key.to_vec());
-    let bitmap = if let Some(bm) = cache.get_mut(&cache_key) {
-        bm
-    } else {
-        let bm = match db.get_cf(cf, key)? {
-            Some(bytes) => deserialize_bitmap(&bytes)?,
-            None => RoaringBitmap::new(),
-        };
-        cache.entry(cache_key).or_insert(bm)
-    };
-    f(bitmap);
-    Ok(())
+/// `flush` copies them to the batch.  Using a cache means that multiple mutations
+/// to the same key within one batch compose correctly — without it, each read
+/// would see the pre-batch DB state and later writes would silently overwrite
+/// earlier ones.
+#[derive(Default)]
+pub(super) struct BitmapCache {
+    by_address: HashMap<Vec<u8>, RoaringBitmap>,
+    by_topic: HashMap<Vec<u8>, RoaringBitmap>,
 }
 
-/// Writes all cached bitmap mutations to `batch`, consuming the cache.
-pub(super) fn flush_bitmap_cache(cache: BitmapCache, batch: &mut WriteBatch<RepositoryCF>) {
-    for ((cf, key), bitmap) in cache {
+impl BitmapCache {
+    /// Writes all cached bitmap mutations to `batch`, consuming the cache.
+    pub(super) fn flush(self, batch: &mut WriteBatch<RepositoryCF>) {
+        write_bitmaps_to_batch(self.by_address, RepositoryCF::LogBlocksByAddress, batch);
+        write_bitmaps_to_batch(self.by_topic, RepositoryCF::LogBlocksByTopic, batch);
+    }
+}
+
+fn write_bitmaps_to_batch(
+    bitmaps: HashMap<Vec<u8>, RoaringBitmap>,
+    cf: RepositoryCF,
+    batch: &mut WriteBatch<RepositoryCF>,
+) {
+    for (key, bitmap) in bitmaps {
         if bitmap.is_empty() {
             batch.delete_cf(cf, &key);
         } else {
             batch.put_cf(cf, &key, &serialize_bitmap(&bitmap));
         }
     }
+}
+
+/// Mutates the bitmap for `key` in `bitmaps`, loading it from `db` on first access.
+fn with_chunk(
+    db: &RocksDB<RepositoryCF>,
+    bitmaps: &mut HashMap<Vec<u8>, RoaringBitmap>,
+    cf: RepositoryCF,
+    key: &[u8],
+    f: impl FnOnce(&mut RoaringBitmap),
+) -> RepositoryResult<()> {
+    let bitmap = if let Some(bm) = bitmaps.get_mut(key) {
+        bm
+    } else {
+        let bm = match db.get_cf(cf, key)? {
+            Some(bytes) => deserialize_bitmap(&bytes)?,
+            None => RoaringBitmap::new(),
+        };
+        bitmaps.entry(key.to_vec()).or_insert(bm)
+    };
+    f(bitmap);
+    Ok(())
 }
 
 /// Updates the log index coverage metadata in `batch`.
@@ -128,7 +143,7 @@ pub(super) fn index_logs<'a>(
     for log in logs {
         with_chunk(
             db,
-            cache,
+            &mut cache.by_address,
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
             |bm| {
@@ -138,7 +153,7 @@ pub(super) fn index_logs<'a>(
         for topic in log.topics() {
             with_chunk(
                 db,
-                cache,
+                &mut cache.by_topic,
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
                 |bm| {
@@ -161,7 +176,7 @@ pub(super) fn deindex_logs<'a>(
     for log in logs {
         with_chunk(
             db,
-            cache,
+            &mut cache.by_address,
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
             |bm| {
@@ -171,7 +186,7 @@ pub(super) fn deindex_logs<'a>(
         for topic in log.topics() {
             with_chunk(
                 db,
-                cache,
+                &mut cache.by_topic,
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
                 |bm| {
@@ -296,7 +311,7 @@ mod tests {
         log_index_started: bool,
     ) {
         let mut batch = db.new_write_batch();
-        let mut cache = BitmapCache::new();
+        let mut cache = BitmapCache::default();
         index_logs(
             db,
             &mut cache,
@@ -305,7 +320,7 @@ mod tests {
             logs,
         )
         .unwrap();
-        flush_bitmap_cache(cache, &mut batch);
+        cache.flush(&mut batch);
         update_coverage(&mut batch, &block_number.to_be_bytes(), log_index_started);
         db.write(batch).unwrap();
     }
@@ -374,9 +389,9 @@ mod tests {
         index_block(&db, 1, std::slice::from_ref(&log), true);
 
         let mut batch = db.new_write_batch();
-        let mut cache = BitmapCache::new();
+        let mut cache = BitmapCache::default();
         deindex_logs(&db, &mut cache, 1u32, chunk_start(1), &[log]).unwrap();
-        flush_bitmap_cache(cache, &mut batch);
+        cache.flush(&mut batch);
         rollback_coverage(&mut batch, &0u64.to_be_bytes());
         db.write(batch).unwrap();
 
@@ -475,7 +490,7 @@ mod tests {
 
         // Roll back blocks 0, 1, 2 in one batch.
         let mut batch = db.new_write_batch();
-        let mut cache = BitmapCache::new();
+        let mut cache = BitmapCache::default();
         for block in 0u64..=2 {
             deindex_logs(
                 &db,
@@ -486,7 +501,7 @@ mod tests {
             )
             .unwrap();
         }
-        flush_bitmap_cache(cache, &mut batch);
+        cache.flush(&mut batch);
         db.write(batch).unwrap();
 
         let (bitmap, _) = query(

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -218,6 +218,10 @@ fn coverage(db: &RocksDB<RepositoryCF>) -> RepositoryResult<Option<Range<u64>>> 
 
 /// Reads all chunks overlapping `range` for `key_prefix` from `cf`, ORs them together,
 /// and masks to `range`.
+///
+/// Uses `range_iterator_cf` so that RocksDB can exploit per-prefix bloom filters
+/// (configured via `prefix_extractor_len`) to skip SST files that contain no chunks for
+/// this address or topic — useful when the queried address/topic is sparse.
 fn read_range(
     db: &RocksDB<RepositoryCF>,
     cf: RepositoryCF,
@@ -225,22 +229,29 @@ fn read_range(
     range: Range<u64>,
 ) -> RepositoryResult<RoaringBitmap> {
     let from_chunk = chunk_start(range.start);
-    let to_chunk = chunk_start(range.end.saturating_sub(1));
+    // Upper bound: first key that is lexicographically past the last chunk we need.
+    // chunk_start(range.end - 1) + CHUNK_SIZE is the chunk *after* the last relevant one,
+    // and since chunk bytes are the suffix, appending 0xFF..FF would also work, but an
+    // exact chunk key is cleaner and keeps us within the same prefix.
+    let to_chunk_exclusive = chunk_start(range.end.saturating_sub(1)) + CHUNK_SIZE;
+
+    let mut from_key = key_prefix.to_vec();
+    from_key.extend_from_slice(&from_chunk.to_be_bytes());
+    let mut to_key = key_prefix.to_vec();
+    to_key.extend_from_slice(&to_chunk_exclusive.to_be_bytes());
 
     let mut result = RoaringBitmap::new();
-    let mut chunk = from_chunk;
-    while chunk <= to_chunk {
-        let mut key = key_prefix.to_vec();
-        key.extend_from_slice(&chunk.to_be_bytes());
-        if let Some(bytes) = db.get_cf(cf, &key)? {
-            // Bitmaps store offsets relative to chunk_start; shift back to absolute block numbers.
-            let chunk_base = chunk as u32;
-            result |= deserialize_bitmap(&bytes)?
-                .into_iter()
-                .map(|offset| chunk_base + offset)
-                .collect::<RoaringBitmap>();
-        }
-        chunk += CHUNK_SIZE;
+    for (key, value) in db.range_iterator_cf(cf, &from_key, to_key) {
+        // Bitmaps store offsets relative to chunk_start; we need to recover the chunk base
+        // from the key suffix to shift offsets back to absolute block numbers.
+        let chunk_bytes: [u8; 8] = key[key_prefix.len()..]
+            .try_into()
+            .expect("chunk key suffix must be 8 bytes");
+        let chunk_base = u64::from_be_bytes(chunk_bytes) as u32;
+        result |= deserialize_bitmap(&value)?
+            .into_iter()
+            .map(|offset| chunk_base + offset)
+            .collect::<RoaringBitmap>();
     }
 
     result.remove_range(..range.start as u32);

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -1,6 +1,7 @@
 use super::{RepositoryCF, RepositoryDb};
 use alloy::primitives::{Address, B256};
 use roaring::RoaringBitmap;
+use std::collections::HashMap;
 use std::io::Cursor;
 use std::ops::Range;
 use zksync_os_rocksdb::RocksDB;
@@ -45,50 +46,44 @@ fn deserialize_bitmap(bytes: &[u8]) -> Result<RoaringBitmap, RepositoryError> {
         .map_err(|e| RepositoryError::BitmapDeserialize(e.to_string()))
 }
 
-/// Reads the bitmap for `key` from `cf`, applies `f` to it, then writes it back into `batch`
-/// (or deletes the key if the bitmap becomes empty after the mutation).
+/// In-memory cache of pending bitmap mutations for a single write batch.
+/// Reads fall through to the DB on first access; writes stay in the cache until
+/// `flush_bitmap_cache` copies them to the batch.  Using a cache means that
+/// multiple mutations to the same key within one batch compose correctly —
+/// without it, each read would see the pre-batch DB state and later writes
+/// would silently overwrite earlier ones.
+pub(super) type BitmapCache = HashMap<(RepositoryCF, Vec<u8>), RoaringBitmap>;
+
 fn with_chunk(
     db: &RocksDB<RepositoryCF>,
-    batch: &mut WriteBatch<RepositoryCF>,
+    cache: &mut BitmapCache,
     cf: RepositoryCF,
     key: &[u8],
     f: impl FnOnce(&mut RoaringBitmap),
 ) -> RepositoryResult<()> {
-    let mut bitmap = match db.get_cf(cf, key)? {
-        Some(bytes) => deserialize_bitmap(&bytes)?,
-        None => RoaringBitmap::new(),
-    };
-    f(&mut bitmap);
-    if bitmap.is_empty() {
-        batch.delete_cf(cf, key);
+    let cache_key = (cf, key.to_vec());
+    let bitmap = if let Some(bm) = cache.get_mut(&cache_key) {
+        bm
     } else {
-        batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
-    }
+        let bm = match db.get_cf(cf, key)? {
+            Some(bytes) => deserialize_bitmap(&bytes)?,
+            None => RoaringBitmap::new(),
+        };
+        cache.entry(cache_key).or_insert(bm)
+    };
+    f(bitmap);
     Ok(())
 }
 
-pub(super) fn insert_into_chunk(
-    db: &RocksDB<RepositoryCF>,
-    batch: &mut WriteBatch<RepositoryCF>,
-    cf: RepositoryCF,
-    key: &[u8],
-    block_number: u32,
-) -> RepositoryResult<()> {
-    with_chunk(db, batch, cf, key, |bitmap| {
-        bitmap.insert(block_number);
-    })
-}
-
-pub(super) fn remove_from_chunk(
-    db: &RocksDB<RepositoryCF>,
-    batch: &mut WriteBatch<RepositoryCF>,
-    cf: RepositoryCF,
-    key: &[u8],
-    block_number: u32,
-) -> RepositoryResult<()> {
-    with_chunk(db, batch, cf, key, |bitmap| {
-        bitmap.remove(block_number);
-    })
+/// Writes all cached bitmap mutations to `batch`, consuming the cache.
+pub(super) fn flush_bitmap_cache(cache: BitmapCache, batch: &mut WriteBatch<RepositoryCF>) {
+    for ((cf, key), bitmap) in cache {
+        if bitmap.is_empty() {
+            batch.delete_cf(cf, &key);
+        } else {
+            batch.put_cf(cf, &key, &serialize_bitmap(&bitmap));
+        }
+    }
 }
 
 /// Updates the log index coverage metadata in `batch`.
@@ -122,58 +117,66 @@ pub(super) fn rollback_coverage(batch: &mut WriteBatch<RepositoryCF>, block_numb
     );
 }
 
-/// Adds all logs from a single transaction to the log index write batch.
+/// Adds all logs from a single transaction to the bitmap cache.
 pub(super) fn index_logs<'a>(
     db: &RocksDB<RepositoryCF>,
-    batch: &mut WriteBatch<RepositoryCF>,
+    cache: &mut BitmapCache,
     block_number: u32,
     chunk: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
     for log in logs {
-        insert_into_chunk(
+        with_chunk(
             db,
-            batch,
+            cache,
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
-            block_number,
+            |bm| {
+                bm.insert(block_number);
+            },
         )?;
         for topic in log.topics() {
-            insert_into_chunk(
+            with_chunk(
                 db,
-                batch,
+                cache,
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
-                block_number,
+                |bm| {
+                    bm.insert(block_number);
+                },
             )?;
         }
     }
     Ok(())
 }
 
-/// Removes all logs from a single transaction from the log index write batch.
+/// Removes all logs from a single transaction from the bitmap cache.
 pub(super) fn deindex_logs<'a>(
     db: &RocksDB<RepositoryCF>,
-    batch: &mut WriteBatch<RepositoryCF>,
+    cache: &mut BitmapCache,
     block_number: u32,
     chunk: u64,
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
     for log in logs {
-        remove_from_chunk(
+        with_chunk(
             db,
-            batch,
+            cache,
             RepositoryCF::LogBlocksByAddress,
             &address_chunk_key(log.address, chunk),
-            block_number,
+            |bm| {
+                bm.remove(block_number);
+            },
         )?;
         for topic in log.topics() {
-            remove_from_chunk(
+            with_chunk(
                 db,
-                batch,
+                cache,
                 RepositoryCF::LogBlocksByTopic,
                 &topic_chunk_key(*topic, chunk),
-                block_number,
+                |bm| {
+                    bm.remove(block_number);
+                },
             )?;
         }
     }
@@ -293,14 +296,16 @@ mod tests {
         log_index_started: bool,
     ) {
         let mut batch = db.new_write_batch();
+        let mut cache = BitmapCache::new();
         index_logs(
             db,
-            &mut batch,
+            &mut cache,
             block_number as u32,
             chunk_start(block_number),
             logs,
         )
         .unwrap();
+        flush_bitmap_cache(cache, &mut batch);
         update_coverage(&mut batch, &block_number.to_be_bytes(), log_index_started);
         db.write(batch).unwrap();
     }
@@ -308,99 +313,95 @@ mod tests {
     #[test]
     fn address_index_round_trip() {
         let (db, _dir) = open_test_db();
-        let addr = Address::repeat_byte(0xAB);
+        let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 10, std::slice::from_ref(&log), false);
-        index_block(&db, 20, &[log], true);
+        index_block(&db, 0, std::slice::from_ref(&log), false);
+        index_block(&db, 1, &[log], true);
 
         let (bitmap, covered) = query(
             &db,
             RepositoryCF::LogBlocksByAddress,
             addr.as_slice(),
-            0..100,
+            0..10,
         )
         .unwrap();
-        assert_eq!(covered, 10..21);
-        assert!(bitmap.contains(10));
-        assert!(bitmap.contains(20));
-        assert!(!bitmap.contains(15));
+        assert_eq!(covered, 0..2);
+        assert!(bitmap.contains(0));
+        assert!(bitmap.contains(1));
     }
 
     #[test]
     fn topic_index_round_trip() {
         let (db, _dir) = open_test_db();
-        let topic = B256::repeat_byte(0x42);
+        let topic = B256::repeat_byte(1);
         let log = make_log(Address::ZERO, &[topic]);
 
-        index_block(&db, 5, &[log], false);
+        index_block(&db, 0, &[log], false);
 
-        let (bitmap, covered) = query(
-            &db,
-            RepositoryCF::LogBlocksByTopic,
-            topic.as_slice(),
-            0..100,
-        )
-        .unwrap();
-        assert_eq!(covered, 5..6);
-        assert!(bitmap.contains(5));
+        let (bitmap, covered) =
+            query(&db, RepositoryCF::LogBlocksByTopic, topic.as_slice(), 0..10).unwrap();
+        assert_eq!(covered, 0..1);
+        assert!(bitmap.contains(0));
     }
 
     #[test]
     fn query_respects_requested_range() {
         let (db, _dir) = open_test_db();
-        let addr = Address::repeat_byte(0x01);
+        let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 1, std::slice::from_ref(&log), false);
-        index_block(&db, 2, std::slice::from_ref(&log), true);
-        index_block(&db, 3, &[log], true);
+        index_block(&db, 0, std::slice::from_ref(&log), false);
+        index_block(&db, 1, std::slice::from_ref(&log), true);
+        index_block(&db, 2, &[log], true);
 
-        // Request only blocks 2..=3 — block 1 must not appear.
+        // Request only blocks 1..=2 — block 0 must not appear.
         let (bitmap, covered) =
-            query(&db, RepositoryCF::LogBlocksByAddress, addr.as_slice(), 2..4).unwrap();
-        assert_eq!(covered, 2..4);
-        assert!(!bitmap.contains(1));
+            query(&db, RepositoryCF::LogBlocksByAddress, addr.as_slice(), 1..3).unwrap();
+        assert_eq!(covered, 1..3);
+        assert!(!bitmap.contains(0));
+        assert!(bitmap.contains(1));
         assert!(bitmap.contains(2));
-        assert!(bitmap.contains(3));
     }
 
     #[test]
     fn deindex_removes_block() {
         let (db, _dir) = open_test_db();
-        let addr = Address::repeat_byte(0xCC);
+        let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 7, std::slice::from_ref(&log), false);
-        index_block(&db, 8, std::slice::from_ref(&log), true);
+        index_block(&db, 0, std::slice::from_ref(&log), false);
+        index_block(&db, 1, std::slice::from_ref(&log), true);
 
         let mut batch = db.new_write_batch();
-        deindex_logs(&db, &mut batch, 8u32, chunk_start(8), &[log]).unwrap();
-        rollback_coverage(&mut batch, &7u64.to_be_bytes());
+        let mut cache = BitmapCache::new();
+        deindex_logs(&db, &mut cache, 1u32, chunk_start(1), &[log]).unwrap();
+        flush_bitmap_cache(cache, &mut batch);
+        rollback_coverage(&mut batch, &0u64.to_be_bytes());
         db.write(batch).unwrap();
 
         let (bitmap, covered) = query(
             &db,
             RepositoryCF::LogBlocksByAddress,
             addr.as_slice(),
-            0..100,
+            0..10,
         )
         .unwrap();
-        assert_eq!(covered, 7..8);
-        assert!(bitmap.contains(7));
-        assert!(!bitmap.contains(8));
+        assert_eq!(covered, 0..1);
+        assert!(bitmap.contains(0));
+        assert!(!bitmap.contains(1));
     }
 
     #[test]
     fn no_index_returns_empty() {
         let (db, _dir) = open_test_db();
-        let addr = Address::repeat_byte(0xFF);
+        let addr = Address::repeat_byte(1);
 
         let (bitmap, covered) = query(
             &db,
             RepositoryCF::LogBlocksByAddress,
             addr.as_slice(),
-            0..1000,
+            0..10,
         )
         .unwrap();
         assert!(covered.is_empty());
@@ -410,35 +411,35 @@ mod tests {
     #[test]
     fn different_addresses_do_not_interfere() {
         let (db, _dir) = open_test_db();
-        let addr_a = Address::repeat_byte(0x0A);
-        let addr_b = Address::repeat_byte(0x0B);
+        let addr_a = Address::repeat_byte(1);
+        let addr_b = Address::repeat_byte(2);
 
-        index_block(&db, 10, &[make_log(addr_a, &[])], false);
-        index_block(&db, 11, &[make_log(addr_b, &[])], true);
+        index_block(&db, 0, &[make_log(addr_a, &[])], false);
+        index_block(&db, 1, &[make_log(addr_b, &[])], true);
 
         let (bitmap_a, _) = query(
             &db,
             RepositoryCF::LogBlocksByAddress,
             addr_a.as_slice(),
-            0..100,
+            0..10,
         )
         .unwrap();
         let (bitmap_b, _) = query(
             &db,
             RepositoryCF::LogBlocksByAddress,
             addr_b.as_slice(),
-            0..100,
+            0..10,
         )
         .unwrap();
 
-        assert!(bitmap_a.contains(10) && !bitmap_a.contains(11));
-        assert!(bitmap_b.contains(11) && !bitmap_b.contains(10));
+        assert!(bitmap_a.contains(0) && !bitmap_a.contains(1));
+        assert!(bitmap_b.contains(1) && !bitmap_b.contains(0));
     }
 
     #[test]
     fn chunk_boundary_spanning_query() {
         let (db, _dir) = open_test_db();
-        let addr = Address::repeat_byte(0x77);
+        let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
         let last_in_chunk0 = CHUNK_SIZE - 1;
@@ -456,5 +457,48 @@ mod tests {
         assert!(bitmap.contains(last_in_chunk0 as u32));
         assert!(bitmap.contains(first_in_chunk1 as u32));
         assert_eq!(covered, last_in_chunk0..first_in_chunk1 + 1);
+    }
+
+    /// Regression test: rolling back multiple consecutive blocks that all emitted logs for the
+    /// same address must remove *all* of them, not just the last one.
+    ///
+    /// The old `deindex_logs` read bitmaps directly from the DB on every call, so within one
+    /// write batch the last call silently overwrote the earlier ones, leaving stale entries.
+    #[test]
+    fn multi_block_rollback_removes_all_blocks() {
+        let (db, _dir) = open_test_db();
+        let addr = Address::repeat_byte(1);
+
+        index_block(&db, 0, &[make_log(addr, &[])], false);
+        index_block(&db, 1, &[make_log(addr, &[])], true);
+        index_block(&db, 2, &[make_log(addr, &[])], true);
+
+        // Roll back blocks 0, 1, 2 in one batch.
+        let mut batch = db.new_write_batch();
+        let mut cache = BitmapCache::new();
+        for block in 0u64..=2 {
+            deindex_logs(
+                &db,
+                &mut cache,
+                block as u32,
+                chunk_start(block),
+                &[make_log(addr, &[])],
+            )
+            .unwrap();
+        }
+        flush_bitmap_cache(cache, &mut batch);
+        db.write(batch).unwrap();
+
+        let (bitmap, _) = query(
+            &db,
+            RepositoryCF::LogBlocksByAddress,
+            addr.as_slice(),
+            0..10,
+        )
+        .unwrap();
+        assert!(
+            bitmap.is_empty(),
+            "expected empty bitmap after multi-block rollback, got {bitmap:?}"
+        );
     }
 }

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -102,19 +102,16 @@ fn with_chunk(
 }
 
 /// Updates the log index coverage metadata in `batch`.
-/// `log_index_started` indicates whether `log_index_first_block` is already set in the DB;
-/// if not, it is written now (it is only ever set once).
+/// Writes `log_index_first_block` if it is not already present in the DB
+/// (it is only ever set once); always updates `log_index_last_block`.
 pub(super) fn update_coverage(
+    db: &RocksDB<RepositoryCF>,
     batch: &mut WriteBatch<RepositoryCF>,
     block_number_bytes: &[u8],
-    log_index_started: bool,
 ) {
-    if !log_index_started {
-        batch.put_cf(
-            RepositoryCF::Meta,
-            RepositoryCF::log_index_first_block_key(),
-            block_number_bytes,
-        );
+    let first_block_key = RepositoryCF::log_index_first_block_key();
+    if db.get_cf(RepositoryCF::Meta, first_block_key).unwrap().is_none() {
+        batch.put_cf(RepositoryCF::Meta, first_block_key, block_number_bytes);
     }
     batch.put_cf(
         RepositoryCF::Meta,
@@ -305,12 +302,7 @@ mod tests {
     }
 
     /// Writes log index entries and coverage for `block_number` using the production functions.
-    fn index_block(
-        db: &RocksDB<RepositoryCF>,
-        block_number: u64,
-        logs: &[alloy::primitives::Log],
-        log_index_started: bool,
-    ) {
+    fn index_block(db: &RocksDB<RepositoryCF>, block_number: u64, logs: &[alloy::primitives::Log]) {
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
         index_logs(
@@ -322,7 +314,7 @@ mod tests {
         )
         .unwrap();
         cache.flush(&mut batch);
-        update_coverage(&mut batch, &block_number.to_be_bytes(), log_index_started);
+        update_coverage(db, &mut batch, &block_number.to_be_bytes());
         db.write(batch).unwrap();
     }
 
@@ -332,8 +324,8 @@ mod tests {
         let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 0, std::slice::from_ref(&log), false);
-        index_block(&db, 1, &[log], true);
+        index_block(&db, 0, std::slice::from_ref(&log));
+        index_block(&db, 1, &[log]);
 
         let (bitmap, covered) = query(
             &db,
@@ -353,7 +345,7 @@ mod tests {
         let topic = B256::repeat_byte(1);
         let log = make_log(Address::ZERO, &[topic]);
 
-        index_block(&db, 0, &[log], false);
+        index_block(&db, 0, &[log]);
 
         let (bitmap, covered) =
             query(&db, RepositoryCF::LogBlocksByTopic, topic.as_slice(), 0..10).unwrap();
@@ -367,9 +359,9 @@ mod tests {
         let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 0, std::slice::from_ref(&log), false);
-        index_block(&db, 1, std::slice::from_ref(&log), true);
-        index_block(&db, 2, &[log], true);
+        index_block(&db, 0, std::slice::from_ref(&log));
+        index_block(&db, 1, std::slice::from_ref(&log));
+        index_block(&db, 2, &[log]);
 
         // Request only blocks 1..=2 — block 0 must not appear.
         let (bitmap, covered) =
@@ -386,8 +378,8 @@ mod tests {
         let addr = Address::repeat_byte(1);
         let log = make_log(addr, &[]);
 
-        index_block(&db, 0, std::slice::from_ref(&log), false);
-        index_block(&db, 1, std::slice::from_ref(&log), true);
+        index_block(&db, 0, std::slice::from_ref(&log));
+        index_block(&db, 1, std::slice::from_ref(&log));
 
         let mut batch = db.new_write_batch();
         let mut cache = BitmapCache::default();
@@ -430,8 +422,8 @@ mod tests {
         let addr_a = Address::repeat_byte(1);
         let addr_b = Address::repeat_byte(2);
 
-        index_block(&db, 0, &[make_log(addr_a, &[])], false);
-        index_block(&db, 1, &[make_log(addr_b, &[])], true);
+        index_block(&db, 0, &[make_log(addr_a, &[])]);
+        index_block(&db, 1, &[make_log(addr_b, &[])]);
 
         let (bitmap_a, _) = query(
             &db,
@@ -460,8 +452,8 @@ mod tests {
 
         let last_in_chunk0 = CHUNK_SIZE - 1;
         let first_in_chunk1 = CHUNK_SIZE;
-        index_block(&db, last_in_chunk0, std::slice::from_ref(&log), false);
-        index_block(&db, first_in_chunk1, &[log], true);
+        index_block(&db, last_in_chunk0, std::slice::from_ref(&log));
+        index_block(&db, first_in_chunk1, &[log]);
 
         let (bitmap, covered) = query(
             &db,
@@ -485,9 +477,9 @@ mod tests {
         let (db, _dir) = open_test_db();
         let addr = Address::repeat_byte(1);
 
-        index_block(&db, 0, &[make_log(addr, &[])], false);
-        index_block(&db, 1, &[make_log(addr, &[])], true);
-        index_block(&db, 2, &[make_log(addr, &[])], true);
+        index_block(&db, 0, &[make_log(addr, &[])]);
+        index_block(&db, 1, &[make_log(addr, &[])]);
+        index_block(&db, 2, &[make_log(addr, &[])]);
 
         // Roll back blocks 0, 1, 2 in one batch.
         let mut batch = db.new_write_batch();

--- a/lib/storage/src/db/repository/log_index.rs
+++ b/lib/storage/src/db/repository/log_index.rs
@@ -45,25 +45,40 @@ fn deserialize_bitmap(bytes: &[u8]) -> Result<RoaringBitmap, RepositoryError> {
         .map_err(|e| RepositoryError::BitmapDeserialize(e.to_string()))
 }
 
-/// Reads the bitmap for `key` from `cf`, sets `block_number`, writes back into `batch`.
-pub(super) fn update_chunk(
+/// Reads the bitmap for `key` from `cf`, applies `f` to it, then writes it back into `batch`
+/// (or deletes the key if the bitmap becomes empty after the mutation).
+fn with_chunk(
+    db: &RocksDB<RepositoryCF>,
+    batch: &mut WriteBatch<RepositoryCF>,
+    cf: RepositoryCF,
+    key: &[u8],
+    f: impl FnOnce(&mut RoaringBitmap),
+) -> RepositoryResult<()> {
+    let mut bitmap = match db.get_cf(cf, key)? {
+        Some(bytes) => deserialize_bitmap(&bytes)?,
+        None => RoaringBitmap::new(),
+    };
+    f(&mut bitmap);
+    if bitmap.is_empty() {
+        batch.delete_cf(cf, key);
+    } else {
+        batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
+    }
+    Ok(())
+}
+
+pub(super) fn insert_into_chunk(
     db: &RocksDB<RepositoryCF>,
     batch: &mut WriteBatch<RepositoryCF>,
     cf: RepositoryCF,
     key: &[u8],
     block_number: u32,
 ) -> RepositoryResult<()> {
-    let mut bitmap = match db.get_cf(cf, key)? {
-        Some(bytes) => deserialize_bitmap(&bytes)?,
-        None => RoaringBitmap::new(),
-    };
-    bitmap.insert(block_number);
-    batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
-    Ok(())
+    with_chunk(db, batch, cf, key, |bitmap| {
+        bitmap.insert(block_number);
+    })
 }
 
-/// Reads the bitmap for `key` from `cf`, removes `block_number`. Deletes the key if the
-/// bitmap becomes empty.
 pub(super) fn remove_from_chunk(
     db: &RocksDB<RepositoryCF>,
     batch: &mut WriteBatch<RepositoryCF>,
@@ -71,17 +86,9 @@ pub(super) fn remove_from_chunk(
     key: &[u8],
     block_number: u32,
 ) -> RepositoryResult<()> {
-    let Some(bytes) = db.get_cf(cf, key)? else {
-        return Ok(());
-    };
-    let mut bitmap = deserialize_bitmap(&bytes)?;
-    bitmap.remove(block_number);
-    if bitmap.is_empty() {
-        batch.delete_cf(cf, key);
-    } else {
-        batch.put_cf(cf, key, &serialize_bitmap(&bitmap));
-    }
-    Ok(())
+    with_chunk(db, batch, cf, key, |bitmap| {
+        bitmap.remove(block_number);
+    })
 }
 
 /// Updates the log index coverage metadata in `batch`.
@@ -124,7 +131,7 @@ pub(super) fn index_logs<'a>(
     logs: impl IntoIterator<Item = &'a alloy::primitives::Log>,
 ) -> RepositoryResult<()> {
     for log in logs {
-        update_chunk(
+        insert_into_chunk(
             db,
             batch,
             RepositoryCF::LogBlocksByAddress,
@@ -132,7 +139,7 @@ pub(super) fn index_logs<'a>(
             block_number,
         )?;
         for topic in log.topics() {
-            update_chunk(
+            insert_into_chunk(
                 db,
                 batch,
                 RepositoryCF::LogBlocksByTopic,

--- a/lib/storage_api/src/repository.rs
+++ b/lib/storage_api/src/repository.rs
@@ -102,6 +102,4 @@ pub enum RepositoryError {
     Eip2718(#[from] alloy::eips::eip2718::Eip2718Error),
     #[error(transparent)]
     Rlp(#[from] alloy::rlp::Error),
-    #[error("failed to deserialize log index bitmap: {0}")]
-    BitmapDeserialize(String),
 }


### PR DESCRIPTION
Second in the `eth_getLogs` index series ([#1156](https://github.com/matter-labs/zksync-os-server/pull/1156) added the trait). This PR builds and maintains the actual index — the next PR wires it into `scan_logs`.

## The problem

`eth_getLogs` currently does an O(block_range) bloom scan: every block is fetched from RocksDB and its bloom filter checked. A 10k-block range with a busy contract takes ~1.5s. With an address constraint, most of those blocks are irrelevant but we have no way to skip them.

## What this adds

A roaring-bitmap inverted index in two new RocksDB column families:
- `LogBlocksByAddress` — key: `address[20] ++ chunk_start[8]`, value: bitmap of block numbers
- `LogBlocksByTopic` — key: `topic[32] ++ chunk_start[8]`, value: bitmap of block numbers

**Chunk size is 2^16 = 65536 blocks.** This aligns with roaring32's internal container boundary: all block numbers within a chunk share the same high 16 bits, so each chunk serializes to exactly one roaring container (≤8 KB). A query spanning N chunks reads and ORs N keys.

**Write path** (`write_block`): for each transaction receipt, every log's address and topics are added to the relevant chunk bitmap in the same RocksDB write batch as the block data — so the index is always consistent with block storage.

**Rollback path** (`rollback`): iterates blocks being rolled back, removes each log from its chunk bitmap (deleting the key if the bitmap becomes empty), and rolls back the `log_index_last_block` coverage marker.

**Coverage metadata** (`log_index_first_block` / `log_index_last_block` in the `Meta` CF): tracks which block range is indexed. `first_block` is written once on the first indexed block and never changes; `last_block` is updated on every write and rollback. Callers intersect their query range with coverage and fall back to bloom scan for any uncovered prefix.

## Reviewing guide

All the interesting logic is in `lib/storage/src/db/repository/log_index.rs` (~510 lines). Start there. `repository.rs` changes are mechanical plumbing (new CFs, passing `log_index_started` flag, calling into the submodule).

The 8 unit tests at the bottom of `log_index.rs` each cover one specific property — read them alongside the functions they exercise:

| Test | What it pins down |
|---|---|
| `address_index_round_trip` | basic write → query |
| `topic_index_round_trip` | same for topic CF |
| `query_respects_requested_range` | result is clipped to requested range, not full coverage |
| `deindex_removes_block` | rollback correctly removes from bitmap and updates coverage |
| `multi_block_rollback_removes_all_blocks` | rolling back multiple blocks in one batch removes all of them (regression) |
| `no_index_returns_empty` | empty DB returns empty bitmap + empty range |
| `different_addresses_do_not_interfere` | address prefix correctly isolates entries |
| `chunk_boundary_spanning_query` | multi-chunk queries OR bitmaps correctly |

See the [testing notes comment](https://github.com/matter-labs/zksync-os-server/pull/1158#issuecomment-4214119226) for E2E test results, the rollback bug found, and the `WriteBatchWithIndex` alternative that was considered and rejected.

## Overhead

**Storage:** ~5 bytes per log per block (roaring bitmap amortized). At genlayer's current density (~3.3 KB/block): <0.2% overhead. At Ethereum mainnet density: ~1.5% overhead.

**Write path:** same number of `db.write(batch)` calls (1 per block). The batch gains 1 write per unique `(address, chunk)` and `(topic, chunk)` pair. Each unique key also requires one DB read (to load the existing bitmap into `BitmapCache`) — worth watching `persist_block` latency after deployment.

## Next PR

PR 3 adds `index_candidates()` to `scan_logs` — uses the bitmap to skip blocks outside the result set, with bloom fallback for the uncovered prefix. Also adds Roman's shadow-mode comparison to validate correctness against the existing bloom scan before cutting over.

Design doc: https://www.notion.so/335a48363f23810e9755cd8028b76973