### PR TITLE
refactor(integration-tests): simplify test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8598,7 +8598,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-chain-state"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8669,7 +8669,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8812,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8964,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9019,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9082,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9098,7 +9098,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9107,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures",
  "metrics",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9128,7 +9128,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9198,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -9272,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9289,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9301,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9481,7 +9481,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9559,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9597,7 +9597,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "clap",
  "eyre",
@@ -9658,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9775,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.1"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.1#bef3d7b4d1da937fcccc9bbd6f8bd93e16380dc7"
+source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8598,7 +8598,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-chain-state"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8669,7 +8669,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8812,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8862,7 +8862,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8887,7 +8887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8898,7 +8898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8925,7 +8925,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8964,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9019,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9041,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9082,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9098,7 +9098,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9107,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures",
  "metrics",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9128,7 +9128,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9198,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9260,7 +9260,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -9272,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9289,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9301,7 +9301,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9354,7 +9354,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9481,7 +9481,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9545,7 +9545,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9559,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9597,7 +9597,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "clap",
  "eyre",
@@ -9658,7 +9658,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9702,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9728,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9775,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.1"
-source = "git+https://github.com/romanbrodetski-ai/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,24 +227,24 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-appender-tracing = "0.31.1"
 
 # Reth dependencies
-reth-db-models = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-net-nat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.1" }
+reth-db-models = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-evm-ethereum = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-chainspec = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-trie-common = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives-traits = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-revm = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-storage-api = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-transaction-pool = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-execution-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network-peers = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-net-nat = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-eth-wire = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-discv5 = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-provider = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-rpc-eth-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-tasks = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
 
 zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,24 +227,24 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-appender-tracing = "0.31.1"
 
 # Reth dependencies
