### PR TITLE
feat(observability): add tokio runtime and per-handler task metrics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [env]
 # Workspace directory to properly resolve artifacts relative paths
 # it will always be relative to the workspace and can be rewritten if required

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build
         env:
           # Build static binaries
-          RUSTFLAGS: '-C target-feature=+crt-static'
+          RUSTFLAGS: '-C target-feature=+crt-static --cfg tokio_unstable'
         run: |
           cargo build --profile "${RELEASE_PROFILE}" \
             --target "${{ matrix.target }}" --bin "${ZKSYNC_OS_SERVER_BIN}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14263,7 +14263,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_consensus_types"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "openraft",
  "reth-network-peers",
@@ -14832,6 +14832,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,7 +3902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12043,6 +12043,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-metrics"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e81d53caf955549b1dec7af4ac2149e94cc25ed97b4a545151140281e2f528"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-native-tls"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14664,6 +14676,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-metrics",
  "tracing",
  "tracing-logfmt",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ zk_os_basic_system_dev = { package = "basic_system", git = "https://github.com/m
 # Other dependencies.
 
 tokio = "1.45.1"
+tokio-metrics = "0.5.0"
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7", features = ["codec"], default-features = false }
 ruint = { version = "1.12", default-features = false }

--- a/lib/observability/Cargo.toml
+++ b/lib/observability/Cargo.toml
@@ -39,4 +39,5 @@ opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-appender-tracing.workspace = true
 
+tokio-metrics.workspace = true
 reth-tasks.workspace = true

--- a/lib/observability/src/lib.rs
+++ b/lib/observability/src/lib.rs
@@ -30,6 +30,8 @@ pub use component_state_reporter::{ComponentStateHandle, ComponentStateReporter,
 mod metrics;
 pub use metrics::GENERAL_METRICS;
 
+pub mod tokio_runtime;
+
 /// Internal trait used in `ObservabilityGuard::with_timeout()` to inspect action results.
 trait InspectResults {
     fn inspect_results(&self, action_name: &str);

--- a/lib/observability/src/prometheus.rs
+++ b/lib/observability/src/prometheus.rs
@@ -7,6 +7,8 @@ use reth_tasks::shutdown::GracefulShutdown;
 use vise::MetricsCollection;
 use vise_exporter::MetricsExporter;
 
+use crate::tokio_runtime;
+
 #[derive(Debug, Clone)]
 enum PrometheusTransport {
     Pull {
@@ -53,6 +55,7 @@ impl PrometheusExporterConfig {
 
     /// Runs the exporter. This future should be spawned in a separate Tokio task.
     pub async fn run(self, shutdown: GracefulShutdown) -> anyhow::Result<()> {
+        tokio_runtime::spawn_monitor();
         let registry = MetricsCollection::lazy().collect();
         let metrics_exporter =
             MetricsExporter::new(registry.into()).with_graceful_shutdown(shutdown.ignore_guard());

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -1,0 +1,62 @@
+//! Tokio runtime health metrics.
+//!
+//! Exposes worker thread saturation, queue depths, and blocking pool usage to Prometheus.
+//! These metrics are the primary signal for diagnosing worker thread starvation — where
+//! synchronous code running on async worker threads starves other tasks without necessarily
+//! saturating CPU (e.g. blocking storage reads block the thread but do no compute).
+
+use std::time::Duration;
+
+use tokio::runtime::Handle;
+use tokio_metrics::RuntimeMonitor;
+use vise::{Gauge, Global, Metrics, Unit};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "tokio_runtime")]
+struct TokioRuntimeMetrics {
+    /// Ratio of time worker threads spent busy vs total elapsed, summed across all workers.
+    /// Values approaching `workers_count` indicate full saturation.
+    worker_busy_ratio: Gauge<f64>,
+    /// Number of worker threads in the runtime.
+    workers_count: Gauge<u64>,
+    /// Tasks currently in the runtime's global queue.
+    global_queue_depth: Gauge<u64>,
+    /// Total live tasks in the runtime.
+    live_tasks_count: Gauge<u64>,
+    /// Total tasks waiting across all worker-local queues.
+    total_local_queue_depth: Gauge<u64>,
+    /// Tasks queued for `spawn_blocking`, waiting for a thread.
+    blocking_queue_depth: Gauge<u64>,
+    /// Threads currently spawned by the runtime for `spawn_blocking`.
+    blocking_threads_count: Gauge<u64>,
+    /// Idle `spawn_blocking` threads available for reuse.
+    idle_blocking_threads_count: Gauge<u64>,
+    /// Mean task poll duration during the last interval.
+    #[metrics(unit = Unit::Seconds)]
+    mean_poll_duration: Gauge<f64>,
+}
+
+#[vise::register]
+static METRICS: Global<TokioRuntimeMetrics> = Global::new();
+
+/// Spawns a background task that samples Tokio runtime metrics once per second.
+///
+/// Must be called from within a Tokio runtime context.
+pub fn spawn_monitor() {
+    let handle = Handle::current();
+    tokio::spawn(async move {
+        let monitor = RuntimeMonitor::new(&handle);
+        for interval in monitor.intervals() {
+            METRICS.worker_busy_ratio.set(interval.busy_ratio());
+            METRICS.workers_count.set(interval.workers_count as u64);
+            METRICS.global_queue_depth.set(interval.global_queue_depth as u64);
+            METRICS.live_tasks_count.set(interval.live_tasks_count as u64);
+            METRICS.total_local_queue_depth.set(interval.total_local_queue_depth as u64);
+            METRICS.blocking_queue_depth.set(interval.blocking_queue_depth as u64);
+            METRICS.blocking_threads_count.set(interval.blocking_threads_count as u64);
+            METRICS.idle_blocking_threads_count.set(interval.idle_blocking_threads_count as u64);
+            METRICS.mean_poll_duration.set(interval.mean_poll_duration.as_secs_f64());
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+}

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -49,13 +49,27 @@ pub fn spawn_monitor() {
         for interval in monitor.intervals() {
             METRICS.worker_busy_ratio.set(interval.busy_ratio());
             METRICS.workers_count.set(interval.workers_count as u64);
-            METRICS.global_queue_depth.set(interval.global_queue_depth as u64);
-            METRICS.live_tasks_count.set(interval.live_tasks_count as u64);
-            METRICS.total_local_queue_depth.set(interval.total_local_queue_depth as u64);
-            METRICS.blocking_queue_depth.set(interval.blocking_queue_depth as u64);
-            METRICS.blocking_threads_count.set(interval.blocking_threads_count as u64);
-            METRICS.idle_blocking_threads_count.set(interval.idle_blocking_threads_count as u64);
-            METRICS.mean_poll_duration.set(interval.mean_poll_duration.as_secs_f64());
+            METRICS
+                .global_queue_depth
+                .set(interval.global_queue_depth as u64);
+            METRICS
+                .live_tasks_count
+                .set(interval.live_tasks_count as u64);
+            METRICS
+                .total_local_queue_depth
+                .set(interval.total_local_queue_depth as u64);
+            METRICS
+                .blocking_queue_depth
+                .set(interval.blocking_queue_depth as u64);
+            METRICS
+                .blocking_threads_count
+                .set(interval.blocking_threads_count as u64);
+            METRICS
+                .idle_blocking_threads_count
+                .set(interval.idle_blocking_threads_count as u64);
+            METRICS
+                .mean_poll_duration
+                .set(interval.mean_poll_duration.as_secs_f64());
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
     });

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -8,6 +8,8 @@
 use std::time::Duration;
 
 use tokio::runtime::Handle;
+use tokio::spawn;
+use tokio::time::sleep;
 use tokio_metrics::RuntimeMonitor;
 use vise::{Gauge, Global, Metrics, Unit};
 
@@ -44,7 +46,7 @@ static METRICS: Global<TokioRuntimeMetrics> = Global::new();
 /// Must be called from within a Tokio runtime context.
 pub fn spawn_monitor() {
     let handle = Handle::current();
-    tokio::spawn(async move {
+    spawn(async move {
         let monitor = RuntimeMonitor::new(&handle);
         for interval in monitor.intervals() {
             METRICS.worker_busy_ratio.set(interval.busy_ratio());
@@ -70,7 +72,7 @@ pub fn spawn_monitor() {
             METRICS
                 .mean_poll_duration
                 .set(interval.mean_poll_duration.as_secs_f64());
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(1)).await;
         }
     });
 }

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -46,6 +46,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-metrics.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 vise.workspace = true

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -82,6 +82,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     wait_for_db: impl Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
     tracing::info!("Starting JSON-RPC server at {}", config.address);
+    metrics::spawn_task_monitors();
 
     let mut rpc = RpcModule::new(());
     let eth_call_handler = EthCallHandler::new(

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,8 +1,13 @@
 use alloy::rpc::types::Filter;
+use std::collections::HashMap;
+use std::sync::LazyLock;
 use std::time::Duration;
+use tokio::spawn;
+use tokio::time::sleep;
+use tokio_metrics::TaskMonitor;
 use vise::{
-    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Histogram, LabeledFamily, Metrics,
-    Unit,
+    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Global, Histogram,
+    LabeledFamily, Metrics, Unit,
 };
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
@@ -92,7 +97,7 @@ pub struct Api {
 }
 
 #[vise::register]
-pub static API_METRICS: vise::Global<Api> = vise::Global::new();
+pub static API_METRICS: Global<Api> = Global::new();
 
 /// Metrics for the transaction submission pipeline.
 #[derive(Debug, Metrics)]
@@ -109,7 +114,7 @@ pub struct TxSubmission {
 }
 
 #[vise::register]
-pub static TX_SUBMISSION: vise::Global<TxSubmission> = vise::Global::new();
+pub static TX_SUBMISSION: Global<TxSubmission> = Global::new();
 
 /// Reason why an `eth_sendRawTransaction` was rejected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
@@ -167,4 +172,73 @@ pub enum TxRejectionReason {
     PoolEip7702Error,
     /// Other pool error.
     PoolOther,
+}
+
+/// RPC methods to instrument with per-handler task metrics.
+/// Add any method suspected of blocking worker threads.
+const MONITORED_METHODS: &[&str] = &[
+    "eth_call",
+    "eth_estimateGas",
+    "eth_feeHistory",
+    "eth_getLogs",
+    "eth_sendRawTransaction",
+    "eth_sendRawTransactionSync",
+    "debug_traceCall",
+    "debug_traceTransaction",
+    "debug_traceBlockByHash",
+    "debug_traceBlockByNumber",
+];
+
+/// Map from RPC method name to its `TaskMonitor`. Populated once at startup from
+/// `MONITORED_METHODS`. The middleware uses this to instrument matching requests.
+pub static TASK_MONITORS: LazyLock<HashMap<&'static str, TaskMonitor>> = LazyLock::new(|| {
+    MONITORED_METHODS
+        .iter()
+        .map(|&m| (m, TaskMonitor::new()))
+        .collect()
+});
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "rpc_task")]
+struct RpcTaskMetrics {
+    /// Mean time a handler task waits in the scheduler queue before a worker thread picks it up.
+    /// Rising values indicate worker saturation — tasks are ready but no thread is free.
+    #[metrics(unit = Unit::Seconds, labels = ["method"])]
+    mean_scheduled_duration: LabeledFamily<String, Gauge<f64>>,
+    /// Mean handler execution time (time actually spent on-CPU or blocked on RocksDB).
+    /// Together with `mean_scheduled_duration` this decomposes `api_response_time_seconds`
+    /// into queue-wait vs. actual work, pinpointing whether latency comes from starvation
+    /// or from slow handlers.
+    #[metrics(unit = Unit::Seconds, labels = ["method"])]
+    mean_poll_duration: LabeledFamily<String, Gauge<f64>>,
+    /// Number of polls exceeding the 10µs threshold in the last sample interval.
+    #[metrics(labels = ["method"])]
+    slow_polls_count: LabeledFamily<String, Gauge<u64>>,
+}
+
+#[vise::register]
+static RPC_TASK_METRICS: Global<RpcTaskMetrics> = Global::new();
+
+/// Spawns a background task that samples per-handler task metrics once per second.
+///
+/// Must be called from within a Tokio runtime context.
+pub fn spawn_task_monitors() {
+    let mut intervals: Vec<(&'static str, _)> = TASK_MONITORS
+        .iter()
+        .map(|(&method, monitor)| (method, monitor.intervals()))
+        .collect();
+
+    spawn(async move {
+        loop {
+            sleep(Duration::from_secs(1)).await;
+            for (method, iter) in &mut intervals {
+                let metrics = iter.next().expect("infinite iterator");
+                RPC_TASK_METRICS.mean_scheduled_duration[*method]
+                    .set(metrics.mean_scheduled_duration().as_secs_f64());
+                RPC_TASK_METRICS.mean_poll_duration[*method]
+                    .set(metrics.mean_poll_duration().as_secs_f64());
+                RPC_TASK_METRICS.slow_polls_count[*method].set(metrics.total_slow_poll_count);
+            }
+        }
+    });
 }

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -1,6 +1,7 @@
-use crate::metrics::API_METRICS;
+use crate::metrics::{API_METRICS, TASK_MONITORS};
 use crate::result::internal_rpc_err;
 use futures::FutureExt as _;
+use futures::future::Either;
 use jsonrpsee::core::middleware::{Batch, BatchEntry, Notification};
 use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
 use jsonrpsee::types::Request;
@@ -164,7 +165,9 @@ impl RpcServiceT for Monitoring {
         &self,
         request: Request<'a>,
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
-        let method = request.method_name().to_owned();
+        let method_name = request.method_name();
+        let monitor = TASK_MONITORS.get(method_name);
+        let method = method_name.to_owned();
         let request_size = request.params.as_ref().map_or(0, |p| p.get().len());
         let inner = self.inner.clone();
 
@@ -172,6 +175,10 @@ impl RpcServiceT for Monitoring {
             let id = request.id.clone().into_owned();
             let handler = async move { inner.call(request).await };
             let on_panic = || MethodResponse::error(id, internal_rpc_err("Internal error"));
+            let handler = match monitor {
+                Some(m) => Either::Left(m.instrument(handler)),
+                None => Either::Right(handler),
+            };
             CallGuard::new(CallKind::Call, method, request_size)
                 .handle_result(handler, on_panic)
                 .await


### PR DESCRIPTION
## Summary

**Runtime-level metrics (`lib/observability`)**
- Adds `tokio-metrics` integration, sampling runtime state once per second from within the prometheus exporter task
- Exposes worker thread saturation (\`worker_busy_ratio\`), queue depths (\`global_queue_depth\`, \`total_local_queue_depth\`), and blocking pool usage (\`blocking_queue_depth\`, \`blocking_threads_count\`) as Prometheus gauges under the \`tokio_runtime_*\` prefix
- Enables \`tokio_unstable\` in \`.cargo/config.toml\` (required for queue depth and blocking pool metrics) and propagates it to the \`release-bins\` CI workflow where \`RUSTFLAGS\` is set explicitly and would otherwise override the config file

**Per-handler task metrics (`lib/rpc`)**
- Instruments specific RPC handlers with \`TaskMonitor\` (from \`tokio-metrics\`) via the existing monitoring middleware — no per-handler changes needed
- Exposes three Prometheus gauges per monitored method under the \`rpc_task_*\` prefix:
  - \`rpc_task_mean_scheduled_duration_seconds\` — time a handler task waits in the scheduler queue before a worker thread picks it up; rising values indicate worker saturation
  - \`rpc_task_mean_poll_duration_seconds\` — handler execution time (on-CPU or blocked on RocksDB); together with scheduled duration this decomposes \`api_response_time\` into queue-wait vs. actual work
  - \`rpc_task_slow_polls_count\` — number of polls exceeding the 10µs threshold in the last sample interval
- Sampled once per second from a dedicated background task; accumulates all events in the window so intra-second spikes are not missed
- Monitored methods: \`eth_call\`, \`eth_estimateGas\`, \`eth_feeHistory\`, \`eth_getLogs\`, \`eth_sendRawTransaction\`, \`eth_sendRawTransactionSync\`, \`debug_traceCall\`, \`debug_traceTransaction\`, \`debug_traceBlockByHash\`, \`debug_traceBlockByNumber\`

## Motivation

We observed residual \`eth_sendRawTransaction\` latency spikes visible in Traefik but absent from our own \`api_response_time\` metrics. The hypothesis is worker thread starvation: handlers like \`eth_call\` and \`eth_getLogs\` run synchronous RocksDB reads directly on tokio worker threads, blocking those threads without consuming CPU.

The runtime-level metrics confirm or rule out saturation at the global level. The per-handler task metrics pinpoint which specific method is causing it and whether the latency is from queue wait (starvation) or from the handler itself being slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)