### PR TITLE
feat(l1-watcher): adapt upgrade logic to V31 `BytecodeSupplier`

### DIFF
--- a/integration-tests/src/upgrade/builder.rs
+++ b/integration-tests/src/upgrade/builder.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy::sol_types::{SolCall, SolValue};
 use blake2::{Blake2s256, Digest};
 use std::collections::BTreeMap;
@@ -142,9 +142,7 @@ impl ProtocolUpgradeBuilder {
             //        VM uses Blake2s). This is the **lookup key** the
             //        `set_bytecode_on_address` system hook on L2 hands to the
             //        preimage cache, and the corresponding preimage body must be
-            //        exactly the raw bytecode (length = observable len). It is also
-            //        what the upgrade tx's `factory_deps` array carries so the
-            //        server can fetch matching preimages from `BytecodesSupplier`.
+            //        exactly the raw bytecode (length = observable len).
             //
             //   3) `Blake2s256(raw + padding + artifacts)`
             //        Aliases: `account_properties.bytecode_hash`, "padded blake
@@ -186,16 +184,26 @@ impl ProtocolUpgradeBuilder {
             //   - records a *new* preimage of shape B keyed by hash (3),
             //   - writes hash (3) to `account.bytecode_hash`.
             //
-            // So the upgrade tx must carry: hash (2), `bytecodeLength = observable
-            // len`, hash (1) — and the supplier (or test fixture) must register
-            // shape A under hash (2). Anything else either panics on length, fails
-            // the proof-env hash check, or silently writes an unusable account.
+            // So the inner force-deployment payload must carry: hash (2),
+            // `bytecodeLength = observable len`, hash (1) — and the supplier
+            // (or test fixture) must register shape A under hash (2). Anything
+            // else either panics on length, fails the proof-env hash check, or
+            // silently writes an unusable account.
+            //
+            // The `L2CanonicalTransaction.factoryDeps` array is a *separate*
+            // field and carries hash (1), matching `EVMBytecodePublished`'s
+            // topic1 on `BytecodesSupplier`. The server uses these to topic-
+            // filter supplier events in `fetch_force_preimages`, then re-keys
+            // each fetched preimage under hash (2) before insertion. zksync-os
+            // itself parses `factoryDeps` but never resolves it as preimages,
+            // so its semantic is purely server-side.
             //
             // ----- Branch selection below -----
             //
             // `include_factory_deps == true` — production / BytecodesSupplier path.
             //   The server's `fetch_force_preimages` will scan supplier events and
-            //   register shape A under hash (2). Send hash (2) + observable len.
+            //   register shape A under hash (2). Send hash (2) + observable len in
+            //   the inner payload, and hash (1) in the outer `factoryDeps`.
             //
             // `include_factory_deps == false` — legacy path used by v30→v31 tests.
             //   No supplier interaction; instead the test pre-runs `Create` on L2
@@ -243,14 +251,13 @@ impl ProtocolUpgradeBuilder {
             });
 
             if self.include_factory_deps {
-                // `factory_deps` carries the *same* hash the supplier-fed preimage
-                // cache will be keyed by — i.e. hash (2). The server's
-                // `L1UpgradeTxWatcher::fetch_force_preimages` reads this list and
-                // resolves each entry against scanned `EVMBytecodePublished`
-                // events, computing Blake2s on each event payload to match.
-                factory_deps.push(U256::from_be_slice(
-                    deployed_bytecode_info.bytecodeHash.as_ref(),
-                ));
+                // `factory_deps` carries hash (1) — `keccak256(raw_bytecode)`,
+                // which is `EVMBytecodePublished`'s topic1 on `BytecodesSupplier`.
+                // The server's `L1UpgradeTxWatcher::fetch_force_preimages` filters
+                // supplier events by this topic, then re-keys each fetched
+                // preimage under hash (2) (Blake2s) for the L2 lookup above. The
+                // two distinct hashes mirror the production v31 layout.
+                factory_deps.push(U256::from_be_slice(keccak256(&bytecode).as_ref()));
             }
         }
 

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -242,6 +242,11 @@ alloy::sol! {
 
         /// Address of the L1 bytecodes supplier used for upgrades (v31+).
         function L1_BYTECODES_SUPPLIER() external view returns (address);
+
+        /// The block number on the CTM's chain where `setUpgradeDiamondCutInner` ran for the
+        /// given (old) protocol version. Non-zero means this CTM owns the upgrade cut data for
+        /// that version. Populated starting with the V31 ChainTypeManager.
+        function upgradeCutDataBlock(uint256 protocolVersion) external view returns (uint256);
     }
 
     // `IZKChain.sol`
