### PR TITLE
feat(l1-sender): make configurable gas limit for L1

### DIFF
--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -19,6 +19,10 @@ pub struct L1SenderConfig<Input> {
     /// Max fee per blob gas we are willing to spend (in wei).
     pub max_fee_per_blob_gas_wei: u128,
 
+    /// Per-transaction gas limit when the settlement layer is L1.
+    /// Ignored when settling on a gateway
+    pub l1_gas_limit: u64,
+
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     pub command_limit: usize,
 

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -205,6 +205,8 @@ pub async fn run_l1_sender<Input: SendToL1>(
                         operator_address,
                         config.max_fee_per_gas_wei,
                         config.max_priority_fee_per_gas_wei,
+                        gateway,
+                        config.l1_gas_limit,
                     )
                     .await?
                     .with_to(to_address)
@@ -603,6 +605,8 @@ async fn tx_request_with_gas_fields(
     operator_address: Address,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
+    gateway: bool,
+    l1_gas_limit: u64,
 ) -> anyhow::Result<TransactionRequest> {
     let eip1559_est = provider.estimate_eip1559_fees().await?;
     L1_SENDER_METRICS.report_l1_eip_1559_estimation(eip1559_est)?;
@@ -643,7 +647,10 @@ async fn tx_request_with_gas_fields(
         .with_from(operator_address)
         .with_max_fee_per_gas(capped_max_fee_per_gas)
         .with_max_priority_fee_per_gas(capped_max_priority_fee_per_gas)
-        .with_gas_limit(15000000);
+        // We don't care much about high gas limit on gateway since it doesn't have a concept of priority fee there,
+        // although the transactions there(like containing interop bundles) can consume significant amount of gas
+        // On L1 the limit is configurable since it can actually impact the time of inclusion
+        .with_gas_limit(if gateway { 15_000_000 } else { l1_gas_limit });
     Ok(tx)
 }
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -767,6 +767,11 @@ pub struct L1SenderConfig {
     #[config(default_t = 2 * EtherUnit::Gwei)]
     pub max_fee_per_blob_gas: EtherAmount,
 
+    /// Per-transaction gas limit used when settling on L1.
+    /// Ignored when settling on a gateway (which uses a higher fixed limit).
+    #[config(default_t = 2_000_000)]
+    pub l1_gas_limit: u64,
+
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     #[config(default_t = 16)]
     pub command_limit: usize,
@@ -1333,6 +1338,7 @@ impl L1SenderConfig {
             max_fee_per_gas_wei: self.max_fee_per_gas.0,
             max_priority_fee_per_gas_wei: self.max_priority_fee_per_gas.0,
             max_fee_per_blob_gas_wei: self.max_fee_per_blob_gas.0,
+            l1_gas_limit: self.l1_gas_limit,
             command_limit: self.command_limit,
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
@@ -1618,6 +1624,7 @@ mod tests {
                 max_fee_per_gas: 200 * EtherUnit::Gwei,
                 max_priority_fee_per_gas: 1 * EtherUnit::Gwei,
                 max_fee_per_blob_gas: 2 * EtherUnit::Gwei,
+                l1_gas_limit: 2_000_000,
                 command_limit: 16,
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),


### PR DESCRIPTION
## Summary

L1 sender now has different gas limits depending on SL. 
In case it's Gateway - the gas limit stays the same 15M, since transactions there can consume large amounts of gas(up to 10M even in interop integration tests)
In case it's L1 - there's a separate config value, which is by default set to 2M - judging by statistics, the max amount of gas consumed is ~500k. Left there as a config value just for a case it will need further adjustments in the future
