### PR TITLE
chore: more doc comments for watchers

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -10,6 +10,17 @@ use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_storage_api::WriteFinality;
 
+/// Watches settlement-layer commit events and advances the committed finality frontier.
+///
+/// This component reads `ReportCommittedBatchRangeZKsyncOS` events, resolves the committed batch
+/// payload from L1 calldata, updates `WriteFinality`, and inserts the discovered batch into
+/// `CommittedBatchProvider`.
+///
+/// Depended on by:
+/// - `L1ExecuteWatcher`, which waits on the committed batches this watcher publishes;
+/// - `Batcher` and `PriorityTreeManager`, which consume the same committed batch data during
+///   startup replay and live operation;
+/// - node startup / recovery logic, which relies on the committed frontier stored in finality.
 pub struct L1CommitWatcher<Finality> {
     zk_chain: ZkChain<DynProvider>,
     next_batch_number: u64,

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -16,8 +16,16 @@ use zksync_os_contract_interface::models::StoredBatchInfo;
 const INIT_MAX_PARALLEL_BATCH_FETCHES: usize = 10;
 const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// In-memory store of committed batches discovered either during startup catch-up or by live L1
-/// watcher.
+/// In-memory store of committed batches discovered on startup and by the live commit watcher.
+///
+/// This component provides a single lookup / wait API for committed batch metadata regardless of
+/// whether the batch came from startup catch-up or from the live `L1CommitWatcher`.
+///
+/// Depended on by:
+/// - `L1ExecuteWatcher`, which waits for a committed batch before marking it executed;
+/// - `Batcher`, which replays existing L1 batches before creating new ones;
+/// - `PriorityTreeManager`, which reconstructs / advances the priority tree using committed batch
+///   boundaries.
 ///
 /// Construct it with [`Self::new`], which eagerly loads the startup frontier batches needed by
 /// startup bookkeeping. Then run [`Self::init`] in a background task to populate the remaining

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -7,6 +7,19 @@ use zksync_os_contract_interface::IExecutor::BlockExecution;
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_storage_api::WriteFinality;
 
+/// Watches settlement-layer execution events and advances the executed finality frontier.
+///
+/// This component reads `BlockExecution` events, waits until the corresponding committed batch is
+/// available in `CommittedBatchProvider`, and then updates `WriteFinality` with the latest
+/// executed batch / block numbers.
+///
+/// Depends on `CommittedBatchProvider` to resolve the executed batch back to its committed block range;
+///
+/// Depended on by:
+/// - `PriorityTreeManager`, which replays and caches priority operations up to the executed
+///   frontier;
+/// - startup / replay code that reads executed finality to decide where block processing resumes;
+/// - RPC-facing storage initialization, which uses executed progress as part of node recovery.
 pub struct L1ExecuteWatcher<Finality> {
     contract_address: Address,
     next_batch_number: u64,

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -13,6 +13,11 @@ use crate::util::find_l1_block_by_interop_root_id;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessRawEvents};
 
+/// Watches interop root updates on the settlement layer and feeds them into the interop subpool.
+///
+/// This component reads `NewInteropRoot` events from the bridgehub message root contract,
+/// de-duplicates multiple logs for the same `logId`, and inserts the latest `IndexedInteropRoot`
+/// into `InteropRootsSubpool`.
 pub struct InteropWatcher {
     contract_address: Address,
     starting_interop_root_id: u64,

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -11,12 +11,17 @@ use zksync_os_contract_interface::IExecutor::{BlockExecution, ReportCommittedBat
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_storage_api::{PersistedBatch, WriteBatch};
 
-/// Persists executed batches via [`WriteBatch`].
-/// Note: batches are discovered by `commit_watcher.rs` from L1 as soon as they are committed.
-/// However, `commit_watcher.rs` only saves them **in memory** (via `committed_batch_provider.rs`).
-/// Only when batch is also executed on L1, this logic kicks in and batches are **persisted on disc**.
-/// Committed batches can be rolled back on L1, which is not the case for executed - so this separation
-/// ensures that we don't need to rollback any persistent node state on L1 commit rollback.
+/// Watches commit and execute events together and persists only irreversibly executed batches.
+///
+/// This component keeps committed batches in memory until the matching `BlockExecution` event
+/// arrives, and only then writes a `PersistedBatch` through `WriteBatch`. That split avoids having
+/// to roll back persistent storage for batches that were committed but later reverted on L1.
+///
+/// Depended on by:
+/// - `ExecutedBatchStorage`, which is the concrete persistent store typically passed into this
+///   watcher;
+/// - `RpcStorage` and RPC namespaces, which read persisted batch data to answer batch- and
+///   proof-related requests;
 pub struct L1PersistBatchWatcher<BatchStorage> {
     zk_chain: ZkChain<DynProvider>,
     batch_storage: BatchStorage,

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -11,6 +11,11 @@ use zksync_os_contract_interface::ZkChain;
 use zksync_os_mempool::subpools::l1::L1Subpool;
 use zksync_os_types::L1PriorityEnvelope;
 
+/// Watches L1 priority transaction events and feeds them into the L1 transaction subpool.
+///
+/// This component reads `NewPriorityRequest` events from the L1 mailbox, waits until the same
+/// priority request is visible from the settlement layer, and then inserts the corresponding
+/// `L1PriorityEnvelope` into `L1Subpool`.
 pub struct L1TxWatcher {
     contract_address: Address,
     next_l1_priority_id: u64,

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -28,7 +28,11 @@ const INITIAL_LOOKBEHIND_BLOCKS: u64 = 100_000;
 /// and we don't expect a lot of results.
 const UPGRADE_DATA_LOOKBEHIND_BLOCKS: u64 = 2_500_000;
 
-/// Watches L1 and the settlement layer (SL) for protocol upgrade data.
+/// Watches L1 and the settlement layer for protocol upgrade scheduling and payload data.
+///
+/// This component listens for `UpdateUpgradeTimestamp` events on L1, fetches the matching upgrade
+/// cut data and force-deploy preimages from the appropriate contracts, waits until the scheduled
+/// timestamp, and then inserts an `UpgradeInfo` item into `UpgradeSubpool`.
 ///
 /// When settling on Gateway, the upgrade data is split across two layers:
 /// - **Gateway (SL)**: `NewUpgradeCutData` / `NewUpgradeCutHash` events from `ChainTypeManager`,


### PR DESCRIPTION
## Summary

Adds more doc comments for structs in `l1_watcher` crate.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