@@ -913,6 +918,17 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("serverNotifierAddress", None)
+    }
+}
+
+/// Returns `true` if the error came from the contract itself (empty return data or a revert),
+/// which is how an EVM reports a call to a function selector that the deployed code does not
+/// implement. Network / transport failures return `false` so they can be propagated.
+pub fn is_method_missing(err: &alloy::contract::Error) -> bool {
+    match err {
+        alloy::contract::Error::ZeroData(..) => true,
+        alloy::contract::Error::TransportError(te) => te.as_error_resp().is_some(),
+        _ => false,
     }
 }
 

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -249,6 +249,23 @@ alloy::sol! {
         function upgradeCutDataBlock(uint256 protocolVersion) external view returns (uint256);
     }
 
+    // `SettlementLayerV31UpgradeBase.sol` — the per-chain upgrade init contract.
+    // `NewUpgradeCutData` carries a placeholder `additionalForceDeploymentsData`
+    // that `upgradeChainFromVersion` rewrites per-chain inside the delegatecall
+    // via `getL2UpgradeTxData(bridgehub, chainId, existingTxData)`. The server
+    // must call this before executing the L2 upgrade tx — otherwise the
+    // placeholder's empty `additionalForceDeploymentsData` would revert inside
+    // `performForceDeployedContractsInit`.
+    #[sol(rpc)]
+    interface ISettlementLayerV31Upgrade {
+        function getL2UpgradeTxData(
+            address _bridgehub,
+            uint256 _chainId,
+            bool _zksyncOS,
+            bytes memory _existingTxData
+        ) external view returns (bytes memory);
+    }
+
     // `IZKChain.sol`
     #[sol(rpc)]
     interface IZKChain {

--- a/lib/contract_interface/src/settlement_layer_intervals.rs
+++ b/lib/contract_interface/src/settlement_layer_intervals.rs
@@ -1,4 +1,4 @@
-use crate::{IChainAssetHandler, ZkChain};
+use crate::{IChainAssetHandler, ZkChain, is_method_missing};
 use alloy::primitives::{Address, U256};
 use alloy::providers::DynProvider;
 use anyhow::Context;
@@ -207,15 +207,4 @@ async fn find_settlement_layer_intervals(
         });
     }
     Ok(intervals)
