### PR TITLE
fix(rpc): fix monitoring middleware sync handler measurement and panic handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,7 +3834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10380,9 +10380,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -21,6 +21,8 @@ pub struct ApiMetrics {
     pub errors: LabeledFamily<(String, i32), Counter, 2>,
     #[metrics(labels = ["method"])]
     pub cancelled: LabeledFamily<String, Counter>,
+    #[metrics(labels = ["method"])]
+    pub panicked: LabeledFamily<String, Counter>,
 }
 
 #[vise::register]

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -1,12 +1,15 @@
 use crate::metrics::API_METRICS;
+use crate::result::internal_rpc_err;
+use futures::FutureExt as _;
 use jsonrpsee::core::middleware::{Batch, BatchEntry, Notification};
 use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
 use jsonrpsee::types::Request;
 use jsonrpsee::{BatchResponseBuilder, MethodResponse};
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum CallKind {
     Call,
     Notification,
@@ -29,20 +32,24 @@ impl Monitoring {
 
 /// Ensures latency is recorded even if the future is dropped mid-flight (client disconnected).
 struct CallGuard {
+    kind: CallKind,
     method: String,
     started: Instant,
     request_size: usize,
     /// `Some((output_size, error_code))` once the future has resolved.
     completed: Option<(usize, Option<i32>)>,
+    panicked: bool,
 }
 
 impl CallGuard {
-    fn new(method: String, request_size: usize) -> Self {
+    fn new(kind: CallKind, method: String, request_size: usize) -> Self {
         Self {
+            kind,
             method,
             started: Instant::now(),
             request_size,
             completed: None,
+            panicked: false,
         }
     }
 }
@@ -97,8 +104,11 @@ impl Drop for CallGuard {
         if cancelled {
             API_METRICS.cancelled[&self.method].inc();
         }
+        if self.panicked {
+            API_METRICS.panicked[&self.method].inc();
+        }
         log_and_report(
-            CallKind::Call,
+            self.kind,
             &self.method,
             elapsed,
             self.request_size,
@@ -120,11 +130,19 @@ impl RpcServiceT for Monitoring {
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
         let method = request.method_name().to_owned();
         let request_size = request.params.as_ref().map_or(0, |p| p.get().len());
-        let fut = self.inner.call(request);
+        let inner = self.inner.clone();
 
         async move {
-            let mut guard = CallGuard::new(method, request_size);
-            let out = fut.await;
+            let id = request.id.clone().into_owned();
+            let mut guard = CallGuard::new(CallKind::Call, method.clone(), request_size);
+            let result = AssertUnwindSafe(async move { inner.call(request).await })
+                .catch_unwind()
+                .await;
+            guard.panicked = result.is_err();
+            let out = result.unwrap_or_else(|_| {
+                tracing::error!(method = %method, "RPC handler panicked");
+                MethodResponse::error(id, internal_rpc_err("Internal error"))
+            });
             guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
             out
         }
@@ -203,22 +221,19 @@ impl RpcServiceT for Monitoring {
     ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
         let request_size = n.params.as_ref().map_or(0, |p| p.get().len());
         let method = n.method_name().to_owned();
-        let fut = self.inner.notification(n);
+        let inner = self.inner.clone();
 
         async move {
-            let started = Instant::now();
-            let out = fut.await;
-            let output_size = out.as_json().get().len();
-
-            log_and_report(
-                CallKind::Notification,
-                &method,
-                started.elapsed(),
-                request_size,
-                output_size,
-                out.as_error_code(),
-                false,
-            );
+            let mut guard = CallGuard::new(CallKind::Notification, method.clone(), request_size);
+            let result = AssertUnwindSafe(async move { inner.notification(n).await })
+                .catch_unwind()
+                .await;
+            guard.panicked = result.is_err();
+            let out = result.unwrap_or_else(|_| {
+                tracing::error!(method = %method, "Notification handler panicked");
+                MethodResponse::notification()
+            });
+            guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
             out
         }
     }

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -52,6 +52,21 @@ impl CallGuard {
             panicked: false,
         }
     }
+
+    async fn handle_result<F>(
+        mut self,
+        fut: F,
+        on_panic: impl FnOnce() -> MethodResponse + Send,
+    ) -> MethodResponse
+    where
+        F: Future<Output = MethodResponse> + Send,
+    {
+        let result = AssertUnwindSafe(fut).catch_unwind().await;
+        self.panicked = result.is_err();
+        let out = result.unwrap_or_else(|_| on_panic());
+        self.completed = Some((out.as_json().get().len(), out.as_error_code()));
+        out
+    }
 }
 
 /// Ensures batch-level metrics are recorded even if the future is dropped mid-flight (client disconnected).
@@ -155,15 +170,11 @@ impl RpcServiceT for Monitoring {
 
         async move {
             let id = request.id.clone().into_owned();
-            let mut guard = CallGuard::new(CallKind::Call, method, request_size);
-            let result = AssertUnwindSafe(async move { inner.call(request).await })
-                .catch_unwind()
-                .await;
-            guard.panicked = result.is_err();
-            let out = result
-                .unwrap_or_else(|_| MethodResponse::error(id, internal_rpc_err("Internal error")));
-            guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
-            out
+            let handler = async move { inner.call(request).await };
+            let on_panic = || MethodResponse::error(id, internal_rpc_err("Internal error"));
+            CallGuard::new(CallKind::Call, method, request_size)
+                .handle_result(handler, on_panic)
+                .await
         }
     }
 
@@ -243,15 +254,10 @@ impl RpcServiceT for Monitoring {
         let inner = self.inner.clone();
 
         async move {
-            let mut guard = CallGuard::new(CallKind::Notification, method, request_size);
-            let result = AssertUnwindSafe(async move { inner.notification(n).await })
-                .catch_unwind()
-                .await;
-            guard.panicked = result.is_err();
-            let out = result.unwrap_or_else(|_| MethodResponse::notification());
-            guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
-            out
+            let handler = async move { inner.notification(n).await };
+            CallGuard::new(CallKind::Notification, method, request_size)
+                .handle_result(handler, MethodResponse::notification)
+                .await
         }
     }
 }
-

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -7,7 +7,7 @@ use jsonrpsee::types::Request;
 use jsonrpsee::{BatchResponseBuilder, MethodResponse};
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 #[derive(Clone, Copy, Debug)]
 pub enum CallKind {
@@ -101,6 +101,12 @@ impl Drop for CallGuard {
         let elapsed = self.started.elapsed();
         let cancelled = self.completed.is_none();
         let (output_size, error_code) = self.completed.take().unwrap_or((0, None));
+        API_METRICS.response_time[&self.method].observe(elapsed);
+        API_METRICS.request_size[&self.method].observe(self.request_size);
+        API_METRICS.response_size[&self.method].observe(output_size);
+        if let Some(code) = error_code {
+            API_METRICS.errors[&(self.method.clone(), code)].inc();
+        }
         if cancelled {
             API_METRICS.cancelled[&self.method].inc();
         }
@@ -113,15 +119,24 @@ impl Drop for CallGuard {
                 }
             }
         }
-        log_and_report(
-            self.kind,
-            &self.method,
-            elapsed,
-            self.request_size,
-            output_size,
-            error_code,
-            cancelled,
-        );
+
+        macro_rules! log {
+            ($target:literal) => {
+                tracing::debug!(
+                    target: $target,
+                    kind = ?self.kind,
+                    cancelled,
+                    "rpc call completed kind={:?} cancelled={}", self.kind, cancelled
+                )
+            };
+        }
+
+        match self.method.as_str() {
+            "eth_call" => log!("rpc::monitoring::eth::call"),
+            "eth_sendRawTransaction" => log!("rpc::monitoring::eth::sendRawTransaction"),
+            "debug_traceTransaction" => log!("rpc::monitoring::debug::traceTransaction"),
+            _ => log!("rpc::monitoring::call"),
+        }
     }
 }
 
@@ -240,37 +255,3 @@ impl RpcServiceT for Monitoring {
     }
 }
 
