### PR TITLE
fix: minor issues that lead to panic/error

### DIFF
--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -127,6 +127,10 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
         from: u64,
         to: u64,
     ) -> EthFilterResult<Vec<Log>> {
+        // return empty vector if the range is invalid.
+        if from > to {
+            return Ok(Vec::new());
+        }
         if let Some(max_blocks_per_filter) = self
             .query_limits
             .max_blocks_per_filter

--- a/lib/state_full_diffs/src/lib.rs
+++ b/lib/state_full_diffs/src/lib.rs
@@ -108,9 +108,20 @@ impl WriteState for FullDiffsState {
     where
         J: IntoIterator<Item = (B256, &'a Vec<u8>)>,
     {
+        // NOTE: keep this order as "preimages first, storage second".
+        //
+        // Storage also updates `latest_block`, which signals that block N is written to disk (base).
+        // As such, preimages might be missing for a short period (not yet written to disk, but purged from overlay).
+        //
+        // TODO: The right fix here would be to have `block_range_available()` depend on both storage & preimages being written.
+        //
+        // We intentionally defer the proper fix for now.
+        // Whilst we prefer the above, it requires tracking preimages progress for persistent state across restarts.
+        // That implies extra metadata and migration / compatibility work.
+        // Given lack of migration support, we prefer to keep the current behavior and defer the fix until migrations are supported.
+        self.preimages.add(new_preimages)?;
         self.storage
             .add_block(block_number, storage_diffs, override_allowed)?;
-        self.preimages.add(new_preimages)?;
         Ok(())
     }
 }

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -59,9 +59,16 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                 "ProverInputGenerator is disabled — passing through blocks with ProverInput::Fake"
             );
             while let Some((block_output, replay_record, tree)) = input.recv().await {
-                output
+                if output
                     .send((block_output, replay_record, ProverInput::Fake, tree))
-                    .await?;
+                    .await
+                    .is_err()
+                {
+                    tracing::info!(
+                        "Prover input generator output channel closed, stopping component"
+                    );
+                    return Ok(());
+                }
             }
             return Ok(());
         }
@@ -83,7 +90,10 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
             block_number = result.0.header.number,
             "sending block with prover input to batcher",
         );
-        output.send(result).await?;
+        if output.send(result).await.is_err() {
+            tracing::info!("Prover input generator output channel closed, stopping component");
+            return Ok(());
+        }
         latency_tracker.enter_state(GenericComponentState::ProcessingOrWaitingRecv);
 
         // Process remaining items with up to `maximum_in_flight_blocks` in parallel.
@@ -114,7 +124,10 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                         block_number = item.0.header.number,
                         "sending block with prover input to batcher",
                     );
-                    output.send(item).await?;
+                    if output.send(item).await.is_err() {
+                        tracing::info!("Prover input generator output channel closed, stopping component");
+                        return Ok(());
+                    }
                     latency_tracker.enter_state(GenericComponentState::ProcessingOrWaitingRecv);
                 }
             }


### PR DESCRIPTION
## Summary

- "preimages first, storage second" for `StateFullDiffs`, it was fixed for compacted storage some time ago but not for this one
- fix shutdown for PIG
- `from > to` check for get_logs


<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

