### PR TITLE
feat(rpc): use log index in eth_getLogs to skip candidate blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14585,6 +14585,7 @@ dependencies = [
  "zksync_os_mini_merkle_tree",
  "zksync_os_multivm",
  "zksync_os_rpc_api",
+ "zksync_os_storage",
  "zksync_os_storage_api",
  "zksync_os_types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14560,6 +14560,7 @@ dependencies = [
  "jsonrpsee",
  "reth-rpc-eth-types",
  "reth-tasks",
+ "roaring",
  "ruint",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10380,9 +10380,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 zksync_os_mempool.workspace = true
 zksync_os_mini_merkle_tree.workspace = true
 zksync_os_rpc_api = { workspace = true, features = ["server"] }
+zksync_os_storage.workspace = true
 zksync_os_storage_api.workspace = true
 zksync_os_types.workspace = true
 zksync_os_multivm.workspace = true

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -39,6 +39,7 @@ blake2.workspace = true
 dashmap.workspace = true
 futures.workspace = true
 jsonrpsee = { workspace = true, default-features = false, features = ["macros", "client"] }
+roaring.workspace = true
 ruint.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/lib/rpc/src/eth_filter/index.rs
+++ b/lib/rpc/src/eth_filter/index.rs
@@ -1,0 +1,128 @@
+use std::ops::{BitAnd, BitOr, Range};
+
+use alloy::{
+    primitives::{Address, B256},
+    rpc::types::{Filter, FilterSet},
+};
+use roaring::RoaringBitmap;
+use zksync_os_storage_api::{LogIndex, RepositoryResult};
+
+trait IteratorExt: Iterator {
+    /// Same as nightly `Iterator::try_reduce`, for stable Rust.
+    fn try_reduce<T, E, F>(mut self, mut f: F) -> Result<Option<T>, E>
+    where
+        Self: Sized + Iterator<Item = Result<T, E>>,
+        F: FnMut(T, T) -> T,
+    {
+        let first = match self.next() {
+            None => return Ok(None),
+            Some(Err(e)) => return Err(e),
+            Some(Ok(x)) => x,
+        };
+        self.try_fold(first, |acc, item| item.map(|x| f(acc, x)))
+            .map(Some)
+    }
+}
+
+impl<I: Iterator> IteratorExt for I {}
+
+/// Builds a candidate-block bitmap from the log index for `filter` over `range`.
+///
+/// Returns the candidates for the filter over `range`.
+/// Blocks outside `covered` must be checked via bloom filter.
+/// Returns empty candidates if the filter has no address or topic constraints.
+pub(crate) fn candidates(
+    repo: &dyn LogIndex,
+    filter: &Filter,
+    range: Range<u64>,
+) -> RepositoryResult<Candidates> {
+    // Within a group bitmaps are OR'd (any match); groups are AND'd (all must match).
+    let mut groups: Vec<Candidates> = vec![];
+
+    if !filter.address.is_empty() {
+        groups.push(address_candidates(repo, &filter.address, range.clone())?);
+    }
+    for topics in filter.topics.iter().filter(|ts| !ts.is_empty()) {
+        groups.push(topic_candidates(repo, topics, range.clone())?);
+    }
+
+    Ok(groups.into_iter().reduce(|a, b| a & b).unwrap_or_default())
+}
+
+/// OR's the bitmaps for all addresses in the filter.
+fn address_candidates(
+    repo: &dyn LogIndex,
+    addresses: &FilterSet<Address>,
+    range: Range<u64>,
+) -> RepositoryResult<Candidates> {
+    Ok(addresses
+        .iter()
+        .map(|addr| {
+            repo.blocks_for_address(*addr, range.clone())
+                .map(Candidates::from)
+        })
+        .try_reduce(|a, b| a | b)?
+        .unwrap_or_default())
+}
+
+/// OR's the bitmaps for all topics in a single topic position.
+fn topic_candidates(
+    repo: &dyn LogIndex,
+    topics: &FilterSet<B256>,
+    range: Range<u64>,
+) -> RepositoryResult<Candidates> {
+    Ok(topics
+        .iter()
+        .map(|topic| {
+            repo.blocks_for_topic(*topic, range.clone())
+                .map(Candidates::from)
+        })
+        .try_reduce(|a, b| a | b)?
+        .unwrap_or_default())
+}
+
+/// A set of candidate blocks from the log index, together with the range of blocks the index covers.
+/// Blocks outside `covered` must be checked via bloom filter regardless of `bitmap`.
+pub struct Candidates {
+    pub bitmap: RoaringBitmap,
+    pub covered: Range<u64>,
+}
+
+impl BitOr for Candidates {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        Self {
+            bitmap: self.bitmap | other.bitmap,
+            covered: intersect(self.covered, other.covered),
+        }
+    }
+}
+
+impl BitAnd for Candidates {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        Self {
+            bitmap: self.bitmap & other.bitmap,
+            covered: intersect(self.covered, other.covered),
+        }
+    }
+}
+
+impl Default for Candidates {
+    fn default() -> Self {
+        Self {
+            bitmap: RoaringBitmap::new(),
+            covered: 0..0,
+        }
+    }
+}
+
+impl From<(RoaringBitmap, Range<u64>)> for Candidates {
+    fn from((bitmap, covered): (RoaringBitmap, Range<u64>)) -> Self {
+        Self { bitmap, covered }
+    }
+}
+
+fn intersect(a: Range<u64>, b: Range<u64>) -> Range<u64> {
+    a.start.max(b.start)..a.end.min(b.end)
+}

