### PR TITLE
feat: allow l1 poll interval to be configured

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -394,6 +394,8 @@ impl Tester {
         let general_config = GeneralConfig {
             rocks_db_path: rocks_db_path.clone(),
             l1_rpc_url: l1.address.clone(),
+            l1_rpc_poll_interval: Duration::from_millis(100),
+            gateway_rpc_poll_interval: Duration::from_millis(100),
             ..default_config.general_config
         };
         let sequencer_config = SequencerConfig {

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -371,7 +371,7 @@ pub struct GeneralConfig {
     /// Poll interval used by the L1/Gateway alloy provider when waiting for transaction receipts.
     /// Alloy's default is 7 seconds for HTTP transports, using the same criteria here.
     #[config(default_t = 7 * TimeUnit::Seconds)]
-    pub l1_provider_poll_interval: Duration,
+    pub l1_rpc_poll_interval: Duration,
 
     /// Gateway's JSON RPC API.
     /// Must be present if the chain is currently settling to Gateway.

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -368,7 +368,7 @@ pub struct GeneralConfig {
     #[config(default_t = "http://localhost:8545".into())]
     pub l1_rpc_url: String,
 
-    /// Poll interval used by the L1/Gateway alloy provider when waiting for transaction receipts.
+    /// Poll interval used by the L1 alloy provider when waiting for transaction receipts.
     /// Alloy's default is 7 seconds for HTTP transports, using the same criteria here.
     #[config(default_t = 7 * TimeUnit::Seconds)]
     pub l1_rpc_poll_interval: Duration,
@@ -376,6 +376,11 @@ pub struct GeneralConfig {
     /// Gateway's JSON RPC API.
     /// Must be present if the chain is currently settling to Gateway.
     pub gateway_rpc_url: Option<String>,
+
+    /// Poll interval used by the Gateway alloy provider when waiting for transaction receipts.
+    /// Alloy's default is 7 seconds for HTTP transports, using the same criteria here.
+    #[config(default_t = 7 * TimeUnit::Seconds)]
+    pub gateway_rpc_poll_interval: Duration,
 
     /// Gateway chain ID. Used by the migration watcher to construct `SetSLChainId` system
     /// transactions when a `MigrateToGateway` event fires. Defaults to 506 (ZKsync Gateway).

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -368,6 +368,11 @@ pub struct GeneralConfig {
     #[config(default_t = "http://localhost:8545".into())]
     pub l1_rpc_url: String,
 
+    /// Poll interval used by the L1/Gateway alloy provider when waiting for transaction receipts.
+    /// Alloy's default is 7 seconds for HTTP transports, using the same criteria here.
+    #[config(default_t = 7 * TimeUnit::Seconds)]
+    pub l1_provider_poll_interval: Duration,
+
     /// Gateway's JSON RPC API.
     /// Must be present if the chain is currently settling to Gateway.
     pub gateway_rpc_url: Option<String>,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -189,9 +189,15 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     // This is the only place where we initialize L1 provider, every component shares the same
     // cloned provider.
-    let l1_provider = build_node_provider(&config.general_config.l1_rpc_url).await;
+    let l1_provider = build_node_provider(
+        &config.general_config.l1_rpc_url,
+        config.general_config.l1_provider_poll_interval,
+    )
+    .await;
     let gateway_provider = match &config.general_config.gateway_rpc_url {
-        Some(url) => Some(build_node_provider(url).await),
+        Some(url) => {
+            Some(build_node_provider(url, config.general_config.l1_provider_poll_interval).await)
+        }
         None => None,
     };
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     .await;
     let gateway_provider = match &config.general_config.gateway_rpc_url {
         Some(url) => {
-            Some(build_node_provider(url, config.general_config.l1_rpc_poll_interval).await)
+            Some(build_node_provider(url, config.general_config.gateway_rpc_poll_interval).await)
         }
         None => None,
     };

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -191,12 +191,12 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     // cloned provider.
     let l1_provider = build_node_provider(
         &config.general_config.l1_rpc_url,
-        config.general_config.l1_provider_poll_interval,
+        config.general_config.l1_rpc_poll_interval,
     )
     .await;
     let gateway_provider = match &config.general_config.gateway_rpc_url {
         Some(url) => {
-            Some(build_node_provider(url, config.general_config.l1_provider_poll_interval).await)
+            Some(build_node_provider(url, config.general_config.l1_rpc_poll_interval).await)
         }
         None => None,
     };

--- a/node/bin/src/provider.rs
+++ b/node/bin/src/provider.rs
@@ -42,6 +42,7 @@ impl RetryPolicy for OptimisticRetryPolicy {
 
 pub async fn build_node_provider(
     rpc_url: &str,
+    poll_interval: Duration,
 ) -> FillProvider<
     impl TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
     impl Provider<Ethereum> + Clone + 'static,
@@ -56,7 +57,8 @@ pub async fn build_node_provider(
         .layer(retry_layer)
         .connect(rpc_url)
         .await
-        .expect("failed to connect to L1 api");
+        .expect("failed to connect to L1 api")
+        .with_poll_interval(poll_interval);
     ProviderBuilder::new()
         .wallet(EthereumWallet::new(PrivateKeySigner::random()))
         .connect_client(client)


### PR DESCRIPTION
## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

zksyncos is using the default alloy poll time. That's 7 seconds. When zksyncos is used in test environments that's too long.
This PR adds the possibility to configure shorter polling times for development environments:

```yaml
# config.yaml
general:
  rocks_db_path: /db/node1                                                                                                                                                                                                                                                           
  l1_provider_poll_interval: 100ms
```

## Related:

Closes #1176 