### PR TITLE
fix(rpc): correct error codes and add detailed rejection metrics for eth_sendRawTransaction

### DIFF
--- a/lib/mempool/src/lib.rs
+++ b/lib/mempool/src/lib.rs
@@ -12,9 +12,7 @@ pub use pool::{MarkingTxStream, Pool};
 mod metrics;
 
 // Re-export some of the reth mempool's types.
-pub use reth_transaction_pool::error::{
-    InvalidPoolTransactionError, PoolError, PoolErrorKind,
-};
+pub use reth_transaction_pool::error::{InvalidPoolTransactionError, PoolError, PoolErrorKind};
 pub use reth_transaction_pool::{
     CanonicalStateUpdate, NewSubpoolTransactionStream, NewTransactionEvent, PoolConfig,
     PoolUpdateKind, SubPoolLimit,

--- a/lib/mempool/src/lib.rs
+++ b/lib/mempool/src/lib.rs
@@ -12,7 +12,9 @@ pub use pool::{MarkingTxStream, Pool};
 mod metrics;
 
 // Re-export some of the reth mempool's types.
-pub use reth_transaction_pool::error::PoolError;
+pub use reth_transaction_pool::error::{
+    InvalidPoolTransactionError, PoolError, PoolErrorKind,
+};
 pub use reth_transaction_pool::{
     CanonicalStateUpdate, NewSubpoolTransactionStream, NewTransactionEvent, PoolConfig,
     PoolUpdateKind, SubPoolLimit,

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -1,8 +1,9 @@
 use crate::config::RpcConfig;
 use crate::eth_call_handler::EthCallHandler;
+use crate::metrics::{TX_SUBMISSION_METRICS, TxRejectionReason};
 use crate::result::{ToRpcResult, internal_rpc_err, unimplemented_rpc_err};
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
-use crate::tx_handler::TxHandler;
+use crate::tx_handler::{EthSendRawTransactionSyncError, TxHandler};
 use alloy::consensus::TrieAccount;
 use alloy::consensus::transaction::Recovered;
 use alloy::dyn_abi::TypedData;
@@ -782,6 +783,9 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.tx_handler
             .send_raw_transaction_impl(bytes)
             .await
+            .inspect_err(|err| {
+                TX_SUBMISSION_METRICS.rejections[&TxRejectionReason::from(err)].inc();
+            })
             .to_rpc_result()
     }
 
@@ -793,6 +797,11 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.tx_handler
             .send_raw_transaction_sync_impl(bytes, max_wait_ms)
             .await
+            .inspect_err(|err| {
+                if let EthSendRawTransactionSyncError::Regular(inner) = err {
+                    TX_SUBMISSION_METRICS.rejections[&TxRejectionReason::from(inner)].inc();
+                }
+            })
             .to_rpc_result()
     }
 

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
-use vise::{Buckets, Counter, Histogram, LabeledFamily, Metrics, Unit};
+use vise::{
+    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Histogram, LabeledFamily, Metrics,
+    Unit,
+};
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
@@ -36,7 +39,67 @@ pub struct TxSubmissionMetrics {
     /// Time spent forwarding a transaction to the main node (external nodes only).
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
     pub forwarding_latency: Histogram<Duration>,
+    /// Count of `eth_sendRawTransaction` rejections, labeled by reason.
+    pub rejections: Family<TxRejectionReason, Counter>,
 }
 
 #[vise::register]
 pub static TX_SUBMISSION_METRICS: vise::Global<TxSubmissionMetrics> = vise::Global::new();