--- a/lib/rpc/src/eth_filter/index.rs
+++ b/lib/rpc/src/eth_filter/index.rs
@@ -126,3 +126,130 @@ impl From<(RoaringBitmap, Range<u64>)> for Candidates {
 fn intersect(a: Range<u64>, b: Range<u64>) -> Range<u64> {
     a.start.max(b.start)..a.end.min(b.end)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, B256};
+    use std::collections::HashMap;
+    use zksync_os_storage_api::RepositoryResult;
+
+    #[derive(Debug, Default)]
+    struct MockIndex {
+        addresses: HashMap<Address, (RoaringBitmap, Range<u64>)>,
+        topics: HashMap<B256, (RoaringBitmap, Range<u64>)>,
+    }
+
+    impl MockIndex {
+        fn with_address(mut self, addr: Address, blocks: &[u64], covered: Range<u64>) -> Self {
+            self.addresses
+                .insert(addr, (blocks.iter().map(|&b| b as u32).collect(), covered));
+            self
+        }
+
+        fn with_topic(mut self, topic: B256, blocks: &[u64], covered: Range<u64>) -> Self {
+            self.topics
+                .insert(topic, (blocks.iter().map(|&b| b as u32).collect(), covered));
+            self
+        }
+    }
+
+    impl LogIndex for MockIndex {
+        fn blocks_for_address(
+            &self,
+            address: Address,
+            _range: Range<u64>,
+        ) -> RepositoryResult<(RoaringBitmap, Range<u64>)> {
+            Ok(self.addresses.get(&address).cloned().unwrap_or_default())
+        }
+
+        fn blocks_for_topic(
+            &self,
+            topic: B256,
+            _range: Range<u64>,
+        ) -> RepositoryResult<(RoaringBitmap, Range<u64>)> {
+            Ok(self.topics.get(&topic).cloned().unwrap_or_default())
+        }
+    }
+
+    fn blocks(c: &Candidates) -> Vec<u32> {
+        c.bitmap.iter().collect()
+    }
+
+    #[test]
+    fn unconstrained_filter_returns_empty_candidates() {
+        let index = MockIndex::default();
+        let filter = Filter::new();
+        let c = candidates(&index, &filter, 0..100).unwrap();
+        assert!(c.bitmap.is_empty());
+        assert_eq!(c.covered, 0..0);
+    }
+
+    #[test]
+    fn single_address_uses_address_index() {
+        let addr = Address::repeat_byte(0x01);
+        let index = MockIndex::default().with_address(addr, &[2, 4, 6], 0..10);
+        let filter = Filter::new().address(addr);
+        let c = candidates(&index, &filter, 0..10).unwrap();
+        assert_eq!(blocks(&c), vec![2, 4, 6]);
+        assert_eq!(c.covered, 0..10);
+    }
+
+    #[test]
+    fn multiple_addresses_are_ored() {
+        let a = Address::repeat_byte(0x01);
+        let b = Address::repeat_byte(0x02);
+        let index = MockIndex::default()
+            .with_address(a, &[1, 3], 0..10)
+            .with_address(b, &[3, 5], 0..10);
+        let filter = Filter::new().address(vec![a, b]);
+        let c = candidates(&index, &filter, 0..10).unwrap();
+        assert_eq!(blocks(&c), vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn address_and_topic_are_anded() {
+        let addr = Address::repeat_byte(0x01);
+        let topic = B256::repeat_byte(0x42);
+        let index = MockIndex::default()
+            .with_address(addr, &[1, 2, 3], 0..10)
+            .with_topic(topic, &[2, 3, 4], 0..10);
+        let filter = Filter::new().address(addr).event_signature(topic);
+        let c = candidates(&index, &filter, 0..10).unwrap();
+        assert_eq!(blocks(&c), vec![2, 3]);
+    }
+
+    #[test]
+    fn multiple_topics_at_same_position_are_ored() {
+        let t1 = B256::repeat_byte(0x01);
+        let t2 = B256::repeat_byte(0x02);
+        let index = MockIndex::default()
+            .with_topic(t1, &[1, 3], 0..10)
+            .with_topic(t2, &[3, 5], 0..10);
+        let filter = Filter::new().event_signature(vec![t1, t2]);
+        let c = candidates(&index, &filter, 0..10).unwrap();
+        assert_eq!(blocks(&c), vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn coverage_is_intersected_across_groups() {
+        let addr = Address::repeat_byte(0x01);
+        let topic = B256::repeat_byte(0x42);
+        let index = MockIndex::default()
+            .with_address(addr, &[5], 0..10)
+            .with_topic(topic, &[5], 4..12);
+        let filter = Filter::new().address(addr).event_signature(topic);
+        let c = candidates(&index, &filter, 0..12).unwrap();
+        assert_eq!(c.covered, 4..10);
+    }
+
+    #[test]
+    fn no_index_coverage_returns_empty_covered() {
+        let addr = Address::repeat_byte(0x01);
+        let index = MockIndex::default(); // no index entries → default (empty, 0..0)
+        let filter = Filter::new().address(addr);
+        let c = candidates(&index, &filter, 0..10).unwrap();
+        assert!(c.bitmap.is_empty());
+        assert_eq!(c.covered, 0..0);
+    }
+}

--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -2,7 +2,6 @@ use crate::config::RpcConfig;
 use crate::result::ToRpcResult;
 use crate::rpc_storage::ReadRpcStorage;
 use crate::types::QueryLimits;
-mod index;
 mod pending;
 use pending::{FullTransactionsReceiver, PendingTransactionKind, PendingTransactionsReceiver};
 mod registry;

--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -2,6 +2,7 @@ use crate::config::RpcConfig;
 use crate::result::ToRpcResult;
 use crate::rpc_storage::ReadRpcStorage;
 use crate::types::QueryLimits;
+mod index;
 mod pending;
 use pending::{FullTransactionsReceiver, PendingTransactionKind, PendingTransactionsReceiver};
 mod registry;

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,6 +1,6 @@
 use super::EthFilterError;
 use crate::eth_impl::build_api_log;
-use crate::metrics::{API_METRICS, FilterCategory, GetLogsStat};
+use crate::metrics::{FilterCategory, GET_LOGS_METRICS, GetLogsStat};
 use alloy::rpc::types::{Filter, Log};
 use zksync_os_storage::log_index_filter::candidates;
 use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
@@ -137,30 +137,30 @@ impl BlockScanStats {
 impl Drop for BlockScanStats {
     fn drop(&mut self) {
         let cat = self.category;
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
             .observe(self.skipped_by_index);
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
             .observe(self.bloom_true_positive);
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
             .observe(self.bloom_false_positive);
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
             .observe(self.bloom_negative);
-        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
+        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
             .observe(self.logs_returned);
         if self.total > 0 {
-            API_METRICS.get_logs_index_skip_ratio[&cat]
+            GET_LOGS_METRICS.index_skip_ratio[&cat]
                 .observe(self.skipped_by_index as f64 / self.total as f64);
-            API_METRICS.get_logs_index_coverage[&cat]
+            GET_LOGS_METRICS.index_coverage[&cat]
                 .observe(self.covered_len as f64 / self.total as f64);
         }
         let bloom_checked = self.bloom_true_positive + self.bloom_false_positive;
         if bloom_checked > 0 {
-            API_METRICS.get_logs_bloom_precision[&cat]
+            GET_LOGS_METRICS.bloom_precision[&cat]
                 .observe(self.bloom_true_positive as f64 / bloom_checked as f64);
         }
         if self.truncated {
-            API_METRICS.get_logs_truncated[&cat].inc();
+            GET_LOGS_METRICS.truncated[&cat].inc();
         }
     }
 }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,7 +1,7 @@
 use super::EthFilterError;
 use zksync_os_storage::log_index_filter::candidates;
 use crate::eth_impl::build_api_log;
-use crate::metrics::{API_METRICS, GetLogsStat};
+use crate::metrics::{API_METRICS, FilterCategory, GetLogsStat};
 use alloy::rpc::types::{Filter, Log};
 use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
 
@@ -21,10 +21,7 @@ pub(crate) fn scan_logs(
     let candidates = candidates(repo, filter, from..to + 1)?;
 
     let is_multi_block_range = from != to;
-    let mut stats = BlockScanStats::new(
-        to - from + 1,
-        filter.address.is_empty() && !filter.has_topics(),
-    );
+    let mut stats = BlockScanStats::new(to - from + 1, filter, candidates.covered_len());
     let mut logs = Vec::new();
 
     for number in from..=to {
@@ -111,25 +108,27 @@ fn collect_matching_logs(filter: &Filter, stored_txs: Vec<StoredTxData>, out: &m
 /// Observes Prometheus metrics when dropped, ensuring they are recorded on all exit paths.
 struct BlockScanStats {
     total: u64,
+    covered_len: u64,
     skipped_by_index: u64,
     bloom_true_positive: u64,
     bloom_false_positive: u64,
     bloom_negative: u64,
     logs_returned: u64,
-    unconstrained: bool,
+    category: FilterCategory,
     truncated: bool,
 }
 
 impl BlockScanStats {
-    fn new(total: u64, unconstrained: bool) -> Self {
+    fn new(total: u64, filter: &Filter, covered_len: u64) -> Self {
         Self {
             total,
+            covered_len,
             skipped_by_index: 0,
             bloom_true_positive: 0,
             bloom_false_positive: 0,
             bloom_negative: 0,
             logs_returned: 0,
-            unconstrained,
+            category: FilterCategory::from(filter),
             truncated: false,
         }
     }
@@ -137,19 +136,28 @@ impl BlockScanStats {
 
 impl Drop for BlockScanStats {
     fn drop(&mut self) {
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::Total].observe(self.total);
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::SkippedByIndex]
+        let cat = self.category;
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
             .observe(self.skipped_by_index);
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomTruePositive]
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
             .observe(self.bloom_true_positive);
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomFalsePositive]
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
             .observe(self.bloom_false_positive);
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomNegative]
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
             .observe(self.bloom_negative);
-        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::LogsReturned]
+        API_METRICS.get_logs_scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
             .observe(self.logs_returned);
-        if self.unconstrained {
-            API_METRICS.get_logs_unconstrained.inc();
+        if self.total > 0 {
+            API_METRICS.get_logs_index_skip_ratio[&cat]
+                .observe(self.skipped_by_index as f64 / self.total as f64);
+            API_METRICS.get_logs_index_coverage[&cat]
+                .observe(self.covered_len as f64 / self.total as f64);
+        }
+        let bloom_checked = self.bloom_true_positive + self.bloom_false_positive;
+        if bloom_checked > 0 {
+            API_METRICS.get_logs_bloom_fp_rate[&cat]
+                .observe(self.bloom_false_positive as f64 / bloom_checked as f64);
         }
         if self.truncated {
             API_METRICS.get_logs_truncated.inc();

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,8 +1,8 @@
 use super::EthFilterError;
-use zksync_os_storage::log_index_filter::candidates;
 use crate::eth_impl::build_api_log;
 use crate::metrics::{API_METRICS, FilterCategory, GetLogsStat};
 use alloy::rpc::types::{Filter, Log};
+use zksync_os_storage::log_index_filter::candidates;
 use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
 
 type EthFilterResult<T> = Result<T, EthFilterError>;

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -160,7 +160,7 @@ impl Drop for BlockScanStats {
                 .observe(self.bloom_true_positive as f64 / bloom_checked as f64);
         }
         if self.truncated {
-            API_METRICS.get_logs_truncated.inc();
+            API_METRICS.get_logs_truncated[&cat].inc();
         }
     }
 }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -156,8 +156,8 @@ impl Drop for BlockScanStats {
         }
         let bloom_checked = self.bloom_true_positive + self.bloom_false_positive;
         if bloom_checked > 0 {
-            API_METRICS.get_logs_bloom_fp_rate[&cat]
-                .observe(self.bloom_false_positive as f64 / bloom_checked as f64);
+            API_METRICS.get_logs_bloom_precision[&cat]
+                .observe(self.bloom_true_positive as f64 / bloom_checked as f64);
         }
         if self.truncated {
             API_METRICS.get_logs_truncated.inc();

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,6 +1,6 @@
 use super::EthFilterError;
 use crate::eth_impl::build_api_log;
-use crate::metrics::{FilterCategory, GET_LOGS_METRICS, GetLogsStat};
+use crate::metrics::{FilterCategory, GET_LOGS, GetLogsStat};
 use alloy::rpc::types::{Filter, Log};
 use zksync_os_storage::log_index_filter::candidates;
 use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
@@ -137,30 +137,30 @@ impl BlockScanStats {
 impl Drop for BlockScanStats {
     fn drop(&mut self) {
         let cat = self.category;
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
+        GET_LOGS.scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
+        GET_LOGS.scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
             .observe(self.skipped_by_index);
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
+        GET_LOGS.scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
             .observe(self.bloom_true_positive);
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
+        GET_LOGS.scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
             .observe(self.bloom_false_positive);
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
+        GET_LOGS.scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
             .observe(self.bloom_negative);
-        GET_LOGS_METRICS.scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
+        GET_LOGS.scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
             .observe(self.logs_returned);
         if self.total > 0 {
-            GET_LOGS_METRICS.index_skip_ratio[&cat]
+            GET_LOGS.index_skip_ratio[&cat]
                 .observe(self.skipped_by_index as f64 / self.total as f64);
-            GET_LOGS_METRICS.index_coverage[&cat]
+            GET_LOGS.index_coverage[&cat]
                 .observe(self.covered_len as f64 / self.total as f64);
         }
         let bloom_checked = self.bloom_true_positive + self.bloom_false_positive;
         if bloom_checked > 0 {
-            GET_LOGS_METRICS.bloom_precision[&cat]
+            GET_LOGS.bloom_precision[&cat]
                 .observe(self.bloom_true_positive as f64 / bloom_checked as f64);
         }
         if self.truncated {
-            GET_LOGS_METRICS.truncated[&cat].inc();
+            GET_LOGS.truncated[&cat].inc();
         }
     }
 }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -138,21 +138,17 @@ impl Drop for BlockScanStats {
     fn drop(&mut self) {
         let cat = self.category;
         GET_LOGS.scanned_blocks[&(GetLogsStat::Total, cat)].observe(self.total);
-        GET_LOGS.scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)]
-            .observe(self.skipped_by_index);
+        GET_LOGS.scanned_blocks[&(GetLogsStat::SkippedByIndex, cat)].observe(self.skipped_by_index);
         GET_LOGS.scanned_blocks[&(GetLogsStat::BloomTruePositive, cat)]
             .observe(self.bloom_true_positive);
         GET_LOGS.scanned_blocks[&(GetLogsStat::BloomFalsePositive, cat)]
             .observe(self.bloom_false_positive);
-        GET_LOGS.scanned_blocks[&(GetLogsStat::BloomNegative, cat)]
-            .observe(self.bloom_negative);
-        GET_LOGS.scanned_blocks[&(GetLogsStat::LogsReturned, cat)]
-            .observe(self.logs_returned);
+        GET_LOGS.scanned_blocks[&(GetLogsStat::BloomNegative, cat)].observe(self.bloom_negative);
+        GET_LOGS.scanned_blocks[&(GetLogsStat::LogsReturned, cat)].observe(self.logs_returned);
         if self.total > 0 {
             GET_LOGS.index_skip_ratio[&cat]
                 .observe(self.skipped_by_index as f64 / self.total as f64);
-            GET_LOGS.index_coverage[&cat]
-                .observe(self.covered_len as f64 / self.total as f64);
+            GET_LOGS.index_coverage[&cat].observe(self.covered_len as f64 / self.total as f64);
         }
         let bloom_checked = self.bloom_true_positive + self.bloom_false_positive;
         if bloom_checked > 0 {

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -28,8 +28,7 @@ pub(crate) fn scan_logs(
     let mut logs = Vec::new();
 
     for number in from..=to {
-        // Within the covered range, skip blocks the index says have no matching logs.
-        if candidates.covered.contains(&number) && !candidates.bitmap.contains(number as u32) {
+        if !candidates.may_contain(number) {
             stats.skipped_by_index += 1;
             continue;
         }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,4 +1,5 @@
 use super::EthFilterError;
+use super::index::candidates;
 use crate::eth_impl::build_api_log;
 use crate::metrics::API_METRICS;
 use alloy::rpc::types::{Filter, Log};
@@ -6,10 +7,10 @@ use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
 
 type EthFilterResult<T> = Result<T, EthFilterError>;
 
-/// Scans blocks in `from..=to` using per-block bloom filters and returns matching logs.
+/// Scans blocks in `from..=to` and returns matching logs.
 ///
-/// This is the naive O(block_range) implementation. It will be replaced by an inverted index
-/// lookup once the index is implemented.
+/// Uses the log index (if available) to skip blocks that cannot contain matching logs. Blocks
+/// outside the index's covered range fall back to per-block bloom filter checks.
 pub(crate) fn scan_logs(
     repo: &dyn ReadRepository,
     filter: &Filter,
@@ -17,11 +18,22 @@ pub(crate) fn scan_logs(
     to: u64,
     max_logs: Option<usize>,
 ) -> EthFilterResult<Vec<Log>> {
+    let candidates = candidates(repo, filter, from..to + 1)?;
+
     let is_multi_block_range = from != to;
-    let mut stats = BlockScanStats::new(to - from + 1);
+    let mut stats = BlockScanStats::new(
+        to - from + 1,
+        filter.address.is_empty() && !filter.has_topics(),
+    );
     let mut logs = Vec::new();
 
     for number in from..=to {
+        // Within the covered range, skip blocks the index says have no matching logs.
+        if candidates.covered.contains(&number) && !candidates.bitmap.contains(number as u32) {
+            stats.skipped_by_index += 1;
+            continue;
+        }
+
         let Some(block) = repo.get_block_by_number(number)? else {
             return Err(EthFilterError::BlockNotFound(number.into()));
         };
@@ -35,9 +47,9 @@ pub(crate) fn scan_logs(
             let logs_before = logs.len();
             collect_matching_logs(filter, stored_txs, &mut logs);
             if logs.len() > logs_before {
-                stats.true_positive += 1;
+                stats.bloom_true_positive += 1;
             } else {
-                stats.false_positive += 1;
+                stats.bloom_false_positive += 1;
             }
 
             // size check but only if range is multiple blocks, so we always return all
@@ -46,6 +58,7 @@ pub(crate) fn scan_logs(
                 && is_multi_block_range
                 && logs.len() > max_logs
             {
+                stats.truncated = true;
                 return Err(EthFilterError::QueryExceedsMaxResults {
                     max_logs,
                     from_block: from,
@@ -53,10 +66,11 @@ pub(crate) fn scan_logs(
                 });
             }
         } else {
-            stats.negative += 1;
+            stats.bloom_negative += 1;
         }
     }
 
+    stats.logs_returned = logs.len() as u64;
     Ok(logs)
 }
 
@@ -98,18 +112,26 @@ fn collect_matching_logs(filter: &Filter, stored_txs: Vec<StoredTxData>, out: &m
 /// Observes Prometheus metrics when dropped, ensuring they are recorded on all exit paths.
 struct BlockScanStats {
     total: u64,
-    true_positive: u64,
-    false_positive: u64,
-    negative: u64,
+    skipped_by_index: u64,
+    bloom_true_positive: u64,
+    bloom_false_positive: u64,
+    bloom_negative: u64,
+    logs_returned: u64,
+    unconstrained: bool,
+    truncated: bool,
 }
 
 impl BlockScanStats {
-    fn new(total: u64) -> Self {
+    fn new(total: u64, unconstrained: bool) -> Self {
         Self {
             total,
-            true_positive: 0,
-            false_positive: 0,
-            negative: 0,
+            skipped_by_index: 0,
+            bloom_true_positive: 0,
+            bloom_false_positive: 0,
+            bloom_negative: 0,
+            logs_returned: 0,
+            unconstrained,
+            truncated: false,
         }
     }
 }
@@ -117,8 +139,18 @@ impl BlockScanStats {
 impl Drop for BlockScanStats {
     fn drop(&mut self) {
         API_METRICS.get_logs_scanned_blocks[&"total"].observe(self.total);
-        API_METRICS.get_logs_scanned_blocks[&"true_positive"].observe(self.true_positive);
-        API_METRICS.get_logs_scanned_blocks[&"false_positive"].observe(self.false_positive);
-        API_METRICS.get_logs_scanned_blocks[&"negative"].observe(self.negative);
+        API_METRICS.get_logs_scanned_blocks[&"skipped_by_index"].observe(self.skipped_by_index);
+        API_METRICS.get_logs_scanned_blocks[&"bloom_true_positive"]
+            .observe(self.bloom_true_positive);
+        API_METRICS.get_logs_scanned_blocks[&"bloom_false_positive"]
+            .observe(self.bloom_false_positive);
+        API_METRICS.get_logs_scanned_blocks[&"bloom_negative"].observe(self.bloom_negative);
+        API_METRICS.get_logs_scanned_blocks[&"logs_returned"].observe(self.logs_returned);
+        if self.unconstrained {
+            API_METRICS.get_logs_unconstrained.inc();
+        }
+        if self.truncated {
+            API_METRICS.get_logs_truncated.inc();
+        }
     }
 }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,7 +1,7 @@
 use super::EthFilterError;
 use zksync_os_storage::log_index_filter::candidates;
 use crate::eth_impl::build_api_log;
-use crate::metrics::API_METRICS;
+use crate::metrics::{API_METRICS, GetLogsStat};
 use alloy::rpc::types::{Filter, Log};
 use zksync_os_storage_api::{ReadRepository, RepositoryBlock, StoredTxData};
 
@@ -138,14 +138,17 @@ impl BlockScanStats {
 
 impl Drop for BlockScanStats {
     fn drop(&mut self) {
-        API_METRICS.get_logs_scanned_blocks[&"total"].observe(self.total);
-        API_METRICS.get_logs_scanned_blocks[&"skipped_by_index"].observe(self.skipped_by_index);
-        API_METRICS.get_logs_scanned_blocks[&"bloom_true_positive"]
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::Total].observe(self.total);
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::SkippedByIndex]
+            .observe(self.skipped_by_index);
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomTruePositive]
             .observe(self.bloom_true_positive);
-        API_METRICS.get_logs_scanned_blocks[&"bloom_false_positive"]
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomFalsePositive]
             .observe(self.bloom_false_positive);
-        API_METRICS.get_logs_scanned_blocks[&"bloom_negative"].observe(self.bloom_negative);
-        API_METRICS.get_logs_scanned_blocks[&"logs_returned"].observe(self.logs_returned);
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::BloomNegative]
+            .observe(self.bloom_negative);
+        API_METRICS.get_logs_scanned_blocks[&GetLogsStat::LogsReturned]
+            .observe(self.logs_returned);
         if self.unconstrained {
             API_METRICS.get_logs_unconstrained.inc();
         }

--- a/lib/rpc/src/eth_filter/scan.rs
+++ b/lib/rpc/src/eth_filter/scan.rs
@@ -1,5 +1,5 @@
 use super::EthFilterError;
-use super::index::candidates;
+use zksync_os_storage::log_index_filter::candidates;
 use crate::eth_impl::build_api_log;
 use crate::metrics::API_METRICS;
 use alloy::rpc::types::{Filter, Log};

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,6 +1,6 @@
 use alloy::rpc::types::Filter;
 use std::time::Duration;
-use vise::{Buckets, Counter, EncodeLabelValue, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Histogram, LabeledFamily, Metrics, Unit};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
@@ -22,7 +22,7 @@ pub enum GetLogsStat {
 }
 
 /// Filter constraint category for an `eth_getLogs` call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "filter", rename_all = "snake_case")]
 pub enum FilterCategory {
     /// No address or topic constraints; every block must be scanned.
@@ -52,14 +52,14 @@ pub struct ApiMetrics {
     #[metrics(labels = ["kind", "filter"], buckets = BLOCK_COUNTS)]
     pub get_logs_scanned_blocks: LabeledFamily<(GetLogsStat, FilterCategory), Histogram<u64>, 2>,
     /// Per-call fraction of blocks skipped by the log index (skipped / total).
-    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
-    pub get_logs_index_skip_ratio: LabeledFamily<FilterCategory, Histogram<f64>>,
+    #[metrics(buckets = RATIO_BUCKETS)]
+    pub get_logs_index_skip_ratio: Family<FilterCategory, Histogram<f64>>,
     /// Per-call bloom filter precision among blocks that reached the bloom check (true positives / bloom-passed blocks).
-    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
-    pub get_logs_bloom_precision: LabeledFamily<FilterCategory, Histogram<f64>>,
+    #[metrics(buckets = RATIO_BUCKETS)]
+    pub get_logs_bloom_precision: Family<FilterCategory, Histogram<f64>>,
     /// Per-call fraction of the queried block range covered by the log index.
-    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
-    pub get_logs_index_coverage: LabeledFamily<FilterCategory, Histogram<f64>>,
+    #[metrics(buckets = RATIO_BUCKETS)]
+    pub get_logs_index_coverage: Family<FilterCategory, Histogram<f64>>,
     /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`.
     pub get_logs_truncated: Counter,
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -49,22 +49,31 @@ impl From<&Filter> for FilterCategory {
     }
 }
 
+/// Metrics for `eth_getLogs` scan behaviour.
 #[derive(Debug, Metrics)]
-pub struct ApiMetrics {
-    /// Block disposition per `eth_getLogs` call, broken down by outcome kind and filter category.
+#[metrics(prefix = "get_logs")]
+pub struct GetLogsMetrics {
+    /// Block disposition per call, broken down by outcome kind and filter category.
     #[metrics(labels = ["kind", "filter"], buckets = BLOCK_COUNTS)]
-    pub get_logs_scanned_blocks: LabeledFamily<(GetLogsStat, FilterCategory), Histogram<u64>, 2>,
+    pub scanned_blocks: LabeledFamily<(GetLogsStat, FilterCategory), Histogram<u64>, 2>,
     /// Per-call fraction of blocks skipped by the log index (skipped / total).
     #[metrics(buckets = RATIO_BUCKETS)]
-    pub get_logs_index_skip_ratio: Family<FilterCategory, Histogram<f64>>,
+    pub index_skip_ratio: Family<FilterCategory, Histogram<f64>>,
     /// Per-call bloom filter precision among blocks that reached the bloom check (true positives / bloom-passed blocks).
     #[metrics(buckets = RATIO_BUCKETS)]
-    pub get_logs_bloom_precision: Family<FilterCategory, Histogram<f64>>,
+    pub bloom_precision: Family<FilterCategory, Histogram<f64>>,
     /// Per-call fraction of the queried block range covered by the log index.
     #[metrics(buckets = RATIO_BUCKETS)]
-    pub get_logs_index_coverage: Family<FilterCategory, Histogram<f64>>,
-    /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`, broken down by filter category.
-    pub get_logs_truncated: Family<FilterCategory, Counter>,
+    pub index_coverage: Family<FilterCategory, Histogram<f64>>,
+    /// Number of calls truncated due to exceeding `max_logs`, broken down by filter category.
+    pub truncated: Family<FilterCategory, Counter>,
+}
+
+#[vise::register]
+pub static GET_LOGS_METRICS: vise::Global<GetLogsMetrics> = vise::Global::new();
+
+#[derive(Debug, Metrics)]
+pub struct ApiMetrics {
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]
     pub response_time: LabeledFamily<String, Histogram<Duration>>,
     #[metrics(unit = Unit::Bytes, labels = ["method"], buckets = BYTES_BUCKETS)]

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,6 +1,9 @@
 use alloy::rpc::types::Filter;
 use std::time::Duration;
-use vise::{Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{
+    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Histogram, LabeledFamily, Metrics,
+    Unit,
+};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -7,8 +7,13 @@ const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1
 
 #[derive(Debug, Metrics)]
 pub struct ApiMetrics {
-    #[metrics(labels = ["method"], buckets = BLOCK_COUNTS)]
+    /// Block disposition per `eth_getLogs` call, broken down by outcome kind.
+    #[metrics(labels = ["kind"], buckets = BLOCK_COUNTS)]
     pub get_logs_scanned_blocks: LabeledFamily<&'static str, Histogram<u64>>,
+    /// Number of `eth_getLogs` calls with no address or topic constraints (full block scan).
+    pub get_logs_unconstrained: Counter,
+    /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`.
+    pub get_logs_truncated: Counter,
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]
     pub response_time: LabeledFamily<String, Histogram<Duration>>,
     #[metrics(unit = Unit::Bytes, labels = ["method"], buckets = BYTES_BUCKETS)]

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -60,8 +60,8 @@ pub struct ApiMetrics {
     /// Per-call fraction of the queried block range covered by the log index.
     #[metrics(buckets = RATIO_BUCKETS)]
     pub get_logs_index_coverage: Family<FilterCategory, Histogram<f64>>,
-    /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`.
-    pub get_logs_truncated: Counter,
+    /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`, broken down by filter category.
+    pub get_logs_truncated: Family<FilterCategory, Counter>,
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]
     pub response_time: LabeledFamily<String, Histogram<Duration>>,
     #[metrics(unit = Unit::Bytes, labels = ["method"], buckets = BYTES_BUCKETS)]

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -52,7 +52,7 @@ impl From<&Filter> for FilterCategory {
 /// Metrics for `eth_getLogs` scan behaviour.
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "get_logs")]
-pub struct GetLogsMetrics {
+pub struct GetLogs {
     /// Block disposition per call, broken down by outcome kind and filter category.
     #[metrics(labels = ["kind", "filter"], buckets = BLOCK_COUNTS)]
     pub scanned_blocks: LabeledFamily<(GetLogsStat, FilterCategory), Histogram<u64>, 2>,
@@ -70,10 +70,11 @@ pub struct GetLogsMetrics {
 }
 
 #[vise::register]
-pub static GET_LOGS_METRICS: vise::Global<GetLogsMetrics> = vise::Global::new();
+pub static GET_LOGS: vise::Global<GetLogs> = vise::Global::new();
 
 #[derive(Debug, Metrics)]
-pub struct ApiMetrics {
+#[metrics(prefix = "api")]
+pub struct Api {
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]
     pub response_time: LabeledFamily<String, Histogram<Duration>>,
     #[metrics(unit = Unit::Bytes, labels = ["method"], buckets = BYTES_BUCKETS)]
@@ -89,12 +90,12 @@ pub struct ApiMetrics {
 }
 
 #[vise::register]
-pub static API_METRICS: vise::Global<ApiMetrics> = vise::Global::new();
+pub static API_METRICS: vise::Global<Api> = vise::Global::new();
 
 /// Metrics for the transaction submission pipeline.
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "tx_submission")]
-pub struct TxSubmissionMetrics {
+pub struct TxSubmission {
     /// Time spent validating and inserting a transaction into the local mempool.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
     pub mempool_latency: Histogram<Duration>,
@@ -104,4 +105,4 @@ pub struct TxSubmissionMetrics {
 }
 
 #[vise::register]
-pub static TX_SUBMISSION_METRICS: vise::Global<TxSubmissionMetrics> = vise::Global::new();
+pub static TX_SUBMISSION: vise::Global<TxSubmission> = vise::Global::new();

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -54,9 +54,9 @@ pub struct ApiMetrics {
     /// Per-call fraction of blocks skipped by the log index (skipped / total).
     #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
     pub get_logs_index_skip_ratio: LabeledFamily<FilterCategory, Histogram<f64>>,
-    /// Per-call bloom filter false-positive rate among blocks that reached the bloom check.
+    /// Per-call bloom filter precision among blocks that reached the bloom check (true positives / bloom-passed blocks).
     #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
-    pub get_logs_bloom_fp_rate: LabeledFamily<FilterCategory, Histogram<f64>>,
+    pub get_logs_bloom_precision: LabeledFamily<FilterCategory, Histogram<f64>>,
     /// Per-call fraction of the queried block range covered by the log index.
     #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
     pub get_logs_index_coverage: LabeledFamily<FilterCategory, Histogram<f64>>,

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,15 +1,27 @@
 use std::time::Duration;
-use vise::{Buckets, Counter, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{Buckets, Counter, EncodeLabelValue, Histogram, LabeledFamily, Metrics, Unit};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
 const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1B .. 10MB
 
+/// Dimension for per-call `eth_getLogs` scan statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(label = "kind", rename_all = "snake_case")]
+pub enum GetLogsStat {
+    Total,
+    SkippedByIndex,
+    BloomTruePositive,
+    BloomFalsePositive,
+    BloomNegative,
+    LogsReturned,
+}
+
 #[derive(Debug, Metrics)]
 pub struct ApiMetrics {
     /// Block disposition per `eth_getLogs` call, broken down by outcome kind.
     #[metrics(labels = ["kind"], buckets = BLOCK_COUNTS)]
-    pub get_logs_scanned_blocks: LabeledFamily<&'static str, Histogram<u64>>,
+    pub get_logs_scanned_blocks: LabeledFamily<GetLogsStat, Histogram<u64>>,
     /// Number of `eth_getLogs` calls with no address or topic constraints (full block scan).
     pub get_logs_unconstrained: Counter,
     /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`.

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,9 +1,12 @@
 use std::time::Duration;
+use alloy::rpc::types::Filter;
 use vise::{Buckets, Counter, EncodeLabelValue, Histogram, LabeledFamily, Metrics, Unit};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
 const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1B .. 10MB
+const RATIO_BUCKETS: Buckets =
+    Buckets::values(&[0.0, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0]);
 
 /// Dimension for per-call `eth_getLogs` scan statistics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
@@ -17,13 +20,45 @@ pub enum GetLogsStat {
     LogsReturned,
 }
 
+/// Filter constraint category for an `eth_getLogs` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(label = "filter", rename_all = "snake_case")]
+pub enum FilterCategory {
+    /// No address or topic constraints; every block must be scanned.
+    Unconstrained,
+    /// Address constraint only; index can skip by address.
+    AddressOnly,
+    /// Topic constraint(s) only; index can skip by topic.
+    TopicOnly,
+    /// Both address and topic constraints; index uses both.
+    AddressAndTopic,
+}
+
+impl From<&Filter> for FilterCategory {
+    fn from(filter: &Filter) -> Self {
+        match (filter.address.is_empty(), filter.has_topics()) {
+            (true, false) => Self::Unconstrained,
+            (false, false) => Self::AddressOnly,
+            (true, true) => Self::TopicOnly,
+            (false, true) => Self::AddressAndTopic,
+        }
+    }
+}
+
 #[derive(Debug, Metrics)]
 pub struct ApiMetrics {
-    /// Block disposition per `eth_getLogs` call, broken down by outcome kind.
-    #[metrics(labels = ["kind"], buckets = BLOCK_COUNTS)]
-    pub get_logs_scanned_blocks: LabeledFamily<GetLogsStat, Histogram<u64>>,
-    /// Number of `eth_getLogs` calls with no address or topic constraints (full block scan).
-    pub get_logs_unconstrained: Counter,
+    /// Block disposition per `eth_getLogs` call, broken down by outcome kind and filter category.
+    #[metrics(labels = ["kind", "filter"], buckets = BLOCK_COUNTS)]
+    pub get_logs_scanned_blocks: LabeledFamily<(GetLogsStat, FilterCategory), Histogram<u64>, 2>,
+    /// Per-call fraction of blocks skipped by the log index (skipped / total).
+    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
+    pub get_logs_index_skip_ratio: LabeledFamily<FilterCategory, Histogram<f64>>,
+    /// Per-call bloom filter false-positive rate among blocks that reached the bloom check.
+    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
+    pub get_logs_bloom_fp_rate: LabeledFamily<FilterCategory, Histogram<f64>>,
+    /// Per-call fraction of the queried block range covered by the log index.
+    #[metrics(labels = ["filter"], buckets = RATIO_BUCKETS)]
+    pub get_logs_index_coverage: LabeledFamily<FilterCategory, Histogram<f64>>,
     /// Number of `eth_getLogs` calls truncated due to exceeding `max_logs`.
     pub get_logs_truncated: Counter,
     #[metrics(unit = Unit::Seconds, labels = ["method"], buckets = LATENCIES_FAST)]

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,12 +1,13 @@
-use std::time::Duration;
 use alloy::rpc::types::Filter;
+use std::time::Duration;
 use vise::{Buckets, Counter, EncodeLabelValue, Histogram, LabeledFamily, Metrics, Unit};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
 const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1B .. 10MB
-const RATIO_BUCKETS: Buckets =
-    Buckets::values(&[0.0, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0]);
+const RATIO_BUCKETS: Buckets = Buckets::values(&[
+    0.0, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
+]);
 
 /// Dimension for per-call `eth_getLogs` scan statistics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -183,9 +183,7 @@ impl MempoolLatencyGuard {
 
 impl Drop for MempoolLatencyGuard {
     fn drop(&mut self) {
-        TX_SUBMISSION
-            .mempool_latency
-            .observe(self.0.elapsed());
+        TX_SUBMISSION.mempool_latency.observe(self.0.elapsed());
     }
 }
 
@@ -200,8 +198,6 @@ impl ForwardingLatencyGuard {
 
 impl Drop for ForwardingLatencyGuard {
     fn drop(&mut self) {
-        TX_SUBMISSION
-            .forwarding_latency
-            .observe(self.0.elapsed());
+        TX_SUBMISSION.forwarding_latency.observe(self.0.elapsed());
     }
 }

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -1,5 +1,5 @@
 use crate::eth_impl::build_api_receipt;
-use crate::metrics::TX_SUBMISSION_METRICS;
+use crate::metrics::TX_SUBMISSION;
 use crate::{ReadRpcStorage, RpcConfig};
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
@@ -183,7 +183,7 @@ impl MempoolLatencyGuard {
 
 impl Drop for MempoolLatencyGuard {
     fn drop(&mut self) {
-        TX_SUBMISSION_METRICS
+        TX_SUBMISSION
             .mempool_latency
             .observe(self.0.elapsed());
     }
@@ -200,7 +200,7 @@ impl ForwardingLatencyGuard {
 
 impl Drop for ForwardingLatencyGuard {
     fn drop(&mut self) {
-        TX_SUBMISSION_METRICS
+        TX_SUBMISSION
             .forwarding_latency
             .observe(self.0.elapsed());
     }

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -19,7 +19,7 @@ zksync_os_batch_types.workspace = true
 
 zksync_os_interface.workspace = true
 
-alloy = { workspace = true, default-features = false, features = ["eips", "rlp"] }
+alloy = { workspace = true, default-features = false, features = ["eips", "rlp", "rpc-types"] }
 dashmap.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db;
 pub mod in_memory;
 pub mod lazy;
+pub mod log_index_filter;
 mod metrics;

--- a/lib/storage/src/log_index_filter.rs
+++ b/lib/storage/src/log_index_filter.rs
@@ -31,7 +31,7 @@ impl<I: Iterator> IteratorExt for I {}
 /// Returns the candidates for the filter over `range`.
 /// Blocks outside `covered` must be checked via bloom filter.
 /// Returns empty candidates if the filter has no address or topic constraints.
-pub(crate) fn candidates(
+pub fn candidates(
     repo: &dyn LogIndex,
     filter: &Filter,
     range: Range<u64>,
@@ -131,6 +131,7 @@ fn intersect(a: Range<u64>, b: Range<u64>) -> Range<u64> {
 mod tests {
     use super::*;
     use alloy::primitives::{Address, B256};
+    use alloy::rpc::types::Filter;
     use std::collections::HashMap;
     use zksync_os_storage_api::RepositoryResult;
 

--- a/lib/storage/src/log_index_filter.rs
+++ b/lib/storage/src/log_index_filter.rs
@@ -94,6 +94,11 @@ impl Candidates {
     pub fn may_contain(&self, block_number: u64) -> bool {
         !self.covered.contains(&block_number) || self.bitmap.contains(block_number as u32)
     }
+
+    /// Returns the number of blocks the index covers.
+    pub fn covered_len(&self) -> u64 {
+        self.covered.end.saturating_sub(self.covered.start)
+    }
 }
 
 impl BitOr for Candidates {

--- a/lib/storage/src/log_index_filter.rs
+++ b/lib/storage/src/log_index_filter.rs
@@ -84,8 +84,16 @@ fn topic_candidates(
 /// A set of candidate blocks from the log index, together with the range of blocks the index covers.
 /// Blocks outside `covered` must be checked via bloom filter regardless of `bitmap`.
 pub struct Candidates {
-    pub bitmap: RoaringBitmap,
-    pub covered: Range<u64>,
+    bitmap: RoaringBitmap,
+    covered: Range<u64>,
+}
+
+impl Candidates {
+    /// Returns `true` if the block at `number` may contain matching logs.
+    /// Blocks outside the covered range always return `true` (must fall back to bloom).
+    pub fn may_contain(&self, block_number: u64) -> bool {
+        !self.covered.contains(&block_number) || self.bitmap.contains(block_number as u32)
+    }
 }
 
 impl BitOr for Candidates {


### PR DESCRIPTION
## Summary

- Adds a log index lookup before the bloom filter scan in `eth_getLogs`. Blocks within the index's covered range that are not in the candidate bitmap are skipped entirely; blocks outside fall back to bloom filter.
- Extracts index composition logic into `eth_filter/index.rs` with a `Candidates` struct supporting `|` (OR within group) and `&` (AND across groups) operators.
- Adds per-call Prometheus metrics: block disposition by kind (`total`, `skipped_by_index`, `bloom_true_positive`, `bloom_false_positive`, `bloom_negative`, `logs_returned`), plus counters for unconstrained and truncated queries.
- Unit tests for `candidates()` composition logic in `index.rs`.

## Test plan

- [ ] Unit tests pass: `cargo nextest run -p zksync_os_rpc --lib`
- [ ] Clippy/fmt clean: `cargo fmt --all -- --check && cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -- -D warnings`
- [ ] Deploy to stage and verify `get_logs_scanned_blocks[skipped_by_index]` metric is non-zero for constrained filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)