### PR TITLE
feat: async batch provider init

### DIFF
--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -121,6 +121,12 @@ impl CommittedBatchProvider {
         }
     }
 
+    /// Returns `DiscoveredCommittedBatch` from in-memory map if available.
+    pub fn get(&self, batch_number: u64) -> Option<DiscoveredCommittedBatch> {
+        let inner = self.inner.read().expect("lock poisoned");
+        inner.batches.get(&batch_number).cloned()
+    }
+
     /// Fetches a batch set with bounded concurrency to reduce startup latency without issuing an
     /// unbounded number of L1 requests.
     async fn load_batch_numbers(

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -4,7 +4,7 @@ use alloy::providers::DynProvider;
 use anyhow::Context;
 use futures::stream::{self, StreamExt};
 use rangemap::RangeInclusiveMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::time::sleep;
@@ -73,21 +73,25 @@ impl CommittedBatchProvider {
     /// soon as possible. The remaining committed batches are fetched afterwards, with bounded
     /// parallelism.
     pub async fn init(&self, l1_state: &L1State, max_l1_blocks_to_scan: u64) -> anyhow::Result<()> {
-        self.load_batches_in_background(
+        let (prioritized_batch_numbers, remaining_batch_numbers) = startup_batch_numbers(
+            l1_state.last_committed_batch,
+            l1_state.last_proved_batch,
+            l1_state.last_executed_batch,
+        );
+
+        self.load_batch_numbers(
             l1_state.diamond_proxy_sl.clone(),
             max_l1_blocks_to_scan,
-            startup_priority_batch_numbers(
-                l1_state.last_committed_batch,
-                l1_state.last_proved_batch,
-                l1_state.last_executed_batch,
-            ),
-            startup_remaining_batch_numbers(
-                l1_state.last_committed_batch,
-                l1_state.last_proved_batch,
-                l1_state.last_executed_batch,
-            ),
+            prioritized_batch_numbers,
         )
-        .await
+        .await?;
+        self.load_batch_numbers(
+            l1_state.diamond_proxy_sl.clone(),
+            max_l1_blocks_to_scan,
+            remaining_batch_numbers,
+        )
+        .await?;
+        Ok(())
     }
 
     pub(crate) fn insert(&self, batch: DiscoveredCommittedBatch) {
@@ -116,30 +120,6 @@ impl CommittedBatchProvider {
             }
             sleep(WAIT_FOR_BATCH_POLL_INTERVAL).await;
         }
-    }
-
-    /// Fills the provider in two phases so startup-critical frontier batches become available
-    /// before the rest of the historical committed range.
-    async fn load_batches_in_background(
-        &self,
-        diamond_proxy_sl: ZkChain<DynProvider>,
-        max_l1_blocks_to_scan: u64,
-        prioritized_batch_numbers: Vec<u64>,
-        remaining_batch_numbers: Vec<u64>,
-    ) -> anyhow::Result<()> {
-        self.load_batch_numbers(
-            diamond_proxy_sl.clone(),
-            max_l1_blocks_to_scan,
-            prioritized_batch_numbers,
-        )
-        .await?;
-        self.load_batch_numbers(
-            diamond_proxy_sl,
-            max_l1_blocks_to_scan,
-            remaining_batch_numbers,
-        )
-        .await?;
-        Ok(())
     }
 
     /// Fetches a batch set with bounded concurrency to reduce startup latency without issuing an
@@ -182,38 +162,21 @@ impl Inner {
     }
 }
 
-/// Returns unique startup frontier batches in the order they are most likely to unblock startup
-/// bookkeeping: committed, proved, then executed.
-fn startup_priority_batch_numbers(
+/// Returns startup frontier batches first, then the remaining committed startup range.
+///
+/// The prioritized vector preserves the bookkeeping order most likely to unblock startup:
+/// committed, proved, then executed.
+fn startup_batch_numbers(
     last_committed_batch: u64,
     last_proved_batch: u64,
     last_executed_batch: u64,
-) -> Vec<u64> {
-    let mut seen = HashSet::new();
-    [last_committed_batch, last_proved_batch, last_executed_batch]
-        .into_iter()
-        .filter(|batch_number| *batch_number > 0)
-        .filter(|batch_number| seen.insert(*batch_number))
-        .collect()
-}
+) -> (Vec<u64>, Vec<u64>) {
+    let prioritized = [last_committed_batch, last_proved_batch, last_executed_batch];
+    let (prioritized_in_range, remaining_batch_numbers): (Vec<_>, Vec<_>) =
+        (last_executed_batch.max(1)..=last_committed_batch)
+            .partition(|batch_number| prioritized.contains(batch_number));
 
-/// Returns the rest of the startup committed range after removing the frontier batches that are
-/// loaded first.
-fn startup_remaining_batch_numbers(
-    last_committed_batch: u64,
-    last_proved_batch: u64,
-    last_executed_batch: u64,
-) -> Vec<u64> {
-    let prioritized: HashSet<_> = startup_priority_batch_numbers(
-        last_committed_batch,
-        last_proved_batch,
-        last_executed_batch,
-    )
-    .into_iter()
-    .collect();
-    (last_executed_batch.max(1)..=last_committed_batch)
-        .filter(|batch_number| !prioritized.contains(batch_number))
-        .collect()
+    (prioritized_in_range, remaining_batch_numbers)
 }
 
 /// Resolves a committed batch from L1 by first finding the block that committed it and then
@@ -236,15 +199,18 @@ async fn fetch_batch(
 
 #[cfg(test)]
 mod tests {
-    use super::{startup_priority_batch_numbers, startup_remaining_batch_numbers};
+    use super::startup_batch_numbers;
 
     #[test]
     fn prioritizes_frontier_batches_once() {
-        assert_eq!(startup_priority_batch_numbers(10, 8, 8), vec![10, 8]);
+        assert_eq!(startup_batch_numbers(10, 8, 8), (vec![8, 10], vec![9]));
     }
 
     #[test]
     fn excludes_prioritized_batches_from_remaining_range() {
-        assert_eq!(startup_remaining_batch_numbers(10, 8, 6), vec![7, 9]);
+        assert_eq!(
+            startup_batch_numbers(10, 8, 6),
+            (vec![6, 8, 10], vec![7, 9])
+        );
     }
 }

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -1,12 +1,20 @@
 use crate::util;
 use alloy::primitives::BlockNumber;
+use alloy::providers::DynProvider;
 use anyhow::Context;
+use futures::stream::{self, StreamExt};
 use rangemap::RangeInclusiveMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use tokio::time::sleep;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
+use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_contract_interface::models::StoredBatchInfo;
+
+const INIT_MAX_PARALLEL_BATCH_FETCHES: usize = 10;
+const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Clone)]
 pub struct CommittedBatchProvider {
@@ -20,12 +28,13 @@ struct Inner {
 }
 
 impl CommittedBatchProvider {
-    pub async fn init(
+    pub async fn new(
         l1_state: &L1State,
-        max_l1_blocks_to_scan: u64,
         load_genesis_batch_info: impl AsyncFnOnce() -> StoredBatchInfo,
     ) -> anyhow::Result<Self> {
-        let mut inner = Inner::default();
+        let provider = Self {
+            inner: Arc::new(RwLock::new(Inner::default())),
+        };
         // Special case for genesis
         if l1_state.last_executed_batch == 0 {
             let batch_info = load_genesis_batch_info().await;
@@ -36,37 +45,31 @@ impl CommittedBatchProvider {
                 batch_hash_l1,
                 batch_info.hash(),
             );
-            inner.insert(DiscoveredCommittedBatch {
+            provider.insert(DiscoveredCommittedBatch {
                 batch_info,
                 block_range: 0..=0,
             });
         }
-        // todo: this can take a while and should ideally happen in the background
-        // Ignore genesis here as it was handled above
-        for batch_number in l1_state.last_executed_batch.max(1)..=l1_state.last_committed_batch {
-            let sl_block_with_commit = util::find_l1_commit_block_by_batch_number(
-                l1_state.diamond_proxy_sl.clone(),
-                batch_number,
-                max_l1_blocks_to_scan,
-            )
-            .await?;
-            let discovered_batch = util::fetch_stored_batch_data(
-                &l1_state.diamond_proxy_sl,
-                sl_block_with_commit,
-                batch_number,
-            )
-            .await?
-            .with_context(|| format!("failed to find committed batch {batch_number} on L1"))?;
-            tracing::info!(
-                batch_number = discovered_batch.number(),
-                "discovered committed batch on startup"
-            );
-            inner.insert(discovered_batch);
-        }
 
-        Ok(Self {
-            inner: Arc::new(RwLock::new(inner)),
-        })
+        Ok(provider)
+    }
+
+    pub async fn init(&self, l1_state: &L1State, max_l1_blocks_to_scan: u64) -> anyhow::Result<()> {
+        self.load_batches_in_background(
+            l1_state.diamond_proxy_sl.clone(),
+            max_l1_blocks_to_scan,
+            startup_priority_batch_numbers(
+                l1_state.last_committed_batch,
+                l1_state.last_proved_batch,
+                l1_state.last_executed_batch,
+            ),
+            startup_remaining_batch_numbers(
+                l1_state.last_committed_batch,
+                l1_state.last_proved_batch,
+                l1_state.last_executed_batch,
+            ),
+        )
+        .await
     }
 
     pub(crate) fn insert(&self, batch: DiscoveredCommittedBatch) {
@@ -74,18 +77,73 @@ impl CommittedBatchProvider {
         inner.insert(batch);
     }
 
-    pub fn get(&self, batch_number: u64) -> Option<DiscoveredCommittedBatch> {
-        let inner = self.inner.read().expect("lock poisoned");
-        inner.batches.get(&batch_number).cloned()
+    pub async fn wait_for_batch(&self, batch_number: u64) -> DiscoveredCommittedBatch {
+        let mut logged_wait = false;
+        loop {
+            let batch = {
+                let inner = self.inner.read().expect("lock poisoned");
+                inner.batches.get(&batch_number).cloned()
+            };
+            if let Some(batch) = batch {
+                return batch;
+            }
+            if !logged_wait {
+                tracing::info!("waiting for committed batch {batch_number} to load");
+                logged_wait = true;
+            }
+            sleep(WAIT_FOR_BATCH_POLL_INTERVAL).await;
+        }
     }
 
-    pub fn get_by_block_number(
+    async fn load_batches_in_background(
         &self,
-        block_number: BlockNumber,
-    ) -> Option<DiscoveredCommittedBatch> {
-        let inner = self.inner.read().expect("lock poisoned");
-        let batch_number = inner.block_range_index.get(&block_number)?;
-        inner.batches.get(batch_number).cloned()
+        diamond_proxy_sl: ZkChain<DynProvider>,
+        max_l1_blocks_to_scan: u64,
+        prioritized_batch_numbers: Vec<u64>,
+        remaining_batch_numbers: Vec<u64>,
+    ) -> anyhow::Result<()> {
+        self.load_batch_numbers(
+            diamond_proxy_sl.clone(),
+            max_l1_blocks_to_scan,
+            prioritized_batch_numbers,
+        )
+        .await?;
+        self.load_batch_numbers(
+            diamond_proxy_sl,
+            max_l1_blocks_to_scan,
+            remaining_batch_numbers,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn load_batch_numbers(
+        &self,
+        diamond_proxy_sl: ZkChain<DynProvider>,
+        max_l1_blocks_to_scan: u64,
+        batch_numbers: Vec<u64>,
+    ) -> anyhow::Result<()> {
+        stream::iter(batch_numbers)
+            .map(|batch_number| {
+                let provider = self.clone();
+                let diamond_proxy_sl = diamond_proxy_sl.clone();
+                async move {
+                    let discovered_batch =
+                        fetch_batch(diamond_proxy_sl, batch_number, max_l1_blocks_to_scan).await?;
+                    tracing::info!(
+                        "discovered committed batch {} on startup",
+                        discovered_batch.number()
+                    );
+                    provider.insert(discovered_batch);
+                    Ok::<_, anyhow::Error>(())
+                }
+            })
+            .buffer_unordered(INIT_MAX_PARALLEL_BATCH_FETCHES)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(())
     }
 }
 
@@ -94,5 +152,66 @@ impl Inner {
         self.block_range_index
             .insert(batch.block_range.clone(), batch.number());
         self.batches.insert(batch.number(), batch);
+    }
+}
+
+fn startup_priority_batch_numbers(
+    last_committed_batch: u64,
+    last_proved_batch: u64,
+    last_executed_batch: u64,
+) -> Vec<u64> {
+    let mut seen = HashSet::new();
+    [last_committed_batch, last_proved_batch, last_executed_batch]
+        .into_iter()
+        .filter(|batch_number| *batch_number > 0)
+        .filter(|batch_number| seen.insert(*batch_number))
+        .collect()
+}
+
+fn startup_remaining_batch_numbers(
+    last_committed_batch: u64,
+    last_proved_batch: u64,
+    last_executed_batch: u64,
+) -> Vec<u64> {
+    let prioritized: HashSet<_> = startup_priority_batch_numbers(
+        last_committed_batch,
+        last_proved_batch,
+        last_executed_batch,
+    )
+    .into_iter()
+    .collect();
+    (last_executed_batch.max(1)..=last_committed_batch)
+        .filter(|batch_number| !prioritized.contains(batch_number))
+        .collect()
+}
+
+async fn fetch_batch(
+    diamond_proxy_sl: ZkChain<DynProvider>,
+    batch_number: u64,
+    max_l1_blocks_to_scan: u64,
+) -> anyhow::Result<DiscoveredCommittedBatch> {
+    let sl_block_with_commit = util::find_l1_commit_block_by_batch_number(
+        diamond_proxy_sl.clone(),
+        batch_number,
+        max_l1_blocks_to_scan,
+    )
+    .await?;
+    util::fetch_stored_batch_data(&diamond_proxy_sl, sl_block_with_commit, batch_number)
+        .await?
+        .with_context(|| format!("failed to find committed batch {batch_number} on L1"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{startup_priority_batch_numbers, startup_remaining_batch_numbers};
+
+    #[test]
+    fn prioritizes_frontier_batches_once() {
+        assert_eq!(startup_priority_batch_numbers(10, 8, 8), vec![10, 8]);
+    }
+
+    #[test]
+    fn excludes_prioritized_batches_from_remaining_range() {
+        assert_eq!(startup_remaining_batch_numbers(10, 8, 6), vec![7, 9]);
     }
 }

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -19,11 +19,10 @@ const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// In-memory store of committed batches discovered either during startup catch-up or by live L1
 /// watcher.
 ///
-/// Construct it with [`Self::new`], then run [`Self::init`] in a background task to populate
-/// historical batches while consumers use [`Self::wait_for_batch`] to block until a specific batch
-/// becomes available. During startup, `init()` loads committed batches in the inclusive range
-/// `max(last_executed_batch, 1)..=last_committed_batch`, with the startup frontier batches loaded
-/// first.
+/// Construct it with [`Self::new`], which eagerly loads the startup frontier batches needed by
+/// startup bookkeeping. Then run [`Self::init`] in a background task to populate the remaining
+/// historical committed range while consumers use [`Self::wait_for_batch`] to block until a
+/// specific batch becomes available.
 #[derive(Debug, Clone)]
 pub struct CommittedBatchProvider {
     inner: Arc<RwLock<Inner>>,
@@ -36,12 +35,11 @@ struct Inner {
 }
 
 impl CommittedBatchProvider {
-    /// Creates an empty provider and inserts the genesis batch if startup state still points at it.
-    ///
-    /// Historical committed batches are intentionally not loaded here. Call [`Self::init`] in a
-    /// background task to populate the rest of the startup range.
+    /// Creates a provider, inserts the genesis batch if needed, and eagerly loads the startup
+    /// frontier batches used by startup bookkeeping.
     pub async fn new(
         l1_state: &L1State,
+        max_l1_blocks_to_scan: u64,
         load_genesis_batch_info: impl AsyncFnOnce() -> StoredBatchInfo,
     ) -> anyhow::Result<Self> {
         let provider = Self {
@@ -63,28 +61,29 @@ impl CommittedBatchProvider {
             });
         }
 
-        Ok(provider)
-    }
-
-    /// Loads historical committed batches discovered on startup.
-    ///
-    /// The three frontier batches used by startup bookkeeping are fetched first so callers waiting
-    /// on `last_committed_batch`, `last_proved_batch`, or `last_executed_batch` can proceed as
-    /// soon as possible. The remaining committed batches are fetched afterwards, with bounded
-    /// parallelism.
-    pub async fn init(&self, l1_state: &L1State, max_l1_blocks_to_scan: u64) -> anyhow::Result<()> {
-        let (prioritized_batch_numbers, remaining_batch_numbers) = startup_batch_numbers(
+        let (prioritized_batch_numbers, _) = startup_batch_numbers(
             l1_state.last_committed_batch,
             l1_state.last_proved_batch,
             l1_state.last_executed_batch,
         );
+        provider
+            .load_batch_numbers(
+                l1_state.diamond_proxy_sl.clone(),
+                max_l1_blocks_to_scan,
+                prioritized_batch_numbers,
+            )
+            .await?;
 
-        self.load_batch_numbers(
-            l1_state.diamond_proxy_sl.clone(),
-            max_l1_blocks_to_scan,
-            prioritized_batch_numbers,
-        )
-        .await?;
+        Ok(provider)
+    }
+
+    /// Loads the remaining historical committed batches discovered on startup.
+    pub async fn init(&self, l1_state: &L1State, max_l1_blocks_to_scan: u64) -> anyhow::Result<()> {
+        let (_, remaining_batch_numbers) = startup_batch_numbers(
+            l1_state.last_committed_batch,
+            l1_state.last_proved_batch,
+            l1_state.last_executed_batch,
+        );
         self.load_batch_numbers(
             l1_state.diamond_proxy_sl.clone(),
             max_l1_blocks_to_scan,

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -28,6 +28,10 @@ struct Inner {
 }
 
 impl CommittedBatchProvider {
+    /// Creates an empty provider and inserts the genesis batch if startup state still points at it.
+    ///
+    /// Historical committed batches are intentionally not loaded here. Call [`Self::init`] in a
+    /// background task to populate the rest of the startup range.
     pub async fn new(
         l1_state: &L1State,
         load_genesis_batch_info: impl AsyncFnOnce() -> StoredBatchInfo,
@@ -54,6 +58,12 @@ impl CommittedBatchProvider {
         Ok(provider)
     }
 
+    /// Loads historical committed batches discovered on startup.
+    ///
+    /// The three frontier batches used by startup bookkeeping are fetched first so callers waiting
+    /// on `last_committed_batch`, `last_proved_batch`, or `last_executed_batch` can proceed as
+    /// soon as possible. The remaining committed batches are fetched afterwards, with bounded
+    /// parallelism.
     pub async fn init(&self, l1_state: &L1State, max_l1_blocks_to_scan: u64) -> anyhow::Result<()> {
         self.load_batches_in_background(
             l1_state.diamond_proxy_sl.clone(),
@@ -77,6 +87,10 @@ impl CommittedBatchProvider {
         inner.insert(batch);
     }
 
+    /// Waits until the requested batch is available in memory.
+    ///
+    /// Startup initialization and live L1 watchers both populate this provider, so callers can use
+    /// a single API regardless of whether the batch is historical or just arrived from L1.
     pub async fn wait_for_batch(&self, batch_number: u64) -> DiscoveredCommittedBatch {
         let mut logged_wait = false;
         loop {
@@ -95,6 +109,8 @@ impl CommittedBatchProvider {
         }
     }
 
+    /// Fills the provider in two phases so startup-critical frontier batches become available
+    /// before the rest of the historical committed range.
     async fn load_batches_in_background(
         &self,
         diamond_proxy_sl: ZkChain<DynProvider>,
@@ -117,6 +133,8 @@ impl CommittedBatchProvider {
         Ok(())
     }
 
+    /// Fetches a batch set with bounded concurrency to reduce startup latency without issuing an
+    /// unbounded number of L1 requests.
     async fn load_batch_numbers(
         &self,
         diamond_proxy_sl: ZkChain<DynProvider>,
@@ -155,6 +173,8 @@ impl Inner {
     }
 }
 
+/// Returns unique startup frontier batches in the order they are most likely to unblock startup
+/// bookkeeping: committed, proved, then executed.
 fn startup_priority_batch_numbers(
     last_committed_batch: u64,
     last_proved_batch: u64,
@@ -168,6 +188,8 @@ fn startup_priority_batch_numbers(
         .collect()
 }
 
+/// Returns the rest of the startup committed range after removing the frontier batches that are
+/// loaded first.
 fn startup_remaining_batch_numbers(
     last_committed_batch: u64,
     last_proved_batch: u64,
@@ -185,6 +207,8 @@ fn startup_remaining_batch_numbers(
         .collect()
 }
 
+/// Resolves a committed batch from L1 by first finding the block that committed it and then
+/// decoding the corresponding stored batch data.
 async fn fetch_batch(
     diamond_proxy_sl: ZkChain<DynProvider>,
     batch_number: u64,

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -16,6 +16,14 @@ use zksync_os_contract_interface::models::StoredBatchInfo;
 const INIT_MAX_PARALLEL_BATCH_FETCHES: usize = 10;
 const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// In-memory store of committed batches discovered either during startup catch-up or by live L1
+/// watcher.
+///
+/// Construct it with [`Self::new`], then run [`Self::init`] in a background task to populate
+/// historical batches while consumers use [`Self::wait_for_batch`] to block until a specific batch
+/// becomes available. During startup, `init()` loads committed batches in the inclusive range
+/// `max(last_executed_batch, 1)..=last_committed_batch`, with the startup frontier batches loaded
+/// first.
 #[derive(Debug, Clone)]
 pub struct CommittedBatchProvider {
     inner: Arc<RwLock<Inner>>,
@@ -99,6 +107,7 @@ impl CommittedBatchProvider {
                 inner.batches.get(&batch_number).cloned()
             };
             if let Some(batch) = batch {
+                tracing::info!("returning batch {batch_number} from CommittedBatchProvider");
                 return batch;
             }
             if !logged_wait {

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -3,8 +3,6 @@ use crate::{CommittedBatchProvider, L1WatcherConfig, ProcessL1Event, util};
 use alloy::primitives::Address;
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::Log;
-use backon::{ConstantBuilder, Retryable};
-use std::time::Duration;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_storage_api::WriteFinality;
@@ -89,19 +87,10 @@ impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
                 "skipping already processed executed batch",
             );
         } else {
-            // We might discover batch execute event before we discover commit event. In this case
-            // we retry for up to 30s (enough for two L1 blocks to be mined).
-            let discovered_batch = (|| async {
-                self.committed_batch_provider
-                    .get(batch_number)
-                    .ok_or_else(|| L1WatcherError::BatchNotCommitted(batch_number))
-            })
-            .retry(
-                ConstantBuilder::default()
-                    .with_max_times(30)
-                    .with_delay(Duration::from_secs(1)),
-            )
-            .await?;
+            let discovered_batch = self
+                .committed_batch_provider
+                .wait_for_batch(batch_number)
+                .await;
             let last_executed_block = discovered_batch.last_block_number();
             self.finality.update_finality_status(|finality| {
                 assert!(

--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -211,14 +211,10 @@ impl<ReplayStorage: ReadReplay + Clone, Finality: ReadFinality + Clone>
                         .wait_for(|f| next_batch_number <= f.last_executed_batch)
                         .await
                         .context("failed to wait for next finalized batch")?;
-                    // Below should be infallible as batch is guaranteed to have been processed as
-                    // executed. Hence, already discovered as committed.
-                    // todo: non-local reasoning, refactor once `CommittedBatchProvider` loads
-                    //       batches asynchronously
                     let range = self
                         .committed_batch_provider
-                        .get(next_batch_number)
-                        .with_context(|| format!("unexpected state: batch {next_batch_number} was executed but not discovered as committed"))?
+                        .wait_for_batch(next_batch_number)
+                        .await
                         .block_range;
                     let ranges = vec![(next_batch_number, range)];
                     (None, ranges)

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -3,7 +3,6 @@ use crate::batcher::seal_criteria::BatchInfoAccumulator;
 use crate::config::BatcherConfig;
 use alloy::consensus::BlobTransactionSidecar;
 use alloy::primitives::Address;
-use anyhow::Context;
 use async_trait::async_trait;
 use std::pin::Pin;
 use tokio::sync::mpsc;
@@ -82,13 +81,8 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
         // `last_executed_batch + 1`.
         let last_executed_batch = self
             .committed_batch_provider
-            .get(self.startup_config.last_executed_batch)
-            .with_context(|| {
-                format!(
-                    "last executed batch {} must have been discovered on L1",
-                    self.startup_config.last_executed_batch
-                )
-            })?;
+            .wait_for_batch(self.startup_config.last_executed_batch)
+            .await;
         let first_expected_block = last_executed_batch.last_block_number() + 1;
         let mut prev_batch_info = last_executed_batch.batch_info;
 
@@ -136,13 +130,8 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                 if prev_batch_info.batch_number < self.startup_config.last_committed_batch {
                     let committed_batch = self
                         .committed_batch_provider
-                        .get(prev_batch_info.batch_number + 1)
-                        .with_context(|| {
-                            format!(
-                                "committed batch {} must have been discovered on L1",
-                                prev_batch_info.batch_number + 1
-                            )
-                        })?;
+                        .wait_for_batch(prev_batch_info.batch_number + 1)
+                        .await;
                     // Validate that the existing batch's first block matches the next block in the stream
                     anyhow::ensure!(
                         committed_batch.first_block_number() == next_block_number,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -302,20 +302,24 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let tree_db = tree_at_genesis.tree;
     let tree_for_rpc = Arc::new(tree_db.clone());
 
-    // todo: this can take a while; ideally committed batches should be loaded in the background
-    //       and then `get()` method can be made async so that it waits for relevant batch to load
-    let committed_batch_provider = CommittedBatchProvider::init(
-        &l1_state,
-        config.l1_watcher_config.max_blocks_to_process,
-        || async {
-            let genesis_state = genesis.state().await;
-            load_genesis_stored_batch_info(genesis_state, genesis_root_hash, genesis_root_leaves)
-                .await
-                .unwrap()
-        },
-    )
+    let committed_batch_provider = CommittedBatchProvider::new(&l1_state, || async {
+        let genesis_state = genesis.state().await;
+        load_genesis_stored_batch_info(genesis_state, genesis_root_hash, genesis_root_leaves)
+            .await
+            .unwrap()
+    })
     .await
     .expect("failed to init CommittedBatchProvider");
+
+    let committed_batch_provider_for_init = committed_batch_provider.clone();
+    let l1_state_for_init = l1_state.clone();
+    let max_blocks_to_process = config.l1_watcher_config.max_blocks_to_process;
+    runtime.spawn_critical_task("committed batch provider init", async move {
+        committed_batch_provider_for_init
+            .init(&l1_state_for_init, max_blocks_to_process)
+            .await
+            .expect("failed to initialize CommittedBatchProvider");
+    });
 
     let state = State::new(&config.general_config, &genesis).await;
 
@@ -1360,8 +1364,8 @@ async fn commit_proof_execute_block_numbers(
         0
     } else {
         committed_batch_provider
-            .get(l1_state.last_committed_batch)
-            .expect("last committed batch was not discovered on L1")
+            .wait_for_batch(l1_state.last_committed_batch)
+            .await
             .last_block_number()
     };
 
@@ -1370,8 +1374,8 @@ async fn commit_proof_execute_block_numbers(
         0
     } else {
         committed_batch_provider
-            .get(l1_state.last_proved_batch)
-            .expect("last proved batch was not discovered on L1")
+            .wait_for_batch(l1_state.last_proved_batch)
+            .await
             .last_block_number()
     };
 
@@ -1379,8 +1383,8 @@ async fn commit_proof_execute_block_numbers(
         0
     } else {
         committed_batch_provider
-            .get(l1_state.last_executed_batch)
-            .expect("last executed batch was not discovered on L1")
+            .wait_for_batch(l1_state.last_executed_batch)
+            .await
             .last_block_number()
     };
     (last_committed_block, last_proved_block, last_executed_block)

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -336,7 +336,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     );
 
     let (last_l1_committed_block, last_l1_proved_block, last_l1_executed_block) =
-        commit_proof_execute_block_numbers(runtime, &l1_state, &committed_batch_provider)
+        commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider)
             .await
             .expect("failed to resolve startup committed batches");
 
@@ -1363,63 +1363,37 @@ fn check_batch_verification_mismatch(
 }
 
 async fn commit_proof_execute_block_numbers(
-    runtime: &Runtime,
     l1_state: &L1State,
     committed_batch_provider: &CommittedBatchProvider,
 ) -> anyhow::Result<(u64, u64, u64)> {
     let last_committed_block = if l1_state.last_committed_batch == 0 {
         0
     } else {
-        wait_for_batch_or_shutdown(
-            runtime,
-            committed_batch_provider,
-            l1_state.last_committed_batch,
-        )
-        .await?
-        .last_block_number()
+        committed_batch_provider
+            .get(l1_state.last_committed_batch)
+            .expect("last_committed_batch is expected to be loaded")
+            .last_block_number()
     };
 
     // only used to log on node startup
     let last_proved_block = if l1_state.last_proved_batch == 0 {
         0
     } else {
-        wait_for_batch_or_shutdown(
-            runtime,
-            committed_batch_provider,
-            l1_state.last_proved_batch,
-        )
-        .await?
-        .last_block_number()
+        committed_batch_provider
+            .get(l1_state.last_proved_batch)
+            .expect("last_proved_batch is expected to be loaded")
+            .last_block_number()
     };
 
     let last_executed_block = if l1_state.last_executed_batch == 0 {
         0
     } else {
-        wait_for_batch_or_shutdown(
-            runtime,
-            committed_batch_provider,
-            l1_state.last_executed_batch,
-        )
-        .await?
-        .last_block_number()
+        committed_batch_provider
+            .get(l1_state.last_executed_batch)
+            .expect("last_executed_batch is expected to be loaded")
+            .last_block_number()
     };
     Ok((last_committed_block, last_proved_block, last_executed_block))
-}
-
-async fn wait_for_batch_or_shutdown(
-    runtime: &Runtime,
-    committed_batch_provider: &CommittedBatchProvider,
-    batch_number: u64,
-) -> anyhow::Result<zksync_os_batch_types::DiscoveredCommittedBatch> {
-    let shutdown = runtime.on_shutdown_signal().clone();
-    tokio::pin!(shutdown);
-
-    tokio::select! {
-        batch = committed_batch_provider.wait_for_batch(batch_number) => Ok(batch),
-        _ = &mut shutdown => anyhow::bail!(
-            "shutdown started while waiting for committed batch {batch_number} during startup"
-        ),
-    }
 }
 
 fn run_fake_snark_provers(

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -302,31 +302,27 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let tree_db = tree_at_genesis.tree;
     let tree_for_rpc = Arc::new(tree_db.clone());
 
-    let committed_batch_provider = CommittedBatchProvider::new(&l1_state, || async {
-        let genesis_state = genesis.state().await;
-        load_genesis_stored_batch_info(genesis_state, genesis_root_hash, genesis_root_leaves)
-            .await
-            .unwrap()
-    })
+    let committed_batch_provider = CommittedBatchProvider::new(
+        &l1_state,
+        config.l1_watcher_config.max_blocks_to_process,
+        || async {
+            let genesis_state = genesis.state().await;
+            load_genesis_stored_batch_info(genesis_state, genesis_root_hash, genesis_root_leaves)
+                .await
+                .unwrap()
+        },
+    )
     .await
     .expect("failed to init CommittedBatchProvider");
 
     let committed_batch_provider_for_init = committed_batch_provider.clone();
     let l1_state_for_init = l1_state.clone();
     let max_blocks_to_process = config.l1_watcher_config.max_blocks_to_process;
-    let runtime_for_init = runtime.clone();
-    runtime.spawn_critical_with_shutdown_signal("committed batch provider init", |shutdown| async move {
-        tokio::pin!(shutdown);
-
-        tokio::select! {
-            result = committed_batch_provider_for_init.init(&l1_state_for_init, max_blocks_to_process) => {
-                if let Err(err) = result {
-                    tracing::error!(%err, "failed to initialize CommittedBatchProvider");
-                    let _ = runtime_for_init.initiate_graceful_shutdown();
-                }
-            }
-            _ = &mut shutdown => {}
-        }
+    runtime.spawn_critical_task("committed batch provider init", async move {
+        committed_batch_provider_for_init
+            .init(&l1_state_for_init, max_blocks_to_process)
+            .await
+            .expect("failed to initialize CommittedBatchProvider");
     });
 
     let state = State::new(&config.general_config, &genesis).await;

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -336,9 +336,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     );
 
     let (last_l1_committed_block, last_l1_proved_block, last_l1_executed_block) =
-        commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider)
-            .await
-            .expect("failed to resolve startup committed batches");
+        commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider).await;
 
     let node_startup_state = NodeStateOnStartup {
         node_role,
@@ -1365,7 +1363,7 @@ fn check_batch_verification_mismatch(
 async fn commit_proof_execute_block_numbers(
     l1_state: &L1State,
     committed_batch_provider: &CommittedBatchProvider,
-) -> anyhow::Result<(u64, u64, u64)> {
+) -> (u64, u64, u64) {
     let last_committed_block = if l1_state.last_committed_batch == 0 {
         0
     } else {
@@ -1393,7 +1391,7 @@ async fn commit_proof_execute_block_numbers(
             .expect("last_executed_batch is expected to be loaded")
             .last_block_number()
     };
-    Ok((last_committed_block, last_proved_block, last_executed_block))
+    (last_committed_block, last_proved_block, last_executed_block)
 }
 
 fn run_fake_snark_provers(

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -314,11 +314,19 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let committed_batch_provider_for_init = committed_batch_provider.clone();
     let l1_state_for_init = l1_state.clone();
     let max_blocks_to_process = config.l1_watcher_config.max_blocks_to_process;
-    runtime.spawn_critical_task("committed batch provider init", async move {
-        committed_batch_provider_for_init
-            .init(&l1_state_for_init, max_blocks_to_process)
-            .await
-            .expect("failed to initialize CommittedBatchProvider");
+    let runtime_for_init = runtime.clone();
+    runtime.spawn_critical_with_shutdown_signal("committed batch provider init", |shutdown| async move {
+        tokio::pin!(shutdown);
+
+        tokio::select! {
+            result = committed_batch_provider_for_init.init(&l1_state_for_init, max_blocks_to_process) => {
+                if let Err(err) = result {
+                    tracing::error!(%err, "failed to initialize CommittedBatchProvider");
+                    let _ = runtime_for_init.initiate_graceful_shutdown();
+                }
+            }
+            _ = &mut shutdown => {}
+        }
     });
 
     let state = State::new(&config.general_config, &genesis).await;
@@ -332,7 +340,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     );
 
     let (last_l1_committed_block, last_l1_proved_block, last_l1_executed_block) =
-        commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider).await;
+        commit_proof_execute_block_numbers(runtime, &l1_state, &committed_batch_provider)
+            .await
+            .expect("failed to resolve startup committed batches");
 
     let node_startup_state = NodeStateOnStartup {
         node_role,
@@ -1357,37 +1367,63 @@ fn check_batch_verification_mismatch(
 }
 
 async fn commit_proof_execute_block_numbers(
+    runtime: &Runtime,
     l1_state: &L1State,
     committed_batch_provider: &CommittedBatchProvider,
-) -> (u64, u64, u64) {
+) -> anyhow::Result<(u64, u64, u64)> {
     let last_committed_block = if l1_state.last_committed_batch == 0 {
         0
     } else {
-        committed_batch_provider
-            .wait_for_batch(l1_state.last_committed_batch)
-            .await
-            .last_block_number()
+        wait_for_batch_or_shutdown(
+            runtime,
+            committed_batch_provider,
+            l1_state.last_committed_batch,
+        )
+        .await?
+        .last_block_number()
     };
 
     // only used to log on node startup
     let last_proved_block = if l1_state.last_proved_batch == 0 {
         0
     } else {
-        committed_batch_provider
-            .wait_for_batch(l1_state.last_proved_batch)
-            .await
-            .last_block_number()
+        wait_for_batch_or_shutdown(
+            runtime,
+            committed_batch_provider,
+            l1_state.last_proved_batch,
+        )
+        .await?
+        .last_block_number()
     };
 
     let last_executed_block = if l1_state.last_executed_batch == 0 {
         0
     } else {
-        committed_batch_provider
-            .wait_for_batch(l1_state.last_executed_batch)
-            .await
-            .last_block_number()
+        wait_for_batch_or_shutdown(
+            runtime,
+            committed_batch_provider,
+            l1_state.last_executed_batch,
+        )
+        .await?
+        .last_block_number()
     };
-    (last_committed_block, last_proved_block, last_executed_block)
+    Ok((last_committed_block, last_proved_block, last_executed_block))
+}
+
+async fn wait_for_batch_or_shutdown(
+    runtime: &Runtime,
+    committed_batch_provider: &CommittedBatchProvider,
+    batch_number: u64,
+) -> anyhow::Result<zksync_os_batch_types::DiscoveredCommittedBatch> {
+    let shutdown = runtime.on_shutdown_signal().clone();
+    tokio::pin!(shutdown);
+
+    tokio::select! {
+        batch = committed_batch_provider.wait_for_batch(batch_number) => Ok(batch),
+        _ = &mut shutdown => anyhow::bail!(
+            "shutdown started while waiting for committed batch {batch_number} during startup"
+        ),
+    }
 }
 
 fn run_fake_snark_provers(


### PR DESCRIPTION
## Summary

Resolves TODO for CommittedBatchProvider, now batches that were already committed on start-up are loaded in background and other components await them with `wait_for_batch`. `[last_committed_batch, last_proved_batch, last_executed_batch]` these batches should be loaded first because we need them for `commit_proof_execute_block_numbers` during node start-up.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