+
+/// Reason why an `eth_sendRawTransaction` was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(label = "reason", rename_all = "snake_case")]
+pub enum TxRejectionReason {
+    /// Client sent bytes that don't decode as a valid signed transaction.
+    DecodeFailed,
+    /// Transaction signature is invalid.
+    InvalidSignature,
+    /// Node is temporarily not accepting transactions (e.g. syncing).
+    NotAccepting,
+    /// The signer address is on the blacklist.
+    BlacklistedSigner,
+    /// Forwarding the transaction to the main node failed (transport error).
+    ForwardTransportError,
+    /// Forwarding the transaction to the main node failed (main node rejected it).
+    ForwardRejected,
+    /// Transaction already exists in the pool.
+    PoolAlreadyImported,
+    /// Replacement transaction's gas price is too low.
+    PoolReplacementUnderpriced,
+    /// Transaction fee cap is below the protocol minimum.
+    PoolFeeCapBelowMinimum,
+    /// Sender exceeded the per-account slot capacity.
+    PoolSpammerExceededCapacity,
+    /// Transaction discarded due to pool size limits.
+    PoolDiscardedOnInsert,
+    /// Transaction type conflicts with an existing transaction for this sender.
+    PoolConflictingTxType,
+    /// Transaction exceeds the block gas limit.
+    PoolExceedsGasLimit,
+    /// Transaction gas limit exceeds per-tx maximum.
+    PoolMaxTxGasLimitExceeded,
+    /// Transaction fee exceeds the configured cap.
+    PoolExceedsFeeCap,
+    /// Transaction init code exceeds max size.
+    PoolExceedsMaxInitCodeSize,
+    /// Transaction input data is oversized.
+    PoolOversizedData,
+    /// Transaction is underpriced.
+    PoolUnderpriced,
+    /// Transaction would overdraw the sender's balance.
+    PoolOverdraft,
+    /// Nonce exceeds u64 limit (EIP-2681).
+    PoolNonceOverflow,
+    /// Intrinsic gas is too low.
+    PoolIntrinsicGasTooLow,
+    /// Transaction priority fee is below the minimum.
+    PoolPriorityFeeBelowMinimum,
+    /// Consensus-level invalid transaction.
+    PoolConsensusError,
+    /// EIP-4844 blob transaction error.
+    PoolEip4844Error,
+    /// EIP-7702 transaction error.
+    PoolEip7702Error,
+    /// Other pool error.
+    PoolOther,
+}

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -14,6 +14,7 @@ use crate::zks_impl::ZksError;
 use alloy::primitives::Bytes;
 use alloy::rpc::types::error::EthRpcErrorCode;
 use alloy::sol_types::{ContractError, RevertReason};
+use alloy::transports::{RpcError, TransportErrorKind};
 use jsonrpsee::core::RpcResult;
 use std::fmt;
 use std::fmt::Display;
@@ -77,12 +78,16 @@ impl<Ok> ToRpcResult<Ok, EthSendRawTransactionError> for Result<Ok, EthSendRawTr
         self.map_err(|err| match err {
             EthSendRawTransactionError::FailedToDecodeSignedTransaction
             | EthSendRawTransactionError::InvalidTransactionSignature
-            | EthSendRawTransactionError::BlacklistedSigner => {
+            | EthSendRawTransactionError::BlacklistedSigner
+            | EthSendRawTransactionError::PoolError(_) => {
                 invalid_params_rpc_err(err.to_string())
             }
-            EthSendRawTransactionError::NotAcceptingTransactions(_)
-            | EthSendRawTransactionError::PoolError(_)
-            | EthSendRawTransactionError::ForwardError(_) => internal_rpc_err(err.to_string()),
+            EthSendRawTransactionError::NotAcceptingTransactions(_) => {
+                internal_rpc_err(err.to_string())
+            }
+            EthSendRawTransactionError::ForwardError(ref rpc_err) => {
+                forward_error_to_rpc_err(rpc_err, &err)
+            }
         })
     }
 }
@@ -122,12 +127,28 @@ impl<Ok> ToRpcResult<Ok, EthSendRawTransactionSyncError>
         EthSendRawTransactionSyncError: Display,
     {
         self.map_err(|err| match err {
-            err @ EthSendRawTransactionSyncError::Regular(_) => internal_rpc_err(err.to_string()),
+            EthSendRawTransactionSyncError::Regular(inner) => {
+                Result::<(), _>::Err(inner).to_rpc_result().unwrap_err()
+            }
             err @ EthSendRawTransactionSyncError::Timeout(_) => {
                 // Code 4 is used as per EIP-7966 (see https://eips.ethereum.org/EIPS/eip-7966)
                 rpc_error_with_code(4, err.to_string())
             }
         })
+    }
+}
+
+/// Converts an alloy `RpcError` from tx forwarding into a jsonrpsee error object,
+/// preserving the original JSON-RPC error code when the main node returned one.
+/// Falls back to internal error (-32603) for transport failures.
+fn forward_error_to_rpc_err(
+    rpc_err: &RpcError<TransportErrorKind>,
+    display: &impl fmt::Display,
+) -> jsonrpsee::types::error::ErrorObject<'static> {
+    if let RpcError::ErrorResp(payload) = rpc_err {
+        rpc_error_with_code(payload.code as i32, display.to_string())
+    } else {
+        internal_rpc_err(display.to_string())
     }
 }
 

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -79,9 +79,7 @@ impl<Ok> ToRpcResult<Ok, EthSendRawTransactionError> for Result<Ok, EthSendRawTr
             EthSendRawTransactionError::FailedToDecodeSignedTransaction
             | EthSendRawTransactionError::InvalidTransactionSignature
             | EthSendRawTransactionError::BlacklistedSigner
