### PR TITLE
fix: return back required confirmations to 1

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -46,11 +46,6 @@ const METHOD_NOT_FOUND_CODE: i64 = -32601;
 type TransactionReceiptFuture =
     BoxFuture<'static, Result<TransactionReceipt, PendingTransactionError>>;
 
-const REQUIRED_CONFIRMATIONS_L1: u64 = 3;
-/// In case there's only one chain connected to gateway, it is very likely that there will be not enough block production
-/// to reach 3 confirmations for such transactions
-const REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
-
 /// Process responsible for sending transactions to L1.
 /// Handles one type of l1 command (e.g. Commit or Prove).
 /// Loads up to `command_limit` commands from the channel and sends them to L1 in parallel.
@@ -137,11 +132,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
             .into_iter()
             .map(|(tx_hash, cmd)| {
                 let fut = PendingTransactionBuilder::new(provider.root().clone(), tx_hash)
-                    .with_required_confirmations(if gateway {
-                        REQUIRED_CONFIRMATIONS_GATEWAY
-                    } else {
-                        REQUIRED_CONFIRMATIONS_L1
-                    })
+                    .with_required_confirmations(1)
                     .get_receipt()
                     .boxed();
                 (fut, cmd, Instant::now())
@@ -259,11 +250,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
                         // reorg happens and transaction will not be included in the new fork (very-very
                         // unlikely), L1 sender will crash at some point (because a consequent L1
                         // transactions will fail) and recover from the new L1 state after restart.
-                        .with_required_confirmations(if gateway {
-                            REQUIRED_CONFIRMATIONS_GATEWAY
-                        } else {
-                            REQUIRED_CONFIRMATIONS_L1
-                        })
+                        .with_required_confirmations(1)
                         // Ensure we don't wait indefinitely and crash if the transaction is not
                         // included on L1 in a reasonable time.
                         .with_timeout(Some(config.transaction_timeout));


### PR DESCRIPTION
Partial revert of commit 51b65bf03fad370ec1cd6bdfcd5832bee1771390 as it makes tests and local development flaky

## Summary

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

