### PR TITLE
fix(sender): sender config no longer bottle-necked by pipeline constants

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -165,7 +165,7 @@ pub async fn run_l1_sender<Input: SendToL1>(
     // At this point, all in-flight transactions from the previous session are confirmed.
     // Only actual SendToL1 commands are expected from here on.
 
-    /// TODO: prefetched channel is a temporary solution, until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
+    // TODO: prefetched channel is a temporary solution, until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
     let (prefetched_commands_sender, prefetched_commands) =
         mpsc::channel::<L1SenderCommand<Input>>(config.command_limit);
     let prefetch = prefetch_l1_sender_commands(inbound, prefetched_commands_sender, command_name);

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -32,7 +32,7 @@ use anyhow::Context as _;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::Instant;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::watch;
 use zksync_os_observability::{ComponentStateHandle, ComponentStateReporter};
 use zksync_os_operator_signer::SignerConfig;
@@ -90,10 +90,13 @@ pub async fn run_l1_sender<Input: SendToL1>(
     let latency_tracker =
         ComponentStateReporter::global().handle_for(Input::NAME, L1SenderState::WaitingRecv);
     let command_name = Input::NAME;
+    anyhow::ensure!(
+        config.command_limit > 0,
+        "l1 sender command_limit must be greater than zero"
+    );
 
     let operator_address =
-        register_operator::<_, Input>(&mut provider, config.operator_signer).await?;
-    let mut cmd_buffer = Vec::with_capacity(config.command_limit);
+        register_operator::<_, Input>(&mut provider, config.operator_signer.clone()).await?;
     // Process all potential passthrough commands first
     if process_prepending_passthrough_commands(
         &mut inbound,
@@ -161,6 +164,78 @@ pub async fn run_l1_sender<Input: SendToL1>(
 
     // At this point, all in-flight transactions from the previous session are confirmed.
     // Only actual SendToL1 commands are expected from here on.
+
+    /// TODO: prefetched channel is a temporary solution, until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
+    let (prefetched_commands_sender, prefetched_commands) =
+        mpsc::channel::<L1SenderCommand<Input>>(config.command_limit);
+    let prefetch = prefetch_l1_sender_commands(inbound, prefetched_commands_sender, command_name);
+    let sender = run_prefetched_l1_sender(
+        prefetched_commands,
+        outbound,
+        to_address,
+        provider,
+        config,
+        gateway,
+        commit_submitted_tx,
+        operator_address,
+        command_name,
+        latency_tracker,
+    );
+
+    tokio::pin!(prefetch);
+    tokio::pin!(sender);
+
+    tokio::select! {
+        result = &mut sender => result,
+        result = &mut prefetch => {
+            result?;
+            // Wait for inbound transactions before finishing. Consistent with old behavior
+            sender.await
+        }
+    }
+}
+
+/// Forwards commands to an internal channel, usually with a larger capacity
+/// TODO: This is a temporary solution until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
+/// We need this to achieve config.command_limit throughput, otehrwise backpressure mechanism will limit this.
+async fn prefetch_l1_sender_commands<Input: SendToL1>(
+    mut inbound: PeekableReceiver<L1SenderCommand<Input>>,
+    output: Sender<L1SenderCommand<Input>>,
+    command_name: &'static str,
+) -> anyhow::Result<()> {
+    while let Some(command) = inbound.recv().await {
+        if output.send(command).await.is_err() {
+            tracing::debug!(
+                command_name,
+                "prefetched L1 command receiver closed, stopping prefetch"
+            );
+            return Ok(());
+        }
+    }
+
+    tracing::info!(command_name, "inbound channel closed");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_prefetched_l1_sender<F, P, Input>(
+    mut inbound: Receiver<L1SenderCommand<Input>>,
+    outbound: Sender<SignedBatchEnvelope<FriProof>>,
+    to_address: Address,
+    provider: FillProvider<F, P>,
+    config: L1SenderConfig<Input>,
+    gateway: bool,
+    commit_submitted_tx: Option<watch::Sender<u64>>,
+    operator_address: Address,
+    command_name: &'static str,
+    latency_tracker: ComponentStateHandle<L1SenderState>,
+) -> anyhow::Result<()>
+where
+    F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet>,
+    P: Provider<Ethereum>,
+    Input: SendToL1,
+{
+    let mut cmd_buffer = Vec::with_capacity(config.command_limit);
     loop {
         latency_tracker.enter_state(L1SenderState::WaitingRecv);
         // This sleeps until **at least one** command is received from the channel. Additionally,

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -32,7 +32,7 @@ use anyhow::Context as _;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::Instant;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use zksync_os_observability::{ComponentStateHandle, ComponentStateReporter};
 use zksync_os_operator_signer::SignerConfig;
@@ -90,13 +90,10 @@ pub async fn run_l1_sender<Input: SendToL1>(
     let latency_tracker =
         ComponentStateReporter::global().handle_for(Input::NAME, L1SenderState::WaitingRecv);
     let command_name = Input::NAME;
-    anyhow::ensure!(
-        config.command_limit > 0,
-        "l1 sender command_limit must be greater than zero"
-    );
 
     let operator_address =
-        register_operator::<_, Input>(&mut provider, config.operator_signer.clone()).await?;
+        register_operator::<_, Input>(&mut provider, config.operator_signer).await?;
+    let mut cmd_buffer = Vec::with_capacity(config.command_limit);
     // Process all potential passthrough commands first
     if process_prepending_passthrough_commands(
         &mut inbound,
@@ -164,78 +161,6 @@ pub async fn run_l1_sender<Input: SendToL1>(
 
     // At this point, all in-flight transactions from the previous session are confirmed.
     // Only actual SendToL1 commands are expected from here on.
-
-    // TODO: prefetched channel is a temporary solution, until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
-    let (prefetched_commands_sender, prefetched_commands) =
-        mpsc::channel::<L1SenderCommand<Input>>(config.command_limit);
-    let prefetch = prefetch_l1_sender_commands(inbound, prefetched_commands_sender, command_name);
-    let sender = run_prefetched_l1_sender(
-        prefetched_commands,
-        outbound,
-        to_address,
-        provider,
-        config,
-        gateway,
-        commit_submitted_tx,
-        operator_address,
-        command_name,
-        latency_tracker,
-    );
-
-    tokio::pin!(prefetch);
-    tokio::pin!(sender);
-
-    tokio::select! {
-        result = &mut sender => result,
-        result = &mut prefetch => {
-            result?;
-            // Wait for inbound transactions before finishing. Consistent with old behavior
-            sender.await
-        }
-    }
-}
-
-/// Forwards commands to an internal channel, usually with a larger capacity
-/// TODO: This is a temporary solution until OUTPUT_BUFFER_SIZE is replaced by a different mechanism.
-/// We need this to achieve config.command_limit throughput, otehrwise backpressure mechanism will limit this.
-async fn prefetch_l1_sender_commands<Input: SendToL1>(
-    mut inbound: PeekableReceiver<L1SenderCommand<Input>>,
-    output: Sender<L1SenderCommand<Input>>,
-    command_name: &'static str,
-) -> anyhow::Result<()> {
-    while let Some(command) = inbound.recv().await {
-        if output.send(command).await.is_err() {
-            tracing::debug!(
-                command_name,
-                "prefetched L1 command receiver closed, stopping prefetch"
-            );
-            return Ok(());
-        }
-    }
-
-    tracing::info!(command_name, "inbound channel closed");
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn run_prefetched_l1_sender<F, P, Input>(
-    mut inbound: Receiver<L1SenderCommand<Input>>,
-    outbound: Sender<SignedBatchEnvelope<FriProof>>,
-    to_address: Address,
-    provider: FillProvider<F, P>,
-    config: L1SenderConfig<Input>,
-    gateway: bool,
-    commit_submitted_tx: Option<watch::Sender<u64>>,
-    operator_address: Address,
-    command_name: &'static str,
-    latency_tracker: ComponentStateHandle<L1SenderState>,
-) -> anyhow::Result<()>
-where
-    F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet>,
-    P: Provider<Ethereum>,
-    Input: SendToL1,
-{
-    let mut cmd_buffer = Vec::with_capacity(config.command_limit);
     loop {
         latency_tracker.enter_state(L1SenderState::WaitingRecv);
         // This sleeps until **at least one** command is received from the channel. Additionally,

--- a/lib/l1_sender/src/upgrade_gatekeeper.rs
+++ b/lib/l1_sender/src/upgrade_gatekeeper.rs
@@ -82,7 +82,7 @@ impl PipelineComponent for UpgradeGatekeeper {
     type Output = L1SenderCommand<CommitCommand>;
 
     const NAME: &'static str = "upgrade_gatekeeper";
-    const OUTPUT_BUFFER_SIZE: usize = 5;
+    const OUTPUT_BUFFER_SIZE: usize = 30;
 
     async fn run(
         self,

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -768,6 +768,7 @@ pub struct L1SenderConfig {
     pub max_fee_per_blob_gas: EtherAmount,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
+    /// For this to work properly `OUTPUT_BUFFER_SIZE`s have to be large enough
     #[config(default_t = 16)]
     pub command_limit: usize,
 

--- a/node/bin/src/priority_tree_pipeline_step.rs
+++ b/node/bin/src/priority_tree_pipeline_step.rs
@@ -57,7 +57,7 @@ where
     type Output = L1SenderCommand<ExecuteCommand>;
 
     const NAME: &'static str = "priority_tree";
-    const OUTPUT_BUFFER_SIZE: usize = 5;
+    const OUTPUT_BUFFER_SIZE: usize = 30;
 
     async fn run(
         mut self,

--- a/node/bin/src/prover_api/gapless_l1_proof_sender.rs
+++ b/node/bin/src/prover_api/gapless_l1_proof_sender.rs
@@ -26,7 +26,7 @@ impl PipelineComponent for GaplessL1ProofSender {
     type Output = L1SenderCommand<ProofCommand>;
 
     const NAME: &'static str = "gapless_l1_proof_sender";
-    const OUTPUT_BUFFER_SIZE: usize = 5;
+    const OUTPUT_BUFFER_SIZE: usize = 30;
 
     async fn run(
         self,


### PR DESCRIPTION
## Summary

We already have configurable limit on transactions sent to L1 in parallel. However the backpressure mechanism (OUTPUT_BUFFER_SIZE) limits us due to the way we read things from the channel. I increased it to 30, I think this is large enough limit.
<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

