### PR TITLE
feat(l1-sender): increase L1 required confirmations

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1221,6 +1221,7 @@ impl AnvilL1 {
                 .port(locked_port.port)
                 .chain_id(L1_CHAIN_ID)
                 .block_time(1)
+                .arg("--mixed-mining")
                 .arg("--load-state")
                 .arg(l1_state_path)
         })?;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1220,6 +1220,7 @@ impl AnvilL1 {
             anvil
                 .port(locked_port.port)
                 .chain_id(L1_CHAIN_ID)
+                .block_time(1)
                 .arg("--load-state")
                 .arg(l1_state_path)
         })?;

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -20,9 +20,9 @@ use alloy::providers::ext::DebugApi;
 use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::utils::Eip1559Estimation;
 use alloy::providers::{PendingTransactionError, Provider, WalletProvider};
-use anyhow::Context as _;
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+use anyhow::Context as _;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::Instant;
@@ -313,7 +313,7 @@ async fn process_prepending_passthrough_commands<Input: SendToL1>(
 }
 
 /// Estimates EIP-1559 fees using the 30th percentile of priority fees over the last 3 blocks.
-/// 
+///
 /// `estimate_eip1559_fees_with` in alloy hardcodes the block count and percentile, so we call
 /// `get_fee_history` directly and delegate the rest to alloy's default estimator.
 async fn estimate_eip1559_fees(provider: &dyn Provider) -> anyhow::Result<Eip1559Estimation> {

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -9,7 +9,9 @@ pub mod upgrade_gatekeeper;
 use crate::batcher_model::{FriProof, SignedBatchEnvelope};
 use crate::commands::{L1SenderCommand, SendToL1};
 use crate::config::L1SenderConfig;
-use crate::metrics::{L1_SENDER_METRICS, L1SenderState};
+use crate::metrics::{
+    L1_SENDER_METRICS, L1SenderState, PriorityFeeEstimatePercentile, PriorityFeeEstimateWindow,
+};
 use alloy::consensus::BlobTransactionValidationError;
 use alloy::eips::eip7594::BlobTransactionSidecarVariant;
 use alloy::eips::{BlockId, BlockNumberOrTag, Encodable2718};
@@ -312,18 +314,25 @@ async fn process_prepending_passthrough_commands<Input: SendToL1>(
     }
 }
 
-/// Estimates EIP-1559 fees using the 30th percentile of priority fees over the last 3 blocks.
+const ESTIMATION_PERCENTILE_P20: f64 = 20.0;
+const ESTIMATION_PERCENTILE_P30: f64 = 30.0;
+const ESTIMATION_PERCENTILE_P50: f64 = 50.0;
+
+/// Estimates EIP-1559 fees using the provided percentile of priority fees over the specified
+/// fee-history window.
 ///
 /// `estimate_eip1559_fees_with` in alloy hardcodes the block count and percentile, so we call
 /// `get_fee_history` directly and delegate the rest to alloy's default estimator.
