### PR TITLE
feat(l1_sender): configurable tx timeout and inclusion latency metric

### DIFF
--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -25,6 +25,9 @@ pub struct L1SenderConfig<Input> {
     /// How often to poll L1 for new blocks.
     pub poll_interval: Duration,
 
+    /// Maximum time to wait for a transaction to be included on L1.
+    pub transaction_timeout: Duration,
+
     /// Use Fusaka blob transaction format if the timestamp has passed.
     pub fusaka_upgrade_timestamp: u64,
 

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -23,19 +23,12 @@ use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use std::time::Duration;
+use std::time::Instant;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use zksync_os_observability::{ComponentStateHandle, ComponentStateReporter};
 use zksync_os_operator_signer::SignerConfig;
 use zksync_os_pipeline::PeekableReceiver;
-
-/// Maximum time to wait for a transaction to be included on L1.
-///
-/// Normally 15-30 seconds is enough for normal priority transactions, and 60-120 is enough for
-/// lower gas price transactions. We picked 300 seconds conservatively as it should cover most
-/// scenarios with network congestion.
-const TRANSACTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Future that resolves into a (fallible) transaction receipt.
 type TransactionReceiptFuture =
@@ -132,7 +125,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
         // so that we send them downstream also in order.
         // This holds true because l1 transactions are included in the order of sender nonce.
         // Keep this in mind if changing sending logic (that is, if adding `buffer` we'd need to set nonce manually)
-        let pending_txs: Vec<(TransactionReceiptFuture, Input)> =
+        let pending_txs: Vec<(TransactionReceiptFuture, Input, Instant)> =
             futures::stream::iter(commands.drain(..))
                 .then(|mut cmd| async {
                     let mut tx_request = tx_request_with_gas_fields(
@@ -188,7 +181,9 @@ pub async fn run_l1_sender<Input: SendToL1>(
                     // finds it.
                     let pending_tx = provider
                         .send_raw_transaction(&tx.encoded_2718())
-                        .await?
+                        .await?;
+                    let submitted_at = Instant::now();
+                    let pending_tx = pending_tx
                         // We are being optimistic with our transaction inclusion here. But, even if
                         // reorg happens and transaction will not be included in the new fork (very-very
                         // unlikely), L1 sender will crash at some point (because a consequent L1
@@ -196,7 +191,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
                         .with_required_confirmations(1)
                         // Ensure we don't wait indefinitely and crash if the transaction is not
                         // included on L1 in a reasonable time.
-                        .with_timeout(Some(TRANSACTION_TIMEOUT));
+                        .with_timeout(Some(config.transaction_timeout));
                     let tx_hash = *pending_tx.tx_hash();
                     tracing::info!(
                         "{command_name}: L1 transaction submitted for {range}. Hash: {tx_hash:?} Waiting for inclusion...",
@@ -223,7 +218,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
                     cmd.as_mut()
                         .iter_mut()
                         .for_each(|envelope| envelope.set_stage(Input::SENT_STAGE));
-                    anyhow::Ok((receipt_fut, cmd))
+                    anyhow::Ok((receipt_fut, cmd, submitted_at))
                 })
                 // We could buffer the stream here to enable sending multiple batches of transactions in parallel,
                 // but this is not necessary for now - we wait for them to be included in parallel
@@ -233,8 +228,12 @@ pub async fn run_l1_sender<Input: SendToL1>(
         latency_tracker.enter_state(L1SenderState::WaitingL1Inclusion);
 
         let mut completed_commands = Vec::with_capacity(pending_txs.len());
-        for (receipt_fut, command) in pending_txs {
-            let receipt = receipt_fut.await?;
+        for (receipt_fut, command, submitted_at) in pending_txs {
+            let receipt = receipt_fut.await;
+            // Observe latency before propagating errors so timeout cases are recorded
+            L1_SENDER_METRICS.tx_inclusion_latency_seconds[&command_name]
+                .observe(submitted_at.elapsed().as_secs_f64());
+            let receipt = receipt?;
             validate_tx_receipt(&provider, &command, receipt).await?;
             completed_commands.push(command);
         }

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -98,6 +98,11 @@ pub struct L1SenderMetrics {
     /// Last nonce used
     #[metrics(labels = ["command"])]
     pub nonce: LabeledFamily<&'static str, Gauge<u64>>,
+
+    /// Time from tx submission (send_raw_transaction success) to L1 inclusion confirmation (seconds).
+    /// Buckets cover 0.5s → ~17 minutes in doubling steps, spanning normal (15-30s) to heavily congested (10min+).
+    #[metrics(labels = ["command"], buckets = Buckets::exponential(0.5..=1024.0, 2.0))]
+    pub tx_inclusion_latency_seconds: LabeledFamily<&'static str, Histogram<f64>>,
 }
 
 impl L1SenderMetrics {

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -765,6 +765,13 @@ pub struct L1SenderConfig {
     #[config(default_t = 1 * TimeUnit::Seconds)]
     pub poll_interval: Duration,
 
+    /// Maximum time to wait for an L1 transaction to be included.
+    ///
+    /// Normally 15-30 seconds is sufficient for normal-priority transactions; 60-120s covers most
+    /// lower-gas-price cases. 600 seconds is a conservative default that handles heavy congestion.
+    #[config(default_t = 600 * TimeUnit::Seconds)]
+    pub transaction_timeout: Duration,
+
     /// Use Fusaka blob transaction format if the timestamp has passed.
     ///
     /// Defaults to `2^64-1` which is practically never. This is needed for local setup as anvil
@@ -1318,6 +1325,7 @@ impl L1SenderConfig {
             max_fee_per_blob_gas_wei: self.max_fee_per_blob_gas.0,
             command_limit: self.command_limit,
             poll_interval: self.poll_interval,
+            transaction_timeout: self.transaction_timeout,
             fusaka_upgrade_timestamp: self.fusaka_upgrade_timestamp,
             phantom_data: Default::default(),
         }
@@ -1602,6 +1610,7 @@ mod tests {
                 max_fee_per_blob_gas: 2 * EtherUnit::Gwei,
                 command_limit: 16,
                 poll_interval: Duration::from_millis(100),
+                transaction_timeout: Duration::from_secs(600),
                 fusaka_upgrade_timestamp: u64::MAX,
                 enabled: true,
                 pubdata_mode: Some(PubdataMode::Blobs),


### PR DESCRIPTION
## Summary

* [x] Add configurable tx timeout for l1 sender
* [x] Bump timeout from 5 to 10 minutes, as we have a few cases >5 minutes, but none >10
* [x] Add tx inclusion latency metric

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

