### PR TITLE
ci: ignore RUSTSEC-2026-0104 (rustls-webpki CRL panic)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 'RUSTSEC-2025-0055' todo: waiting for ark-relations to release a patch https://github.com/arkworks-rs/snark/issues/413
-          ignore: 'RUSTSEC-2025-0055'
+          # 'RUSTSEC-2026-0104' rustls-webpki CRL panic; we don't parse CRLs, waiting for transitive deps to upgrade
+          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0104'
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ ignore = [
     # `rand` unsoundness with custom logger using `rand::rng()`. Too many
     # transitive deps still pin 0.8.5, so upgrading is not feasible right now.
     "RUSTSEC-2026-0097",
+    # `rustls-webpki` reachable panic in CRL parsing. We don't parse CRLs, so
+    # this is not exploitable. Waiting for transitive deps to pick up >=0.103.13.
+    "RUSTSEC-2026-0104",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- Adds `RUSTSEC-2026-0104` to the ignore list in both `deny.toml` (cargo-deny) and `.github/workflows/cargo-audit.yml` (cargo-audit)
- The advisory was published 2026-04-22 and immediately broke the scheduled security audit on main
- **Not exploitable here**: the panic is only reachable via `BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der` — we don't parse CRLs

## Fix

Waiting for whichever transitive dep pulls in `rustls-webpki` to upgrade to `>=0.103.13`. Will remove the ignore entry at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)