-reth-db-models = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-evm-ethereum = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-chainspec = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-trie-common = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-primitives = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-primitives-traits = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-revm = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-storage-api = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-transaction-pool = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-execution-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-network = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-network-peers = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-net-nat = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-eth-wire = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-discv5 = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-provider = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-rpc-eth-types = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-tasks = { git = "https://github.com/romanbrodetski-ai/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-db-models = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-evm-ethereum = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-chainspec = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-trie-common = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-primitives-traits = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-revm = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-storage-api = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-transaction-pool = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-execution-types = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-network-peers = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-net-nat = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-eth-wire = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-discv5 = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-provider = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-rpc-eth-types = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-tasks = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
 
 zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.4" }
 

--- a/integration-tests-macros/src/lib.rs
+++ b/integration-tests-macros/src/lib.rs
@@ -25,7 +25,7 @@ impl Parse for CaseList {
 enum ParamKind {
     TestCase,
     Tester,
-    TesterBuilder,
+    TestEnvironment,
 }
 
 fn param_kind(arg: &FnArg) -> Result<Option<ParamKind>> {
@@ -46,7 +46,7 @@ fn type_kind(ty: &Type) -> Option<ParamKind> {
     match ident.as_str() {
         "TestCase" => Some(ParamKind::TestCase),
         "Tester" => Some(ParamKind::Tester),
-        "TesterBuilder" => Some(ParamKind::TesterBuilder),
+        "TestEnvironment" => Some(ParamKind::TestEnvironment),
         _ => None,
     }
 }
@@ -61,25 +61,12 @@ fn path_matches(path: &syn::Path, expected: &[&str]) -> bool {
             .all(|(actual, expected)| actual == expected)
 }
 
-fn split_helper_attrs(
-    attrs: Vec<Attribute>,
-) -> Result<(Vec<Attribute>, Option<syn::Expr>, Option<TokenStream2>)> {
+fn split_helper_attrs(attrs: Vec<Attribute>) -> Result<(Vec<Attribute>, Option<TokenStream2>)> {
     let mut output = Vec::with_capacity(attrs.len());
-    let mut builder_expr = None;
     let mut runtime_args = None;
 
     for attr in attrs {
-        if attr.path().is_ident("test_builder") {
-            if builder_expr.is_some() {
-                return Err(syn::Error::new_spanned(
-                    attr,
-                    "duplicate `test_builder` attribute",
-                ));
-            }
-            builder_expr = Some(attr.parse_args()?);
-        } else if attr.path().is_ident("test_runtime")
-            || path_matches(attr.path(), &["tokio", "test"])
-        {
+        if attr.path().is_ident("test_runtime") || path_matches(attr.path(), &["tokio", "test"]) {
             if runtime_args.is_some() {
                 return Err(syn::Error::new_spanned(
                     attr,
@@ -94,7 +81,7 @@ fn split_helper_attrs(
         }
     }
 
-    Ok((output, builder_expr, runtime_args))
+    Ok((output, runtime_args))
 }
 
 fn case_fn_name(case: &Path) -> Result<syn::Ident> {
@@ -114,19 +101,19 @@ fn case_fn_name(case: &Path) -> Result<syn::Ident> {
 /// module with one wrapper test per case:
 ///
 /// - each wrapper binds `let case = <path>;`
-/// - if the function takes a `TesterBuilder`, the wrapper starts from `case.builder()`
-/// - if the function takes a `Tester`, the wrapper builds it with `case.builder().build().await?`
+/// - if the function takes a `TestEnvironment`, the wrapper prepares it from the case
+/// - if the function takes a `Tester`, the wrapper prepares the environment and launches a default node
 /// - if the function takes a `TestCase`, the wrapper passes the case value directly
 /// - each wrapper is annotated with `#[test_log::test(tokio::test)]` by default
 ///
 /// Supported parameter types are:
 ///
 /// - `TestCase`
-/// - `TesterBuilder`
+/// - `TestEnvironment`
 /// - `Tester`
 ///
-/// `TestCase` may be combined with either `TesterBuilder` or `Tester`.
-/// `TesterBuilder` and `Tester` cannot be used together in the same function signature.
+/// `TestCase` may be combined with either `TestEnvironment` or `Tester`.
+/// `TestEnvironment` and `Tester` cannot be used together in the same function signature.
 ///
 /// # Cases
 ///
@@ -138,21 +125,6 @@ fn case_fn_name(case: &Path) -> Result<syn::Ident> {
 ///
 /// Each path should evaluate to a `TestCase`, typically one of the exported constants from
 /// `zksync_os_integration_tests`.
-///
-/// # Builder customization
-///
-/// Use `#[test_builder(...)]` when every generated case should apply the same builder tweak before
-/// the `TesterBuilder` or `Tester` is created. The argument must be a function or closure with the
-/// shape `fn(TesterBuilder) -> TesterBuilder`.
-///
-/// ```ignore
-/// #[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
-/// #[test_builder(|builder| builder.block_time(Duration::from_secs(5)))]
-/// async fn pending_nonce_uses_slow_blocks(tester: Tester) -> anyhow::Result<()> {
-///     // `tester` is built from the adjusted builder for each case.
-///     Ok(())
-/// }
-/// ```
 ///
 /// # Runtime customization
 ///
@@ -199,11 +171,14 @@ fn case_fn_name(case: &Path) -> Result<syn::Ident> {
 /// Customize the builder inside the test before constructing a `Tester`:
 ///
 /// ```ignore
-/// use zksync_os_integration_tests::{CURRENT_TO_L1, TesterBuilder, test_multisetup};
+/// use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, test_multisetup};
 ///
 /// #[test_multisetup([CURRENT_TO_L1])]
-/// async fn prover_flow(builder: TesterBuilder) -> anyhow::Result<()> {
-///     let tester = builder.enable_prover().build().await?;
+/// async fn prover_flow(env: TestEnvironment) -> anyhow::Result<()> {
+///     let mut config = env.default_config().await?;
+///     config.prover_api_config.fake_fri_provers.enabled = false;
+///     config.prover_api_config.fake_snark_provers.enabled = false;
+///     let tester = env.launch(config).await?;
 ///     tester.prover_tester.wait_for_batch_proven(1).await?;
 ///     Ok(())
 /// }
@@ -231,9 +206,8 @@ fn case_fn_name(case: &Path) -> Result<syn::Ident> {
 ///
 /// - the annotated function must be `async`
 /// - methods taking `self` are not supported
-/// - only `TestCase`, `TesterBuilder`, and `Tester` parameters are accepted
-/// - `TesterBuilder` and `Tester` cannot be used together in the same function
-/// - `#[test_builder(...)]` may be used at most once
+/// - only `TestCase`, `TestEnvironment`, and `Tester` parameters are accepted
+/// - `TestEnvironment` and `Tester` cannot be used together in the same function
 /// - `#[test_runtime(...)]` may be used at most once
 #[proc_macro_attribute]
 pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -246,7 +220,7 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
             .into();
     }
 
-    let (wrapper_attrs, builder_expr, runtime_args) = match split_helper_attrs(input.attrs) {
+    let (wrapper_attrs, runtime_args) = match split_helper_attrs(input.attrs) {
         Ok(attrs) => attrs,
         Err(err) => return err.into_compile_error().into(),
     };
@@ -256,7 +230,7 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mod_name = input.sig.ident.clone();
     input.sig.ident = impl_name.clone();
 
-    let mut needs_builder = false;
+    let mut needs_environment = false;
     let mut needs_tester = false;
     let mut arg_exprs = Vec::with_capacity(input.sig.inputs.len());
 
@@ -265,9 +239,9 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(Some(ParamKind::TestCase)) => {
                 arg_exprs.push(quote!(case));
             }
-            Ok(Some(ParamKind::TesterBuilder)) => {
-                needs_builder = true;
-                arg_exprs.push(quote!(builder.clone()));
+            Ok(Some(ParamKind::TestEnvironment)) => {
+                needs_environment = true;
+                arg_exprs.push(quote!(environment));
             }
             Ok(Some(ParamKind::Tester)) => {
                 needs_tester = true;
@@ -276,7 +250,7 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(None) => {
                 return syn::Error::new_spanned(
                     arg,
-                    "supported parameters are `Tester`, `TesterBuilder`, and `TestCase`",
+                    "supported parameters are `Tester`, `TestEnvironment`, and `TestCase`",
                 )
                 .into_compile_error()
                 .into();
@@ -285,37 +259,26 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    if needs_builder && needs_tester {
+    if needs_environment && needs_tester {
         return syn::Error::new_spanned(
             &input.sig.inputs,
-            "`TesterBuilder` and `Tester` cannot be used together in the same test function",
+            "`TestEnvironment` and `Tester` cannot be used together in the same test function",
         )
         .into_compile_error()
         .into();
     }
 
-    let builder_setup = if needs_builder || needs_tester {
-        if let Some(builder_expr) = builder_expr {
-            quote! {
-                let builder = {
-                    let configure: fn(
-                        ::zksync_os_integration_tests::TesterBuilder,
-                    ) -> ::zksync_os_integration_tests::TesterBuilder = #builder_expr;
-                    let builder: ::zksync_os_integration_tests::TesterBuilder = case.builder();
-                    configure(builder)
-                };
-            }
-        } else {
-            quote! {
-                let builder: ::zksync_os_integration_tests::TesterBuilder = case.builder();
-            }
+    let environment_setup = if needs_environment || needs_tester {
+        quote! {
+            let environment: ::zksync_os_integration_tests::TestEnvironment =
+                case.environment().await?;
         }
     } else {
         quote! {}
     };
     let tester_setup = if needs_tester {
         quote! {
-            let tester = builder.build().await?;
+            let tester = environment.launch_default().await?;
         }
     } else {
         quote! {}
@@ -346,7 +309,7 @@ pub fn test_multisetup(attr: TokenStream, item: TokenStream) -> TokenStream {
             #(#wrapper_attrs)*
             async fn #fn_name() -> anyhow::Result<()> {
                 let case = #case;
-                #builder_setup
+                #environment_setup
                 #tester_setup
                 #impl_name(#(#arg_exprs),*).await
             }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -97,9 +97,11 @@ pub const BATCH_VERIFICATION_KEYS: [&str; 2] = [
     "0x7094f4b57ed88624583f68d2f241858f7dafb6d2558bc22d18991690d36b4e47",
     "0xf9306dd03807c08b646d47c739bd51e4d2a25b02bad0efb3d93f095982ac98cd",
 ];
-/// Shutdown completes in <5 seconds when there is no CPU starvation. PIG runs CPU-bound work on a
-/// blocking thread and may slow shutdown; 15s is ample even in that case.
-const NODE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+/// Shutdown completes in <5 seconds when there is no CPU starvation. But because prover input
+/// generator runs its CPU-bound task on a blocking thread it can significantly slow down graceful
+/// shutdown. We put 60s here until zksync-os v0.4.0 which will get rid of RISC-V simulator and
+/// allow async/abortable prover input generation.
+const NODE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
 const PORT_ACQUISITION_TIMEOUT: Duration = Duration::from_secs(15);
 const PORT_ACQUISITION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Set of addresses (i.e. public keys) expected by batch verification. Derived from [`BATCH_VERIFICATION_KEYS`].

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -4,9 +4,10 @@ use crate::network::Zksync;
 use crate::node_log::NodeLogState;
 use crate::prover_tester::ProverTester;
 use crate::provider::{ZksyncApi, ZksyncTestingProvider};
+use crate::test_config::{build_node_config, disable_prover_input_generation};
 use crate::utils::LockedPort;
 use alloy::network::EthereumWallet;
-use alloy::primitives::{Address, U256};
+use alloy::primitives::U256;
 use alloy::providers::utils::Eip1559Estimator;
 use alloy::providers::{
     DynProvider, Identity, PendingTransactionBuilder, Provider, ProviderBuilder, WalletProvider,
@@ -29,12 +30,8 @@ use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_network::NodeRecord;
+use zksync_os_server::config::Config;
 pub use zksync_os_server::config::DeploymentFilterConfig;
-use zksync_os_server::config::{
-    BatchVerificationConfig, Config, FakeFriProversConfig, FakeSnarkProversConfig, FeeConfig,
-    GeneralConfig, NetworkConfig, ProofStorageConfig, ProverApiConfig, ProverInputGeneratorConfig,
-    RpcConfig, SequencerConfig, StatusServerConfig,
-};
 use zksync_os_server::default_protocol_version::{
     NEXT_PROTOCOL_VERSION, PROTOCOL_VERSION, PROTOCOL_VERSION_V31_0,
 };
@@ -51,6 +48,7 @@ mod network;
 mod node_log;
 mod prover_tester;
 pub mod provider;
+pub mod test_config;
 pub mod upgrade;
 mod utils;
 
@@ -79,13 +77,6 @@ impl TestCase {
         }
     }
 
-    pub const fn next_to_l1() -> Self {
-        Self {
-            protocol_version: NEXT_PROTOCOL_VERSION,
-            settlement_layer: SettlementLayer::L1,
-        }
-    }
-
     pub const fn next_to_gateway() -> Self {
         Self {
             protocol_version: NEXT_PROTOCOL_VERSION,
@@ -93,19 +84,12 @@ impl TestCase {
         }
     }
 
-    pub fn builder(self) -> TesterBuilder {
-        Tester::builder()
-            .protocol_version(self.protocol_version)
-            .settlement_layer(self.settlement_layer)
-    }
-
-    pub async fn setup(self) -> anyhow::Result<Tester> {
-        self.builder().build().await
+    pub async fn environment(self) -> anyhow::Result<TestEnvironment> {
+        TestEnvironment::from_case(self).await
     }
 }
 
 pub const CURRENT_TO_L1: TestCase = TestCase::current_to_l1();
-pub const NEXT_TO_L1: TestCase = TestCase::next_to_l1();
 pub const NEXT_TO_GATEWAY: TestCase = TestCase::next_to_gateway();
 
 /// Set of private keys for batch verification participants.
@@ -113,11 +97,11 @@ pub const BATCH_VERIFICATION_KEYS: [&str; 2] = [
     "0x7094f4b57ed88624583f68d2f241858f7dafb6d2558bc22d18991690d36b4e47",
     "0xf9306dd03807c08b646d47c739bd51e4d2a25b02bad0efb3d93f095982ac98cd",
 ];
-/// Shutdown completes in <5 seconds when there is no CPU starvation. But because prover input
-/// generator runs its CPU-bound task on a blocking thread it can significantly slow down graceful
-/// shutdown. We put 60s here until zksync-os v0.4.0 which will get rid of RISC-V simulator and
-/// allow async/abortable prover input generation.
-const NODE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+/// Shutdown completes in <5 seconds when there is no CPU starvation. PIG runs CPU-bound work on a
+/// blocking thread and may slow shutdown; 15s is ample even in that case.
+const NODE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+const PORT_ACQUISITION_TIMEOUT: Duration = Duration::from_secs(15);
+const PORT_ACQUISITION_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Set of addresses (i.e. public keys) expected by batch verification. Derived from [`BATCH_VERIFICATION_KEYS`].
 static BATCH_VERIFICATION_ADDRESSES: LazyLock<Vec<String>> = LazyLock::new(|| {
     BATCH_VERIFICATION_KEYS
@@ -130,10 +114,139 @@ static BATCH_VERIFICATION_ADDRESSES: LazyLock<Vec<String>> = LazyLock::new(|| {
         .to_vec()
 });
 
+pub struct TestEnvironment {
+    l1: AnvilL1,
+    chain_layout: ChainLayout<'static>,
+    gateway: Option<GatewayContext>,
+    prepared_runtime: PreparedRuntime,
+}
+
+struct PreparedRuntime {
+    tempdir: Arc<TempDir>,
+    ports: Ports,
+}
+
+struct GatewayContext {
+    rpc_url: String,
+    node: SupportingNode,
+}
+
+impl PreparedRuntime {
+    async fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            tempdir: Arc::new(tempfile::tempdir()?),
+            ports: Ports::acquire_unused().await?,
+        })
+    }
+}
+
+impl TestEnvironment {
+    async fn from_case(case: TestCase) -> anyhow::Result<Self> {
+        match case.settlement_layer {
+            SettlementLayer::L1 => {
+                let chain_layout = ChainLayout::Default {
+                    protocol_version: case.protocol_version,
+                };
+                let l1 = AnvilL1::start(chain_layout).await?;
+                let prepared_runtime = PreparedRuntime::new().await?;
+                Ok(Self {
+                    l1,
+                    chain_layout,
+                    gateway: None,
+                    prepared_runtime,
+                })
+            }
+            SettlementLayer::Gateway => {
+                let protocol_version = case.protocol_version;
+                let chain_layout = ChainLayout::GatewayChain {
+                    protocol_version,
+                    chain_index: 0,
+                };
+                let l1 = AnvilL1::start(ChainLayout::Gateway { protocol_version }).await?;
+                let mut gateway_config =
+                    build_node_config(&l1, ChainLayout::Gateway { protocol_version }).await?;
+                if !prover_input_generation_enabled() {
+                    disable_prover_input_generation(&mut gateway_config);
+                }
+                let gateway = Tester::launch_with_new_runtime(
+                    l1.clone(),
+                    ChainLayout::Gateway { protocol_version },
+                    gateway_config,
+                )
+                .await?;
+                let gateway = GatewayContext::from_tester(gateway);
+                let prepared_runtime = PreparedRuntime::new().await?;
+                Ok(Self {
+                    l1,
+                    chain_layout,
+                    gateway: Some(gateway),
+                    prepared_runtime,
+                })
+            }
+        }
+    }
+
+    pub async fn default_config(&self) -> anyhow::Result<Config> {
+        let mut config = build_node_config(&self.l1, self.chain_layout).await?;
+        if let Some(gateway) = &self.gateway {
+            config.general_config.gateway_rpc_url = Some(gateway.rpc_url.clone());
+        }
+        Tester::bind_runtime_config(
+            &self.l1,
+            self.prepared_runtime.tempdir.as_ref(),
+            &mut config,
+            &self.prepared_runtime.ports,
+        );
+        Ok(config)
+    }
+
+    pub async fn launch_default(self) -> anyhow::Result<Tester> {
+        let config = self.default_config().await?;
+        self.launch(config).await
+    }
+
+    pub async fn launch(mut self, mut config: Config) -> anyhow::Result<Tester> {
+        if !prover_input_generation_enabled() {
+            disable_prover_input_generation(&mut config);
+        }
+        Tester::bind_runtime_config(
+            &self.l1,
+            self.prepared_runtime.tempdir.as_ref(),
+            &mut config,
+            &self.prepared_runtime.ports,
+        );
+        let supporting_gateway = if let Some(gateway) = self.gateway.take() {
+            config
+                .general_config
+                .gateway_rpc_url
+                .get_or_insert_with(|| gateway.rpc_url.clone());
+            wait_for_gateway_readiness(&self.l1, &gateway.rpc_url, &config).await?;
+            Some(gateway.node)
+        } else {
+            None
+        };
+        let mut tester = Tester::launch_node_inner(
+            self.l1,
+            config,
+            self.prepared_runtime.tempdir,
+            self.chain_layout,
+            None,
+            true,
+            Some(self.prepared_runtime.ports),
+        )
+        .await?;
+        if let Some(gateway) = supporting_gateway {
+            tester.owned_supporting_nodes.push(gateway);
+        }
+        Ok(tester)
+    }
+}
+
+/// A running primary test node together with its effective config, clients and any supporting
+/// runtimes that need to stay alive for the test topology.
 #[derive(Debug)]
 pub struct Tester {
-    pub l1: AnvilL1,
-
+    l1: AnvilL1,
     pub l2_provider: EthDynProvider,
     /// ZKsync OS-specific provider. Generally prefer to use `l2_provider` as we strive for the
     /// system to be Ethereum-compatible. But this can be useful if you need to assert custom fields
@@ -145,38 +258,65 @@ pub struct Tester {
 
     runtime: Runtime,
     task_manager_handle: Option<JoinHandle<Result<(), PanickedTaskError>>>,
+    config: Config,
 
     #[allow(dead_code)]
     tempdir: Arc<tempfile::TempDir>,
 
-    // Present only when p2p networking is enabled for this test node.
-    node_record: Option<NodeRecord>,
+    // Needed to be able to connect external nodes
+    node_record: NodeRecord,
     l2_rpc_address: String,
+    #[expect(dead_code)]
+    status_server_url: String,
     gateway_rpc_url: Option<String>,
     sl_provider: EthDynProvider,
     log_state: NodeLogState,
     chain_layout: ChainLayout<'static>,
-    enable_prover_input_generation: bool,
-    enable_p2p: bool,
-    supporting_nodes: Vec<Tester>,
+    owned_supporting_nodes: Vec<SupportingNode>,
 }
 
+/// A stopped test node that keeps its database, effective config and L1 alive so it can be
+/// started again.
 #[derive(Debug)]
 pub struct StoppedTester {
     l1: AnvilL1,
+    config: Config,
     tempdir: Arc<tempfile::TempDir>,
     log_state: NodeLogState,
     chain_layout: ChainLayout<'static>,
-    enable_prover_input_generation: bool,
-    enable_p2p: bool,
+    owned_supporting_nodes: Vec<SupportingNode>,
 }
 
-struct NodeLaunchState {
-    tempdir: Arc<TempDir>,
-    log_state: Option<NodeLogState>,
+#[derive(Debug)]
+struct SupportingNode {
+    runtime: Runtime,
+    _tempdir: Arc<TempDir>,
+}
+
+struct Ports {
+    l2_rpc: LockedPort,
+    prover_api: LockedPort,
+    network: LockedPort,
+    status: LockedPort,
 }
 
 impl Tester {
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    fn apply_external_node_defaults(&self, config: &mut Config) {
+        config.general_config.node_role = NodeRole::ExternalNode;
+        config.network_config.boot_nodes = vec![self.node_record.into()];
+        config.general_config.main_node_rpc_url = Some(self.l2_rpc_address.clone());
+        config.general_config.gateway_rpc_url = self.gateway_rpc_url.clone();
+        config.prover_api_config.fake_fri_provers.enabled = true;
+        config.prover_api_config.fake_snark_provers.enabled = true;
+        config.prover_input_generator_config.logging_enabled = false;
+        config.batch_verification_config.server_enabled = false;
+        config.l1_sender_config.pubdata_mode = None;
+    }
+
     pub fn l1_provider(&self) -> &EthDynProvider {
         &self.l1.provider
     }
@@ -241,34 +381,34 @@ impl Tester {
 }
 
 impl Tester {
-    pub fn builder() -> TesterBuilder {
-        TesterBuilder::default()
-    }
-
     pub async fn setup() -> anyhow::Result<Self> {
-        Self::builder().build().await
-    }
-
-    pub async fn setup_with_overrides(
-        config_overrides: impl FnOnce(&mut Config),
-    ) -> anyhow::Result<Self> {
-        let chain_layout = ChainLayout::Default {
-            protocol_version: PROTOCOL_VERSION,
-        };
-        let l1 = AnvilL1::start(chain_layout).await?;
-        Self::launch_node(
-            l1,
-            false,
-            prover_input_generation_enabled(),
-            false,
-            Some(config_overrides),
-            chain_layout,
-        )
-        .await
+        CURRENT_TO_L1.environment().await?.launch_default().await
     }
 
     pub fn l2_rpc_url(&self) -> &str {
         &self.l2_rpc_address
+    }
+
+    pub fn external_node_config(&self) -> Config {
+        let mut config = self.config.clone();
+        self.apply_external_node_defaults(&mut config);
+        config
+    }
+
+    pub async fn wait_for_initial_deposit(&self) -> anyhow::Result<()> {
+        tokio::time::timeout(
+            Duration::from_secs(60),
+            self.l2_zk_provider.wait_for_block(2),
+        )
+        .await
+        .context("timed out waiting for block 2 (initial deposit)")??;
+        ensure_test_wallet_funded(
+            &self.l1,
+            &self.l2_provider,
+            &self.l2_zk_provider,
+            &self.l2_wallet,
+        )
+        .await
     }
 
     pub async fn launch_external_node(&self) -> anyhow::Result<Self> {
@@ -289,66 +429,55 @@ impl Tester {
         &self,
         config_overrides: Option<impl FnOnce(&mut Config)>,
     ) -> anyhow::Result<Self> {
-        let boot_node = self.node_record.context(
-            "main node was started without p2p networking; use `TesterBuilder::enable_p2p()`",
-        )?;
-        let overrides_fun = |config: &mut Config| {
-            config.general_config.node_role = NodeRole::ExternalNode;
-            config.network_config.boot_nodes = vec![boot_node.into()];
-            config.general_config.main_node_rpc_url = Some(self.l2_rpc_address.clone());
-            config.l1_sender_config.pubdata_mode = None;
-            config.general_config.gateway_rpc_url = self.gateway_rpc_url.clone();
-            if let Some(f) = config_overrides {
-                f(config)
-            }
-        };
+        let mut config = self.external_node_config();
+        if let Some(config_overrides) = config_overrides {
+            config_overrides(&mut config);
+        }
+        self.launch_from_config(config).await
+    }
 
-        Self::launch_node(
-            self.l1.clone(),
-            false,
-            self.enable_prover_input_generation,
-            true,
-            Some(overrides_fun),
-            self.chain_layout,
-        )
-        .await
+    pub async fn launch_from_config(&self, config: Config) -> anyhow::Result<Self> {
+        Self::launch_with_new_runtime(self.l1.clone(), self.chain_layout, config).await
     }
 
     /// Gracefully shut down and restart the node, reusing the same database and L1.
     ///
     /// Returns a new `Tester` connected to the restarted node. The original `Tester` is consumed.
     ///
-    /// Note that allocated ports might change between old node and new one.
+    /// Restart keeps the same config by default, including the original ports.
     pub async fn stop(self) -> anyhow::Result<StoppedTester> {
-        // Drop all fields that might rely on node being alive (e.g. alloy provider that uses RPC).
         let Self {
             runtime,
-            task_manager_handle: _,
             l1,
+            config,
             tempdir,
             log_state,
             chain_layout,
-            enable_prover_input_generation,
-            enable_p2p,
+            owned_supporting_nodes,
             ..
         } = self;
-        if !runtime.graceful_shutdown_with_timeout(NODE_SHUTDOWN_TIMEOUT) {
-            panic!("node failed to shutdown in time");
-        }
+        shutdown_runtime(runtime).await?;
         Ok(StoppedTester {
             l1,
             tempdir,
             log_state,
             chain_layout,
-            enable_prover_input_generation,
-            enable_p2p,
+            config,
+            owned_supporting_nodes,
         })
     }
 
+    /// Restart keeps the same config by default. The internal P2P network port may change.
     pub async fn restart(self) -> anyhow::Result<Self> {
         self.stop().await?.start().await
     }
 
+    pub async fn restart_with_config(self, config: Config) -> anyhow::Result<Self> {
+        self.stop().await?.start_with_config(config).await
+    }
+
+    /// Gracefully shut down and restart the node, reusing the same database and L1,
+    /// while applying additional config overrides for the restarted node.
     pub async fn restart_with_overrides(
         self,
         config_overrides: impl FnOnce(&mut Config),
@@ -359,165 +488,73 @@ impl Tester {
             .await
     }
 
-    async fn launch_node(
+    /// Gracefully shut down the node.
+    pub async fn shutdown(self) -> anyhow::Result<()> {
+        let Self {
+            runtime,
+            owned_supporting_nodes,
+            ..
+        } = self;
+        drop(owned_supporting_nodes);
+        shutdown_runtime(runtime).await?;
+        Ok(())
+    }
+
+    async fn launch_with_new_runtime(
         l1: AnvilL1,
-        enable_prover: bool,
-        enable_prover_input_generation: bool,
-        enable_p2p: bool,
-        config_overrides: Option<impl FnOnce(&mut Config)>,
         chain_layout: ChainLayout<'static>,
+        mut config: Config,
     ) -> anyhow::Result<Self> {
         let tempdir = Arc::new(tempfile::tempdir()?);
-        Self::launch_node_inner(
-            l1,
-            enable_prover,
-            enable_prover_input_generation,
-            enable_p2p,
-            config_overrides,
-            NodeLaunchState {
-                tempdir,
-                log_state: None,
-            },
-            chain_layout,
-        )
-        .await
+        let ports = Ports::acquire_unused().await?;
+        Self::bind_runtime_config(&l1, tempdir.as_ref(), &mut config, &ports);
+        Self::launch_node_inner(l1, config, tempdir, chain_layout, None, true, Some(ports)).await
+    }
+
+    fn bind_runtime_config(l1: &AnvilL1, tempdir: &TempDir, config: &mut Config, ports: &Ports) {
+        config.general_config.rocks_db_path = tempdir.path().join("rocksdb");
+        config.general_config.l1_rpc_url = l1.address.clone();
+        config.rpc_config.address = format!("0.0.0.0:{}", ports.l2_rpc.port);
+        config.prover_api_config.address = format!("0.0.0.0:{}", ports.prover_api.port);
+        config.prover_api_config.proof_storage.path = tempdir.path().join("proof_storage_path");
+        config.status_server_config.address = format!("0.0.0.0:{}", ports.status.port);
+        config.network_config.address = Ipv4Addr::LOCALHOST;
+        config.network_config.interface = None;
+        config.network_config.port = ports.network.port;
+        config.network_config.secret_key = Some(zksync_os_network::rng_secret_key());
     }
 
     async fn launch_node_inner(
         l1: AnvilL1,
-        enable_prover: bool,
-        enable_prover_input_generation: bool,
-        enable_p2p: bool,
-        config_overrides: Option<impl FnOnce(&mut Config)>,
-        launch_state: NodeLaunchState,
+        config: Config,
+        tempdir: Arc<TempDir>,
         chain_layout: ChainLayout<'static>,
+        log_state: Option<NodeLogState>,
+        wait_for_initial_deposit: bool,
+        held_ports: Option<Ports>,
     ) -> anyhow::Result<Self> {
-        let NodeLaunchState { tempdir, log_state } = launch_state;
-        // Initialize and **hold** locked ports for the duration of node initialization.
-        let l2_locked_port = LockedPort::acquire_unused().await?;
-        let prover_api_locked_port = LockedPort::acquire_unused().await?;
-        let network_locked_port = if enable_p2p {
-            Some(LockedPort::acquire_unused().await?)
-        } else {
-            None
+        let _ports = match held_ports {
+            Some(ports) => ports,
+            None => Ports::from_config(&config).await?,
         };
-        let status_locked_port = LockedPort::acquire_unused().await?;
-        let l2_rpc_address = format!("0.0.0.0:{}", l2_locked_port.port);
-        let l2_rpc_ws_url = format!("ws://localhost:{}", l2_locked_port.port);
-        let prover_api_address = format!("0.0.0.0:{}", prover_api_locked_port.port);
-        let status_address = format!("0.0.0.0:{}", status_locked_port.port);
+        #[cfg(feature = "prover-tests")]
+        let enable_prover = !config.prover_api_config.fake_fri_provers.enabled;
+        let l2_rpc_address = config.rpc_config.address.clone();
+        let l2_rpc_ws_url = format!("ws://localhost:{}", parse_local_port(&l2_rpc_address)?);
+        let status_server_url = config
+            .status_server_config
+            .address
+            .replace("0.0.0.0:", "http://localhost:");
 
-        let rocks_db_path = tempdir.path().join("rocksdb");
-        // ENs will not use this dir
-        let proof_storage_path = tempdir.path().join("proof_storage_path");
-
-        let default_config = load_chain_config(chain_layout).await;
-
-        // Create a handle to run the sequencer in the background
-        let general_config = GeneralConfig {
-            rocks_db_path: rocks_db_path.clone(),
-            l1_rpc_url: l1.address.clone(),
-            l1_rpc_poll_interval: Duration::from_millis(100),
-            gateway_rpc_poll_interval: Duration::from_millis(100),
-            ..default_config.general_config
-        };
-        let sequencer_config = SequencerConfig {
-            fee_collector_address: Address::random(),
-            ..default_config.sequencer_config
-        };
-        let rpc_config = RpcConfig {
-            address: l2_rpc_address.clone(),
-            // Override default with a higher value as the test can be slow in CI
-            send_raw_transaction_sync_timeout: Duration::from_secs(10),
-            ..default_config.rpc_config
-        };
-        let prover_api_config = ProverApiConfig {
-            fake_fri_provers: FakeFriProversConfig {
-                enabled: !enable_prover,
-                ..default_config.prover_api_config.fake_fri_provers
-            },
-            fake_snark_provers: FakeSnarkProversConfig {
-                enabled: !enable_prover,
-                ..default_config.prover_api_config.fake_snark_provers
-            },
-            address: prover_api_address,
-            proof_storage: ProofStorageConfig {
-                path: proof_storage_path.clone(),
-                ..default_config.prover_api_config.proof_storage
-            },
-            ..default_config.prover_api_config
-        };
-        let batch_verification_config = BatchVerificationConfig {
-            server_enabled: false,
-            client_enabled: false,
-            threshold: 1, // default to 1 of 2
-            accepted_signers: BATCH_VERIFICATION_ADDRESSES.clone(),
-            request_timeout: Duration::from_millis(500),
-            retry_delay: Duration::from_secs(1),
-            total_timeout: Duration::from_secs(300),
-            signing_key: BATCH_VERIFICATION_KEYS[0].into(),
-        };
-
-        let status_server_config = StatusServerConfig {
-            enabled: true,
-            address: status_address,
-        };
-
-        let (network_config, node_record) = if let Some(network_locked_port) = &network_locked_port
-        {
-            let network_secret_key = zksync_os_network::rng_secret_key();
-            let node_record = NodeRecord::from_secret_key(
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), network_locked_port.port),
-                &network_secret_key,
-            );
-            (
-                NetworkConfig {
-                    enabled: true,
-                    secret_key: Some(network_secret_key),
-                    address: Ipv4Addr::LOCALHOST,
-                    interface: None,
-                    port: network_locked_port.port,
-                    boot_nodes: vec![],
-                },
-                Some(node_record),
-            )
-        } else {
-            (
-                NetworkConfig {
-                    enabled: false,
-                    secret_key: None,
-                    ..default_config.network_config.clone()
-                },
-                None,
-            )
-        };
-
-        let mut config = Config {
-            general_config,
-            network_config,
-            genesis_config: default_config.genesis_config,
-            rpc_config,
-            mempool_config: default_config.mempool_config,
-            tx_validator_config: default_config.tx_validator_config,
-            sequencer_config,
-            l1_sender_config: default_config.l1_sender_config,
-            l1_watcher_config: default_config.l1_watcher_config,
-            batcher_config: default_config.batcher_config,
-            prover_input_generator_config: ProverInputGeneratorConfig {
-                logging_enabled: enable_prover,
-                enable_input_generation: enable_prover_input_generation,
-                ..default_config.prover_input_generator_config
-            },
-            prover_api_config,
-            status_server_config,
-            observability_config: default_config.observability_config,
-            gas_adjuster_config: default_config.gas_adjuster_config,
-            batch_verification_config,
-            base_token_price_updater_config: default_config.base_token_price_updater_config,
-            interop_fee_updater_config: default_config.interop_fee_updater_config,
-            external_price_api_client_config: default_config.external_price_api_client_config,
-            fee_config: default_config.fee_config,
-        };
+        let network_secret_key = config
+            .network_config
+            .secret_key
+            .as_ref()
+            .context("network secret key should be present in test config")?;
+        let node_record = NodeRecord::from_secret_key(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), config.network_config.port),
+            network_secret_key,
+        );
 
         if let Some(ephemeral_state) = &config.general_config.ephemeral_state {
             tracing::info!("Loading ephemeral state from {}", ephemeral_state.display());
@@ -526,13 +563,12 @@ impl Tester {
                 &config.general_config.rocks_db_path,
             );
         }
-        if let Some(f) = config_overrides {
-            f(&mut config)
-        }
         let node_role = config.general_config.node_role;
         let log_state = log_state.unwrap_or_else(|| NodeLogState::fresh(node_role));
         let log_tag = log_state.tag();
         let gateway_rpc_url = config.general_config.gateway_rpc_url.clone();
+        #[cfg(feature = "prover-tests")]
+        let prover_api_address = config.prover_api_config.address.clone();
 
         let runtime = RuntimeBuilder::new(RuntimeConfig::with_existing_handle(Handle::current()))
             .build()
@@ -543,7 +579,7 @@ impl Tester {
             role = %node_role,
         );
         tracing::info!(parent: &node_span, "Launching test node");
-        zksync_os_server::run::<FullDiffsState>(&runtime, config)
+        zksync_os_server::run::<FullDiffsState>(&runtime, config.clone())
             .instrument(node_span)
             .await;
         let task_manager_handle = runtime
@@ -552,7 +588,7 @@ impl Tester {
 
         #[cfg(feature = "prover-tests")]
         if enable_prover {
-            let base_url = format!("http://localhost:{}", prover_api_locked_port.port);
+            let base_url = prover_api_address.replace("0.0.0.0:", "http://localhost:");
             let app_bin_path = utils::materialize_multiblock_batch_bin(
                 &tempdir.path().join("app_bins"),
                 "v6",
@@ -627,17 +663,6 @@ impl Tester {
             .connect(&l2_rpc_ws_url)
             .await?;
 
-        // Deposits fail before genesis upgrade tx is processed, so we wait for the first block with upgrade tx.
-        // Second block contains pre-baked L1->L2 transactions and funding the test wallet should happen there, so we wait for it as well.
-        l2_zk_provider.wait_for_block(2).await?;
-        ensure_test_wallet_funded(
-            &l1,
-            &EthDynProvider::new(l2_provider.clone()),
-            &DynProvider::new(l2_zk_provider.clone()),
-            &l2_wallet,
-        )
-        .await?;
-
         let sl_provider = if let Some(gateway_rpc_url) = &gateway_rpc_url {
             let sl_provider = (|| async {
                 let sl_provider = ProviderBuilder::new()
@@ -669,7 +694,7 @@ impl Tester {
             EthDynProvider::new(l2_provider.clone()),
             DynProvider::new(l2_zk_provider.clone()),
         );
-        Ok(Tester {
+        let tester = Tester {
             l1,
             l2_provider: EthDynProvider::new(l2_provider.clone()),
             l2_zk_provider: DynProvider::new(l2_zk_provider.clone()),
@@ -677,67 +702,205 @@ impl Tester {
             prover_tester,
             runtime,
             task_manager_handle: Some(task_manager_handle),
+            config,
             l2_rpc_address: l2_rpc_address.replace("0.0.0.0:", "http://localhost:"),
+            status_server_url,
             gateway_rpc_url,
             sl_provider,
             node_record,
             log_state,
             tempdir: tempdir.clone(),
             chain_layout,
-            enable_prover_input_generation,
-            enable_p2p,
-            supporting_nodes: Vec::new(),
-        })
+            owned_supporting_nodes: Vec::new(),
+        };
+        if wait_for_initial_deposit {
+            tester.wait_for_initial_deposit().await?;
+        }
+        Ok(tester)
     }
 }
 
 impl StoppedTester {
-    pub fn l1_provider(&self) -> &EthDynProvider {
-        &self.l1.provider
+    pub fn config(&self) -> &Config {
+        &self.config
     }
 
-    pub fn l1_wallet(&self) -> &EthereumWallet {
-        &self.l1.wallet
+    pub fn l1_provider(&self) -> &EthDynProvider {
+        &self.l1.provider
     }
 
     pub fn chain_layout(&self) -> ChainLayout<'static> {
         self.chain_layout
     }
 
+    pub async fn shutdown(self) -> anyhow::Result<()> {
+        drop(self.owned_supporting_nodes);
+        Ok(())
+    }
+
     pub async fn start(self) -> anyhow::Result<Tester> {
-        Tester::launch_node_inner(
-            self.l1,
+        let config = self.config.clone();
+        self.start_with_config(config).await
+    }
+
+    pub async fn start_with_config(self, config: Config) -> anyhow::Result<Tester> {
+        let Self {
+            l1,
+            tempdir,
+            chain_layout,
+            log_state,
+            owned_supporting_nodes,
+            ..
+        } = self;
+        let ports = Ports::from_config(&config).await?;
+        let mut tester = Tester::launch_node_inner(
+            l1,
+            config,
+            tempdir,
+            chain_layout,
+            Some(log_state.restarted()),
             false,
-            self.enable_prover_input_generation,
-            self.enable_p2p,
-            None::<fn(&mut Config)>,
-            NodeLaunchState {
-                tempdir: self.tempdir,
-                log_state: Some(self.log_state.restarted()),
-            },
-            self.chain_layout,
+            Some(ports),
         )
-        .await
+        .await?;
+        tester.owned_supporting_nodes = owned_supporting_nodes;
+        Ok(tester)
     }
 
     pub async fn start_with_overrides(
         self,
         config_overrides: impl FnOnce(&mut Config),
     ) -> anyhow::Result<Tester> {
-        Tester::launch_node_inner(
-            self.l1,
-            false,
-            self.enable_prover_input_generation,
-            self.enable_p2p,
-            Some(config_overrides),
-            NodeLaunchState {
-                tempdir: self.tempdir,
-                log_state: Some(self.log_state.restarted()),
-            },
-            self.chain_layout,
-        )
-        .await
+        let mut config = self.config.clone();
+        config_overrides(&mut config);
+        self.start_with_config(config).await
     }
+}
+
+impl SupportingNode {
+    fn from_tester(tester: Tester) -> Self {
+        let Tester {
+            runtime,
+            tempdir,
+            owned_supporting_nodes,
+            ..
+        } = tester;
+        drop(owned_supporting_nodes);
+        Self {
+            runtime,
+            _tempdir: tempdir,
+        }
+    }
+}
+
+impl GatewayContext {
+    fn from_tester(tester: Tester) -> Self {
+        let rpc_url = tester.l2_rpc_url().to_owned();
+        Self {
+            rpc_url,
+            node: SupportingNode::from_tester(tester),
+        }
+    }
+}
+
+impl Drop for SupportingNode {
+    fn drop(&mut self) {
+        let _ = self
+            .runtime
+            .graceful_shutdown_with_timeout(NODE_SHUTDOWN_TIMEOUT);
+    }
+}
+
+impl Ports {
+    async fn acquire_unused() -> anyhow::Result<Self> {
+        Ok(Self {
+            l2_rpc: LockedPort::acquire_unused().await?,
+            prover_api: LockedPort::acquire_unused().await?,
+            network: LockedPort::acquire_unused().await?,
+            status: LockedPort::acquire_unused().await?,
+        })
+    }
+
+    async fn from_config(config: &Config) -> anyhow::Result<Self> {
+        Ok(Self {
+            l2_rpc: acquire_port_with_retry(parse_local_port(&config.rpc_config.address)?)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to acquire L2 RPC port {}",
+                        config.rpc_config.address
+                    )
+                })?,
+            prover_api: acquire_port_with_retry(parse_local_port(
+                &config.prover_api_config.address,
+            )?)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to acquire prover API port {}",
+                    config.prover_api_config.address
+                )
+            })?,
+            network: acquire_port_with_retry(config.network_config.port)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to acquire network port {}",
+                        config.network_config.port
+                    )
+                })?,
+            status: acquire_port_with_retry(parse_local_port(
+                &config.status_server_config.address,
+            )?)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to acquire status server port {}",
+                    config.status_server_config.address
+                )
+            })?,
+        })
+    }
+}
+
+fn parse_local_port(address: &str) -> anyhow::Result<u16> {
+    let port = address
+        .rsplit_once(':')
+        .context("address should contain a port")?
+        .1;
+    port.parse().context("address port should be numeric")
+}
+
+async fn acquire_port_with_retry(port: u16) -> anyhow::Result<LockedPort> {
+    let deadline = tokio::time::Instant::now() + PORT_ACQUISITION_TIMEOUT;
+    loop {
+        match LockedPort::acquire(port).await {
+            Ok(locked_port) => return Ok(locked_port),
+            Err(err) if tokio::time::Instant::now() < deadline => {
+                tracing::info!(port, %err, "retrying port acquisition");
+                tokio::time::sleep(PORT_ACQUISITION_POLL_INTERVAL).await;
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "port {port} did not become acquirable within {PORT_ACQUISITION_TIMEOUT:?}"
+                    )
+                });
+            }
+        }
+    }
+}
+
+async fn shutdown_runtime(runtime: Runtime) -> anyhow::Result<()> {
+    let shutdown_ok = tokio::task::spawn_blocking(move || {
+        runtime.graceful_shutdown_with_timeout(NODE_SHUTDOWN_TIMEOUT)
+    })
+    .await
+    .expect("failed to join graceful shutdown task");
+    if !shutdown_ok {
+        panic!("node failed to shutdown in time");
+    }
+    Ok(())
 }
 
 async fn ensure_test_wallet_funded(
@@ -836,162 +999,12 @@ async fn ensure_test_wallet_funded(
     .await
 }
 
-#[derive(Clone)]
-struct NodeBuilderOptions {
-    enable_prover: bool,
-    enable_prover_input_generation: bool,
-    enable_p2p: bool,
-    block_time: Option<Duration>,
-    batch_verification_threshold: Option<u64>,
-    fee_config: Option<FeeConfig>,
-    gas_price_scale_factor: Option<f64>,
-    estimate_gas_pubdata_price_factor: Option<f64>,
-}
-
-impl Default for NodeBuilderOptions {
-    fn default() -> Self {
-        Self {
-            enable_prover: false,
-            enable_prover_input_generation: true,
-            enable_p2p: false,
-            block_time: None,
-            batch_verification_threshold: None,
-            fee_config: None,
-            gas_price_scale_factor: None,
-            estimate_gas_pubdata_price_factor: None,
-        }
-    }
-}
-
-impl NodeBuilderOptions {
-    fn apply_to_config(&self, config: &mut Config) {
-        if let Some(block_time) = self.block_time {
-            config.sequencer_config.block_time = block_time;
-        }
-        if let Some(batch_verification_threshold) = self.batch_verification_threshold {
-            config.batch_verification_config.server_enabled = true;
-            config.batch_verification_config.threshold = batch_verification_threshold;
-        }
-        if let Some(fee_config) = self.fee_config.clone() {
-            config.fee_config = fee_config;
-        }
-        if let Some(factor) = self.gas_price_scale_factor {
-            config.rpc_config.gas_price_scale_factor = factor;
-        }
-        if let Some(factor) = self.estimate_gas_pubdata_price_factor {
-            config.rpc_config.estimate_gas_pubdata_price_factor = factor;
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct TesterBuilder {
-    options: NodeBuilderOptions,
-    protocol_version: &'static str,
-    settlement_layer: SettlementLayer,
-}
-
-impl Default for TesterBuilder {
-    fn default() -> Self {
-        Self {
-            options: NodeBuilderOptions::default(),
-            protocol_version: PROTOCOL_VERSION,
-            settlement_layer: SettlementLayer::L1,
-        }
-    }
-}
-
-impl TesterBuilder {
-    #[cfg(feature = "prover-tests")]
-    pub fn enable_prover(mut self) -> Self {
-        self.options.enable_prover = true;
-        self
-    }
-
-    pub fn block_time(mut self, block_time: Duration) -> Self {
-        self.options.block_time = Some(block_time);
-        self
-    }
-
-    pub fn enable_p2p(mut self) -> Self {
-        self.options.enable_p2p = true;
-        self
-    }
-
-    pub fn batch_verification(mut self, threshold: u64) -> Self {
-        self.options.enable_p2p = true;
-        self.options.batch_verification_threshold = Some(threshold);
-        self
-    }
-
-    pub fn fee_config(mut self, c: FeeConfig) -> Self {
-        self.options.fee_config = Some(c);
-        self
-    }
-
-    pub fn gas_price_scale_factor(mut self, factor: f64) -> Self {
-        self.options.gas_price_scale_factor = Some(factor);
-        self
-    }
-
-    pub fn estimate_gas_pubdata_price_factor(mut self, factor: f64) -> Self {
-        self.options.estimate_gas_pubdata_price_factor = Some(factor);
-        self
-    }
-
-    pub fn protocol_version(mut self, protocol_version: &'static str) -> Self {
-        self.protocol_version = protocol_version;
-        self
-    }
-
-    pub fn settlement_layer(mut self, settlement_layer: SettlementLayer) -> Self {
-        self.settlement_layer = settlement_layer;
-        self
-    }
-
-    pub async fn build(self) -> anyhow::Result<Tester> {
-        match self.settlement_layer {
-            SettlementLayer::L1 => {
-                let chain_layout = ChainLayout::Default {
-                    protocol_version: self.protocol_version,
-                };
-                let l1 = AnvilL1::start(chain_layout).await?;
-                let mut options = self.options;
-                if !prover_input_generation_enabled() {
-                    options.enable_prover_input_generation = false;
-                }
-                Tester::launch_node(
-                    l1,
-                    options.enable_prover,
-                    options.enable_prover_input_generation,
-                    options.enable_p2p,
-                    Some(move |config: &mut Config| options.apply_to_config(config)),
-                    chain_layout,
-                )
-                .await
-            }
-            SettlementLayer::Gateway => {
-                let mut options = self.options;
-                if !prover_input_generation_enabled() {
-                    options.enable_prover_input_generation = false;
-                }
-                let gateway_tester = GatewayTester::builder()
-                    .protocol_version(self.protocol_version)
-                    .num_chains(1)
-                    .chain_options(options)
-                    .build()
-                    .await?;
-                Ok(gateway_tester.into_primary_chain())
-            }
-        }
-    }
-}
-
-/// Multi-chain test environment with multiple L2 chains settling to a gateway chain.
+/// Multi-node owner for gateway-settling tests.
+///
+/// Owns one gateway tester plus one tester per settling chain.
 pub struct GatewayTester {
-    pub l1: AnvilL1,
-    pub gateway: Tester,
-    pub chains: Vec<Tester>,
+    gateway: Tester,
+    chains: Vec<Tester>,
 }
 
 impl GatewayTester {
@@ -1008,35 +1021,18 @@ impl GatewayTester {
         &self.chains[index]
     }
 
-    /// Get chain A (first chain)
-    pub fn chain_a(&self) -> &Tester {
-        self.chain(0)
-    }
-
-    /// Get chain B (second chain)
-    pub fn chain_b(&self) -> &Tester {
-        self.chain(1)
+    pub fn chain_mut(&mut self, index: usize) -> &mut Tester {
+        &mut self.chains[index]
     }
 
     pub fn gateway(&self) -> &Tester {
         &self.gateway
-    }
-
-    pub fn into_gateway(self) -> Tester {
-        self.gateway
-    }
-
-    pub fn into_primary_chain(mut self) -> Tester {
-        let mut chain = self.chains.remove(0);
-        chain.supporting_nodes.push(self.gateway);
-        chain
     }
 }
 
 pub struct GatewayTesterBuilder {
     protocol_version: &'static str,
     num_chains: Option<usize>,
-    chain_options: NodeBuilderOptions,
     deployment_filter: Option<DeploymentFilterConfig>,
 }
 
@@ -1045,7 +1041,6 @@ impl Default for GatewayTesterBuilder {
         Self {
             protocol_version: PROTOCOL_VERSION_V31_0,
             num_chains: None,
-            chain_options: NodeBuilderOptions::default(),
             deployment_filter: None,
         }
     }
@@ -1062,16 +1057,6 @@ impl GatewayTesterBuilder {
         self
     }
 
-    pub fn enable_chain_p2p(mut self) -> Self {
-        self.chain_options.enable_p2p = true;
-        self
-    }
-
-    fn chain_options(mut self, chain_options: NodeBuilderOptions) -> Self {
-        self.chain_options = chain_options;
-        self
-    }
-
     /// Set the deployment filter config for all chains.
     pub fn deployment_filter(mut self, config: DeploymentFilterConfig) -> Self {
         self.deployment_filter = Some(config);
@@ -1083,13 +1068,15 @@ impl GatewayTesterBuilder {
 
         let protocol_version = self.protocol_version;
         let l1 = AnvilL1::start(ChainLayout::Gateway { protocol_version }).await?;
-        let gateway = Tester::launch_node(
+        let mut gateway_config =
+            build_node_config(&l1, ChainLayout::Gateway { protocol_version }).await?;
+        if !prover_input_generation_enabled() {
+            disable_prover_input_generation(&mut gateway_config);
+        }
+        let gateway = Tester::launch_with_new_runtime(
             l1.clone(),
-            false,
-            self.chain_options.enable_prover_input_generation,
-            false,
-            None::<fn(&mut Config)>,
             ChainLayout::Gateway { protocol_version },
+            gateway_config,
         )
         .await?;
         let gateway_rpc_url = gateway.l2_rpc_url().to_owned();
@@ -1105,26 +1092,24 @@ impl GatewayTesterBuilder {
                 .genesis_config
                 .chain_id
                 .expect("Chain ID must be set in chain config");
-            wait_for_gateway_readiness(&l1, &gateway, &chain_config).await?;
+            wait_for_gateway_readiness(&l1, gateway.l2_rpc_url(), &chain_config).await?;
             let gateway_rpc_url = gateway_rpc_url.clone();
-            let chain_options = self.chain_options.clone();
             let deployment_filter = self.deployment_filter.clone();
 
-            let tester = Tester::launch_node(
-                l1.clone(),
-                chain_options.enable_prover,
-                chain_options.enable_prover_input_generation,
-                chain_options.enable_p2p,
-                Some(move |config: &mut Config| {
-                    config.general_config.gateway_rpc_url = Some(gateway_rpc_url.clone());
-                    chain_options.apply_to_config(config);
-                    if let Some(deployment_filter) = deployment_filter {
-                        config.sequencer_config.tx_validator.deployment_filter = deployment_filter;
-                    }
-                }),
-                chain_layout,
-            )
-            .await?;
+            let mut tester_config = build_node_config(&l1, chain_layout).await?;
+            if !prover_input_generation_enabled() {
+                disable_prover_input_generation(&mut tester_config);
+            }
+            tester_config.general_config.gateway_rpc_url = Some(gateway_rpc_url);
+            if let Some(deployment_filter) = deployment_filter {
+                tester_config
+                    .sequencer_config
+                    .tx_validator
+                    .deployment_filter = deployment_filter;
+            }
+
+            let tester =
+                Tester::launch_with_new_runtime(l1.clone(), chain_layout, tester_config).await?;
 
             tracing::info!(
                 "L2 chain {} started with chain_id {} on {}",
@@ -1136,11 +1121,7 @@ impl GatewayTesterBuilder {
             chains.push(tester);
         }
 
-        Ok(GatewayTester {
-            l1,
-            gateway,
-            chains,
-        })
+        Ok(GatewayTester { gateway, chains })
     }
 }
 
@@ -1150,7 +1131,7 @@ fn prover_input_generation_enabled() -> bool {
 
 async fn wait_for_gateway_readiness(
     l1: &AnvilL1,
-    gateway: &Tester,
+    gateway_rpc_url: &str,
     chain_config: &Config,
 ) -> anyhow::Result<()> {
     let chain_id = chain_config
@@ -1164,14 +1145,9 @@ async fn wait_for_gateway_readiness(
 
     (|| async {
         let gateway_provider = ProviderBuilder::new()
-            .connect(gateway.l2_rpc_url())
+            .connect(gateway_rpc_url)
             .await
-            .with_context(|| {
-                format!(
-                    "failed to connect to gateway RPC at {}",
-                    gateway.l2_rpc_url()
-                )
-            })?;
+            .with_context(|| format!("failed to connect to gateway RPC at {gateway_rpc_url}"))?;
 
         L1State::fetch_finalized(
             DynProvider::new(l1.provider.clone()),

--- a/integration-tests/src/test_config.rs
+++ b/integration-tests/src/test_config.rs
@@ -1,0 +1,40 @@
+use crate::config::{ChainLayout, load_chain_config};
+use crate::{AnvilL1, BATCH_VERIFICATION_ADDRESSES, BATCH_VERIFICATION_KEYS};
+use alloy::primitives::Address;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use zksync_os_server::config::Config;
+
+pub(crate) fn disable_prover_input_generation(config: &mut Config) {
+    if config.prover_api_config.fake_fri_provers.enabled
+        && config.prover_api_config.fake_snark_provers.enabled
+    {
+        config.prover_input_generator_config.enable_input_generation = false;
+    }
+}
+
+pub(crate) async fn build_node_config(
+    l1: &AnvilL1,
+    chain_layout: ChainLayout<'static>,
+) -> anyhow::Result<Config> {
+    let mut config = load_chain_config(chain_layout).await;
+    config.general_config.l1_rpc_url = l1.address.clone();
+    config.sequencer_config.fee_collector_address = Address::random();
+    config.rpc_config.send_raw_transaction_sync_timeout = Duration::from_secs(10);
+    config.prover_api_config.fake_fri_provers.enabled = true;
+    config.prover_api_config.fake_snark_provers.enabled = true;
+    config.batch_verification_config.server_enabled = false;
+    config.batch_verification_config.client_enabled = false;
+    config.batch_verification_config.threshold = 1;
+    config.batch_verification_config.accepted_signers = BATCH_VERIFICATION_ADDRESSES.clone();
+    config.batch_verification_config.request_timeout = Duration::from_millis(500);
+    config.batch_verification_config.retry_delay = Duration::from_secs(1);
+    config.batch_verification_config.total_timeout = Duration::from_secs(300);
+    config.batch_verification_config.signing_key = BATCH_VERIFICATION_KEYS[0].into();
+    config.status_server_config.enabled = true;
+    config.network_config.enabled = true;
+    config.network_config.address = Ipv4Addr::LOCALHOST;
+    config.network_config.interface = None;
+    config.network_config.boot_nodes.clear();
+    Ok(config)
+}

--- a/integration-tests/src/test_config.rs
+++ b/integration-tests/src/test_config.rs
@@ -19,6 +19,8 @@ pub(crate) async fn build_node_config(
 ) -> anyhow::Result<Config> {
     let mut config = load_chain_config(chain_layout).await;
     config.general_config.l1_rpc_url = l1.address.clone();
+    config.general_config.l1_rpc_poll_interval = Duration::from_millis(100);
+    config.general_config.gateway_rpc_poll_interval = Duration::from_millis(100);
     config.sequencer_config.fee_collector_address = Address::random();
     config.rpc_config.send_raw_transaction_sync_timeout = Duration::from_secs(10);
     config.prover_api_config.fake_fri_provers.enabled = true;

--- a/integration-tests/src/upgrade/tester.rs
+++ b/integration-tests/src/upgrade/tester.rs
@@ -31,8 +31,8 @@ use zksync_os_types::{
 /// Tester assumes that governance is an EOA account, and uses impersonation
 /// to execute the upgrade with it.
 #[derive(Debug)]
-pub struct UpgradeTester {
-    pub tester: Tester,
+pub struct UpgradeTester<'a> {
+    pub tester: &'a Tester,
     // Bridgehub contract on L1
     pub bridgehub_l1: zksync_os_contract_interface::Bridgehub<DynProvider>,
     // Bridgehub contract on SL
@@ -61,9 +61,9 @@ pub struct UpgradeTester {
     pub settles_to_gateway: bool,
 }
 
-impl UpgradeTester {
+impl<'a> UpgradeTester<'a> {
     /// Prepares tester for the default upgrade scenario.
-    pub async fn for_default_upgrade(tester: Tester) -> anyhow::Result<Self> {
+    pub async fn for_default_upgrade(tester: &'a Tester) -> anyhow::Result<Self> {
         let upgrade_tester = Self::fetch(tester).await?;
         upgrade_tester.enable_impersonation().await?;
         upgrade_tester.wait_for_genesis_upgrade().await?;
@@ -174,7 +174,7 @@ impl UpgradeTester {
     }
 
     // Fetch the contracts configuration from the tester.
-    async fn fetch(tester: Tester) -> anyhow::Result<Self> {
+    async fn fetch(tester: &'a Tester) -> anyhow::Result<Self> {
         let chain_config: Config = load_chain_config(tester.chain_layout).await;
         let chain_id = chain_config
             .genesis_config

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -3,7 +3,7 @@ use fs2::FileExt;
 use std::{
     fs::File,
     io::ErrorKind,
-    net::{Ipv4Addr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddrV4, UdpSocket},
 };
 use tokio::net::TcpListener;
 
@@ -17,13 +17,16 @@ impl LockedPort {
     /// Returns the unused port (same value as input, except for `0`).
     async fn check_port_is_unused(port: u16) -> anyhow::Result<u16> {
         let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
-        let listener = TcpListener::bind(addr)
+        let tcp_listener = TcpListener::bind(addr)
             .await
             .with_context(|| format!("failed to bind to port={port}"))?;
-        let port = listener
+        let port = tcp_listener
             .local_addr()
             .context("failed to get local address for random port")?
             .port();
+        let udp_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+            .with_context(|| format!("failed to bind UDP socket to port={port}"))?;
+        drop(udp_socket);
         Ok(port)
     }
 
@@ -38,18 +41,34 @@ impl LockedPort {
     pub async fn acquire_unused() -> anyhow::Result<Self> {
         loop {
             let port = Self::pick_unused_port().await?;
-            let lockpath = std::env::temp_dir().join(format!("zksync-os-port{port}.lock"));
-            let lockfile = match File::create(lockpath) {
-                Ok(lockfile) => lockfile,
-                Err(err) if err.kind() == ErrorKind::PermissionDenied => continue,
-                Err(err) => {
-                    return Err(err)
-                        .with_context(|| format!("failed to create lockfile for port={port}"));
-                }
-            };
-            if lockfile.try_lock_exclusive().is_ok() {
-                break Ok(Self { port, lockfile });
+            if let Ok(locked_port) = Self::try_lock(port).await {
+                break Ok(locked_port);
             }
+        }
+    }
+
+    /// Acquire a specific port and lock it. Lock lasts until the returned `LockedPort` is dropped.
+    pub async fn acquire(port: u16) -> anyhow::Result<Self> {
+        Self::try_lock(port).await
+    }
+
+    async fn try_lock(port: u16) -> anyhow::Result<Self> {
+        let port = Self::check_port_is_unused(port).await?;
+        let lockpath = std::env::temp_dir().join(format!("zksync-os-port{port}.lock"));
+        let lockfile = match File::create(lockpath) {
+            Ok(lockfile) => lockfile,
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                anyhow::bail!("failed to create lockfile for port={port}: permission denied");
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to create lockfile for port={port}"));
+            }
+        };
+        if lockfile.try_lock_exclusive().is_ok() {
+            Ok(Self { port, lockfile })
+        } else {
+            anyhow::bail!("failed to lock port={port}")
         }
     }
 }

--- a/integration-tests/tests/node/batcher.rs
+++ b/integration-tests/tests/node/batcher.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, ReceiptAssert};
 use zksync_os_integration_tests::provider::{ZksyncApi, ZksyncTestingProvider};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
 
 const TRANSACTIONS_TO_SEND_BEFORE_RESTART: usize = 5;
 
@@ -29,17 +29,18 @@ async fn fetch_l1_state(tester: &Tester) -> anyhow::Result<L1State> {
 ///   1. Start with `batcher.enabled = false` — blocks execute and are stored locally but
 ///      nothing is batched or submitted to L1.
 ///   2. Mine several blocks and confirm that L1 commitment count did not move.
-///   3. Restart in normal mode (batcher + fake provers enabled by default).
+///   3. Restart with overrides that re-enable the batcher.
 ///   4. Wait for the last pre-restart block to be finalized (= executed on L1), proving the
 ///      node settled all pending blocks after re-enabling the batcher.
 #[test_multisetup([CURRENT_TO_L1])]
 #[test_runtime(flavor = "multi_thread")]
-async fn uncommitted_blocks_are_settled_after_batcher_reenabled() -> anyhow::Result<()> {
-    let tester = Tester::setup_with_overrides(|config| {
-        config.batcher_config.enabled = false;
-        config.sequencer_config.block_time = Duration::from_millis(50);
-    })
-    .await?;
+async fn uncommitted_blocks_are_settled_after_batcher_reenabled(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.batcher_config.enabled = false;
+    config.sequencer_config.block_time = Duration::from_millis(50);
+    let tester = env.launch(config).await?;
 
     let initial_committed = fetch_l1_state(&tester).await?.last_committed_batch;
 
@@ -65,9 +66,10 @@ async fn uncommitted_blocks_are_settled_after_batcher_reenabled() -> anyhow::Res
         "no new batches should be committed while the batcher is disabled"
     );
 
-    // Restart in normal mode. Batcher is enabled by default; fake provers are enabled by
-    // default in the test harness (enable_prover = false → fake_*_provers.enabled = true).
-    let restarted = tester.restart().await?;
+    // Plain restart preserves config, so explicitly re-enable the batcher on restart.
+    let mut restarted_config = tester.config().clone();
+    restarted_config.batcher_config.enabled = true;
+    let restarted = tester.restart_with_config(restarted_config).await?;
 
     // The restarted node must pick up all pending uncommitted blocks and settle them on L1.
     // Wait until the last pre-restart block is finalized (= executed on L1).

--- a/integration-tests/tests/node/external_node.rs
+++ b/integration-tests/tests/node/external_node.rs
@@ -10,22 +10,32 @@ use backon::{ConstantBuilder, Retryable};
 use zksync_os_integration_tests::BATCH_VERIFICATION_KEYS;
 use zksync_os_integration_tests::provider::ZksyncTestingProvider;
 use zksync_os_integration_tests::{
-    CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, TesterBuilder, assert_traits::ReceiptAssert,
+    CURRENT_TO_L1, NEXT_TO_GATEWAY, TestEnvironment, Tester, assert_traits::ReceiptAssert,
     contracts::EventEmitter, test_multisetup,
 };
 use zksync_os_server::config::Config;
 
-#[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
-async fn batch_verification_works(builder: TesterBuilder) -> anyhow::Result<()> {
-    let builder = builder.batch_verification(1);
-    let main_node = builder.build().await?;
+async fn launch_en(
+    main_node: &Tester,
+    configure: impl FnOnce(&mut Config),
+) -> anyhow::Result<Tester> {
+    let mut config = main_node.external_node_config();
+    configure(&mut config);
+    main_node.launch_from_config(config).await
+}
 
-    let _en1 = main_node
-        .launch_external_node_overrides(|config: &mut Config| {
-            let bv_config = &mut config.batch_verification_config;
-            bv_config.client_enabled = true;
-        })
-        .await?;
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
+async fn batch_verification_works(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.batch_verification_config.server_enabled = true;
+    config.batch_verification_config.threshold = 1;
+    let main_node = env.launch(config).await?;
+
+    let _en1 = launch_en(&main_node, |config: &mut Config| {
+        let bv_config = &mut config.batch_verification_config;
+        bv_config.client_enabled = true;
+    })
+    .await?;
 
     let deploy_tx_receipt = EventEmitter::deploy_builder(main_node.l2_provider.clone())
         .send()
@@ -45,16 +55,17 @@ async fn batch_verification_works(builder: TesterBuilder) -> anyhow::Result<()> 
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-async fn batch_verification_without_enough_ens(builder: TesterBuilder) -> anyhow::Result<()> {
-    let builder = builder.batch_verification(2);
-    let main_node = builder.build().await?;
+async fn batch_verification_without_enough_ens(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.batch_verification_config.server_enabled = true;
+    config.batch_verification_config.threshold = 2;
+    let main_node = env.launch(config).await?;
 
-    let _en1 = main_node
-        .launch_external_node_overrides(|config: &mut Config| {
-            let bv_config = &mut config.batch_verification_config;
-            bv_config.client_enabled = true;
-        })
-        .await?;
+    let _en1 = launch_en(&main_node, |config: &mut Config| {
+        let bv_config = &mut config.batch_verification_config;
+        bv_config.client_enabled = true;
+    })
+    .await?;
 
     // Do some random transaction
     let _deploy_tx_receipt = EventEmitter::deploy_builder(main_node.l2_provider.clone())
@@ -73,17 +84,18 @@ async fn batch_verification_without_enough_ens(builder: TesterBuilder) -> anyhow
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-async fn batch_verification_with_2_ens(builder: TesterBuilder) -> anyhow::Result<()> {
-    let builder = builder.batch_verification(2);
-    let main_node = builder.build().await?;
+async fn batch_verification_with_2_ens(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.batch_verification_config.server_enabled = true;
+    config.batch_verification_config.threshold = 2;
+    let main_node = env.launch(config).await?;
 
-    let _en1 = main_node
-        .launch_external_node_overrides(|config: &mut Config| {
-            let bv_config = &mut config.batch_verification_config;
-            bv_config.client_enabled = true;
-            bv_config.signing_key = BATCH_VERIFICATION_KEYS[0].into();
-        })
-        .await?;
+    let _en1 = launch_en(&main_node, |config: &mut Config| {
+        let bv_config = &mut config.batch_verification_config;
+        bv_config.client_enabled = true;
+        bv_config.signing_key = BATCH_VERIFICATION_KEYS[0].into();
+    })
+    .await?;
 
     // First block should not get finalized because 2 EN with 2FA are needed.
     // Use a shorter timeout: if finalization hasn't happened in 20s, it won't.
@@ -92,13 +104,12 @@ async fn batch_verification_with_2_ens(builder: TesterBuilder) -> anyhow::Result
         .wait_not_finalized(1, Duration::from_secs(20))
         .await?;
 
-    let _en2 = main_node
-        .launch_external_node_overrides(|config: &mut Config| {
-            let bv_config = &mut config.batch_verification_config;
-            bv_config.client_enabled = true;
-            bv_config.signing_key = BATCH_VERIFICATION_KEYS[1].into();
-        })
-        .await?;
+    let _en2 = launch_en(&main_node, |config: &mut Config| {
+        let bv_config = &mut config.batch_verification_config;
+        bv_config.client_enabled = true;
+        bv_config.signing_key = BATCH_VERIFICATION_KEYS[1].into();
+    })
+    .await?;
 
     // Do some random transaction
     let deploy_tx_receipt = EventEmitter::deploy_builder(main_node.l2_provider.clone())
@@ -119,9 +130,8 @@ async fn batch_verification_with_2_ens(builder: TesterBuilder) -> anyhow::Result
 }
 
 #[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
-#[test_builder(|builder| builder.enable_p2p())]
 async fn transaction_replay(main_node: Tester) -> anyhow::Result<()> {
-    let en1 = main_node.launch_external_node().await?;
+    let en1 = launch_en(&main_node, |_| {}).await?;
 
     let deploy_tx_receipt = EventEmitter::deploy_builder(main_node.l2_provider.clone())
         .send()
@@ -134,7 +144,7 @@ async fn transaction_replay(main_node: Tester) -> anyhow::Result<()> {
 
     check_contract_present(&en1, contract_address).await?;
 
-    let en2 = main_node.launch_external_node().await?;
+    let en2 = launch_en(&main_node, |_| {}).await?;
 
     check_contract_present(&en2, contract_address).await?;
 
@@ -156,10 +166,9 @@ async fn transaction_replay(main_node: Tester) -> anyhow::Result<()> {
 /// It is easy to write to a channel that the EN doesn't need
 /// which leads to the EN getting stuck when the channel is full.
 #[test_multisetup([CURRENT_TO_L1])]
-#[test_builder(|builder| builder.enable_p2p())]
 #[test_runtime(flavor = "multi_thread")]
 async fn does_not_get_stuck(main_node: Tester) -> anyhow::Result<()> {
-    let en1 = main_node.launch_external_node().await?;
+    let en1 = launch_en(&main_node, |_| {}).await?;
 
     let (send, mut recv) = tokio::sync::mpsc::channel(100);
 
@@ -215,9 +224,8 @@ async fn check_contract_present(en: &Tester, contract_address: Address) -> anyho
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-#[test_builder(|builder| builder.enable_p2p())]
 async fn forward_transactions(main_node: Tester) -> anyhow::Result<()> {
-    let en = main_node.launch_external_node().await?;
+    let en = launch_en(&main_node, |_| {}).await?;
     let alice = en.l2_wallet.default_signer().address();
 
     // Alice's initial nonce

--- a/integration-tests/tests/node/mempool.rs
+++ b/integration-tests/tests/node/mempool.rs
@@ -8,7 +8,7 @@ use futures::FutureExt;
 use std::time::Duration;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::dyn_wallet_provider::EthWalletProvider;
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, TesterBuilder, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
 use zksync_os_server::config::FeeConfig;
 
 #[test_multisetup([CURRENT_TO_L1])]
@@ -116,7 +116,7 @@ async fn sensitive_to_balance_changes(mut tester: Tester) -> anyhow::Result<()> 
 /// A transaction with maxFeePerGas below the chain's base fee must not stall
 /// block production for other senders.
 #[test_multisetup([CURRENT_TO_L1])]
-async fn low_fee_tx_does_not_hang_block_executor(builder: TesterBuilder) -> anyhow::Result<()> {
+async fn low_fee_tx_does_not_hang_block_executor(env: TestEnvironment) -> anyhow::Result<()> {
     // Use a deterministic base fee so the "low fee" value is unambiguous.
     let known_base_fee: u128 = 100_000_000; // 100M wei = 0.1 gwei
     let fee_config = FeeConfig {
@@ -127,11 +127,10 @@ async fn low_fee_tx_does_not_hang_block_executor(builder: TesterBuilder) -> anyh
         native_price_override: Some(U128::from(1_000_000u64)),
         pubdata_price_cap: None,
     };
-    let mut tester = builder
-        .fee_config(fee_config)
-        .block_time(Duration::from_millis(500))
-        .build()
-        .await?;
+    let mut config = env.default_config().await?;
+    config.fee_config = fee_config.clone();
+    config.sequencer_config.block_time = Duration::from_millis(500);
+    let mut tester = env.launch(config).await?;
 
     let alice = tester.l2_wallet.default_signer().address();
     let chain_id = tester.l2_provider.get_chain_id().await?;

--- a/integration-tests/tests/node/rebuild.rs
+++ b/integration-tests/tests/node/rebuild.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::time::Instant;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, test_multisetup};
 use zksync_os_server::config::RebuildBlocksConfig;
 
 const BLOCKS_TO_MINE_BEFORE_REBUILD: u64 = 10;
@@ -18,13 +18,15 @@ const TRANSACTION_SEND_INTERVAL: Duration = Duration::from_millis(5);
 
 #[test_multisetup([CURRENT_TO_L1])]
 #[test_runtime(flavor = "multi_thread")]
-async fn rebuild_after_emptying_historical_block_preserves_unrelated_l2_txs() -> anyhow::Result<()>
-{
-    let tester = Tester::setup_with_overrides(|config| {
+async fn rebuild_after_emptying_historical_block_preserves_unrelated_l2_txs(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    {
         config.batcher_config.enabled = false;
         config.sequencer_config.block_time = Duration::from_millis(50);
-    })
-    .await?;
+    }
+    let tester = env.launch(config).await?;
 
     // This test empties an older block from the main sender, which makes that sender's later
     // transactions invalid because their nonces become too high. A second sender contributes the
@@ -111,15 +113,13 @@ async fn rebuild_after_emptying_historical_block_preserves_unrelated_l2_txs() ->
         .header
         .hash;
 
-    let restarted = tester
-        .restart_with_overrides(|config| {
-            config.sequencer_config.block_rebuild = Some(RebuildBlocksConfig {
-                from_block: block_to_empty,
-                blocks_to_empty: vec![block_to_empty],
-                reset_timestamps: false,
-            });
-        })
-        .await?;
+    let mut restarted_config = tester.config().clone();
+    restarted_config.sequencer_config.block_rebuild = Some(RebuildBlocksConfig {
+        from_block: block_to_empty,
+        blocks_to_empty: vec![block_to_empty],
+        reset_timestamps: false,
+    });
+    let restarted = tester.restart_with_config(restarted_config).await?;
     let rebuild_started_at = Instant::now();
 
     let rebuilt_last_block = (|| async {

--- a/integration-tests/tests/node/restart.rs
+++ b/integration-tests/tests/node/restart.rs
@@ -75,7 +75,7 @@ fn make_full_pipeline_config(config: &mut Config) {
     config.prover_api_config.fake_snark_provers.max_batch_age = Duration::ZERO;
 }
 
-fn configure_failing_block(config: &mut Config, failing_block: u64) {
+fn configure_failing_block(config: &Config, failing_block: u64) {
     let internal_config_path = config
         .general_config
         .rocks_db_path
@@ -198,7 +198,8 @@ async fn revert_batches_on_l1(stopped: &StoppedTester, new_last_batch: u64) -> a
 #[test_multisetup([CURRENT_TO_L1])]
 #[test_runtime(flavor = "multi_thread")]
 async fn node_stop_and_restart_preserves_state() -> anyhow::Result<()> {
-    let tester = Tester::builder().build().await?;
+    let tester = Tester::setup().await?;
+    let original_rpc_url = tester.l2_rpc_url().to_owned();
 
     // Send a transaction and wait for it to be included.
     let receipt = tester
@@ -215,6 +216,7 @@ async fn node_stop_and_restart_preserves_state() -> anyhow::Result<()> {
 
     // Restart the same node (same DB, same L1).
     let restarted = tester.restart().await?;
+    assert_eq!(restarted.l2_rpc_url(), original_rpc_url);
     // Wait for receipt's block to be available. It might not be immediately available because
     // repository DB did not persist the receipt during previous run.
     restarted
@@ -235,7 +237,10 @@ async fn node_stop_and_restart_preserves_state() -> anyhow::Result<()> {
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn node_recovers_from_l1_batch_revert_after_restart_v30() -> anyhow::Result<()> {
-    let tester = Tester::setup_with_overrides(make_commit_only_config).await?;
+    let env = CURRENT_TO_L1.environment().await?;
+    let mut config = env.default_config().await?;
+    make_commit_only_config(&mut config);
+    let tester = env.launch(config).await?;
 
     tester
         .l2_provider
@@ -270,7 +275,9 @@ async fn node_recovers_from_l1_batch_revert_after_restart_v30() -> anyhow::Resul
     let stopped = tester.stop().await?;
     revert_batches_on_l1(&stopped, committed_state.last_executed_batch).await?;
 
-    let restarted = stopped.start_with_overrides(disable_commits_config).await?;
+    let mut restarted_config = stopped.config().clone();
+    disable_commits_config(&mut restarted_config);
+    let restarted = stopped.start_with_config(restarted_config).await?;
     let safe_after_revert =
         block_number_by_id(&restarted, BlockId::Number(BlockNumberOrTag::Safe)).await?;
     assert_eq!(
@@ -293,9 +300,9 @@ async fn node_recovers_from_l1_batch_revert_after_restart_v30() -> anyhow::Resul
         );
     }
 
-    let restarted = restarted
-        .restart_with_overrides(make_full_pipeline_config)
-        .await?;
+    let mut restarted_config = restarted.config().clone();
+    make_full_pipeline_config(&mut restarted_config);
+    let restarted = restarted.restart_with_config(restarted_config).await?;
 
     let executed_receipt = restarted
         .l2_provider
@@ -337,11 +344,11 @@ async fn node_recovers_from_l1_batch_revert_after_restart_v30() -> anyhow::Resul
 #[test_multisetup([CURRENT_TO_L1])]
 #[test_runtime(flavor = "multi_thread")]
 async fn tester_reports_fatal_node_error() -> anyhow::Result<()> {
-    let mut tester = Tester::setup_with_overrides(|config| {
-        make_full_pipeline_config(config);
-        configure_failing_block(config, 1);
-    })
-    .await?;
+    let env = CURRENT_TO_L1.environment().await?;
+    let mut config = env.default_config().await?;
+    make_full_pipeline_config(&mut config);
+    configure_failing_block(&config, 1);
+    let mut tester = env.launch(config).await?;
 
     tester
         .l2_provider

--- a/integration-tests/tests/protocol/interop.rs
+++ b/integration-tests/tests/protocol/interop.rs
@@ -484,8 +484,8 @@ async fn test_interop_l2_to_l1_message_verification() -> anyhow::Result<()> {
     // 2 L2 chains + gateway.
     let multi_chain = GatewayTester::setup(2).await?;
 
-    let chain_a = multi_chain.chain_a();
-    let chain_b = multi_chain.chain_b();
+    let chain_a = multi_chain.chain(0);
+    let chain_b = multi_chain.chain(1);
     let gateway = multi_chain.gateway();
 
     let chain_a_id = chain_a.l2_provider.get_chain_id().await?;
@@ -561,8 +561,8 @@ async fn test_interop_bundle_send() -> Result<()> {
 
     let multi_chain = GatewayTester::setup(2).await?;
 
-    let chain_a = multi_chain.chain_a();
-    let chain_b = multi_chain.chain_b();
+    let chain_a = multi_chain.chain(0);
+    let chain_b = multi_chain.chain(1);
     let gateway = multi_chain.gateway();
 
     let chain_a_id = chain_a.l2_provider.get_chain_id().await?;

--- a/integration-tests/tests/prover.rs
+++ b/integration-tests/tests/prover.rs
@@ -1,12 +1,16 @@
 #![cfg(feature = "prover-tests")]
 
-use zksync_os_integration_tests::{CURRENT_TO_L1, TesterBuilder, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, test_multisetup};
 
 // todo: add gateway test once v31 is fully ready.
 #[test_multisetup([CURRENT_TO_L1])]
-async fn prover(builder: TesterBuilder) -> anyhow::Result<()> {
+async fn prover(env: TestEnvironment) -> anyhow::Result<()> {
     // Test that prover can successfully prove at least one batch
-    let tester = builder.enable_prover().build().await?;
+    let mut config = env.default_config().await?;
+    config.prover_api_config.fake_fri_provers.enabled = false;
+    config.prover_api_config.fake_snark_provers.enabled = false;
+    config.prover_input_generator_config.logging_enabled = true;
+    let tester = env.launch(config).await?;
     // Test environment comes with some L1 transactions by default, so one batch should be provable
     // without any new transactions inside the test.
     tester.prover_tester.wait_for_batch_proven(1).await?;

--- a/integration-tests/tests/rpc/api.rs
+++ b/integration-tests/tests/rpc/api.rs
@@ -15,7 +15,7 @@ use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
 use zksync_os_integration_tests::dyn_wallet_provider::EthDynProvider;
 use zksync_os_integration_tests::provider::ZksyncApi;
 use zksync_os_integration_tests::{
-    CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, TesterBuilder, test_multisetup,
+    CURRENT_TO_L1, NEXT_TO_GATEWAY, TestEnvironment, Tester, test_multisetup,
 };
 use zksync_os_rpc_api::types::BatchStorageProof;
 use zksync_os_server::config::FeeConfig;
@@ -76,8 +76,10 @@ async fn get_code(tester: Tester) -> anyhow::Result<()> {
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-#[test_builder(|builder| builder.block_time(Duration::from_secs(5)))]
-async fn get_transaction_count(tester: Tester) -> anyhow::Result<()> {
+async fn get_transaction_count(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.sequencer_config.block_time = Duration::from_secs(5);
+    let tester = env.launch(config).await?;
     // Test that the node takes pending mempool transactions into account for `eth_getTransactionCount`
     // We set block time to 5 seconds to make sure that transaction spends >5 seconds in the mempool.
     // This gives us time to check that the node returns the correct transaction count.
@@ -124,7 +126,7 @@ async fn get_client_version(tester: Tester) -> anyhow::Result<()> {
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-async fn get_gas_price_uses_configured_scale_factor(builder: TesterBuilder) -> anyhow::Result<()> {
+async fn get_gas_price_uses_configured_scale_factor(env: TestEnvironment) -> anyhow::Result<()> {
     let known_base_fee: u128 = 100_000_000;
     let fee_config = FeeConfig {
         native_price_usd: 3e-9,
@@ -134,11 +136,10 @@ async fn get_gas_price_uses_configured_scale_factor(builder: TesterBuilder) -> a
         native_price_override: Some(U128::from(1_000_000u64)),
         pubdata_price_cap: None,
     };
-    let tester = builder
-        .fee_config(fee_config)
-        .gas_price_scale_factor(2.0)
-        .build()
-        .await?;
+    let mut config = env.default_config().await?;
+    config.fee_config = fee_config.clone();
+    config.rpc_config.gas_price_scale_factor = 2.0;
+    let tester = env.launch(config).await?;
 
     let gas_price = tester.l2_provider.get_gas_price().await?;
     assert_eq!(gas_price, 2 * known_base_fee);
@@ -220,7 +221,7 @@ async fn send_raw_transaction_sync_timeout(tester: Tester) -> anyhow::Result<()>
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-async fn estimate_gas_with_high_prices(builder: TesterBuilder) -> anyhow::Result<()> {
+async fn estimate_gas_with_high_prices(env: TestEnvironment) -> anyhow::Result<()> {
     // Tests the estimations are accurate with high fee overrides.
     // Following config has high pubdata price, that makes base token transfer to take >21000 gas.
     let fee_config = FeeConfig {
@@ -231,11 +232,10 @@ async fn estimate_gas_with_high_prices(builder: TesterBuilder) -> anyhow::Result
         native_per_gas: 100, // doesn't matter
         pubdata_price_cap: None,
     };
-    let tester = builder
-        .fee_config(fee_config)
-        .estimate_gas_pubdata_price_factor(1.0)
-        .build()
-        .await?;
+    let mut config = env.default_config().await?;
+    config.fee_config = fee_config.clone();
+    config.rpc_config.estimate_gas_pubdata_price_factor = 1.0;
+    let tester = env.launch(config).await?;
 
     // Random address.
     let to = address!("0xa5d85D1D865F89a23A95d4F5F74850f289Dbc5f9");

--- a/integration-tests/tests/rpc/debug/tracing.rs
+++ b/integration-tests/tests/rpc/debug/tracing.rs
@@ -15,7 +15,7 @@ use zksync_os_integration_tests::contracts::{
     Counter, EventEmitter, TracingPrimary, TracingSecondary,
 };
 use zksync_os_integration_tests::dyn_wallet_provider::EthDynProvider;
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, TesterBuilder, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
 use zksync_os_server::config::FeeConfig;
 
 fn check_call_frame(
@@ -191,12 +191,11 @@ async fn call_trace_transaction(tester: Tester) -> anyhow::Result<()> {
 
 #[test_multisetup([CURRENT_TO_L1])]
 async fn call_trace_transaction_reports_pubdata_exhaustion(
-    builder: TesterBuilder,
+    env: TestEnvironment,
 ) -> anyhow::Result<()> {
-    let tester = builder
-        .fee_config(pubdata_exhaustion_fee_config())
-        .build()
-        .await?;
+    let mut config = env.default_config().await?;
+    config.fee_config = pubdata_exhaustion_fee_config();
+    let tester = env.launch(config).await?;
     let counter = Counter::deploy(tester.l2_provider.clone()).await?;
 
     let receipt = counter
@@ -229,12 +228,11 @@ async fn call_trace_transaction_reports_pubdata_exhaustion(
 
 #[test_multisetup([CURRENT_TO_L1])]
 async fn call_trace_transaction_reports_pubdata_exhaustion_with_only_top_call(
-    builder: TesterBuilder,
+    env: TestEnvironment,
 ) -> anyhow::Result<()> {
-    let tester = builder
-        .fee_config(pubdata_exhaustion_fee_config())
-        .build()
-        .await?;
+    let mut config = env.default_config().await?;
+    config.fee_config = pubdata_exhaustion_fee_config();
+    let tester = env.launch(config).await?;
     let counter = Counter::deploy(tester.l2_provider.clone()).await?;
 
     let receipt = counter
@@ -273,11 +271,10 @@ async fn call_trace_transaction_reports_pubdata_exhaustion_with_only_top_call(
 }
 
 #[test_multisetup([CURRENT_TO_L1])]
-async fn call_trace_block_reports_pubdata_exhaustion(builder: TesterBuilder) -> anyhow::Result<()> {
-    let tester = builder
-        .fee_config(pubdata_exhaustion_fee_config())
-        .build()
-        .await?;
+async fn call_trace_block_reports_pubdata_exhaustion(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.fee_config = pubdata_exhaustion_fee_config();
+    let tester = env.launch(config).await?;
     let counter = Counter::deploy(tester.l2_provider.clone()).await?;
 
     let receipt = counter

--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -28,11 +28,11 @@ async fn setup() -> Result<(GatewayTester, Address)> {
 
     let signer = PrivateKeySigner::random();
     let unauthorized = signer.address();
-    mc.chains[0]
+    mc.chain_mut(0)
         .l2_provider
         .wallet_mut()
         .register_signer(signer);
-    mc.chains[0]
+    mc.chain_mut(0)
         .l2_provider
         .send_transaction(
             TransactionRequest::default()

--- a/integration-tests/tests/upgrade/mod.rs
+++ b/integration-tests/tests/upgrade/mod.rs
@@ -20,7 +20,7 @@ async fn upgrade_patch_no_deployments() -> anyhow::Result<()> {
     let deadline = U256::MAX; // The protocol version will not have any deadline in this upgrade
 
     let tester = Tester::setup().await?;
-    let upgrade_tester = UpgradeTester::for_default_upgrade(tester).await?;
+    let upgrade_tester = UpgradeTester::for_default_upgrade(&tester).await?;
 
     // Prepare protocol upgrade
     let protocol_upgrade = upgrade_tester
@@ -49,14 +49,12 @@ async fn upgrade_patch_no_deployments_gateway() -> anyhow::Result<()> {
     let upgrade_timestamp = U256::from(1); // Protocol upgrade can be executed immediately.
     let deadline = U256::MAX; // The protocol version will not have any deadline in this upgrade
 
-    // Test that we can deposit L2 funds from a rich L1 account
     let gateway_tester = GatewayTester::builder()
         .protocol_version(NEXT_PROTOCOL_VERSION)
         .num_chains(0)
         .build()
         .await?;
-    let tester = gateway_tester.into_gateway();
-    let upgrade_tester = UpgradeTester::for_default_upgrade(tester).await?;
+    let upgrade_tester = UpgradeTester::for_default_upgrade(gateway_tester.gateway()).await?;
 
     // Prepare protocol upgrade
     let protocol_upgrade = upgrade_tester
@@ -90,8 +88,7 @@ async fn upgrade_patch_no_deployments_settles_to_gateway() -> anyhow::Result<()>
         .num_chains(1)
         .build()
         .await?;
-    let tester = gateway_tester.into_primary_chain();
-    let upgrade_tester = UpgradeTester::for_default_upgrade(tester).await?;
+    let upgrade_tester = UpgradeTester::for_default_upgrade(gateway_tester.chain(0)).await?;
 
     let protocol_upgrade = upgrade_tester
         .protocol_upgrade_builder()
@@ -131,12 +128,12 @@ async fn upgrade_to_v31_with_deployments() -> anyhow::Result<()> {
     .into_iter()
     .collect();
 
-    // Test that we can deposit L2 funds from a rich L1 account
-    let tester = Tester::builder().enable_p2p().build().await?;
-    let upgrade_tester = UpgradeTester::for_default_upgrade(tester).await?;
+    let tester = Tester::setup().await?;
+    let upgrade_tester = UpgradeTester::for_default_upgrade(&tester).await?;
 
-    // Publish the bytecodes for upgrade beforehand via L2 deploy
-    // so that the preimages are known to the node.
+    // Pre-register the force-deployment bytecode via an L2 create tx.
+    // This test exercises the legacy path where the node already knows the preimage
+    // and the upgrade tx does not carry `factory_deps`.
     upgrade_tester
         .publish_bytecodes([SampleForceDeployment::BYTECODE.clone()])
         .await?;
@@ -189,7 +186,10 @@ async fn upgrade_to_v31_with_deployments() -> anyhow::Result<()> {
     let main_node_block = upgrade_tester.tester.l2_provider.get_block_number().await?;
 
     // Ensure that EN can sync from the upgraded node.
-    let en1 = upgrade_tester.tester.launch_external_node().await?;
+    let en1 = upgrade_tester
+        .tester
+        .launch_from_config(upgrade_tester.tester.external_node_config())
+        .await?;
 
     while en1.l2_provider.get_block_number().await? < main_node_block {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -219,20 +219,20 @@ async fn upgrade_to_v32_with_deployments_settles_to_gateway() -> anyhow::Result<
     let gateway_tester = GatewayTester::builder()
         .protocol_version(NEXT_PROTOCOL_VERSION)
         .num_chains(1)
-        .enable_chain_p2p()
         .build()
         .await?;
-    let tester = gateway_tester.into_primary_chain();
-    let upgrade_tester = UpgradeTester::for_default_upgrade(tester).await?;
+    let upgrade_tester = UpgradeTester::for_default_upgrade(gateway_tester.chain(0)).await?;
 
-    // Publish to the L1 BytecodesSupplier only (no L2 deploy). This exercises
-    // the end-to-end path: the server discovers preimages from `EVMBytecodePublished`
-    // events via `fetch_force_preimages`.
+    // Publish the raw runtime bytecode from the force-deployment payload to the
+    // L1 BytecodesSupplier. This exercises the supplier-backed path where the
+    // node discovers force-deployment preimages from `EVMBytecodePublished`
+    // events using the upgrade tx `factory_deps`.
     upgrade_tester
         .publish_bytecodes_to_l1_supplier([SampleForceDeployment::DEPLOYED_BYTECODE.clone()])
         .await?;
 
-    // Prepare protocol upgrade with factory_deps so the server fetches from the supplier.
+    // Prepare protocol upgrade with `factory_deps` so the node fetches preimages
+    // from the supplier instead of relying on a prior L2 deployment.
     let protocol_upgrade = upgrade_tester
         .protocol_upgrade_builder()
         .await?
@@ -263,7 +263,10 @@ async fn upgrade_to_v32_with_deployments_settles_to_gateway() -> anyhow::Result<
     let main_node_block = upgrade_tester.tester.l2_provider.get_block_number().await?;
 
     // Ensure that EN can sync from the upgraded node.
-    let en1 = upgrade_tester.tester.launch_external_node().await?;
+    let en1 = upgrade_tester
+        .tester
+        .launch_from_config(upgrade_tester.tester.external_node_config())
+        .await?;
 
     while en1.l2_provider.get_block_number().await? < main_node_block {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -46,7 +46,7 @@ pub use build_external_config::{build_external_config, load_config_file_sources}
 ///    files are used. In Docker, the `local-chains/` directory is not copied into the image,
 ///    so no files are auto-loaded and config must be provided entirely via environment variables.
 /// 3. **Environment variables** — always override everything.
-#[derive(Debug, ConfigValidate)]
+#[derive(Clone, Debug, ConfigValidate)]
 #[config_validate(root)]
 pub struct Config {
     pub general_config: GeneralConfig,


### PR DESCRIPTION
## Summary
- use reth fork that has a fix to properly release ports. Agreed with @itegulov on this. PR against main repo: https://github.com/paradigmxyz/reth/pull/23282 (unfortunately no acknowledgement from maintainers for now)
- refactor the integration test harness around explicit environment -> config -> launch flow
- unify node launch around config derivation for external nodes and restarts
- trim redundant harness API surface and simplify gateway/multi-node ownership

## Testing
- cargo test -p zksync_os_integration_tests --no-run
- cargo nextest run -p zksync_os_integration_tests --profile no-pig