-            | EthSendRawTransactionError::PoolError(_) => {
-                invalid_params_rpc_err(err.to_string())
-            }
+            | EthSendRawTransactionError::PoolError(_) => invalid_params_rpc_err(err.to_string()),
             EthSendRawTransactionError::NotAcceptingTransactions(_) => {
                 internal_rpc_err(err.to_string())
             }

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -6,11 +6,11 @@ use alloy::eips::Decodable2718;
 use alloy::primitives::{B256, Bytes, U256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::transports::{RpcError, TransportErrorKind};
-use zksync_os_mempool::{InvalidPoolTransactionError, PoolErrorKind};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use zksync_os_mempool::PoolError;
 use zksync_os_mempool::subpools::l2::L2Subpool;
+use zksync_os_mempool::{InvalidPoolTransactionError, PoolErrorKind};
 use zksync_os_rpc_api::types::ZkTransactionReceipt;
 use zksync_os_types::{L2Envelope, L2Transaction, NotAcceptingReason, TransactionAcceptanceState};
 
@@ -186,9 +186,7 @@ impl From<&PoolErrorKind> for TxRejectionReason {
             PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => Self::PoolFeeCapBelowMinimum,
             PoolErrorKind::SpammerExceededCapacity(_) => Self::PoolSpammerExceededCapacity,
             PoolErrorKind::DiscardedOnInsert => Self::PoolDiscardedOnInsert,
-            PoolErrorKind::ExistingConflictingTransactionType(_, _) => {
-                Self::PoolConflictingTxType
-            }
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => Self::PoolConflictingTxType,
             PoolErrorKind::InvalidTransaction(invalid) => Self::from(invalid),
             PoolErrorKind::Other(_) => Self::PoolOther,
         }

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -1,11 +1,12 @@
 use crate::eth_impl::build_api_receipt;
-use crate::metrics::TX_SUBMISSION_METRICS;
+use crate::metrics::{TX_SUBMISSION_METRICS, TxRejectionReason};
 use crate::{ReadRpcStorage, RpcConfig};
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Decodable2718;
 use alloy::primitives::{B256, Bytes, U256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::transports::{RpcError, TransportErrorKind};
+use zksync_os_mempool::{InvalidPoolTransactionError, PoolErrorKind};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use zksync_os_mempool::PoolError;
@@ -159,6 +160,66 @@ pub enum EthSendRawTransactionError {
     ForwardError(#[from] RpcError<TransportErrorKind>),
     #[error("Signer is blacklisted")]
     BlacklistedSigner,
+}
+
+impl From<&EthSendRawTransactionError> for TxRejectionReason {
+    fn from(err: &EthSendRawTransactionError) -> Self {
+        match err {
+            EthSendRawTransactionError::FailedToDecodeSignedTransaction => Self::DecodeFailed,
+            EthSendRawTransactionError::InvalidTransactionSignature => Self::InvalidSignature,
+            EthSendRawTransactionError::NotAcceptingTransactions(_) => Self::NotAccepting,
+            EthSendRawTransactionError::BlacklistedSigner => Self::BlacklistedSigner,
+            EthSendRawTransactionError::ForwardError(rpc_err) => match rpc_err {
+                RpcError::ErrorResp(_) => Self::ForwardRejected,
+                _ => Self::ForwardTransportError,
+            },
+            EthSendRawTransactionError::PoolError(pool_err) => Self::from(&pool_err.kind),
+        }
+    }
+}
+
+impl From<&PoolErrorKind> for TxRejectionReason {
+    fn from(kind: &PoolErrorKind) -> Self {
+        match kind {
+            PoolErrorKind::AlreadyImported => Self::PoolAlreadyImported,
+            PoolErrorKind::ReplacementUnderpriced => Self::PoolReplacementUnderpriced,
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => Self::PoolFeeCapBelowMinimum,
+            PoolErrorKind::SpammerExceededCapacity(_) => Self::PoolSpammerExceededCapacity,
+            PoolErrorKind::DiscardedOnInsert => Self::PoolDiscardedOnInsert,
+            PoolErrorKind::ExistingConflictingTransactionType(_, _) => {
+                Self::PoolConflictingTxType
+            }
+            PoolErrorKind::InvalidTransaction(invalid) => Self::from(invalid),
+            PoolErrorKind::Other(_) => Self::PoolOther,
+        }
+    }
+}
+
+impl From<&InvalidPoolTransactionError> for TxRejectionReason {
+    fn from(err: &InvalidPoolTransactionError) -> Self {
+        match err {
+            InvalidPoolTransactionError::Consensus(_) => Self::PoolConsensusError,
+            InvalidPoolTransactionError::ExceedsGasLimit(_, _) => Self::PoolExceedsGasLimit,
+            InvalidPoolTransactionError::MaxTxGasLimitExceeded(_, _) => {
+                Self::PoolMaxTxGasLimitExceeded
+            }
+            InvalidPoolTransactionError::ExceedsFeeCap { .. } => Self::PoolExceedsFeeCap,
+            InvalidPoolTransactionError::ExceedsMaxInitCodeSize(_, _) => {
+                Self::PoolExceedsMaxInitCodeSize
+            }
+            InvalidPoolTransactionError::OversizedData { .. } => Self::PoolOversizedData,
+            InvalidPoolTransactionError::Underpriced => Self::PoolUnderpriced,
+            InvalidPoolTransactionError::Overdraft { .. } => Self::PoolOverdraft,
+            InvalidPoolTransactionError::Eip2681 => Self::PoolNonceOverflow,
+            InvalidPoolTransactionError::Eip4844(_) => Self::PoolEip4844Error,
+            InvalidPoolTransactionError::Eip7702(_) => Self::PoolEip7702Error,
+            InvalidPoolTransactionError::Other(_) => Self::PoolOther,
+            InvalidPoolTransactionError::IntrinsicGasTooLow => Self::PoolIntrinsicGasTooLow,
+            InvalidPoolTransactionError::PriorityFeeBelowMinimum { .. } => {
+                Self::PoolPriorityFeeBelowMinimum
+            }
+        }
+    }
 }
 
 /// Error types returned by `eth_sendRawTransactionSync` implementation


### PR DESCRIPTION
## Summary

- **Fix error code classification**: `PoolError` was incorrectly mapped to `-32603` (server error) — pool rejections (duplicate, underpriced, invalid nonce) are client errors and now return `-32602`. `ForwardError` preserves the main node's original error code instead of always returning `-32603`. `EthSendRawTransactionSyncError::Regular` now delegates to the inner error's mapping instead of flattening everything to `-32603`.
- **Add `tx_submission_rejections{reason=...}` metric**: a `Family<TxRejectionReason, Counter>` with 25 distinct reason values covering every error path — decode failures, invalid signatures, blacklisted signers, forwarding errors (transport vs rejected), and every `PoolErrorKind`/`InvalidPoolTransactionError` variant individually. This replaces the opaque `-32602`/`-32603` split in Grafana with actionable per-reason visibility.

## Test plan

- [ ] `cargo check -p zksync_os_rpc` passes
- [ ] Verify `tx_submission_rejections` metric appears in Prometheus with correct `reason` labels
- [ ] Submit invalid tx (bad signature) → expect `-32602` and `reason="invalid_signature"` counter increment
- [ ] Submit tx via external node with main node down → expect `-32603` and `reason="forward_transport_error"`
- [ ] Submit duplicate tx → expect `-32602` and `reason="pool_already_imported"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)