### PR TITLE
fix(l1-sender): replace hardcoded 15M gas limit with dynamic estimation

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -210,6 +210,12 @@ pub async fn run_l1_sender<Input: SendToL1>(
                     .with_to(to_address)
                     .with_input(cmd.solidity_call(gateway, &operator_address));
 
+                    // Estimate gas and apply a 2x multiplier. A hardcoded limit (previously 15M)
+                    // causes "insufficient funds" rejections during gas spikes since nodes reserve
+                    // gas_limit * gas_price upfront, regardless of actual gas used.
+                    let estimated_gas = provider.estimate_gas(tx_request.clone()).await?;
+                    tx_request.set_gas_limit(estimated_gas.saturating_mul(2));
+
                     if let Some(blob_sidecar) = cmd.blob_sidecar() {
                         let fee_per_blob_gas = provider.get_blob_base_fee().await?;
                         L1_SENDER_METRICS
@@ -642,8 +648,7 @@ async fn tx_request_with_gas_fields(
     let tx = TransactionRequest::default()
         .with_from(operator_address)
         .with_max_fee_per_gas(capped_max_fee_per_gas)
-        .with_max_priority_fee_per_gas(capped_max_priority_fee_per_gas)
-        .with_gas_limit(15000000);
+        .with_max_priority_fee_per_gas(capped_max_priority_fee_per_gas);
     Ok(tx)
 }
 


### PR DESCRIPTION
## Summary

- The prove operator wallet on Atlas Chain (creator-mainnet) ran out of ETH during an L1 gas price spike on Apr 22, causing repeated server crashes. Root cause: the l1_sender used a hardcoded gas limit of 15,000,000 (~30x the actual gas used of ~495K). Ethereum nodes reserve `gas_limit × gas_price` upfront before executing a transaction, so during a spike to ~7.8 gwei the required budget was 0.116 ETH — exceeding the wallet balance of 0.081 ETH — even though the transaction would have only actually consumed ~0.004 ETH.
- Replace the hardcoded 15M limit with `eth_estimateGas × 2`, reducing the required balance buffer from ~30x to ~2x actual gas cost. At the spike price of 7.8 gwei this would have needed ~0.008 ETH instead of 0.116 ETH, well within the wallet balance.

## Test plan

- [ ] Existing unit/integration tests pass
- [ ] Verify estimated gas matches expected (~495K for prove txs) and gas limit is set to ~2x that
- [ ] Deploy to a testnet env and confirm prove transactions are submitted and mined successfully