### PR TITLE
fix: resolve misc warnings

### DIFF
--- a/lib/gas_adjuster/src/lib.rs
+++ b/lib/gas_adjuster/src/lib.rs
@@ -209,10 +209,7 @@ impl GasAdjuster {
                         anyhow::bail!("Failed to decode blobs from sidecar");
                     }
                 }
-                Err(TryRecvError::Empty) => break Ok(()),
-                Err(TryRecvError::Disconnected) => {
-                    anyhow::bail!("Blob sidecar receiver disconnected")
-                }
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break Ok(()),
             }
         }
     }

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -126,8 +126,6 @@ impl L1Watcher {
 pub enum L1WatcherError {
     #[error("L1 does not have any blocks")]
     NoL1Blocks,
-    #[error("batch {0} was not discovered as committed")]
-    BatchNotCommitted(u64),
     #[error(transparent)]
     Sol(#[from] alloy::sol_types::Error),
     #[error(transparent)]

--- a/lib/network/src/metrics.rs
+++ b/lib/network/src/metrics.rs
@@ -202,6 +202,50 @@ pub struct OutboundDisconnectMetrics {
     pub(crate) subprotocol_specific: Counter,
 }
 
+/// Metrics for peer discovery in `reth_discv5`.
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "discv5")]
+pub struct Discv5Metrics {
+    /// Total peers currently in discv5 kbuckets.
+    pub(crate) kbucket_peers_raw_total: Gauge,
+    /// Total peers currently connected to discv5.
+    pub(crate) sessions_raw_total: Gauge,
+    /// Total discovered peers inserted into discv5 kbuckets.
+    pub(crate) inserted_kbucket_peers_raw_total: Counter,
+    /// Total number of sessions established by discv5.
+    pub(crate) established_sessions_raw_total: Counter,
+    /// Total established sessions with peers that advertise an unreachable ENR.
+    pub(crate) established_sessions_unreachable_enr_total: Counter,
+    /// Total established sessions that pass configured filters.
+    pub(crate) established_sessions_custom_filtered_total: Counter,
+    /// Total unverifiable ENRs discovered by discv5.
+    pub(crate) unverifiable_enrs_raw_total: Counter,
+}
+
+/// Frequency of networks advertised by discovered peers' node records.
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "discv5")]
+pub struct Discv5AdvertisedChainMetrics {
+    /// Frequency of `opel` entries in discovered peers' ENRs.
+    pub(crate) opel: Counter,
+    /// Frequency of `opstack` entries in discovered peers' ENRs.
+    pub(crate) opstack: Counter,
+    /// Frequency of `eth` entries in discovered peers' ENRs.
+    pub(crate) eth: Counter,
+    /// Frequency of `eth2` entries in discovered peers' ENRs.
+    pub(crate) eth2: Counter,
+}
+
+/// Throughput metrics emitted by `reth_metrics::common::mpsc::MeteredPollSender`.
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "network_active_session")]
+pub struct NetworkActiveSessionMetrics {
+    /// Number of messages sent through the active-session channel.
+    pub(crate) messages_sent_total: Counter,
+    /// Number of delayed deliveries caused by back pressure.
+    pub(crate) back_pressure_total: Counter,
+}
+
 /// Installs [`ViseRecorder`] as the global recorder for the `metrics` crate.
 ///
 /// This bridges reth-network metrics (which use the `metrics` crate) to the `vise` collector.
@@ -238,6 +282,14 @@ pub(crate) static INBOUND_DISCONNECT_METRICS: vise::Global<InboundDisconnectMetr
     vise::Global::new();
 #[vise::register]
 pub(crate) static OUTBOUND_DISCONNECT_METRICS: vise::Global<OutboundDisconnectMetrics> =
+    vise::Global::new();
+#[vise::register]
+pub(crate) static DISCV5_METRICS: vise::Global<Discv5Metrics> = vise::Global::new();
+#[vise::register]
+pub(crate) static DISCV5_ADVERTISED_CHAIN_METRICS: vise::Global<Discv5AdvertisedChainMetrics> =
+    vise::Global::new();
+#[vise::register]
+pub(crate) static NETWORK_ACTIVE_SESSION_METRICS: vise::Global<NetworkActiveSessionMetrics> =
     vise::Global::new();
 
 /// A recorder that wraps `vise` metrics into `metrics`-compatible structs.
