### PR TITLE
fix(l1-watcher): verify L1 state before skipping historical commits

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -1,7 +1,7 @@
 use crate::committed_batch_provider::CommittedBatchProvider;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
@@ -92,22 +92,35 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let batch_number = report.batchNumber;
-        // Startup-only guard: skip historical commits that are above the startup committed frontier.
-        // This handles batches that were committed and reverted before the node started.
+        // Startup-only guard: skip historical commits that are above the startup committed frontier,
+        // but only after verifying the batch was actually reverted on L1. A non-zero stored batch
+        // hash means the commit is still valid and must be processed (e.g., the batch was committed
+        // between the EN crash and restart).
         if should_skip_historical_commit(
             self.startup_latest_l1_block,
             self.startup_last_committed_batch,
             batch_number,
             log.block_number,
         ) {
-            tracing::warn!(
+            let batch_hash = self.zk_chain.stored_batch_hash(batch_number).await?;
+            if batch_hash == B256::ZERO {
+                tracing::warn!(
+                    batch_number,
+                    log_block_number = ?log.block_number,
+                    startup_latest_l1_block = self.startup_latest_l1_block,
+                    startup_last_committed_batch = self.startup_last_committed_batch,
+                    "skipping reverted historical committed batch",
+                );
+                return Ok(());
+            }
+            tracing::info!(
                 batch_number,
                 log_block_number = ?log.block_number,
-                startup_latest_l1_block = self.startup_latest_l1_block,
-                startup_last_committed_batch = self.startup_last_committed_batch,
-                "skipping historical committed batch above startup frontier; likely reverted before startup",
+                "historical committed batch is still valid on L1, processing",
             );
-        } else if batch_number < self.next_batch_number {
+        }
+
+        if batch_number < self.next_batch_number {
             tracing::debug!(batch_number, "skipping already processed committed batch");
         } else {
             // Fast-fail if this batch was committed by a prior crashed session's pending tx.

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -49,6 +49,12 @@ impl L1Watcher {
         loop {
             timer.tick().await;
             if let Err(e) = self.poll().await {
+                if matches!(e, L1WatcherError::BatchNotCommitted(_)) {
+                    tracing::warn!(
+                        "batch not yet discovered as committed, will retry next poll: {e}"
+                    );
+                    continue;
+                }
                 tracing::error!("l1 watcher fatal error: {e}");
                 panic!("watcher failed: {e}");
             }


### PR DESCRIPTION
## Summary

- Fixes a race condition where the commit watcher's `should_skip_historical_commit` guard incorrectly skips legitimate batch commits, causing a `BatchNotCommitted` panic and EN crash-loop
- Adds L1 verification (`storedBatchHash`) before skipping historical commits — only skip if the batch was truly reverted (hash is zero)
- Makes `BatchNotCommitted` a recoverable error (warn + retry next poll) instead of a fatal panic

## Context

Observed on 2026-04-09: an EN entered a crash-loop because batch 74531 was committed on L1 between the EN crash and restart. The startup L1 state read `last_committed_batch: 74530`, so `init()` didn't pre-load batch 74531. The commit watcher saw 74531's commit event but the historical guard skipped it (L1 block 10622613 <= startup tip 10622614, batch 74531 > startup frontier 74530). The execute watcher then panicked on `BatchNotCommitted(74531)`.

The guard was introduced in #1096 to handle reverted batches. This fix preserves that behavior (reverted batches are still skipped when `storedBatchHash` returns zero) while correctly processing batches that are still valid on L1.

Closes #1164

## Test plan

- [ ] Verify existing unit tests in `commit_watcher.rs` still pass (`should_skip_historical_commit` logic is unchanged)
- [ ] Verify the revert scenario from #1096 still works: a batch committed then reverted before startup should be skipped (`storedBatchHash` returns zero)
- [ ] Verify the new scenario: a batch committed between EN crash and restart should be processed (`storedBatchHash` returns non-zero)
- [ ] Verify `BatchNotCommitted` no longer crashes the EN — it should log a warning and retry on the next poll cycle
