### PR TITLE
feat(network): add raft transport layer over devp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14251,7 +14251,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_consensus_types"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "openraft",
  "reth-network-peers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -1261,6 +1272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyerror"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71add24cc141a1e8326f249b74c41cfd217aeb2a67c9c6cf9134d175469afd49"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,7 +1339,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-poly",
  "ark-serialize 0.5.0",
@@ -1466,7 +1486,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
@@ -2753,6 +2773,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.0.4",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,11 +3993,32 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5278,6 +5353,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -5907,7 +5985,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96d2465363ed2d81857759fc864cf6bb7997f79327aec028d65bd7989393685"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "clap",
  "crossbeam-channel",
  "crossbeam-utils",
@@ -6623,6 +6701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "match-lookup"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6687,7 +6771,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "portable-atomic",
 ]
 
@@ -7287,6 +7371,42 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openraft"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d35e2f60cdf9bcfc39a020966091017c6dc2a4b43b355a22ca3e76106f4a0a"
+dependencies = [
+ "anyerror",
+ "byte-unit",
+ "chrono",
+ "clap",
+ "derive_more 1.0.0",
+ "futures",
+ "maplit",
+ "openraft-macros",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "validit",
+]
+
+[[package]]
+name = "openraft-macros"
+version = "0.9.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbf0342d747a8da209c8e1d3ca8f788100966669412aaacb449409205931251"
+dependencies = [
+ "chrono",
+ "proc-macro2",
+ "quote",
+ "semver 1.0.26",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "openssl"
@@ -8180,6 +8300,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8550,6 +8690,15 @@ checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
 dependencies = [
  "hashbrown 0.16.0",
  "memchr",
+]
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
 ]
 
 [[package]]
@@ -10045,7 +10194,7 @@ version = "1.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2780e813b755850e50b178931aaf94ed24f6817f46aaaf5d21c13c12d939a249"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.11.0",
  "instant",
  "num-traits",