@@ -370,6 +422,31 @@ impl Recorder for ViseRecorder {
             "network.outbound.subprotocol_specific" => {
                 &OUTBOUND_DISCONNECT_METRICS.subprotocol_specific
             }
+            // Discv5 counters
+            "discv5.inserted_kbucket_peers_raw_total" => {
+                &DISCV5_METRICS.inserted_kbucket_peers_raw_total
+            }
+            "discv5.established_sessions_raw_total" => {
+                &DISCV5_METRICS.established_sessions_raw_total
+            }
+            "discv5.established_sessions_unreachable_enr_total" => {
+                &DISCV5_METRICS.established_sessions_unreachable_enr_total
+            }
+            "discv5.established_sessions_custom_filtered_total" => {
+                &DISCV5_METRICS.established_sessions_custom_filtered_total
+            }
+            "discv5.unverifiable_enrs_raw_total" => &DISCV5_METRICS.unverifiable_enrs_raw_total,
+            "discv5.opel" => &DISCV5_ADVERTISED_CHAIN_METRICS.opel,
+            "discv5.opstack" => &DISCV5_ADVERTISED_CHAIN_METRICS.opstack,
+            "discv5.eth" => &DISCV5_ADVERTISED_CHAIN_METRICS.eth,
+            "discv5.eth2" => &DISCV5_ADVERTISED_CHAIN_METRICS.eth2,
+            // Dynamic `MeteredPollSender` counters used by active sessions
+            "network_active_session.messages_sent_total" => {
+                &NETWORK_ACTIVE_SESSION_METRICS.messages_sent_total
+            }
+            "network_active_session.back_pressure_total" => {
+                &NETWORK_ACTIVE_SESSION_METRICS.back_pressure_total
+            }
             _ => {
                 tracing::warn!(?key, "unknown counter metric");
                 return metrics::Counter::noop();
@@ -397,6 +474,9 @@ impl Recorder for ViseRecorder {
             "network.acc_duration_poll_swarm" => &NETWORK_METRICS.acc_duration_poll_swarm,
             // SessionManagerMetrics gauges
             "network.queued_outgoing_messages" => &SESSION_MANAGER_METRICS.queued_outgoing_messages,
+            // Discv5 gauges
+            "discv5.kbucket_peers_raw_total" => &DISCV5_METRICS.kbucket_peers_raw_total,
+            "discv5.sessions_raw_total" => &DISCV5_METRICS.sessions_raw_total,
             _ => {
                 tracing::warn!(?key, "unknown gauge metric");
                 return metrics::Gauge::noop();

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -386,7 +386,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         };
         db_options.set_max_open_files(max_open_files);
         let existing_cfs = DB::list_cf(&db_options, path).unwrap_or_else(|err| {
-            tracing::warn!(
+            tracing::info!(
                 db_name = CF::DB_NAME,
                 path = ?path,
                 ?err,
@@ -411,7 +411,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             })
             .collect();
         if !obsolete_cfs.is_empty() {
-            tracing::warn!(
+            tracing::info!(
                 db_name = CF::DB_NAME,
                 ?path,
                 ?obsolete_cfs,

--- a/lib/storage_api/src/replay.rs
+++ b/lib/storage_api/src/replay.rs
@@ -95,7 +95,7 @@ pub trait ReadReplayExt: ReadReplay {
                 if let Some(record) = self.get_replay_record(block_num)
                     && output.send(f(record)).await.is_err()
                 {
-                    tracing::warn!("Replay output channel closed, stopping replay forwarder");
+                    tracing::info!("Replay output channel closed, stopping replay forwarder");
                     break;
                 }
             }

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -132,13 +132,13 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         .await
                         .is_err()
                     {
-                        tracing::warn!("Command output channel closed, stopping source");
+                        tracing::info!("Command output channel closed, stopping source");
                         break;
                     }
                 }
                 send_res = output.send(BlockCommand::Produce(ProduceCommand)), if role == ConsensusRole::Leader => {
                     if send_res.is_err() {
-                        tracing::warn!("Command output channel closed, stopping source");
+                        tracing::info!("Command output channel closed, stopping source");
                         break;
                     }
                 }
@@ -176,7 +176,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
             if output.send(command).await.is_err() {
-                tracing::warn!("Command output channel closed, stopping source");
+                tracing::info!("Command output channel closed, stopping source");
                 break;
             }
         }
@@ -213,7 +213,7 @@ impl PipelineComponent for ExternalNodeCommandSource {
             }
 
             if output.send(command).await.is_err() {
-                tracing::warn!("Command output channel closed, stopping source");
+                tracing::info!("Command output channel closed, stopping source");
                 break;
             }
         }


### PR DESCRIPTION
## Summary

- downgrades some unactionable warnings: rocksdb, command sources
- records missing metrics from reth_discv5 (resolves "unknown counter metric")
- do not return error on disconnect in gas adjuster

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