-}
-
-/// Returns `true` if the error came from the contract itself (empty return data or a revert),
-/// which is how an EVM reports a call to a function selector that the deployed code does not
-/// implement. Network / transport failures return `false` so they can be propagated.
-fn is_method_missing(err: &alloy::contract::Error) -> bool {
-    match err {
-        alloy::contract::Error::ZeroData(..) => true,
-        alloy::contract::Error::TransportError(te) => te.as_error_resp().is_some(),
-        _ => false,
-    }
 }

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -14,6 +14,7 @@ use zksync_os_contract_interface::IBytecodeSupplier::EVMBytecodePublished;
 use zksync_os_contract_interface::IChainAdmin::UpdateUpgradeTimestamp;
 use zksync_os_contract_interface::IChainTypeManager::{NewUpgradeCutData, ProposedUpgrade};
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_contract_interface::is_method_missing;
 use zksync_os_mempool::subpools::upgrade::UpgradeSubpool;
 use zksync_os_types::{
     L1UpgradeEnvelope, ProtocolSemanticVersion, ProtocolSemanticVersionError, UpgradeInfo,
@@ -144,49 +145,8 @@ impl L1UpgradeTxWatcher {
             raw_protocol_version,
         } = request;
 
-        // TODO: for now we assume that upgrades cannot be skipped, e.g.
-        // each chain upgrades before the new upgrade is published.
-        // This is a temporary solution and should be fixed ASAP.
-        let mut current_block = self.provider_sl.get_block_number().await?;
-        let start_block = current_block
-            .saturating_sub(UPGRADE_DATA_LOOKBEHIND_BLOCKS) // Upgrade could've been set a long time ago.
-            .max(1u64);
-
-        // TODO: upgrade data can be much farther in history and we can't easily find a block where it was set,
-        // so we scan linearly (in order to not go over the limit per request) but move backwards since it's
-        // more likely to be recent.
-        let mut upgrade_cut_data_logs = Vec::new();
-        while current_block >= start_block && upgrade_cut_data_logs.is_empty() {
-            let from_block = current_block
-                .saturating_sub(self.max_blocks_to_process - 1)
-                .max(start_block);
-
-            let filter = Filter::new()
-                .from_block(from_block)
-                .to_block(current_block)
-                .address(self.ctm_sl)
-                .event_signature(NewUpgradeCutData::SIGNATURE_HASH)
-                .topic1(*raw_protocol_version);
-            upgrade_cut_data_logs = self.provider_sl.get_logs(&filter).await?;
-            current_block = from_block.saturating_sub(1);
-        }
-
-        if upgrade_cut_data_logs.is_empty() {
-            anyhow::bail!(
-                "no upgrade cut found for the suggested protocol version: {}",
-                protocol_version
-            );
-        }
-        if upgrade_cut_data_logs.len() > 1 {
-            tracing::warn!(
-                %protocol_version,
-                "multiple upgrade cuts found for the suggested protocol version; picking the most recent one"
-            );
-        }
-        // Safe unwrap because of checks above
-        // `last()` because, even though we scan backwards, each scan returns a list of ascending result
-        let upgrade_cut_data = upgrade_cut_data_logs.last().unwrap();
-        let raw_diamond_cut: Log<NewUpgradeCutData> = upgrade_cut_data.log_decode()?;
+        let upgrade_cut_data_log = self.find_upgrade_cut_log(*raw_protocol_version).await?;
+        let raw_diamond_cut: Log<NewUpgradeCutData> = upgrade_cut_data_log.log_decode()?;
         let diamond_cut_data = raw_diamond_cut.inner.data.diamondCutData;
         let proposed_upgrade =
             ProposedUpgrade::abi_decode(&diamond_cut_data.initCalldata[4..]).unwrap(); // TODO: we're in fact parsing `upgrade(..)` signature here
@@ -215,6 +175,78 @@ impl L1UpgradeTxWatcher {
         };
 
         Ok(upgrade_tx)
+    }
+
+    /// Finds the `NewUpgradeCutData` event for `raw_protocol_version`.
+    ///
+    /// Prefers `ChainTypeManagerBase.upgradeCutDataBlock(protocolVersion)` (populated starting
+    /// with V31) on each CTM: a non-zero answer pins the cut to a specific block on that CTM's
+    /// chain, so we can fetch the event with a single `eth_getLogs` call against the right
+    /// settlement layer. For pre-V31 CTMs the mapping is absent, so we fall back to the
+    /// pre-existing backward linear scan on the SL CTM.
+    async fn find_upgrade_cut_log(&self, raw_protocol_version: U256) -> anyhow::Result<Log> {
+        let l1_block =
+            get_upgrade_cut_data_block(&self.provider_l1, self.ctm_l1, raw_protocol_version)
+                .await?;
+        // Avoid a redundant RPC when L1 and SL are the same (chain settling on L1).
+        let sl_block = if self.ctm_l1 == self.ctm_sl {
+            l1_block
+        } else {
+            get_upgrade_cut_data_block(&self.provider_sl, self.ctm_sl, raw_protocol_version).await?
+        };
+
+        let target = match (l1_block, sl_block) {
+            (Some(b), _) if b != 0 => Some((&self.provider_l1, self.ctm_l1, b)),
+            (_, Some(b)) if b != 0 => Some((&self.provider_sl, self.ctm_sl, b)),
+            _ => None,
+        };
+
+        if let Some((provider, ctm_address, block)) = target {
+            return fetch_upgrade_cut_log_at(provider, ctm_address, raw_protocol_version, block)
+                .await;
+        }
+
+        // Neither CTM reports a cut data block; either we're on a pre-V31 CTM without this
+        // mapping, or the upgrade has not yet been registered.
+        self.legacy_backward_scan(raw_protocol_version).await
+    }
+
+    /// Pre-V31 fallback: scan `UPGRADE_DATA_LOOKBEHIND_BLOCKS` worth of `NewUpgradeCutData`
+    /// events backward on the SL CTM. Pre-V31 chains do not have Gateway migrations, so the
+    /// cut always lives on the SL CTM (which equals the L1 CTM in that era).
+    async fn legacy_backward_scan(&self, raw_protocol_version: U256) -> anyhow::Result<Log> {
+        let mut current_block = self.provider_sl.get_block_number().await?;
+        let start_block = current_block
+            .saturating_sub(UPGRADE_DATA_LOOKBEHIND_BLOCKS)
+            .max(1u64);
+
+        let mut upgrade_cut_data_logs = Vec::new();
+        while current_block >= start_block && upgrade_cut_data_logs.is_empty() {
+            let from_block = current_block
+                .saturating_sub(self.max_blocks_to_process - 1)
+                .max(start_block);
+
+            let filter = Filter::new()
+                .from_block(from_block)
+                .to_block(current_block)
+                .address(self.ctm_sl)
+                .event_signature(NewUpgradeCutData::SIGNATURE_HASH)
+                .topic1(raw_protocol_version);
+            upgrade_cut_data_logs = self.provider_sl.get_logs(&filter).await?;
+            current_block = from_block.saturating_sub(1);
+        }
+
+        if upgrade_cut_data_logs.is_empty() {
+            anyhow::bail!("no upgrade cut found for raw protocol version {raw_protocol_version}");
+        }
+        if upgrade_cut_data_logs.len() > 1 {
+            tracing::warn!(
+                %raw_protocol_version,
+                "multiple upgrade cuts found; picking the most recent one"
+            );
+        }
+        // `last()` because each scan batch returns logs in ascending order.
+        Ok(upgrade_cut_data_logs.pop().unwrap())
     }
 
     async fn wait_until_timestamp(&self, target_timestamp: u64) {
@@ -528,6 +560,43 @@ pub enum UpgradeTxWatcherError {
     TimestampExceedsU64(U256),
     #[error("Incorrect protocol version: {0}")]
     IncorrectProtocolVersion(#[from] ProtocolSemanticVersionError),
+}
+
+/// Returns `Some(block)` if the CTM exposes `upgradeCutDataBlock` (V31+), where `block == 0`
+/// means the mapping is empty for that version. Returns `None` if the method is missing on the
+/// deployed CTM (pre-V31).
+async fn get_upgrade_cut_data_block(
+    provider: &DynProvider,
+    ctm_address: Address,
+    raw_protocol_version: U256,
+) -> anyhow::Result<Option<u64>> {
+    let ctm = IChainTypeManagerInstance::new(ctm_address, provider.clone());
+    match ctm.upgradeCutDataBlock(raw_protocol_version).call().await {
+        Ok(n) => Ok(Some(n.saturating_to::<u64>())),
+        Err(e) if is_method_missing(&e) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn fetch_upgrade_cut_log_at(
+    provider: &DynProvider,
+    ctm_address: Address,
+    raw_protocol_version: U256,
+    block: u64,
+) -> anyhow::Result<Log> {
+    let filter = Filter::new()
+        .from_block(block)
+        .to_block(block)
+        .address(ctm_address)
+        .event_signature(NewUpgradeCutData::SIGNATURE_HASH)
+        .topic1(raw_protocol_version);
+    let logs = provider.get_logs(&filter).await?;
+    logs.into_iter().next().ok_or_else(|| {
+        anyhow::anyhow!(
+            "upgradeCutDataBlock({raw_protocol_version}) returned {block} on CTM {ctm_address} \
+             but no NewUpgradeCutData event was found at that block"
+        )
+    })
 }
 
 async fn find_l1_block_by_protocol_version(

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -5,7 +5,7 @@ use crate::util::ANVIL_L1_CHAIN_ID;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::dyn_abi::SolType;
-use alloy::primitives::{Address, B256, BlockNumber, U256};
+use alloy::primitives::{Address, B256, BlockNumber, ChainId, U256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
@@ -13,8 +13,8 @@ use blake2::{Blake2s256, Digest};
 use zksync_os_contract_interface::IBytecodeSupplier::EVMBytecodePublished;
 use zksync_os_contract_interface::IChainAdmin::UpdateUpgradeTimestamp;
 use zksync_os_contract_interface::IChainTypeManager::{NewUpgradeCutData, ProposedUpgrade};
-use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::is_method_missing;
+use zksync_os_contract_interface::{Bridgehub, ZkChain};
 use zksync_os_mempool::subpools::upgrade::UpgradeSubpool;
 use zksync_os_types::{
     L1UpgradeEnvelope, ProtocolSemanticVersion, ProtocolSemanticVersionError, UpgradeInfo,
@@ -22,6 +22,7 @@ use zksync_os_types::{
 };
 
 use zksync_os_contract_interface::IChainTypeManager::IChainTypeManagerInstance;
+use zksync_os_contract_interface::ISettlementLayerV31Upgrade::ISettlementLayerV31UpgradeInstance;
 
 /// Limit the number of L1 blocks to scan when looking for the set timestamp transaction.
 const INITIAL_LOOKBEHIND_BLOCKS: u64 = 100_000;
@@ -43,8 +44,10 @@ const UPGRADE_DATA_LOOKBEHIND_BLOCKS: u64 = 2_500_000;
 pub struct L1UpgradeTxWatcher {
     admin_contract_l1: Address,
 
+    l2_chain_id: ChainId,
     provider_l1: DynProvider,
     provider_sl: DynProvider,
+    bridgehub_l1: Address,
     /// Address of the bytecode supplier contract on L1 (used to scan EVMBytecodePublished events)
     bytecode_supplier_address: Address,
     /// Address of the CTM contract on L1 (used to resolve the canonical bytecode supplier)
@@ -59,8 +62,11 @@ pub struct L1UpgradeTxWatcher {
 }
 
 impl L1UpgradeTxWatcher {
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_watcher(
         config: L1WatcherConfig,
+        l2_chain_id: ChainId,
+        bridgehub_l1: Bridgehub<DynProvider>,
         zk_chain_l1: ZkChain<DynProvider>,
         zk_chain_sl: ZkChain<DynProvider>,
         bytecode_supplier_address: Address,
@@ -115,8 +121,10 @@ impl L1UpgradeTxWatcher {
 
         let this = Self {
             admin_contract_l1: admin_l1,
+            l2_chain_id,
             provider_l1: zk_chain_l1.provider().clone(),
             provider_sl: zk_chain_sl.provider().clone(),
+            bridgehub_l1: *bridgehub_l1.address(),
             bytecode_supplier_address,
             ctm_l1,
             ctm_sl,
@@ -148,13 +156,66 @@ impl L1UpgradeTxWatcher {
         let upgrade_cut_data_log = self.find_upgrade_cut_log(*raw_protocol_version).await?;
         let raw_diamond_cut: Log<NewUpgradeCutData> = upgrade_cut_data_log.log_decode()?;
         let diamond_cut_data = raw_diamond_cut.inner.data.diamondCutData;
-        let proposed_upgrade =
+        let mut proposed_upgrade =
             ProposedUpgrade::abi_decode(&diamond_cut_data.initCalldata[4..]).unwrap(); // TODO: we're in fact parsing `upgrade(..)` signature here
 
         let patch_only = protocol_version.minor == self.current_protocol_version.minor;
         let (l2_upgrade_tx, force_preimages) = if patch_only {
             (None, Vec::new())
         } else {
+            // `NewUpgradeCutData` carries a placeholder `additionalForceDeploymentsData`
+            // (`""`) that `upgradeChainFromVersion` rewrites per-chain when the
+            // diamond-cut init runs on L1 — see
+            // `SettlementLayerV31UpgradeBase.upgrade()` which replaces
+            // `l2ProtocolUpgradeTx.data` via `getL2UpgradeTxData(bridgehub, chainId, existingTxData)`.
+            // Call that same function off-chain so the tx we inject into the
+            // mempool matches what L1 actually wrote into the priority queue.
+            //
+            // Route through the upgrade facet's deployed address, which is
+            // `diamond_cut_data.initAddress`. Only "method missing" reverts (pre-v31
+            // init contracts that don't expose this function) fall back to the
+            // original tx data; any other error — RPC failure, decode error, or a
+            // genuine revert like `UnexpectedZKsyncOSFlag` / `UnexpectedUpgradeSelector`
+            // — is propagated, because silently using the placeholder would inject
+            // a tx whose hash diverges from what L1 wrote into the priority queue.
+            let upgrade_init_address = diamond_cut_data.initAddress;
+            let original_tx_data = proposed_upgrade.l2ProtocolUpgradeTx.data.clone();
+            match ISettlementLayerV31UpgradeInstance::new(
+                upgrade_init_address,
+                self.provider_l1.clone(),
+            )
+            .getL2UpgradeTxData(
+                self.bridgehub_l1,
+                U256::from(self.l2_chain_id),
+                true,
+                original_tx_data,
+            )
+            .call()
+            .await
+            {
+                Ok(rewritten) => {
+                    tracing::info!(
+                        init_address = ?upgrade_init_address,
+                        bridgehub = ?self.bridgehub_l1,
+                        l2_chain_id = self.l2_chain_id,
+                        rewritten_len = rewritten.len(),
+                        "rewrote L2 upgrade tx data via getL2UpgradeTxData"
+                    );
+                    proposed_upgrade.l2ProtocolUpgradeTx.data = rewritten;
+                }
+                Err(e) if is_method_missing(&e) => {
+                    tracing::info!(
+                        init_address = ?upgrade_init_address,
+                        "init contract does not expose getL2UpgradeTxData (pre-v31); using original tx data"
+                    );
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::new(e).context(format!(
+                        "getL2UpgradeTxData call failed at init address {upgrade_init_address}"
+                    )));
+                }
+            }
+
             let tx = L1UpgradeEnvelope::try_from(proposed_upgrade.l2ProtocolUpgradeTx).unwrap();
             let force_preimages = self.fetch_force_preimages(&tx.inner.factory_deps).await?;
 
@@ -294,8 +355,7 @@ impl L1UpgradeTxWatcher {
     ///    set_bytecode_on_address.rs:178` → `account_cache.rs:933`), with
     ///    `expected_preimage_len_in_bytes = observable_len`. The corresponding
     ///    preimage body the cache must return is exactly the raw bytes (length =
-    ///    observable len). This is also what each entry in `factory_deps` of the
-    ///    upgrade tx must equal so that we can fetch the matching preimage here.
+    ///    observable len).
     ///
     /// 3. **`Blake2s256(raw + padding + artifacts)`** — the "padded blake hash",
     ///    a.k.a. `account_properties.bytecode_hash`. This is what `set_properties_code`
@@ -327,107 +387,144 @@ impl L1UpgradeTxWatcher {
     /// That's a deliberate design choice — it keeps `BytecodesSupplier` publication
     /// cost proportional to the raw bytecode length, and removes any cross-node
     /// disagreement risk on artifact format.
-    ///
-    /// # Why we scan instead of filtering
-    ///
-    /// `EVMBytecodePublished` is indexed by hash (1) (`keccak256`), not hash (2)
-    /// (`Blake2s256`). Our `factory_deps` carries hash (2). We can't translate
-    /// between them without the bytecode itself, so we have to scan all events in
-    /// range and recompute Blake2s on each payload. If the supplier ever gains a
-    /// second event indexed by hash (2), this can become a topic-filtered lookup.
     async fn fetch_force_preimages(&self, hashes: &[B256]) -> anyhow::Result<Vec<(B256, Vec<u8>)>> {
         if hashes.is_empty() {
             return Ok(Vec::new());
         }
 
         let active_supplier = self.resolve_active_bytecode_supplier().await?;
+        let tip = self.provider_l1.get_block_number().await?;
+        let start_block = tip.saturating_sub(UPGRADE_DATA_LOOKBEHIND_BLOCKS).max(1u64);
+        tracing::info!(
+            supplier = ?active_supplier,
+            num_requested = hashes.len(),
+            tip_block = tip,
+            start_block,
+            "fetch_force_preimages: starting scan"
+        );
+        for (i, h) in hashes.iter().enumerate() {
+            tracing::debug!(idx = i, hash = ?h, "fetch_force_preimages: requested keccak");
+        }
 
-        let mut current_block = self.provider_l1.get_block_number().await?;
-        let start_block = current_block
-            .saturating_sub(UPGRADE_DATA_LOOKBEHIND_BLOCKS)
-            .max(1u64);
+        let requested_keccak: Vec<B256> = hashes.to_vec();
+        let requested_set: std::collections::HashSet<B256> =
+            requested_keccak.iter().copied().collect();
+        let mut by_keccak: HashMap<B256, Vec<u8>> = HashMap::new();
 
-        // `requested` and the `factory_deps` slice both contain hash (2) values —
-        // the Blake2s-of-raw lookup keys the system hook will use on L2.
-        let requested: std::collections::HashSet<B256> = hashes.iter().copied().collect();
-        let mut by_hash: HashMap<B256, Vec<u8>> = HashMap::new();
-
+        // First pass: filter by topic1 for efficiency. This is the fast path
+        // when the contracts side publishes bytecodes and emits events with
+        // keccak256 as topic1 (which `BytecodesSupplier` does).
+        let mut current_block = tip;
         while current_block >= start_block {
             let from_block = current_block
                 .saturating_sub(self.max_blocks_to_process - 1)
                 .max(start_block);
-            // The `EVMBytecodePublished` event is indexed by hash (1) (keccak256
-            // of the raw bytes), which is **not** the hash we're filtering by, so
-            // we don't add a topic1 filter — we'd have to translate from hash (2)
-            // to hash (1) which requires the bytecode itself. Instead we pull all
-            // events in the range and discard non-matches inside the loop.
             let filter = Filter::new()
                 .from_block(from_block)
                 .to_block(current_block)
                 .address(active_supplier)
-                .event_signature(EVMBytecodePublished::SIGNATURE_HASH);
+                .event_signature(EVMBytecodePublished::SIGNATURE_HASH)
+                .topic1(requested_keccak.clone());
             let logs = self.provider_l1.get_logs(&filter).await?;
+            tracing::info!(
+                from_block,
+                to_block = current_block,
+                log_count = logs.len(),
+                "fetch_force_preimages: topic1-filtered query"
+            );
 
             for log in logs {
                 let published = EVMBytecodePublished::decode_log(&log.inner)?.data;
-                let raw_bytecode = published.bytecode.to_vec();
-
-                // Compute hash (2) from the event payload so we can match against
-                // `requested`. We deliberately do NOT use `set_properties_code`
-                // here — that would produce hash (3), which would silently fail to
-                // match anything in `factory_deps` (or, worse, match it via a
-                // misconfigured upgrade tx and then panic the VM on length).
-                let zkos_hash = B256::from_slice(Blake2s256::digest(&raw_bytecode).as_slice());
-
-                // Drop events that publish bytecodes the upgrade tx doesn't ask for.
-                if !requested.contains(&zkos_hash) {
+                let keccak_hash = B256::from(published.bytecodeHash);
+                if !requested_set.contains(&keccak_hash) {
                     continue;
                 }
-
-                if let Some(existing) = by_hash.get(&zkos_hash) {
-                    if existing != &raw_bytecode {
-                        // Two different payloads producing the same Blake2s would
-                        // be a Blake2s collision (or a bug in the supplier). The
-                        // first occurrence wins so we stay deterministic.
-                        tracing::warn!(
-                            hash = ?zkos_hash,
-                            "bytecode supplier emitted duplicate hash with different data; keeping first occurrence"
-                        );
-                    }
-                } else {
-                    // Insert the **raw** bytecode (shape A — length = observable
-                    // len). The system hook will derive the padded shape B
-                    // internally and key it by hash (3) on the account.
-                    by_hash.insert(zkos_hash, raw_bytecode);
-                }
+                let raw_bytecode = published.bytecode.to_vec();
+                by_keccak.entry(keccak_hash).or_insert(raw_bytecode);
             }
 
-            // Stop early once all requested hashes are found.
-            if by_hash.len() == requested.len() {
+            if by_keccak.len() == requested_set.len() {
+                break;
+            }
+            if from_block == start_block {
                 break;
             }
             current_block = from_block.saturating_sub(1);
         }
 
-        // Verify all requested hashes were found.
+        // Diagnostic fallback: if the topic1-filtered scan missed anything, do
+        // an un-filtered scan over the same window and report what's on the
+        // supplier. That'll distinguish "bytecode not published" (supplier has
+        // no event for that hash) from "querying the wrong supplier" (event
+        // is on a different address) from "topic-filter bug" (event is on
+        // this supplier but topic1 doesn't match).
+        if by_keccak.len() != requested_set.len() {
+            tracing::warn!(
+                found = by_keccak.len(),
+                requested = requested_set.len(),
+                "fetch_force_preimages: topic1-filtered scan incomplete, running diagnostic unfiltered scan"
+            );
+            let mut current_block = tip;
+            let mut events_seen = 0usize;
+            while current_block >= start_block {
+                let from_block = current_block
+                    .saturating_sub(self.max_blocks_to_process - 1)
+                    .max(start_block);
+                let filter = Filter::new()
+                    .from_block(from_block)
+                    .to_block(current_block)
+                    .address(active_supplier)
+                    .event_signature(EVMBytecodePublished::SIGNATURE_HASH);
+                let logs = self.provider_l1.get_logs(&filter).await?;
+                for log in logs {
+                    let published = EVMBytecodePublished::decode_log(&log.inner)?.data;
+                    let keccak_hash = B256::from(published.bytecodeHash);
+                    let matches = requested_set.contains(&keccak_hash);
+                    tracing::info!(
+                        hash = ?keccak_hash,
+                        bytecode_len = published.bytecode.len(),
+                        in_requested = matches,
+                        l1_block = log.block_number,
+                        "fetch_force_preimages: [diag] supplier event seen"
+                    );
+                    events_seen += 1;
+                }
+                if from_block == start_block {
+                    break;
+                }
+                current_block = from_block.saturating_sub(1);
+            }
+            tracing::warn!(
+                events_seen,
+                "fetch_force_preimages: [diag] unfiltered scan complete"
+            );
+        }
+
         let missing: Vec<_> = hashes
             .iter()
-            .filter(|h| !by_hash.contains_key(*h))
+            .filter(|h| !by_keccak.contains_key(*h))
             .collect();
         anyhow::ensure!(
             missing.is_empty(),
-            "missing {} factory dep preimage(s) from bytecode supplier: {:?}",
+            "missing {} factory dep preimage(s) from bytecode supplier {:?}: {:?}",
             missing.len(),
+            active_supplier,
             missing
         );
 
+        let mut preimages: Vec<(B256, Vec<u8>)> = Vec::with_capacity(by_keccak.len());
+        for (_, raw_bytecode) in by_keccak {
+            let blake_hash = B256::from_slice(Blake2s256::digest(&raw_bytecode).as_slice());
+            preimages.push((blake_hash, raw_bytecode));
+        }
+
         tracing::info!(
             supplier = ?active_supplier,
-            num_preimages = by_hash.len(),
+            num_preimages = preimages.len(),
             "fetched force deployment preimages from bytecode supplier"
         );
 
-        Ok(by_hash.into_iter().collect())
+        Ok(preimages)
     }
 
     /// Queries the CTM on L1 for the canonical `BytecodesSupplier` address.

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -750,6 +750,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         "l1 upgrade transaction watcher",
         L1UpgradeTxWatcher::create_watcher(
             config.l1_watcher_config.clone().into(),
+            chain_id,
+            node_startup_state.l1_state.bridgehub_l1.clone(),
             node_startup_state.l1_state.diamond_proxy_l1.clone(),
             node_startup_state.l1_state.diamond_proxy_sl.clone(),
             bytecode_supplier_address,


### PR DESCRIPTION
## Summary

Two bug-fix-shaped commits that together make the L1 upgrade watcher work end-to-end against v31 settlement-layer contracts.

* Pre-V31, the watcher located `NewUpgradeCutData` by scanning `UPGRADE_DATA_LOOKBEHIND_BLOCKS` (~2.5M blocks) backwards on the SL CTM — slow and wrong once a chain migrates between settlement layers. V31 CTMs now expose                                 
  `upgradeCutDataBlock(protocolVersion)` which pins the cut to a specific block on whichever CTM owns it.
* `NewUpgradeCutData` carries a placeholder `additionalForceDeploymentsData` (`""`) that `SettlementLayerV31UpgradeBase.upgrade()` rewrites per-chain inside the diamond-cut `delegatecall`. Without mirroring this rewrite off-chain, the L2 upgrade tx the 
  server injects has a different hash from what L1 wrote into the priority queue, and the on-chain `performForceDeployedContractsInit` reverts on the empty placeholder.

Second part is taken from https://github.com/matter-labs/zksync-os-server/pull/1186 but in a slightly adapted form

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

