### PR TITLE
feat(rpc): add txpool_inspect/content/status RPC methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
@@ -790,6 +791,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
@@ -894,6 +896,18 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-rpc-types-txpool"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]

--- a/lib/mempool/src/lib.rs
+++ b/lib/mempool/src/lib.rs
@@ -15,5 +15,5 @@ mod metrics;
 pub use reth_transaction_pool::error::{InvalidPoolTransactionError, PoolError, PoolErrorKind};
 pub use reth_transaction_pool::{
     CanonicalStateUpdate, NewSubpoolTransactionStream, NewTransactionEvent, PoolConfig,
-    PoolUpdateKind, SubPoolLimit,
+    PoolUpdateKind, SubPoolLimit, ValidPoolTransaction,
 };

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -33,7 +33,7 @@ zk_ee.workspace = true
 
 reth-rpc-eth-types.workspace = true
 reth-tasks.workspace = true
-alloy = { workspace = true, default-features = false, features = ["eips", "eip712", "dyn-abi", "rpc-types", "json-rpc", "rand"] }
+alloy = { workspace = true, default-features = false, features = ["eips", "eip712", "dyn-abi", "rpc-types", "json-rpc", "rand", "rpc-types-txpool"] }
 anyhow.workspace = true
 async-trait.workspace = true
 blake2.workspace = true

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -18,6 +18,7 @@ mod rpc_storage;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
 pub mod js_tracer;
+mod txpool_impl;
 mod log_proof_utils;
 mod monitoring_middleware;
 mod net_impl;
@@ -29,6 +30,7 @@ mod web3_impl;
 mod zks_impl;
 
 use crate::debug_impl::DebugNamespace;
+use crate::txpool_impl::TxpoolNamespace;
 use crate::eth_filter::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
@@ -57,6 +59,7 @@ use zksync_os_rpc_api::filter::EthFilterApiServer;
 use zksync_os_rpc_api::net::NetApiServer;
 use zksync_os_rpc_api::ots::OtsApiServer;
 use zksync_os_rpc_api::pubsub::EthPubSubApiServer;
+use zksync_os_rpc_api::txpool::TxpoolApiServer;
 use zksync_os_rpc_api::unstable::UnstableApiServer;
 use zksync_os_rpc_api::web3::Web3ApiServer;
 use zksync_os_rpc_api::zks::ZksApiServer;
@@ -101,7 +104,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     )?;
     let eth_filter = EthFilterNamespace::new(config.clone(), storage.clone(), mempool.clone());
     rpc.merge(eth_filter.clone().into_rpc())?;
-    rpc.merge(EthPubsubNamespace::new(storage.clone(), mempool, runtime.clone()).into_rpc())?;
+    rpc.merge(EthPubsubNamespace::new(storage.clone(), mempool.clone(), runtime.clone()).into_rpc())?;
     rpc.merge(
         ZksNamespace::new(
             bridgehub_address,
@@ -115,6 +118,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     )?;
     rpc.merge(OtsNamespace::new(storage.clone()).into_rpc())?;
     rpc.merge(DebugNamespace::new(storage.clone(), eth_call_handler).into_rpc())?;
+    rpc.merge(TxpoolNamespace::new(mempool.clone()).into_rpc())?;
     rpc.merge(NetNamespace::new(chain_id).into_rpc())?;
     rpc.merge(Web3Namespace.into_rpc())?;
     rpc.merge(UnstableNamespace::new(storage).into_rpc())?;

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -18,25 +18,25 @@ mod rpc_storage;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
 pub mod js_tracer;
-mod txpool_impl;
 mod log_proof_utils;
 mod monitoring_middleware;
 mod net_impl;
 mod sandbox;
 mod tx_handler;
+mod txpool_impl;
 mod types;
 mod unstable_impl;
 mod web3_impl;
 mod zks_impl;
 
 use crate::debug_impl::DebugNamespace;
-use crate::txpool_impl::TxpoolNamespace;
 use crate::eth_filter::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
+use crate::txpool_impl::TxpoolNamespace;
 use crate::unstable_impl::UnstableNamespace;
 use crate::web3_impl::Web3Namespace;
 use crate::zks_impl::ZksNamespace;
@@ -104,7 +104,9 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     )?;
     let eth_filter = EthFilterNamespace::new(config.clone(), storage.clone(), mempool.clone());
     rpc.merge(eth_filter.clone().into_rpc())?;