-fn log_and_report(
-    kind: CallKind,
-    method: &str,
-    elapsed: Duration,
-    request_size: usize,
-    output_size_bytes: usize,
-    error_code: Option<i32>,
-    cancelled: bool,
-) {
-    API_METRICS.response_time[method].observe(elapsed);
-    API_METRICS.request_size[method].observe(request_size);
-    API_METRICS.response_size[method].observe(output_size_bytes);
-    if let Some(code) = error_code {
-        API_METRICS.errors[&(method.to_owned(), code)].inc();
-    }
-
-    macro_rules! log {
-        ($target:literal) => {
-            tracing::debug!(
-                target: $target,
-                ?kind,
-                cancelled,
-                "rpc call completed kind={:?} cancelled={}", kind, cancelled
-            )
-        };
-    }
-
-    match method {
-        "eth_call" => log!("rpc::monitoring::eth::call"),
-        "eth_sendRawTransaction" => log!("rpc::monitoring::eth::sendRawTransaction"),
-        "debug_traceTransaction" => log!("rpc::monitoring::debug::traceTransaction"),
-        _ => log!("rpc::monitoring::call"),
-    }
-}

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -106,6 +106,12 @@ impl Drop for CallGuard {
         }
         if self.panicked {
             API_METRICS.panicked[&self.method].inc();
+            match self.kind {
+                CallKind::Call => tracing::error!(method = %self.method, "RPC handler panicked"),
+                CallKind::Notification => {
+                    tracing::error!(method = %self.method, "Notification handler panicked")
+                }
+            }
         }
         log_and_report(
             self.kind,
@@ -134,15 +140,13 @@ impl RpcServiceT for Monitoring {
 
         async move {
             let id = request.id.clone().into_owned();
-            let mut guard = CallGuard::new(CallKind::Call, method.clone(), request_size);
+            let mut guard = CallGuard::new(CallKind::Call, method, request_size);
             let result = AssertUnwindSafe(async move { inner.call(request).await })
                 .catch_unwind()
                 .await;
             guard.panicked = result.is_err();
-            let out = result.unwrap_or_else(|_| {
-                tracing::error!(method = %method, "RPC handler panicked");
-                MethodResponse::error(id, internal_rpc_err("Internal error"))
-            });
+            let out = result
+                .unwrap_or_else(|_| MethodResponse::error(id, internal_rpc_err("Internal error")));
             guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
             out
         }
@@ -224,15 +228,12 @@ impl RpcServiceT for Monitoring {
         let inner = self.inner.clone();
 
         async move {
-            let mut guard = CallGuard::new(CallKind::Notification, method.clone(), request_size);
+            let mut guard = CallGuard::new(CallKind::Notification, method, request_size);
             let result = AssertUnwindSafe(async move { inner.notification(n).await })
                 .catch_unwind()
                 .await;
             guard.panicked = result.is_err();
-            let out = result.unwrap_or_else(|_| {
-                tracing::error!(method = %method, "Notification handler panicked");
-                MethodResponse::notification()
-            });
+            let out = result.unwrap_or_else(|_| MethodResponse::notification());
             guard.completed = Some((out.as_json().get().len(), out.as_error_code()));
             out
         }


### PR DESCRIPTION
## Summary
- **Sync handlers not measured**: \`inner.call(request)\` was invoked before the \`async move\` block, so sync handlers (dispatched eagerly by jsonrpsee) ran outside \`CallGuard\`'s timer. Fixed by cloning \`inner\` and moving the call to after \`CallGuard::new()\` inside the async block.
- **Panics drop the connection**: for HTTP, a handler panic propagates through hyper's connection task, dropping the TCP connection with no response. Fixed by wrapping the inner call as \`AssertUnwindSafe(async move { inner.call(request).await }).catch_unwind()\`. The extra \`async move\` is required because sync handler panics fire during \`inner.call()\` (before the future is polled), so a plain \`AssertUnwindSafe(inner.call(request)).catch_unwind()\` would not catch them. Panics now return a \`-32603 Internal error\` response. A new \`panicked\` counter (per method) is recorded through \`CallGuard\`, consistent with how \`cancelled\` works. Panics are no longer misrecorded as cancellations.
- **\`notification()\` had no guard**: added a \`kind\` field (\`Call\`/\`Notification\`) to \`CallGuard\` and unified \`notification()\` with the same guard-based instrumentation as \`call()\`, giving notifications proper cancellation and panic coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)