@@ -10169,6 +10318,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10256,6 +10434,23 @@ checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
 dependencies = [
  "libc",
  "libusb1-sys",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10501,7 +10696,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -10517,6 +10712,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -11106,6 +11307,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -12586,6 +12793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12607,6 +12820,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validit"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
+dependencies = [
+ "anyerror",
 ]
 
 [[package]]
@@ -14028,6 +14250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync_os_consensus_types"
+version = "0.19.0"
+dependencies = [
+ "openraft",
+ "reth-network-peers",
+ "zksync_os_storage_api",
+]
+
+[[package]]
 name = "zksync_os_contract_interface"
 version = "0.19.2"
 dependencies = [
@@ -14383,9 +14614,12 @@ dependencies = [
  "alloy",
  "alloy-rlp",
  "assert_matches",
+ "async-trait",
  "backon",
+ "dashmap",
  "futures",
  "metrics",
+ "openraft",
  "reth-chainspec",
  "reth-discv5",
  "reth-eth-wire",
@@ -14396,12 +14630,15 @@ dependencies = [
  "reth-tasks",
  "secrecy",
  "semver 1.0.26",
+ "serde",
+ "serde_json",
  "test-casing",
  "test-log",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
  "vise",
+ "zksync_os_consensus_types",
  "zksync_os_interface",
  "zksync_os_metadata",
  "zksync_os_reth_compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "lib/contract_interface",
+    "lib/consensus_types",
     "lib/crypto",
     "lib/genesis",
     "lib/l1_sender",
@@ -194,6 +195,7 @@ num_cpus = "1.17.0"
 rocksdb = "0.24.0"
 thread_local = "1.1.9"
 pin-project = "1.1.10"
+openraft = { version = "0.9.24", features = ["serde", "generic-snapshot-data", "storage-v2"] }
 assert_matches = "1.5"
 serde_yaml = "0.9"
 secrecy = "0.10.3"
@@ -250,6 +252,7 @@ zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = 
 
 # "Local" dependencies
 zksync_os_contract_interface = { version = "=0.19.2", path = "lib/contract_interface" }
+zksync_os_consensus_types = { version = "=0.19.2", path = "lib/consensus_types" }
 zksync_os_crypto = { version = "=0.19.2", path = "lib/crypto" }
 zksync_os_l1_sender = { version = "=0.19.2", path = "lib/l1_sender" }
 zksync_os_l1_watcher = { version = "=0.19.2", path = "lib/l1_watcher" }

--- a/lib/consensus_types/Cargo.toml
+++ b/lib/consensus_types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "zksync_os_consensus_types"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+openraft.workspace = true
+reth-network-peers.workspace = true
+zksync_os_storage_api.workspace = true

--- a/lib/consensus_types/src/lib.rs
+++ b/lib/consensus_types/src/lib.rs
@@ -1,0 +1,29 @@
+use openraft::{BasicNode, Entry, EntryPayload};
+use reth_network_peers::PeerId;
+use std::io::Cursor;
+use zksync_os_storage_api::ReplayRecord;
+
+pub type RaftNode = BasicNode;
+
+openraft::declare_raft_types!(
+    pub RaftTypeConfig:
+        /// Application data carried in each normal log entry — a block to be replayed.
+        D = ReplayRecord,
+        /// Response returned from `client_write`; unused, we use the canonized-blocks channel instead.
+        R = (),
+        NodeId = PeerId,
+        Node = RaftNode,
+);
+
+/// Formats a Raft log entry as a short human-readable string for debug logging.
+pub fn debug_display_raft_entry(entry: &Entry<RaftTypeConfig>) -> String {
+    let payload = match &entry.payload {
+        EntryPayload::Blank => "blank".to_string(),
+        EntryPayload::Normal(r) => format!(
+            "block number {} (block output hash: {})",
+            r.block_context.block_number, r.block_output_hash
+        ),
+        EntryPayload::Membership(_) => "membership".to_string(),
+    };
+    format!("Entry(log_id_index={}, {})", entry.log_id.index, payload)
+}

--- a/lib/network/Cargo.toml
+++ b/lib/network/Cargo.toml
@@ -15,6 +15,7 @@ zksync_os_storage_api.workspace = true
 zksync_os_types.workspace = true
 zksync_os_metadata.workspace = true
 zksync_os_reth_compat.workspace = true
+zksync_os_consensus_types.workspace = true
 
 zksync_os_interface.workspace = true
 
@@ -27,6 +28,11 @@ alloy = { workspace = true, default-features = false, features = [
 ] }
 alloy-rlp.workspace = true
 backon.workspace = true
+dashmap.workspace = true
+openraft.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+async-trait.workspace = true
 futures.workspace = true
 semver.workspace = true
 tokio.workspace = true

--- a/lib/network/src/lib.rs
+++ b/lib/network/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub(crate) mod metrics;
 pub mod protocol;
+pub mod raft;
 pub mod service;
 pub mod session;
 pub mod version;
@@ -16,3 +17,5 @@ pub use wire::verification::{VerifyBatch, VerifyBatchOutcome, VerifyBatchResult}
 pub use reth_network::config::SecretKey;
 pub use reth_network::config::rng_secret_key;
 pub use reth_network_peers::NodeRecord;
+pub use reth_network_peers::PeerId;
+pub use reth_network_peers::TrustedPeer;

--- a/lib/network/src/raft/mod.rs
+++ b/lib/network/src/raft/mod.rs
@@ -1,0 +1,7 @@
+pub mod protocol;
+pub mod wire;
+
+pub use protocol::{
+    RAFT_PROTOCOL, RaftProtocolHandler, RaftRequestHandler, RaftRouter, RaftTransportError,
+};
+pub use wire::{RaftRequest, RaftResponse, RaftWireMessage, RequestId};

--- a/lib/network/src/raft/protocol.rs
+++ b/lib/network/src/raft/protocol.rs
@@ -1,0 +1,426 @@
+use crate::raft::wire::{RaftRequest, RaftResponse, RaftWireMessage, RequestId};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::StreamExt;
+use reth_eth_wire::multiplex::ProtocolConnection;
+use reth_eth_wire::protocol::Protocol;
+use reth_network::Direction;
+use reth_network::protocol::{ConnectionHandler, OnNotSupported, ProtocolHandler};
+use reth_network::types::Capability;
+use reth_network_peers::PeerId;
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, Instant, sleep};
+use tracing::Instrument;
+
+pub const RAFT_PROTOCOL: &str = "zks_raft";
+const RAFT_PROTOCOL_VERSION: usize = 1;
+// RLPx multiplexing uses the first byte as a sub-protocol message id.
+// Raft has two wire message kinds (request/response), so it needs 2 slots.
+const RAFT_PROTOCOL_MESSAGE_COUNT: u8 = 2;
+const RAFT_OUTBOUND_CHANNEL_CAPACITY: usize = 64;
+
+#[derive(Debug)]
+struct PendingRequest {
+    connection_id: u64,
+    response_tx: oneshot::Sender<Result<RaftResponse, String>>,
+}
+
+#[async_trait]
+pub trait RaftRequestHandler: Send + Sync + 'static {
+    async fn handle(&self, request: RaftRequest) -> Result<RaftResponse, String>;
+}
+
+#[derive(Debug, Clone)]
+pub struct RaftRouter {
+    next_request_id: Arc<AtomicU64>,
+    next_connection_id: Arc<AtomicU64>,
+    // Stores (connection_id, response_sender) so that when a connection drops we can cancel
+    // all requests that were routed through it.
+    pending: Arc<DashMap<RequestId, PendingRequest>>,
+    // Vec<PeerChannel> rather than a single PeerChannel because devp2p can establish two
+    // simultaneous TCP connections for the same peer when both nodes dial each other at the same
+    // time (each node sees an incoming connection from the other while its own outgoing connection
+    // is also completing). devp2p closes the unwanted duplicate shortly after, but there is a
+    // brief window where both connections are alive. Storing all of them means whichever one
+    // devp2p decides to keep stays in the router after the other is removed by its Drop calling
+    // unregister_peer. With a single slot, one connection would be silently orphaned and the peer
+    // would appear disconnected even though the kept connection is alive.
+    peers: Arc<DashMap<PeerId, Vec<PeerChannel>>>,
+}
+
+#[derive(Debug, Clone)]
+struct PeerChannel {
+    connection_id: u64,
+    sender: mpsc::UnboundedSender<RaftWireMessage>,
+}
+
+impl Default for RaftRouter {
+    fn default() -> Self {
+        Self {
+            next_request_id: Arc::new(AtomicU64::new(1)),
+            next_connection_id: Arc::new(AtomicU64::new(1)),
+            pending: Arc::new(DashMap::new()),
+            peers: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+impl RaftRouter {
+    pub fn register_peer(
+        &self,
+        peer_id: PeerId,
+        sender: mpsc::UnboundedSender<RaftWireMessage>,
+    ) -> u64 {
+        let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        self.peers.entry(peer_id).or_default().push(PeerChannel {
+            connection_id,
+            sender,
+        });
+        tracing::info!(%peer_id, connection_id, "raft peer connection registered");
+        connection_id
+    }
+
+    pub fn unregister_peer(&self, peer_id: &PeerId, connection_id: u64) {
+        let mut entry = match self.peers.entry(*peer_id) {
+            dashmap::mapref::entry::Entry::Occupied(e) => e,
+            dashmap::mapref::entry::Entry::Vacant(_) => return,
+        };
+        let channels = entry.get_mut();
+        let before = channels.len();
+        channels.retain(|ch| ch.connection_id != connection_id);
+        if channels.len() == before {
+            // connection_id was not in the list; already removed or never stored
+            return;
+        }
+        if channels.is_empty() {
+            entry.remove();
+            tracing::info!(%peer_id, connection_id, "raft peer unregistered (no remaining connections)");
+        } else {
+            tracing::debug!(%peer_id, connection_id, remaining = channels.len(), "raft connection unregistered, peer still has other connections");
+        }
+    }
+
+    pub fn send_request(
+        &self,
+        peer_id: PeerId,
+        req: RaftRequest,
+    ) -> Result<oneshot::Receiver<Result<RaftResponse, String>>, RaftTransportError> {
+        let Some(channels) = self.peers.get(&peer_id) else {
+            tracing::debug!(%peer_id, connected = self.peers.len(), "raft request failed: peer not connected");
+            return Err(RaftTransportError::NotConnected(peer_id));
+        };
+        let senders = channels.value().clone();
+        drop(channels);
+
+        let id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+
+        let mut msg = RaftWireMessage::Request { id, req };
+        for ch in &senders {
+            match ch.sender.send(msg) {
+                Ok(()) => {
+                    self.pending.insert(
+                        id,
+                        PendingRequest {
+                            connection_id: ch.connection_id,
+                            response_tx: tx,
+                        },
+                    );
+                    return Ok(rx);
+                }
+                Err(tokio::sync::mpsc::error::SendError(returned)) => {
+                    // This channel is dead (receiver dropped); its Drop will call unregister_peer.
+                    // Recover the message and try the next connection.
+                    tracing::debug!(%peer_id, connection_id = ch.connection_id, "raft send failed on connection, trying next");
+                    msg = returned;
+                }
+            }
+        }
+
+        tracing::debug!(%peer_id, request_id = id, "raft request failed: all connections dead");
+        Err(RaftTransportError::SendFailed(peer_id))
+    }
+
+    pub fn connected_peers(&self) -> Vec<PeerId> {
+        self.peers.iter().map(|entry| *entry.key()).collect()
+    }
+
+    pub async fn wait_for_peers(
+        &self,
+        peers: &[PeerId],
+        timeout: Duration,
+    ) -> Result<(), Vec<PeerId>> {
+        let deadline = Instant::now() + timeout;
+        let mut last_progress_log = Instant::now();
+        loop {
+            let connected = self.connected_peers();
+            let missing: Vec<_> = peers
+                .iter()
+                .copied()
+                .filter(|peer| !connected.contains(peer))
+                .collect();
+
+            if missing.is_empty() {
+                tracing::info!(connected = ?connected, "all required raft peers are connected");
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                tracing::warn!(missing = ?missing, connected = ?connected, "timed out waiting for raft peers");
+                return Err(missing);
+            }
+            if last_progress_log.elapsed() >= Duration::from_secs(2) {
+                tracing::info!(missing = ?missing, connected = ?connected, "still waiting for raft peers");
+                last_progress_log = Instant::now();
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    pub fn complete_response(&self, id: RequestId, resp: Result<RaftResponse, String>) {
+        if let Some((_, entry)) = self.pending.remove(&id) {
+            let _ = entry.response_tx.send(resp);
+        }
+    }
+
+    fn cancel_pending_for_connection(&self, connection_id: u64) {
+        let matching: Vec<RequestId> = self
+            .pending
+            .iter()
+            .filter(|e| e.value().connection_id == connection_id)
+            .map(|e| *e.key())
+            .collect();
+        for id in matching {
+            if let Some((_, entry)) = self.pending.remove(&id) {
+                let _ = entry
+                    .response_tx
+                    .send(Err(format!("connection {connection_id} dropped")));
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RaftTransportError {
+    #[error("peer {0} is not connected")]
+    NotConnected(PeerId),
+    #[error("failed to send request to peer {0}")]
+    SendFailed(PeerId),
+}
+
+#[derive(Clone)]
+pub struct RaftProtocolHandler {
+    handler: Arc<dyn RaftRequestHandler>,
+    router: RaftRouter,
+}
+
+impl Debug for RaftProtocolHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RaftProtocolHandler")
+            .finish_non_exhaustive()
+    }
+}
+
+impl RaftProtocolHandler {
+    pub fn new(handler: impl RaftRequestHandler, router: RaftRouter) -> Self {
+        Self {
+            handler: Arc::new(handler),
+            router,
+        }
+    }
+
+    fn establish_connection(&self, peer_id: PeerId, conn: ProtocolConnection) -> RaftConnection {
+        let (outbound_tx, outbound_rx) = mpsc::channel(RAFT_OUTBOUND_CHANNEL_CAPACITY);
+        let (msg_tx, msg_rx) = mpsc::unbounded_channel();
+        let connection_id = self.router.register_peer(peer_id, msg_tx);
+        let task = tokio::spawn(
+            run_raft_connection(
+                peer_id,
+                connection_id,
+                conn,
+                msg_rx,
+                outbound_tx,
+                self.handler.clone(),
+                self.router.clone(),
+            )
+            .instrument(tracing::info_span!("raft_connection", %peer_id, connection_id)),
+        );
+        RaftConnection {
+            peer_id,
+            connection_id,
+            router: self.router.clone(),
+            outbound_rx,
+            task,
+        }
+    }
+
+    pub fn router(&self) -> RaftRouter {
+        self.router.clone()
+    }
+}
+
+impl ProtocolHandler for RaftProtocolHandler {
+    type ConnectionHandler = RaftConnectionHandler;
+
+    fn on_incoming(&self, _socket_addr: SocketAddr) -> Option<Self::ConnectionHandler> {
+        tracing::debug!("incoming raft sub-protocol connection handler requested");
+        Some(RaftConnectionHandler {
+            handler: self.clone(),
+        })
+    }
+
+    fn on_outgoing(
+        &self,
+        _socket_addr: SocketAddr,
+        _peer_id: PeerId,
+    ) -> Option<Self::ConnectionHandler> {
+        tracing::debug!("outgoing raft sub-protocol connection handler requested");
+        Some(RaftConnectionHandler {
+            handler: self.clone(),
+        })
+    }
+}
+
+pub struct RaftConnectionHandler {
+    handler: RaftProtocolHandler,
+}
+
+impl ConnectionHandler for RaftConnectionHandler {
+    type Connection = RaftConnection;
+
+    fn protocol(&self) -> Protocol {
+        Protocol::new(
+            Capability::new_static(RAFT_PROTOCOL, RAFT_PROTOCOL_VERSION),
+            RAFT_PROTOCOL_MESSAGE_COUNT,
+        )
+    }
+
+    fn on_unsupported_by_peer(
+        self,
+        _supported: &reth_eth_wire::capability::SharedCapabilities,
+        _direction: Direction,
+        _peer_id: PeerId,
+    ) -> OnNotSupported {
+        // Raft is an optional sub-protocol; non-raft peers should still be allowed to connect.
+        OnNotSupported::KeepAlive
+    }
+
+    fn into_connection(
+        self,
+        direction: Direction,
+        peer_id: PeerId,
+        conn: ProtocolConnection,
+    ) -> Self::Connection {
+        tracing::info!(
+            "raft sub-protocol connection established (direction={direction:?}, peer_id={peer_id})"
+        );
+        self.handler.establish_connection(peer_id, conn)
+    }
+}
+
+/// Outbound side of a raft sub-protocol connection.
+///
+/// Wraps an mpsc receiver fed by a background Tokio task (`run_raft_connection`) that owns the
+/// connection logic. Dropping this struct aborts the background task and cancels any pending
+/// requests that were routed through this connection.
+pub struct RaftConnection {
+    peer_id: PeerId,
+    connection_id: u64,
+    router: RaftRouter,
+    outbound_rx: mpsc::Receiver<alloy::primitives::bytes::BytesMut>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl futures::Stream for RaftConnection {
+    type Item = alloy::primitives::bytes::BytesMut;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.outbound_rx.poll_recv(cx)
+    }
+}
+
+impl Drop for RaftConnection {
+    fn drop(&mut self) {
+        tracing::info!(
+            "raft connection dropped (peer_id={}, connection_id={}, pending_requests={})",
+            self.peer_id,
+            self.connection_id,
+            self.router.pending.len(),
+        );
+        self.task.abort();
+        self.router
+            .cancel_pending_for_connection(self.connection_id);
+        self.router
+            .unregister_peer(&self.peer_id, self.connection_id);
+    }
+}
+
+async fn run_raft_connection(
+    peer_id: PeerId,
+    connection_id: u64,
+    mut conn: ProtocolConnection,
+    mut msg_rx: mpsc::UnboundedReceiver<RaftWireMessage>,
+    outbound_tx: mpsc::Sender<alloy::primitives::bytes::BytesMut>,
+    handler: Arc<dyn RaftRequestHandler>,
+    router: RaftRouter,
+) {
+    loop {
+        tokio::select! {
+            frame = conn.next() => {
+                let Some(bytes) = frame else {
+                    tracing::info!(%peer_id, connection_id, "raft connection closed by peer");
+                    break;
+                };
+                match RaftWireMessage::decode(&bytes[..]) {
+                    Ok(RaftWireMessage::Request { id, req }) => {
+                        tracing::debug!(%peer_id, request_id = id, "received raft request");
+                        let handler = handler.clone();
+                        let outbound_tx = outbound_tx.clone();
+                        tokio::spawn(async move {
+                            let resp = handler.handle(req).await;
+                            let encoded = RaftWireMessage::Response { id, resp };
+                            let buf = alloy::primitives::bytes::BytesMut::from(
+                                encoded.encode().as_slice(),
+                            );
+                            let _ = outbound_tx.send(buf).await;
+                        });
+                    }
+                    Ok(RaftWireMessage::Response { id, resp }) => {
+                        tracing::debug!(%peer_id, request_id = id, "received raft response");
+                        router.complete_response(id, resp);
+                    }
+                    Err(error) => {
+                        let preview_len = bytes.len().min(64);
+                        let preview_hex = bytes[..preview_len]
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect::<String>();
+                        tracing::warn!(
+                            %peer_id,
+                            connection_id,
+                            %error,
+                            msg_len = bytes.len(),
+                            msg_preview_hex = %preview_hex,
+                            "error decoding raft message; ignoring"
+                        );
+                    }
+                }
+            }
+            msg = msg_rx.recv() => {
+                let Some(msg) = msg else {
+                    break;
+                };
+                let buf = alloy::primitives::bytes::BytesMut::from(msg.encode().as_slice());
+                if outbound_tx.send(buf).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/lib/network/src/raft/wire.rs
+++ b/lib/network/src/raft/wire.rs
@@ -1,0 +1,113 @@
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use reth_network_peers::PeerId;
+use serde::{Deserialize, Serialize};
+use zksync_os_consensus_types::RaftTypeConfig;
+
+pub type RequestId = u64;
+const RAFT_REQUEST_MESSAGE_ID: u8 = 0;
+const RAFT_RESPONSE_MESSAGE_ID: u8 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RaftRequest {
+    AppendEntries(AppendEntriesRequest<RaftTypeConfig>),
+    Vote(VoteRequest<PeerId>),
+    // Snapshotting is currently disabled (SnapshotPolicy::Never); this variant is never sent.
+    InstallSnapshot(InstallSnapshotRequest<RaftTypeConfig>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RaftResponse {
+    AppendEntries(AppendEntriesResponse<PeerId>),
+    Vote(VoteResponse<PeerId>),
+    InstallSnapshot(InstallSnapshotResponse<PeerId>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RaftWireMessage {
+    Request {
+        id: RequestId,
+        req: RaftRequest,
+    },
+    Response {
+        id: RequestId,
+        resp: Result<RaftResponse, String>,
+    },
+}
+
+impl RaftWireMessage {
+    // TEMPORARY: using JSON rather than RLP because openraft types derive serde but not RLP;
+    // switching to RLP would require manual codec impls for every openraft struct.
+    pub fn encode(&self) -> Vec<u8> {
+        #[derive(Serialize)]
+        struct RequestPayload<'a> {
+            id: RequestId,
+            req: &'a RaftRequest,
+        }
+
+        #[derive(Serialize)]
+        struct ResponsePayload<'a> {
+            id: RequestId,
+            resp: &'a Result<RaftResponse, String>,
+        }
+
+        let mut out = Vec::new();
+        match self {
+            RaftWireMessage::Request { id, req } => {
+                out.push(RAFT_REQUEST_MESSAGE_ID);
+                let payload = RequestPayload { id: *id, req };
+                out.extend(serde_json::to_vec(&payload).expect("serialize raft request payload"));
+            }
+            RaftWireMessage::Response { id, resp } => {
+                out.push(RAFT_RESPONSE_MESSAGE_ID);
+                let payload = ResponsePayload { id: *id, resp };
+                out.extend(serde_json::to_vec(&payload).expect("serialize raft response payload"));
+            }
+        }
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        #[derive(Deserialize)]
+        struct RequestPayload {
+            id: RequestId,
+            req: RaftRequest,
+        }
+
+        #[derive(Deserialize)]
+        struct ResponsePayload {
+            id: RequestId,
+            resp: Result<RaftResponse, String>,
+        }
+
+        let (msg_id, payload) = bytes.split_first().ok_or_else(|| {
+            serde_json::Error::io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "empty raft message",
+            ))
+        })?;
+
+        match *msg_id {
+            RAFT_REQUEST_MESSAGE_ID => {
+                let payload = serde_json::from_slice::<RequestPayload>(payload)?;
+                Ok(RaftWireMessage::Request {
+                    id: payload.id,
+                    req: payload.req,
+                })
+            }
+            RAFT_RESPONSE_MESSAGE_ID => {
+                let payload = serde_json::from_slice::<ResponsePayload>(payload)?;
+                Ok(RaftWireMessage::Response {
+                    id: payload.id,
+                    resp: payload.resp,
+                })
+            }
+            other => Err(serde_json::Error::io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown raft message id: {other}"),
+            ))),
+        }
+    }
+}

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -3,6 +3,7 @@ use crate::protocol::{
     ConnectionRegistry, ExternalNodeProtocolConfig, HandlerSharedState, MainNodeProtocolConfig,
     ProtocolEvent, ZksProtocolConfig, ZksProtocolHandler,
 };
+use crate::raft::protocol::RaftProtocolHandler;
 use crate::session::PeerSessionStore;
 use crate::version::{ZksProtocolV1, ZksProtocolV2, ZksProtocolV3};
 use crate::wire::message::ZksMessage;
@@ -173,6 +174,7 @@ impl NetworkService {
         protocol_config: ZksProtocolConfig,
         replay: impl ReadReplay + Clone,
         client: impl ChainSpecProvider<ChainSpec: Hardforks> + BlockNumReader + 'static,
+        raft_handler: Option<RaftProtocolHandler>,
     ) -> Result<Self, NetworkError> {
         // Install ViseRecorder before creating the NetworkManager so that reth-network metrics
         // are captured. This must happen before `NetworkManager::builder()` because that is where
@@ -242,13 +244,16 @@ impl NetworkService {
                 PeersConfig::default()
                     // Sets peer ban duration to 1 second, effectively disabling it
                     .with_ban_duration(Duration::from_secs(1))
-                    // Tune backoff durations to be low, useful while we are in exploratory phase
-                    // and infra issues are expected.
+                    // Keep backoff durations short so that consensus nodes reconnect quickly
+                    // after a peer restart or a transient network glitch. Long backoffs would
+                    // stall raft leader election and block transaction processing.
+                    // (low = transient failure, medium = persistent failure, high = bad peer,
+                    // max = cumulative cap)
                     .with_backoff_durations(PeerBackoffDurations {
-                        low: Duration::from_secs(30),
-                        medium: Duration::from_secs(60),
-                        high: Duration::from_secs(60 * 2),
-                        max: Duration::from_secs(60 * 3),
+                        low: Duration::from_secs(1),
+                        medium: Duration::from_secs(2),
+                        high: Duration::from_secs(5),
+                        max: Duration::from_secs(10),
                     })
                     // Peers' fork id must match, otherwise we could discover peers from other
                     // chains.
@@ -266,7 +271,7 @@ impl NetworkService {
             // Use genesis as chain head
             .set_head(genesis);
         let connection_registry: ConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
-        let cfg_builder = match protocol_config {
+        let mut cfg_builder = match protocol_config {
             ZksProtocolConfig::MainNode(protocol) => Self::register_main_node_rlpx_sub_protocols(
                 cfg_builder,
                 protocol,
@@ -284,6 +289,9 @@ impl NetworkService {
                 )
             }
         };
+        if let Some(raft_handler) = raft_handler {
+            cfg_builder = cfg_builder.add_rlpx_sub_protocol(raft_handler);
+        }
         let net_cfg = cfg_builder.build(client);
         tracing::debug!(?net_cfg, "starting p2p network service");
         // Create network manager. We are not interested in `txpool` because transaction gossip is
@@ -534,12 +542,8 @@ async fn dispatch_verify_batch(
             );
             continue;
         }
-        if connection
-            .outbound_tx
-            .send(ZksMessage::<ZksProtocolV3>::VerifyBatch(request.clone()).encoded())
-            .await
-            .is_err()
-        {
+        let encoded = ZksMessage::<ZksProtocolV3>::VerifyBatch(request.clone()).encoded();
+        if connection.outbound_tx.send(encoded).await.is_err() {
             tracing::warn!(
                 peer_id = %peer_id,
                 request_id = request.request_id,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -434,6 +434,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 }),
                 block_replay_storage.clone(),
                 zk_provider_factory,
+                None,
             )
             .await
         } else {
@@ -462,6 +463,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 }),
                 block_replay_storage.clone(),
                 zk_provider_factory,
+                None,
             )
             .await
         }


### PR DESCRIPTION
## Summary

Next PR in consensus series. Introduces the changes to networking - that will later be used by raft engine.

- Adds `openraft` dependency
- Adds `lib/consensus_types`: shared openraft type config (`RaftTypeConfig`) and `PeerId`-based node identity
- Adds `lib/network/src/raft/`: `RaftProtocolHandler` (a new RLPx sub-protocol), wire encoding for AppendEntries/Vote/InstallSnapshot RPCs, and `RaftRouter` for routing outbound RPCs and matching responses
- `NetworkService::new` gains an optional `raft_handler` parameter; registers the raft sub-protocol when provided
- Tightens peer backoff durations (30–180 s → 1–10 s) so consensus nodes reconnect quickly after restarts



🤖 Generated with [Claude Code](https://claude.com/claude-code)