-async fn estimate_eip1559_fees(provider: &dyn Provider) -> anyhow::Result<Eip1559Estimation> {
+async fn estimate_eip1559_fees(
+    provider: &dyn Provider,
+    blocks_behind: u64,
+    percentile: f64,
+) -> anyhow::Result<Eip1559Estimation> {
     let fee_history = provider
-        .get_fee_history(3, BlockNumberOrTag::Latest, &[30.0])
+        .get_fee_history(blocks_behind, BlockNumberOrTag::Latest, &[percentile])
         .await
         .context("fetching fee history")?;
-    let base_fee_per_gas: u128 = fee_history
-        .latest_block_base_fee()
-        .unwrap_or_default();
+    let base_fee_per_gas: u128 = fee_history.latest_block_base_fee().unwrap_or_default();
     let rewards = fee_history.reward.unwrap_or_default();
     Ok(alloy::providers::utils::eip1559_default_estimator(
         base_fee_per_gas,
@@ -337,8 +346,17 @@ async fn tx_request_with_gas_fields(
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
 ) -> anyhow::Result<TransactionRequest> {
-    let eip1559_est = estimate_eip1559_fees(provider).await?;
-    L1_SENDER_METRICS.report_l1_eip_1559_estimation(eip1559_est)?;
+    // Use alloy's built-in EIP-1559 estimator (20 blocks, 50th percentile by default) for
+    // the actual transaction gas fields.
+    let eip1559_est = provider
+        .estimate_eip1559_fees()
+        .await
+        .context("estimating eip1559 fees")?;
+
+    // Our custom estimations across multiple fee-history windows are emitted as metrics so we can
+    // compare them against alloy's built-in estimator without affecting transaction submission.
+    report_custom_priority_fee_metrics(provider).await?;
+
     tracing::debug!(
         max_priority_fee_per_gas_gwei = ?format_units(eip1559_est.max_priority_fee_per_gas, "gwei"),
         max_fee_per_gas_gwei = ?format_units(eip1559_est.max_fee_per_gas, "gwei"),
@@ -377,6 +395,38 @@ async fn tx_request_with_gas_fields(
         // Default value for `max_aggregated_tx_gas` from zksync-era, should always be enough
         .with_gas_limit(15000000);
     Ok(tx)
+}
+
+async fn report_custom_priority_fee_metrics(provider: &dyn Provider) -> anyhow::Result<()> {
+    for (window, blocks_behind) in [
+        (PriorityFeeEstimateWindow::Blocks3, 3),
+        (PriorityFeeEstimateWindow::Blocks5, 5),
+        (PriorityFeeEstimateWindow::Blocks10, 10),
+    ] {
+        for (percentile_label, percentile) in [
+            (
+                PriorityFeeEstimatePercentile::P20,
+                ESTIMATION_PERCENTILE_P20,
+            ),
+            (
+                PriorityFeeEstimatePercentile::P30,
+                ESTIMATION_PERCENTILE_P30,
+            ),
+            (
+                PriorityFeeEstimatePercentile::P50,
+                ESTIMATION_PERCENTILE_P50,
+            ),
+        ] {
+            let our_eip1559_est =
+                estimate_eip1559_fees(provider, blocks_behind, percentile).await?;
+            L1_SENDER_METRICS.report_estimated_max_priority_fee_per_gas(
+                window,
+                percentile_label,
+                our_eip1559_est.max_priority_fee_per_gas,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 async fn register_operator<

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -346,15 +346,8 @@ async fn tx_request_with_gas_fields(
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
 ) -> anyhow::Result<TransactionRequest> {
-    // Use alloy's built-in EIP-1559 estimator (20 blocks, 50th percentile by default) for
-    // the actual transaction gas fields.
-    let eip1559_est = provider
-        .estimate_eip1559_fees()
-        .await
-        .context("estimating eip1559 fees")?;
-
-    // Our custom estimations across multiple fee-history windows are emitted as metrics so we can
-    // compare them against alloy's built-in estimator without affecting transaction submission.
+    let eip1559_est = provider.estimate_eip1559_fees().await?;
+    L1_SENDER_METRICS.report_l1_eip_1559_estimation(eip1559_est)?;
     report_custom_priority_fee_metrics(provider).await?;
 
     tracing::debug!(
@@ -419,7 +412,7 @@ async fn report_custom_priority_fee_metrics(provider: &dyn Provider) -> anyhow::
         ] {
             let our_eip1559_est =
                 estimate_eip1559_fees(provider, blocks_behind, percentile).await?;
-            L1_SENDER_METRICS.report_estimated_max_priority_fee_per_gas(
+            L1_SENDER_METRICS.report_custom_estimated_max_priority_fee_per_gas(
                 window,
                 percentile_label,
                 our_eip1559_est.max_priority_fee_per_gas,

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -323,8 +323,7 @@ async fn estimate_eip1559_fees(provider: &dyn Provider) -> anyhow::Result<Eip155
         .context("fetching fee history")?;
     let base_fee_per_gas: u128 = fee_history
         .latest_block_base_fee()
-        .unwrap_or_default()
-        .into();
+        .unwrap_or_default();
     let rewards = fee_history.reward.unwrap_or_default();
     Ok(alloy::providers::utils::eip1559_default_estimator(
         base_fee_per_gas,

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -34,6 +34,11 @@ use zksync_os_pipeline::PeekableReceiver;
 type TransactionReceiptFuture =
     BoxFuture<'static, Result<TransactionReceipt, PendingTransactionError>>;
 
+const REQUIRED_CONFIRMATIONS_L1: u64 = 3;
+/// In case there's only one chain connected to gateway, it is very likely that there will be not enough block production
+/// to reach 3 confirmations for such transactions
+const REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
+
 /// Process responsible for sending transactions to L1.
 /// Handles one type of l1 command (e.g. Commit or Prove).
 /// Loads up to `command_limit` commands from the channel and sends them to L1 in parallel.
@@ -188,7 +193,11 @@ pub async fn run_l1_sender<Input: SendToL1>(
                         // reorg happens and transaction will not be included in the new fork (very-very
                         // unlikely), L1 sender will crash at some point (because a consequent L1
                         // transactions will fail) and recover from the new L1 state after restart.
-                        .with_required_confirmations(1)
+                        .with_required_confirmations(if gateway {
+                            REQUIRED_CONFIRMATIONS_GATEWAY
+                        } else {
+                            REQUIRED_CONFIRMATIONS_L1
+                        })
                         // Ensure we don't wait indefinitely and crash if the transaction is not
                         // included on L1 in a reasonable time.
                         .with_timeout(Some(config.transaction_timeout));

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -314,32 +314,6 @@ async fn process_prepending_passthrough_commands<Input: SendToL1>(
     }
 }
 
-const ESTIMATION_PERCENTILE_P20: f64 = 20.0;
-const ESTIMATION_PERCENTILE_P30: f64 = 30.0;
-const ESTIMATION_PERCENTILE_P50: f64 = 50.0;
-
-/// Estimates EIP-1559 fees using the provided percentile of priority fees over the specified
-/// fee-history window.
-///
-/// `estimate_eip1559_fees_with` in alloy hardcodes the block count and percentile, so we call
-/// `get_fee_history` directly and delegate the rest to alloy's default estimator.
-async fn estimate_eip1559_fees(
-    provider: &dyn Provider,
-    blocks_behind: u64,
-    percentile: f64,
-) -> anyhow::Result<Eip1559Estimation> {
-    let fee_history = provider
-        .get_fee_history(blocks_behind, BlockNumberOrTag::Latest, &[percentile])
-        .await
-        .context("fetching fee history")?;
-    let base_fee_per_gas: u128 = fee_history.latest_block_base_fee().unwrap_or_default();
-    let rewards = fee_history.reward.unwrap_or_default();
-    Ok(alloy::providers::utils::eip1559_default_estimator(
-        base_fee_per_gas,
-        &rewards,
-    ))
-}
-
 async fn tx_request_with_gas_fields(
     provider: &dyn Provider,
     operator_address: Address,
@@ -397,18 +371,9 @@ async fn report_custom_priority_fee_metrics(provider: &dyn Provider) -> anyhow::
         (PriorityFeeEstimateWindow::Blocks10, 10),
     ] {
         for (percentile_label, percentile) in [
-            (
-                PriorityFeeEstimatePercentile::P20,
-                ESTIMATION_PERCENTILE_P20,
-            ),
-            (
-                PriorityFeeEstimatePercentile::P30,
-                ESTIMATION_PERCENTILE_P30,
-            ),
-            (
-                PriorityFeeEstimatePercentile::P50,
-                ESTIMATION_PERCENTILE_P50,
-            ),
+            (PriorityFeeEstimatePercentile::P20, 20.0),
+            (PriorityFeeEstimatePercentile::P30, 30.0),
+            (PriorityFeeEstimatePercentile::P50, 50.0),
         ] {
             let our_eip1559_est =
                 estimate_eip1559_fees(provider, blocks_behind, percentile).await?;
@@ -420,6 +385,28 @@ async fn report_custom_priority_fee_metrics(provider: &dyn Provider) -> anyhow::
         }
     }
     Ok(())
+}
+
+/// Estimates EIP-1559 fees using the provided percentile of priority fees over the specified
+/// fee-history window.
+///
+/// `estimate_eip1559_fees_with` in alloy hardcodes the block count and percentile, so we call
+/// `get_fee_history` directly and delegate the rest to alloy's default estimator.
+async fn estimate_eip1559_fees(
+    provider: &dyn Provider,
+    blocks_behind: u64,
+    percentile: f64,
+) -> anyhow::Result<Eip1559Estimation> {
+    let fee_history = provider
+        .get_fee_history(blocks_behind, BlockNumberOrTag::Latest, &[percentile])
+        .await
+        .context("fetching fee history")?;
+    let base_fee_per_gas: u128 = fee_history.latest_block_base_fee().unwrap_or_default();
+    let rewards = fee_history.reward.unwrap_or_default();
+    Ok(alloy::providers::utils::eip1559_default_estimator(
+        base_fee_per_gas,
+        &rewards,
+    ))
 }
 
 async fn register_operator<

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -12,13 +12,15 @@ use crate::config::L1SenderConfig;
 use crate::metrics::{L1_SENDER_METRICS, L1SenderState};
 use alloy::consensus::BlobTransactionValidationError;
 use alloy::eips::eip7594::BlobTransactionSidecarVariant;
-use alloy::eips::{BlockId, Encodable2718};
+use alloy::eips::{BlockId, BlockNumberOrTag, Encodable2718};
 use alloy::network::{Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilder4844};
 use alloy::primitives::Address;
 use alloy::primitives::utils::{format_ether, format_units};
 use alloy::providers::ext::DebugApi;
 use alloy::providers::fillers::{FillProvider, TxFiller};
+use alloy::providers::utils::Eip1559Estimation;
 use alloy::providers::{PendingTransactionError, Provider, WalletProvider};
+use anyhow::Context as _;
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use futures::future::BoxFuture;
@@ -310,13 +312,33 @@ async fn process_prepending_passthrough_commands<Input: SendToL1>(
     }
 }
 
+/// Estimates EIP-1559 fees using the 30th percentile of priority fees over the last 3 blocks.
+/// 
+/// `estimate_eip1559_fees_with` in alloy hardcodes the block count and percentile, so we call
+/// `get_fee_history` directly and delegate the rest to alloy's default estimator.
+async fn estimate_eip1559_fees(provider: &dyn Provider) -> anyhow::Result<Eip1559Estimation> {
+    let fee_history = provider
+        .get_fee_history(3, BlockNumberOrTag::Latest, &[30.0])
+        .await
+        .context("fetching fee history")?;
+    let base_fee_per_gas: u128 = fee_history
+        .latest_block_base_fee()
+        .unwrap_or_default()
+        .into();
+    let rewards = fee_history.reward.unwrap_or_default();
+    Ok(alloy::providers::utils::eip1559_default_estimator(
+        base_fee_per_gas,
+        &rewards,
+    ))
+}
+
 async fn tx_request_with_gas_fields(
     provider: &dyn Provider,
     operator_address: Address,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
 ) -> anyhow::Result<TransactionRequest> {
-    let eip1559_est = provider.estimate_eip1559_fees().await?;
+    let eip1559_est = estimate_eip1559_fees(provider).await?;
     L1_SENDER_METRICS.report_l1_eip_1559_estimation(eip1559_est)?;
     tracing::debug!(
         max_priority_fee_per_gas_gwei = ?format_units(eip1559_est.max_priority_fee_per_gas, "gwei"),

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -1,4 +1,5 @@
 use crate::commands::SendToL1;
+use alloy::eips::eip1559::Eip1559Estimation;
 use alloy::primitives::utils::{format_ether, format_units};
 use alloy::rpc::types::TransactionReceipt;
 use anyhow::Context;
@@ -99,11 +100,18 @@ pub struct L1SenderMetrics {
     #[metrics(labels = ["command"])]
     pub effective_gas_price_gwei: LabeledFamily<&'static str, Gauge<f64>>,
 
+    /// L1 max_fee_per_gas (EIP1559) in gwei - as returned by `Eip1559Estimation`.  Reported by server when sending L1 transactions.
+    #[metrics()]
+    pub estimated_max_fee_per_gas_gwei: Gauge<f64>,
+    /// L1 max_priority_fee_per_gas (EIP1559) in gwei - as returned by `Eip1559Estimation`. Reported by server when sending L1 transactions.
+    #[metrics()]
+    pub estimated_max_priority_fee_per_gas_gwei: Gauge<f64>,
+
     /// L1 max_priority_fee_per_gas (EIP1559) in gwei from our custom estimators over different fee-history windows.
     /// Reported for comparison against alloy's built-in estimator, which drives actual tx submission.
     /// Base fee is omitted — both estimators derive it from the same on-chain value.
     #[metrics(labels = ["window", "percentile"])]
-    pub estimated_max_priority_fee_per_gas_gwei:
+    pub estimated_custom_max_priority_fee_per_gas_gwei:
         LabeledFamily<(PriorityFeeEstimateWindow, PriorityFeeEstimatePercentile), Gauge<f64>, 2>,
 
     /// L1 gas used by L1 transaction per l2 transaction (`gas_used / transactions_per_batch`)
@@ -167,19 +175,31 @@ impl L1SenderMetrics {
         }
         Ok(())
     }
-    pub fn report_estimated_max_priority_fee_per_gas(
+
+    pub fn report_l1_eip_1559_estimation(
         &self,
-        window: PriorityFeeEstimateWindow,
-        percentile: PriorityFeeEstimatePercentile,
-        max_priority_fee_per_gas_wei: u128,
+        eip1559_est: Eip1559Estimation,
     ) -> anyhow::Result<()> {
-        self.estimated_max_priority_fee_per_gas_gwei[&(window, percentile)]
-            .set(Self::wei_to_gwei(max_priority_fee_per_gas_wei)?);
+        self.estimated_max_fee_per_gas_gwei
+            .set(Self::wei_to_gwei(eip1559_est.max_fee_per_gas)?);
+        self.estimated_max_priority_fee_per_gas_gwei
+            .set(Self::wei_to_gwei(eip1559_est.max_priority_fee_per_gas)?);
         Ok(())
     }
     pub fn report_blob_base_fee(&self, base_fee_wei: u128) -> anyhow::Result<()> {
         self.blob_base_fee_gwei
             .set(Self::wei_to_gwei(base_fee_wei)?);
+        Ok(())
+    }
+
+    pub fn report_custom_estimated_max_priority_fee_per_gas(
+        &self,
+        window: PriorityFeeEstimateWindow,
+        percentile: PriorityFeeEstimatePercentile,
+        max_priority_fee_per_gas_wei: u128,
+    ) -> anyhow::Result<()> {
+        self.estimated_custom_max_priority_fee_per_gas_gwei[&(window, percentile)]
+            .set(Self::wei_to_gwei(max_priority_fee_per_gas_wei)?);
         Ok(())
     }
 

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -175,7 +175,6 @@ impl L1SenderMetrics {
         }
         Ok(())
     }
-
     pub fn report_l1_eip_1559_estimation(
         &self,
         eip1559_est: Eip1559Estimation,

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -1,6 +1,5 @@
 use crate::commands::SendToL1;
 use alloy::primitives::utils::{format_ether, format_units};
-use alloy::providers::utils::Eip1559Estimation;
 use alloy::rpc::types::TransactionReceipt;
 use anyhow::Context;
 use vise::{Buckets, EncodeLabelValue, Gauge, Histogram, LabeledFamily, Metrics};
@@ -32,6 +31,22 @@ impl StateLabel for L1SenderState {
             L1SenderState::WaitingL1Inclusion => "waiting_l1_inclusion",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(label = "percentile", rename_all = "snake_case")]
+pub enum PriorityFeeEstimatePercentile {
+    P20,
+    P30,
+    P50,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(label = "window", rename_all = "snake_case")]
+pub enum PriorityFeeEstimateWindow {
+    Blocks3,
+    Blocks5,
+    Blocks10,
 }
 
 #[derive(Debug, Metrics)]
@@ -84,12 +99,12 @@ pub struct L1SenderMetrics {
     #[metrics(labels = ["command"])]
     pub effective_gas_price_gwei: LabeledFamily<&'static str, Gauge<f64>>,
 
-    /// L1 max_fee_per_gas (EIP1559) in gwei - as returned by `Eip1559Estimation`.  Reported by server when sending L1 transactions.
-    #[metrics()]
-    pub estimated_max_fee_per_gas_gwei: Gauge<f64>,
-    /// L1 max_priority_fee_per_gas (EIP1559) in gwei - as returned by `Eip1559Estimation`. Reported by server when sending L1 transactions.
-    #[metrics()]
-    pub estimated_max_priority_fee_per_gas_gwei: Gauge<f64>,
+    /// L1 max_priority_fee_per_gas (EIP1559) in gwei from our custom estimators over different fee-history windows.
+    /// Reported for comparison against alloy's built-in estimator, which drives actual tx submission.
+    /// Base fee is omitted — both estimators derive it from the same on-chain value.
+    #[metrics(labels = ["window", "percentile"])]
+    pub estimated_max_priority_fee_per_gas_gwei:
+        LabeledFamily<(PriorityFeeEstimateWindow, PriorityFeeEstimatePercentile), Gauge<f64>, 2>,
 
     /// L1 gas used by L1 transaction per l2 transaction (`gas_used / transactions_per_batch`)
     #[metrics(labels = ["command"], buckets = Buckets::exponential(1.0..=10_000_000.0, 3.0))]
@@ -152,14 +167,14 @@ impl L1SenderMetrics {
         }
         Ok(())
     }
-    pub fn report_l1_eip_1559_estimation(
+    pub fn report_estimated_max_priority_fee_per_gas(
         &self,
-        eip1559_est: Eip1559Estimation,
+        window: PriorityFeeEstimateWindow,
+        percentile: PriorityFeeEstimatePercentile,
+        max_priority_fee_per_gas_wei: u128,
     ) -> anyhow::Result<()> {
-        self.estimated_max_fee_per_gas_gwei
-            .set(Self::wei_to_gwei(eip1559_est.max_fee_per_gas)?);
-        self.estimated_max_priority_fee_per_gas_gwei
-            .set(Self::wei_to_gwei(eip1559_est.max_priority_fee_per_gas)?);
+        self.estimated_max_priority_fee_per_gas_gwei[&(window, percentile)]
+            .set(Self::wei_to_gwei(max_priority_fee_per_gas_wei)?);
         Ok(())
     }
     pub fn report_blob_base_fee(&self, base_fee_wei: u128) -> anyhow::Result<()> {


### PR DESCRIPTION
## What                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                      
  - Raise required transaction confirmations from 1 to 3 for direct L1 submissions. Gateway submissions stay at 1, since low block production there makes 3 confirmations impractical. Named constants document the rationale.
  - Emit metrics for alternative fee estimation strategies - mostly for observability to make a decision in case other fixes won't be enough                                                                                                                                                           
  - Set `block_time(1)` on the Anvil L1 instance in integration tests so the 3-confirmation wait doesn't stall.