### PR TITLE
fix: bump rustls-webpki to 0.103.12 to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,7 +4281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8250,7 +8250,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10302,7 +10302,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10380,9 +10380,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` from `0.103.10` to `0.103.12` to address two security advisories published 2026-04-14:
  - [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098): Name constraints for URI names were incorrectly accepted
  - [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099): Name constraints were accepted for certificates asserting a wildcard name

## Test plan
- [ ] CI security audit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)