-    rpc.merge(EthPubsubNamespace::new(storage.clone(), mempool.clone(), runtime.clone()).into_rpc())?;
+    rpc.merge(
+        EthPubsubNamespace::new(storage.clone(), mempool.clone(), runtime.clone()).into_rpc(),
+    )?;
     rpc.merge(
         ZksNamespace::new(
             bridgehub_address,

--- a/lib/rpc/src/txpool_impl.rs
+++ b/lib/rpc/src/txpool_impl.rs
@@ -1,0 +1,78 @@
+use crate::eth_impl::build_api_tx;
+use alloy::primitives::Address;
+use alloy::rpc::types::txpool::{TxpoolContent, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus};
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use zksync_os_mempool::subpools::l2::L2Subpool;
+use zksync_os_mempool::{L2PooledTransaction, ValidPoolTransaction};
+use zksync_os_rpc_api::txpool::TxpoolApiServer;
+use zksync_os_rpc_api::types::ZkApiTransaction;
+use zksync_os_types::ZkTransaction;
+
+pub struct TxpoolNamespace<Mempool> {
+    mempool: Mempool,
+}
+
+impl<Mempool: L2Subpool> TxpoolNamespace<Mempool> {
+    pub fn new(mempool: Mempool) -> Self {
+        Self { mempool }
+    }
+}
+
+type PoolTx = Arc<ValidPoolTransaction<L2PooledTransaction>>;
+
+fn inspect_summary(pool_tx: &PoolTx) -> TxpoolInspectSummary {
+    pool_tx.transaction.transaction.clone().into_inner().into()
+}
+
+fn content_tx(pool_tx: &PoolTx) -> ZkApiTransaction {
+    let zk_tx: ZkTransaction = pool_tx.transaction.transaction.clone().into();
+    build_api_tx(zk_tx, None)
+}
+
+fn insert_by_sender<T>(
+    map: &mut BTreeMap<Address, BTreeMap<String, T>>,
+    pool_tx: &PoolTx,
+    value: T,
+) {
+    map.entry(pool_tx.sender())
+        .or_default()
+        .insert(pool_tx.nonce().to_string(), value);
+}
+
+#[async_trait]
+impl<Mempool: L2Subpool> TxpoolApiServer for TxpoolNamespace<Mempool> {
+    async fn inspect(&self) -> RpcResult<TxpoolInspect> {
+        let mut result = TxpoolInspect::default();
+        let all = self.mempool.all_transactions();
+        for pool_tx in &all.pending {
+            insert_by_sender(&mut result.pending, pool_tx, inspect_summary(pool_tx));
+        }
+        for pool_tx in &all.queued {
+            insert_by_sender(&mut result.queued, pool_tx, inspect_summary(pool_tx));
+        }
+        Ok(result)
+    }
+
+    async fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>> {
+        let mut result: TxpoolContent<ZkApiTransaction> = TxpoolContent::default();
+        let all = self.mempool.all_transactions();
+        for pool_tx in &all.pending {
+            insert_by_sender(&mut result.pending, pool_tx, content_tx(pool_tx));
+        }
+        for pool_tx in &all.queued {
+            insert_by_sender(&mut result.queued, pool_tx, content_tx(pool_tx));
+        }
+        Ok(result)
+    }
+
+    async fn status(&self) -> RpcResult<TxpoolStatus> {
+        let (pending, queued) = self.mempool.pending_and_queued_txn_count();
+        Ok(TxpoolStatus {
+            pending: pending as u64,
+            queued: queued as u64,
+        })
+    }
+}

--- a/lib/rpc_api/Cargo.toml
+++ b/lib/rpc_api/Cargo.toml
@@ -15,7 +15,7 @@ zksync_os_genesis.workspace = true
 zksync_os_storage_api.workspace = true
 zksync_os_merkle_tree_api.workspace = true
 
-alloy = { workspace = true, default-features = false, features = ["eips", "eip712", "dyn-abi", "rpc-types", "json-rpc", "rpc-types-trace", "genesis"] }
+alloy = { workspace = true, default-features = false, features = ["eips", "eip712", "dyn-abi", "rpc-types", "json-rpc", "rpc-types-trace", "genesis", "rpc-types-txpool"] }
 alloy-rlp.workspace = true
 anyhow.workspace = true
 blake2.workspace = true

--- a/lib/rpc_api/src/lib.rs
+++ b/lib/rpc_api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod filter;
 pub mod net;
 pub mod ots;
 pub mod pubsub;
+pub mod txpool;
 pub mod types;
 pub mod unstable;
 pub mod web3;

--- a/lib/rpc_api/src/txpool.rs
+++ b/lib/rpc_api/src/txpool.rs
@@ -1,0 +1,33 @@
+use alloy::rpc::types::txpool::{TxpoolContent, TxpoolInspect, TxpoolStatus};
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+
+use crate::types::ZkApiTransaction;
+
+/// `txpool` RPC interface.
+///
+/// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool> for reference.
+#[cfg_attr(not(feature = "server"), rpc(client, namespace = "txpool"))]
+#[cfg_attr(feature = "server", rpc(server, client, namespace = "txpool"))]
+pub trait TxpoolApi {
+    /// Returns a textual summary of all transactions currently pending for inclusion in the next
+    /// block(s), as well as the ones that are being scheduled for future execution only.
+    ///
+    /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_inspect>.
+    #[method(name = "inspect")]
+    async fn inspect(&self) -> RpcResult<TxpoolInspect>;
+
+    /// Returns the exact details of all transactions currently pending for inclusion in the next
+    /// block(s), as well as the ones that are being scheduled for future execution only.
+    ///
+    /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_content>.
+    #[method(name = "content")]
+    async fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>>;
+
+    /// Returns the number of transactions currently pending for inclusion in the next block(s), as
+    /// well as the ones that are being scheduled for future execution only.
+    ///
+    /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_status>.
+    #[method(name = "status")]
+    async fn status(&self) -> RpcResult<TxpoolStatus>;
+}


### PR DESCRIPTION
## Summary

- Adds the standard geth `txpool` RPC namespace: `txpool_inspect`, `txpool_content`, `txpool_status`
- `txpool_inspect` returns a human-readable summary (to/value/gas/gasPrice) of pending and queued txs grouped by sender and nonce
- `txpool_content` returns full transaction objects for pending and queued txs
- `txpool_status` returns pending and queued tx counts

## Motivation

During a GenLayer testnet incident, transactions were accepted by the mempool but never mined. The root cause was a nonce gap: 1625 queued txs on the sequencer with 0 pending. Without `txpool_*` methods, diagnosing this required direct access to internal metrics. These endpoints make mempool state inspectable via standard JSON-RPC, the same way operators do it on geth/reth nodes.

## Implementation notes

- New `TxpoolApi` trait in `lib/rpc_api/src/txpool.rs` using `jsonrpsee` proc macros
- `TxpoolNamespace` in `lib/rpc/src/txpool_impl.rs` backed by `L2Subpool::all_transactions()`
- `TxpoolInspectSummary` uses `pool_tx.transaction.transaction.clone().into_inner().into()` — same pattern as reth's own txpool impl
- `ValidPoolTransaction` re-exported from `zksync_os_mempool` so `txpool_impl` doesn't need a direct `reth_transaction_pool` dep

## Test plan

- [ ] `curl -X POST localhost:3050 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"txpool_status","params":[],"id":1}'`
- [ ] Submit a tx with a nonce gap and verify it appears in `txpool_inspect` under `queued`
- [ ] Verify `txpool_content` returns full tx fields (from, nonce, gas, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)