### PR TITLE
fix: GatewayMigrationWatcher init

### DIFF
--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -40,7 +40,7 @@ impl GatewayMigrationWatcher {
         l2_chain_id: ChainId,
         l1_chain_id: ChainId,
         gw_chain_id: ChainId,
-        current_migration_number: u64,
+        next_migration_number: u64,
         config: L1WatcherConfig,
         sl_chain_id_subpool: SlChainIdSubpool,
     ) -> anyhow::Result<L1Watcher> {
@@ -52,7 +52,7 @@ impl GatewayMigrationWatcher {
             zk_chain.clone(),
             chain_asset_handler_address,
             l2_chain_id,
-            current_migration_number,
+            next_migration_number,
         )
         .await
         .or_else(|err| {
@@ -156,20 +156,20 @@ impl ProcessRawEvents for GatewayMigrationWatcher {
     }
 }
 
-/// Finds the first L1 block where `migrationNumber(_chainId) >= migration_number` on the
+/// Finds the first L1 block where `migrationNumber(_chainId) + 1 >= migration_number` on the
 /// `IChainAssetHandler` contract, using binary search. This is used to determine the starting
 /// L1 block for the gateway migration watcher.
 async fn find_l1_block_by_migration_number(
     zk_chain: ZkChain<DynProvider>,
     chain_asset_handler: Address,
     chain_id: u64,
-    migration_number: u64,
+    next_migration_number: u64,
 ) -> anyhow::Result<BlockNumber> {
     let instance = Arc::new(IChainAssetHandler::new(
         chain_asset_handler,
         zk_chain.provider().clone(),
     ));
-    let target = U256::from(migration_number);
+    let target = U256::from(next_migration_number);
 
     util::find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| {
         let instance = instance.clone();
@@ -187,7 +187,7 @@ async fn find_l1_block_by_migration_number(
                 .block(block.into())
                 .call()
                 .await?;
-            Ok(res >= target)
+            Ok(res + U256::ONE >= target)
         }
     })
     .await


### PR DESCRIPTION
## Summary

We pass next migration number to `GatewayMigrationWatcher::create_watcher` while we assumed it's not next but current. Locally it wasn't caught because `or_else` handles `find_l1_block_by_migration_number` errors for local L1.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

