### PR TITLE
refactor(rpc): offload blocking RPC handlers to the blocking thread pool

### DIFF
--- a/lib/rpc/src/debug_impl.rs
+++ b/lib/rpc/src/debug_impl.rs
@@ -9,7 +9,6 @@ use alloy::rpc::types::trace::geth::{
     GethDebugTracingOptions, GethTrace, TraceResult,
 };
 use alloy::rpc::types::{Bundle, StateContext, TransactionRequest};
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use std::ops::Range;
 use zksync_os_rpc_api::debug::DebugApiServer;
@@ -194,29 +193,28 @@ impl<RpcStorage: ReadRpcStorage> DebugNamespace<RpcStorage> {
     }
 }
 
-#[async_trait]
 impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
-    async fn raw_header(&self, _block_id: BlockId) -> RpcResult<Bytes> {
+    fn raw_header(&self, _block_id: BlockId) -> RpcResult<Bytes> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn raw_block(&self, _block_id: BlockId) -> RpcResult<Bytes> {
+    fn raw_block(&self, _block_id: BlockId) -> RpcResult<Bytes> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn raw_transaction(&self, _hash: TxHash) -> RpcResult<Option<Bytes>> {
+    fn raw_transaction(&self, _hash: TxHash) -> RpcResult<Option<Bytes>> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn raw_transactions(&self, _block_id: BlockId) -> RpcResult<Vec<Bytes>> {
+    fn raw_transactions(&self, _block_id: BlockId) -> RpcResult<Vec<Bytes>> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn raw_receipts(&self, _block_id: BlockId) -> RpcResult<Vec<Bytes>> {
+    fn raw_receipts(&self, _block_id: BlockId) -> RpcResult<Vec<Bytes>> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn debug_trace_block(
+    fn debug_trace_block(
         &self,
         _rlp_block: Bytes,
         _opts: Option<GethDebugTracingOptions>,
@@ -224,7 +222,7 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn debug_trace_block_by_hash(
+    fn debug_trace_block_by_hash(
         &self,
         block: BlockHash,
         opts: Option<GethDebugTracingOptions>,
@@ -233,7 +231,7 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    async fn debug_trace_block_by_number(
+    fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
@@ -242,7 +240,7 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    async fn debug_trace_transaction(
+    fn debug_trace_transaction(
         &self,
         tx_hash: TxHash,
         opts: Option<GethDebugTracingOptions>,
@@ -251,7 +249,7 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    async fn debug_trace_call(
+    fn debug_trace_call(
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
@@ -261,7 +259,7 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    async fn debug_trace_call_many(
+    fn debug_trace_call_many(
         &self,
         _bundles: Vec<Bundle>,
         _state_context: Option<StateContext>,
@@ -270,11 +268,11 @@ impl<RpcStorage: ReadRpcStorage> DebugApiServer for DebugNamespace<RpcStorage> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn debug_chain_config(&self) -> RpcResult<ChainConfig> {
+    fn debug_chain_config(&self) -> RpcResult<ChainConfig> {
         Err(unimplemented_rpc_err())
     }
 
-    async fn debug_code_by_hash(
+    fn debug_code_by_hash(
         &self,
         _hash: B256,
         _block_id: Option<BlockId>,

--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -201,10 +201,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterApiServer
         self.install_filter(transaction_kind)
     }
 
-    fn filter_changes(
-        &self,
-        id: FilterId,
-    ) -> RpcResult<FilterChanges<Transaction<L2Envelope>>> {
+    fn filter_changes(&self, id: FilterId) -> RpcResult<FilterChanges<Transaction<L2Envelope>>> {
         self.filter_changes_impl(id).to_rpc_result()
     }
 

--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -173,15 +173,15 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
 impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterApiServer
     for EthFilterNamespace<RpcStorage, Mempool>
 {
-    async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId> {
+    fn new_filter(&self, filter: Filter) -> RpcResult<FilterId> {
         self.install_filter(FilterKind::Log(Box::new(filter)))
     }
 
-    async fn new_block_filter(&self) -> RpcResult<FilterId> {
+    fn new_block_filter(&self) -> RpcResult<FilterId> {
         self.install_filter(FilterKind::Block)
     }
 
-    async fn new_pending_transaction_filter(
+    fn new_pending_transaction_filter(
         &self,
         kind: Option<PendingTransactionFilterKind>,
     ) -> RpcResult<FilterId> {
@@ -210,16 +210,16 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterApiServer
         self.filter_changes_impl(id).await.to_rpc_result()
     }
 
-    async fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>> {
+    fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>> {
         self.filter_logs_impl(id).to_rpc_result()
     }
 
-    async fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool> {
+    fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool> {
         Ok(self.registry.uninstall(&id))
     }
 
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
-        Ok(self.logs_impl(filter).to_rpc_result()?)
+    fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
+        self.logs_impl(filter).to_rpc_result()
     }
 }
 

--- a/lib/rpc/src/eth_filter/mod.rs
+++ b/lib/rpc/src/eth_filter/mod.rs
@@ -13,7 +13,6 @@ use alloy::rpc::types::{
     Filter, FilterBlockOption, FilterChanges, FilterId, Log, PendingTransactionFilterKind,
     Transaction,
 };
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use scan::scan_logs;
 use zksync_os_mempool::subpools::l2::L2Subpool;
@@ -49,7 +48,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
         Ok(self.registry.install(kind, latest_block))
     }
 
-    async fn filter_changes_impl(
+    fn filter_changes_impl(
         &self,
         id: FilterId,
     ) -> EthFilterResult<FilterChanges<Transaction<L2Envelope>>> {
@@ -63,7 +62,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
         };
 
         match kind {
-            FilterKind::PendingTransaction(filter) => Ok(filter.drain().await),
+            FilterKind::PendingTransaction(filter) => Ok(filter.drain()),
             FilterKind::Block => {
                 let mut block_hashes = Vec::new();
                 for block_number in start_block..=latest_block {
@@ -169,7 +168,6 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterNamespace<RpcStora
     }
 }
 
-#[async_trait]
 impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterApiServer
     for EthFilterNamespace<RpcStorage, Mempool>
 {
@@ -203,11 +201,11 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthFilterApiServer
         self.install_filter(transaction_kind)
     }
 
-    async fn filter_changes(
+    fn filter_changes(
         &self,
         id: FilterId,
     ) -> RpcResult<FilterChanges<Transaction<L2Envelope>>> {
-        self.filter_changes_impl(id).await.to_rpc_result()
+        self.filter_changes_impl(id).to_rpc_result()
     }
 
     fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>> {

--- a/lib/rpc/src/eth_filter/pending.rs
+++ b/lib/rpc/src/eth_filter/pending.rs
@@ -42,7 +42,10 @@ impl PendingTransactionsReceiver {
     /// Returns all new pending transactions received since the last poll.
     fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
         let mut pending_txs = Vec::new();
-        let mut prepared_stream = self.receiver.lock().expect("pending tx receiver lock poisoned");
+        let mut prepared_stream = self
+            .receiver
+            .lock()
+            .expect("pending tx receiver lock poisoned");
 
         while let Ok(tx_hash) = prepared_stream.try_recv() {
             pending_txs.push(tx_hash);

--- a/lib/rpc/src/eth_filter/pending.rs
+++ b/lib/rpc/src/eth_filter/pending.rs
@@ -1,8 +1,8 @@
 use alloy::consensus::transaction::{Recovered, TransactionInfo};
 use alloy::primitives::TxHash;
 use alloy::rpc::types::{FilterChanges, Transaction};
-use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
 use zksync_os_mempool::{L2PooledTransaction, NewSubpoolTransactionStream};
 use zksync_os_types::L2Envelope;
 
@@ -18,10 +18,10 @@ pub(crate) enum PendingTransactionKind {
 }
 
 impl PendingTransactionKind {
-    pub(crate) async fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
+    pub(crate) fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
         match self {
-            Self::Hashes(receiver) => receiver.drain().await,
-            Self::FullTransaction(receiver) => receiver.drain().await,
+            Self::Hashes(receiver) => receiver.drain(),
+            Self::FullTransaction(receiver) => receiver.drain(),
         }
     }
 }
@@ -40,9 +40,9 @@ impl PendingTransactionsReceiver {
     }
 
     /// Returns all new pending transactions received since the last poll.
-    async fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
+    fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
         let mut pending_txs = Vec::new();
-        let mut prepared_stream = self.receiver.lock().await;
+        let mut prepared_stream = self.receiver.lock().expect("pending tx receiver lock poisoned");
 
         while let Ok(tx_hash) = prepared_stream.try_recv() {
             pending_txs.push(tx_hash);
@@ -66,9 +66,12 @@ impl FullTransactionsReceiver {
     }
 
     /// Returns all new pending transactions received since the last poll.
-    async fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
+    fn drain(&self) -> FilterChanges<Transaction<L2Envelope>> {
         let mut pending_txs = Vec::new();
-        let mut prepared_stream = self.txs_stream.lock().await;
+        let mut prepared_stream = self
+            .txs_stream
+            .lock()
+            .expect("full tx stream lock poisoned");
 
         while let Ok(tx) = prepared_stream.try_recv() {
             let (tx, signer) = tx.transaction.to_consensus().into_parts();

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -496,7 +496,7 @@ mod tests {
 impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
     for EthNamespace<RpcStorage, Mempool>
 {
-    async fn protocol_version(&self) -> RpcResult<String> {
+    fn protocol_version(&self) -> RpcResult<String> {
         Ok("zksync_os/0.0.1".to_string())
     }
 
@@ -506,7 +506,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Ok(SyncStatus::None)
     }
 
-    async fn author(&self) -> RpcResult<Address> {
+    fn author(&self) -> RpcResult<Address> {
         // Author aka coinbase aka etherbase is the account where mining profits are credited to.
         // As ZKsync OS is not PoW we do not implement this method.
         Err(unimplemented_rpc_err())
@@ -522,16 +522,16 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.block_number_impl().to_rpc_result()
     }
 
-    async fn chain_id(&self) -> RpcResult<Option<U64>> {
+    fn chain_id(&self) -> RpcResult<Option<U64>> {
         Ok(Some(U64::from(self.chain_id)))
     }
 
-    async fn block_by_hash(&self, hash: B256, full: bool) -> RpcResult<Option<ZkApiBlock>> {
+    fn block_by_hash(&self, hash: B256, full: bool) -> RpcResult<Option<ZkApiBlock>> {
         self.block_by_id_impl(Some(hash.into()), full)
             .to_rpc_result()
     }
 
-    async fn block_by_number(
+    fn block_by_number(
         &self,
         number: BlockNumberOrTag,
         full: bool,
@@ -540,12 +540,12 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>> {
+    fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>> {
         self.block_transaction_count_by_id_impl(hash.into())
             .to_rpc_result()
     }
 
-    async fn block_transaction_count_by_number(
+    fn block_transaction_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
@@ -553,12 +553,12 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn block_uncles_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>> {
+    fn block_uncles_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>> {
         self.block_uncles_count_by_id_impl(hash.into())
             .to_rpc_result()
     }
 
-    async fn block_uncles_count_by_number(
+    fn block_uncles_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
@@ -566,14 +566,11 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn block_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> RpcResult<Option<Vec<ZkTransactionReceipt>>> {
+    fn block_receipts(&self, block_id: BlockId) -> RpcResult<Option<Vec<ZkTransactionReceipt>>> {
         self.block_receipts_impl(block_id).to_rpc_result()
     }
 
-    async fn uncle_by_block_hash_and_index(
+    fn uncle_by_block_hash_and_index(
         &self,
         _hash: B256,
         _index: Index,
@@ -582,7 +579,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Ok(None)
     }
 
-    async fn uncle_by_block_number_and_index(
+    fn uncle_by_block_number_and_index(
         &self,
         _number: BlockNumberOrTag,
         _index: Index,
@@ -591,15 +588,15 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Ok(None)
     }
 
-    async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>> {
+    fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>> {
         self.raw_transaction_by_hash_impl(hash).to_rpc_result()
     }
 
-    async fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<ZkApiTransaction>> {
+    fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<ZkApiTransaction>> {
         self.transaction_by_hash_impl(hash).to_rpc_result()
     }
 
-    async fn raw_transaction_by_block_hash_and_index(
+    fn raw_transaction_by_block_hash_and_index(
         &self,
         hash: B256,
         index: Index,
@@ -608,7 +605,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn transaction_by_block_hash_and_index(
+    fn transaction_by_block_hash_and_index(
         &self,
         hash: B256,
         index: Index,
@@ -617,7 +614,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn raw_transaction_by_block_number_and_index(
+    fn raw_transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
         index: Index,
@@ -626,7 +623,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn transaction_by_block_number_and_index(
+    fn transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
         index: Index,
@@ -635,7 +632,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn transaction_by_sender_and_nonce(
+    fn transaction_by_sender_and_nonce(
         &self,
         address: Address,
         nonce: U64,
@@ -644,15 +641,15 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<ZkTransactionReceipt>> {
+    fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<ZkTransactionReceipt>> {
         self.transaction_receipt_impl(hash).to_rpc_result()
     }
 
-    async fn balance(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256> {
+    fn balance(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256> {
         self.balance_impl(address, block_id).to_rpc_result()
     }
 
-    async fn storage_at(
+    fn storage_at(
         &self,
         address: Address,
         key: JsonStorageKey,
@@ -661,7 +658,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.storage_at_impl(address, key, block_id).to_rpc_result()
     }
 
-    async fn transaction_count(
+    fn transaction_count(
         &self,
         address: Address,
         block_id: Option<BlockId>,
@@ -670,11 +667,11 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes> {
+    fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes> {
         self.get_code_impl(address, block_id).to_rpc_result()
     }
 
-    async fn header_by_number(
+    fn header_by_number(
         &self,
         block_number: BlockNumberOrTag,
     ) -> RpcResult<Option<ZkHeader>> {
@@ -684,14 +681,14 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .map(|block| block.header))
     }
 
-    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<ZkHeader>> {
+    fn header_by_hash(&self, hash: B256) -> RpcResult<Option<ZkHeader>> {
         Ok(self
             .block_by_id_impl(Some(hash.into()), false)
             .to_rpc_result()?
             .map(|block| block.header))
     }
 
-    async fn simulate_v1(
+    fn simulate_v1(
         &self,
         _opts: SimulatePayload,
         _block_number: Option<BlockId>,
@@ -700,7 +697,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Err(unimplemented_rpc_err())
     }
 
-    async fn call(
+    fn call(
         &self,
         request: TransactionRequest,
         block_number: Option<BlockId>,
@@ -712,7 +709,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn call_many(
+    fn call_many(
         &self,
         _bundles: Vec<Bundle>,
         _state_context: Option<StateContext>,
@@ -722,7 +719,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Err(unimplemented_rpc_err())
     }
 
-    async fn create_access_list(
+    fn create_access_list(
         &self,
         _request: TransactionRequest,
         _block_number: Option<BlockId>,
@@ -732,7 +729,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Err(unimplemented_rpc_err())
     }
 
-    async fn estimate_gas(
+    fn estimate_gas(
         &self,
         request: TransactionRequest,
         block_number: Option<BlockId>,
@@ -743,11 +740,11 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn gas_price(&self) -> RpcResult<U256> {
+    fn gas_price(&self) -> RpcResult<U256> {
         self.gas_price_impl().to_rpc_result()
     }
 
-    async fn get_account(
+    fn get_account(
         &self,
         _address: Address,
         _block: BlockId,
@@ -756,16 +753,16 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         Err(unimplemented_rpc_err())
     }
 
-    async fn max_priority_fee_per_gas(&self) -> RpcResult<U256> {
+    fn max_priority_fee_per_gas(&self) -> RpcResult<U256> {
         Ok(U256::from(0))
     }
 
-    async fn blob_base_fee(&self) -> RpcResult<U256> {
+    fn blob_base_fee(&self) -> RpcResult<U256> {
         // todo(EIP-4844)
         Err(unimplemented_rpc_err())
     }
 
-    async fn fee_history(
+    fn fee_history(
         &self,
         block_count: U64,
         newest_block: BlockNumberOrTag,
@@ -775,7 +772,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn send_transaction(&self, _request: TransactionRequest) -> RpcResult<B256> {
+    fn send_transaction(&self, _request: TransactionRequest) -> RpcResult<B256> {
         Err(internal_rpc_err("node has no signer accounts"))
     }
 
@@ -805,19 +802,19 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    async fn sign(&self, _address: Address, _message: Bytes) -> RpcResult<Bytes> {
+    fn sign(&self, _address: Address, _message: Bytes) -> RpcResult<Bytes> {
         Err(internal_rpc_err("node has no signer accounts"))
     }
 
-    async fn sign_transaction(&self, _transaction: TransactionRequest) -> RpcResult<Bytes> {
+    fn sign_transaction(&self, _transaction: TransactionRequest) -> RpcResult<Bytes> {
         Err(internal_rpc_err("node has no signer accounts"))
     }
 
-    async fn sign_typed_data(&self, _address: Address, _data: TypedData) -> RpcResult<Bytes> {
+    fn sign_typed_data(&self, _address: Address, _data: TypedData) -> RpcResult<Bytes> {
         Err(internal_rpc_err("node has no signer accounts"))
     }
 
-    async fn get_proof(
+    fn get_proof(
         &self,
         _address: Address,
         _keys: Vec<JsonStorageKey>,
@@ -828,7 +825,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         ))
     }
 
-    async fn get_account_info(&self, _address: Address, _block: BlockId) -> RpcResult<AccountInfo> {
+    fn get_account_info(&self, _address: Address, _block: BlockId) -> RpcResult<AccountInfo> {
         // todo(#36): implement
         Err(unimplemented_rpc_err())
     }

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -558,10 +558,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
             .to_rpc_result()
     }
 
-    fn block_uncles_count_by_number(
-        &self,
-        number: BlockNumberOrTag,
-    ) -> RpcResult<Option<U256>> {
+    fn block_uncles_count_by_number(&self, number: BlockNumberOrTag) -> RpcResult<Option<U256>> {
         self.block_uncles_count_by_id_impl(number.into())
             .to_rpc_result()
     }
@@ -658,11 +655,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.storage_at_impl(address, key, block_id).to_rpc_result()
     }
 
-    fn transaction_count(
-        &self,
-        address: Address,
-        block_id: Option<BlockId>,
-    ) -> RpcResult<U256> {
+    fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256> {
         self.transaction_count_impl(address, block_id)
             .to_rpc_result()
     }
@@ -671,10 +664,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.get_code_impl(address, block_id).to_rpc_result()
     }
 
-    fn header_by_number(
-        &self,
-        block_number: BlockNumberOrTag,
-    ) -> RpcResult<Option<ZkHeader>> {
+    fn header_by_number(&self, block_number: BlockNumberOrTag) -> RpcResult<Option<ZkHeader>> {
         Ok(self
             .block_by_id_impl(Some(block_number.into()), false)
             .to_rpc_result()?
@@ -744,11 +734,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
         self.gas_price_impl().to_rpc_result()
     }
 
-    fn get_account(
-        &self,
-        _address: Address,
-        _block: BlockId,
-    ) -> RpcResult<Option<TrieAccount>> {
+    fn get_account(&self, _address: Address, _block: BlockId) -> RpcResult<Option<TrieAccount>> {
         // todo(#36): implement
         Err(unimplemented_rpc_err())
     }

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     wait_for_db: impl Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
     tracing::info!("Starting JSON-RPC server at {}", config.address);
-    metrics::spawn_task_monitors();
+    metrics::spawn_task_monitor();
 
     let mut rpc = RpcModule::new(());
     let eth_call_handler = EthCallHandler::new(

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,5 +1,4 @@
 use alloy::rpc::types::Filter;
-use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::spawn;
@@ -174,71 +173,49 @@ pub enum TxRejectionReason {
     PoolOther,
 }
 
-/// RPC methods to instrument with per-handler task metrics.
-/// Add any method suspected of blocking worker threads.
-const MONITORED_METHODS: &[&str] = &[
-    "eth_call",
-    "eth_estimateGas",
-    "eth_feeHistory",
-    "eth_getLogs",
-    "eth_sendRawTransaction",
-    "eth_sendRawTransactionSync",
-    "debug_traceCall",
-    "debug_traceTransaction",
-    "debug_traceBlockByHash",
-    "debug_traceBlockByNumber",
-];
-
-/// Map from RPC method name to its `TaskMonitor`. Populated once at startup from
-/// `MONITORED_METHODS`. The middleware uses this to instrument matching requests.
-pub static TASK_MONITORS: LazyLock<HashMap<&'static str, TaskMonitor>> = LazyLock::new(|| {
-    MONITORED_METHODS
-        .iter()
-        .map(|&m| (m, TaskMonitor::new()))
-        .collect()
-});
+/// Single task monitor covering all RPC request futures.
+/// Tracks worker-thread scheduling lag and poll behaviour across the entire RPC surface,
+/// giving a global health signal for the tokio worker pool.
+pub static RPC_TASK_MONITOR: LazyLock<TaskMonitor> = LazyLock::new(TaskMonitor::new);
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "rpc_task")]
 struct RpcTaskMetrics {
     /// Mean time a handler task waits in the scheduler queue before a worker thread picks it up.
     /// Rising values indicate worker saturation — tasks are ready but no thread is free.
-    #[metrics(unit = Unit::Seconds, labels = ["method"])]
-    mean_scheduled_duration: LabeledFamily<String, Gauge<f64>>,
-    /// Mean handler execution time (time actually spent on-CPU or blocked on RocksDB).
+    #[metrics(unit = Unit::Seconds)]
+    mean_scheduled_duration: Gauge<f64>,
+    /// Mean handler execution time (time actually spent on-CPU or blocked on I/O).
     /// Together with `mean_scheduled_duration` this decomposes `api_response_time_seconds`
-    /// into queue-wait vs. actual work, pinpointing whether latency comes from starvation
-    /// or from slow handlers.
-    #[metrics(unit = Unit::Seconds, labels = ["method"])]
-    mean_poll_duration: LabeledFamily<String, Gauge<f64>>,
+    /// into queue-wait vs. actual work.
+    #[metrics(unit = Unit::Seconds)]
+    mean_poll_duration: Gauge<f64>,
     /// Number of polls exceeding the 10µs threshold in the last sample interval.
-    #[metrics(labels = ["method"])]
-    slow_polls_count: LabeledFamily<String, Gauge<u64>>,
+    slow_polls_count: Gauge<u64>,
 }
 
 #[vise::register]
 static RPC_TASK_METRICS: Global<RpcTaskMetrics> = Global::new();
 
-/// Spawns a background task that samples per-handler task metrics once per second.
+/// Spawns a background task that samples global RPC task metrics once per second.
 ///
 /// Must be called from within a Tokio runtime context.
-pub fn spawn_task_monitors() {
-    let mut intervals: Vec<(&'static str, _)> = TASK_MONITORS
-        .iter()
-        .map(|(&method, monitor)| (method, monitor.intervals()))
-        .collect();
+pub fn spawn_task_monitor() {
+    let mut intervals = RPC_TASK_MONITOR.intervals();
 
     spawn(async move {
         loop {
             sleep(Duration::from_secs(1)).await;
-            for (method, iter) in &mut intervals {
-                let metrics = iter.next().expect("infinite iterator");
-                RPC_TASK_METRICS.mean_scheduled_duration[*method]
-                    .set(metrics.mean_scheduled_duration().as_secs_f64());
-                RPC_TASK_METRICS.mean_poll_duration[*method]
-                    .set(metrics.mean_poll_duration().as_secs_f64());
-                RPC_TASK_METRICS.slow_polls_count[*method].set(metrics.total_slow_poll_count);
-            }
+            let metrics = intervals.next().expect("infinite iterator");
+            RPC_TASK_METRICS
+                .mean_scheduled_duration
+                .set(metrics.mean_scheduled_duration().as_secs_f64());
+            RPC_TASK_METRICS
+                .mean_poll_duration
+                .set(metrics.mean_poll_duration().as_secs_f64());
+            RPC_TASK_METRICS
+                .slow_polls_count
+                .set(metrics.total_slow_poll_count);
         }
     });
 }

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -1,7 +1,6 @@
-use crate::metrics::{API_METRICS, TASK_MONITORS};
+use crate::metrics::{API_METRICS, RPC_TASK_MONITOR};
 use crate::result::internal_rpc_err;
 use futures::FutureExt as _;
-use futures::future::Either;
 use jsonrpsee::core::middleware::{Batch, BatchEntry, Notification};
 use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
 use jsonrpsee::types::Request;
@@ -165,20 +164,14 @@ impl RpcServiceT for Monitoring {
         &self,
         request: Request<'a>,
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
-        let method_name = request.method_name();
-        let monitor = TASK_MONITORS.get(method_name);
-        let method = method_name.to_owned();
+        let method = request.method_name().to_owned();
         let request_size = request.params.as_ref().map_or(0, |p| p.get().len());
         let inner = self.inner.clone();
 
         async move {
             let id = request.id.clone().into_owned();
-            let handler = async move { inner.call(request).await };
+            let handler = RPC_TASK_MONITOR.instrument(async move { inner.call(request).await });
             let on_panic = || MethodResponse::error(id, internal_rpc_err("Internal error"));
-            let handler = match monitor {
-                Some(m) => Either::Left(m.instrument(handler)),
-                None => Either::Right(handler),
-            };
             CallGuard::new(CallKind::Call, method, request_size)
                 .handle_result(handler, on_panic)
                 .await

--- a/lib/rpc/src/net_impl.rs
+++ b/lib/rpc/src/net_impl.rs
@@ -1,5 +1,4 @@
 use alloy::primitives::U64;
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use zksync_os_rpc_api::net::NetApiServer;
 
@@ -13,9 +12,8 @@ impl NetNamespace {
     }
 }
 
-#[async_trait]
 impl NetApiServer for NetNamespace {
-    async fn version(&self) -> RpcResult<Option<U64>> {
+    fn version(&self) -> RpcResult<Option<U64>> {
         Ok(Some(U64::from(self.chain_id)))
     }
 }

--- a/lib/rpc/src/ots_impl.rs
+++ b/lib/rpc/src/ots_impl.rs
@@ -11,7 +11,6 @@ use alloy::rpc::types::trace::otterscan::{
     OtsSlimBlock, OtsTransactionReceipt, TraceEntry, TransactionsWithReceipts,
 };
 use alloy::rpc::types::{Header, Log};
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use zksync_os_rpc_api::ots::OtsApiServer;
 use zksync_os_rpc_api::types::{L2ToL1Log, RpcBlockConvert, ZkApiTransaction};
@@ -297,16 +296,15 @@ impl<RpcStorage: ReadRpcStorage> OtsNamespace<RpcStorage> {
     }
 }
 
-#[async_trait]
 impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
-    async fn get_header_by_number(
+    fn get_header_by_number(
         &self,
         block_number: LenientBlockNumberOrTag,
     ) -> RpcResult<Option<Header>> {
         self.get_header_by_number_impl(block_number).to_rpc_result()
     }
 
-    async fn has_code(
+    fn has_code(
         &self,
         address: Address,
         block_id: Option<LenientBlockNumberOrTag>,
@@ -314,26 +312,26 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
         self.has_code_impl(address, block_id).to_rpc_result()
     }
 
-    async fn get_api_level(&self) -> RpcResult<u64> {
+    fn get_api_level(&self) -> RpcResult<u64> {
         Ok(API_LEVEL)
     }
 
-    async fn get_internal_operations(&self, _tx_hash: TxHash) -> RpcResult<Vec<InternalOperation>> {
+    fn get_internal_operations(&self, _tx_hash: TxHash) -> RpcResult<Vec<InternalOperation>> {
         // todo(tracing)
         Ok(vec![])
     }
 
-    async fn get_transaction_error(&self, _tx_hash: TxHash) -> RpcResult<Option<Bytes>> {
+    fn get_transaction_error(&self, _tx_hash: TxHash) -> RpcResult<Option<Bytes>> {
         // todo: consider saving tx's output or replaying the block here
         Ok(None)
     }
 
-    async fn trace_transaction(&self, _tx_hash: TxHash) -> RpcResult<Option<Vec<TraceEntry>>> {
+    fn trace_transaction(&self, _tx_hash: TxHash) -> RpcResult<Option<Vec<TraceEntry>>> {
         // todo(tracing)
         Ok(Some(vec![]))
     }
 
-    async fn get_block_details(
+    fn get_block_details(
         &self,
         block_number: LenientBlockNumberOrTag,
     ) -> RpcResult<BlockDetails> {
@@ -341,12 +339,12 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
             .to_rpc_result()
     }
 
-    async fn get_block_details_by_hash(&self, block_hash: BlockHash) -> RpcResult<BlockDetails> {
+    fn get_block_details_by_hash(&self, block_hash: BlockHash) -> RpcResult<BlockDetails> {
         self.get_block_details_by_id_impl(block_hash.into())
             .to_rpc_result()
     }
 
-    async fn get_block_transactions(
+    fn get_block_transactions(
         &self,
         block_number: LenientBlockNumberOrTag,
         page_number: usize,
@@ -356,7 +354,7 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
             .to_rpc_result()
     }
 
-    async fn search_transactions_before(
+    fn search_transactions_before(
         &self,
         address: Address,
         block_number: LenientBlockNumberOrTag,
@@ -366,7 +364,7 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
             .to_rpc_result()
     }
 
-    async fn search_transactions_after(
+    fn search_transactions_after(
         &self,
         address: Address,
         block_number: LenientBlockNumberOrTag,
@@ -376,7 +374,7 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
             .to_rpc_result()
     }
 
-    async fn get_transaction_by_sender_and_nonce(
+    fn get_transaction_by_sender_and_nonce(
         &self,
         sender: Address,
         nonce: u64,
@@ -385,7 +383,7 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
             .to_rpc_result()
     }
 
-    async fn get_contract_creator(&self, address: Address) -> RpcResult<Option<ContractCreator>> {
+    fn get_contract_creator(&self, address: Address) -> RpcResult<Option<ContractCreator>> {
         self.get_contract_creator_impl(address).to_rpc_result()
     }
 }

--- a/lib/rpc/src/ots_impl.rs
+++ b/lib/rpc/src/ots_impl.rs
@@ -331,10 +331,7 @@ impl<Repository: ReadRpcStorage> OtsApiServer for OtsNamespace<Repository> {
         Ok(Some(vec![]))
     }
 
-    fn get_block_details(
-        &self,
-        block_number: LenientBlockNumberOrTag,
-    ) -> RpcResult<BlockDetails> {
+    fn get_block_details(&self, block_number: LenientBlockNumberOrTag) -> RpcResult<BlockDetails> {
         self.get_block_details_by_id_impl(block_number.into())
             .to_rpc_result()
     }

--- a/lib/rpc/src/txpool_impl.rs
+++ b/lib/rpc/src/txpool_impl.rs
@@ -1,7 +1,6 @@
 use crate::eth_impl::build_api_tx;
 use alloy::primitives::Address;
 use alloy::rpc::types::txpool::{TxpoolContent, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus};
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -42,9 +41,8 @@ fn insert_by_sender<T>(
         .insert(pool_tx.nonce().to_string(), value);
 }
 
-#[async_trait]
 impl<Mempool: L2Subpool> TxpoolApiServer for TxpoolNamespace<Mempool> {
-    async fn inspect(&self) -> RpcResult<TxpoolInspect> {
+    fn inspect(&self) -> RpcResult<TxpoolInspect> {
         let mut result = TxpoolInspect::default();
         let all = self.mempool.all_transactions();
         for pool_tx in &all.pending {
@@ -56,7 +54,7 @@ impl<Mempool: L2Subpool> TxpoolApiServer for TxpoolNamespace<Mempool> {
         Ok(result)
     }
 
-    async fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>> {
+    fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>> {
         let mut result: TxpoolContent<ZkApiTransaction> = TxpoolContent::default();
         let all = self.mempool.all_transactions();
         for pool_tx in &all.pending {
@@ -68,7 +66,7 @@ impl<Mempool: L2Subpool> TxpoolApiServer for TxpoolNamespace<Mempool> {
         Ok(result)
     }
 
-    async fn status(&self) -> RpcResult<TxpoolStatus> {
+    fn status(&self) -> RpcResult<TxpoolStatus> {
         let (pending, queued) = self.mempool.pending_and_queued_txn_count();
         Ok(TxpoolStatus {
             pending: pending as u64,

--- a/lib/rpc/src/unstable_impl.rs
+++ b/lib/rpc/src/unstable_impl.rs
@@ -1,7 +1,6 @@
 use crate::ReadRpcStorage;
 use crate::result::ToRpcResult;
 use alloy::primitives::{B256, BlockNumber, TxHash};
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use zksync_os_mini_merkle_tree::MiniMerkleTree;
 use zksync_os_rpc_api::unstable::UnstableApiServer;
@@ -61,14 +60,13 @@ impl<RpcStorage: ReadRpcStorage> UnstableNamespace<RpcStorage> {
     }
 }
 
-#[async_trait]
 impl<RpcStorage: ReadRpcStorage> UnstableApiServer for UnstableNamespace<RpcStorage> {
-    async fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<PersistedBatch> {
+    fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<PersistedBatch> {
         self.get_batch_by_block_number_impl(block_number)
             .to_rpc_result()
     }
 
-    async fn get_local_root(&self, batch_number: u64) -> RpcResult<B256> {
+    fn get_local_root(&self, batch_number: u64) -> RpcResult<B256> {
         self.get_local_root_impl(batch_number).to_rpc_result()
     }
 }

--- a/lib/rpc/src/web3_impl.rs
+++ b/lib/rpc/src/web3_impl.rs
@@ -1,5 +1,4 @@
 use alloy::primitives::{B256, Bytes, keccak256};
-use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use zksync_os_metadata::NODE_CLIENT_VERSION;
 use zksync_os_rpc_api::web3::Web3ApiServer;
@@ -7,9 +6,8 @@ use zksync_os_rpc_api::web3::Web3ApiServer;
 #[derive(Default)]
 pub struct Web3Namespace;
 
-#[async_trait]
 impl Web3ApiServer for Web3Namespace {
-    async fn client_version(&self) -> RpcResult<String> {
+    fn client_version(&self) -> RpcResult<String> {
         Ok(NODE_CLIENT_VERSION.to_string())
     }
 

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -446,10 +446,7 @@ impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    fn get_block_metadata_by_number(
-        &self,
-        block_number: u64,
-    ) -> RpcResult<Option<BlockMetadata>> {
+    fn get_block_metadata_by_number(&self, block_number: u64) -> RpcResult<Option<BlockMetadata>> {
         self.get_block_metadata_by_number_impl(block_number)
             .to_rpc_result()
     }

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -287,7 +287,7 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
         }))
     }
 
-    async fn get_block_metadata_by_number_impl(
+    fn get_block_metadata_by_number_impl(
         &self,
         block_number: u64,
     ) -> ZksResult<Option<BlockMetadata>> {
@@ -309,7 +309,7 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
         }))
     }
 
-    async fn get_proof_impl(
+    fn get_proof_impl(
         &self,
         address: Address,
         keys: &[B256],
@@ -419,11 +419,11 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
 
 #[async_trait]
 impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
-    async fn get_bridgehub_contract(&self) -> RpcResult<Address> {
+    fn get_bridgehub_contract(&self) -> RpcResult<Address> {
         Ok(self.bridgehub_address)
     }
 
-    async fn get_bytecode_supplier_contract(&self) -> RpcResult<Address> {
+    fn get_bytecode_supplier_contract(&self) -> RpcResult<Address> {
         Ok(self.bytecode_supplier_address)
     }
 
@@ -446,23 +446,21 @@ impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
             .to_rpc_result()
     }
 
-    async fn get_block_metadata_by_number(
+    fn get_block_metadata_by_number(
         &self,
         block_number: u64,
     ) -> RpcResult<Option<BlockMetadata>> {
         self.get_block_metadata_by_number_impl(block_number)
-            .await
             .to_rpc_result()
     }
 
-    async fn get_proof(
+    fn get_proof(
         &self,
         account: Address,
         keys: Vec<B256>,
         batch_number: u64,
     ) -> RpcResult<Option<BatchStorageProof>> {
         self.get_proof_impl(account, &keys, batch_number)
-            .await
             .to_rpc_result()
     }
 }

--- a/lib/rpc_api/src/debug.rs
+++ b/lib/rpc_api/src/debug.rs
@@ -53,7 +53,7 @@ pub trait DebugApi {
     /// Similar to `debug_traceBlock`, `debug_traceBlockByHash` accepts a block hash and will replay
     /// the block that is already present in the database. For the second parameter see
     /// [`GethDebugTracingOptions`].
-    #[method(name = "traceBlockByHash")]
+    #[method(name = "traceBlockByHash", blocking)]
     fn debug_trace_block_by_hash(
         &self,
         block: BlockHash,
@@ -63,7 +63,7 @@ pub trait DebugApi {
     /// Similar to `debug_traceBlockByHash`, `debug_traceBlockByNumber` accepts a block number
     /// [`BlockNumberOrTag`] and will replay the block that is already present in the database.
     /// For the second parameter see [`GethDebugTracingOptions`].
-    #[method(name = "traceBlockByNumber")]
+    #[method(name = "traceBlockByNumber", blocking)]
     fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
@@ -74,7 +74,7 @@ pub trait DebugApi {
     /// exact same manner as it was executed on the network. It will replay any transaction that
     /// may have been executed prior to this one before it will finally attempt to execute the
     /// transaction that corresponds to the given hash.
-    #[method(name = "traceTransaction")]
+    #[method(name = "traceTransaction", blocking)]
     fn debug_trace_transaction(
         &self,
         tx_hash: TxHash,
@@ -90,7 +90,7 @@ pub trait DebugApi {
     /// The trace can be configured similar to `debug_traceTransaction`,
     /// see [`GethDebugTracingOptions`]. The method returns the same output as
     /// `debug_traceTransaction`.
-    #[method(name = "traceCall")]
+    #[method(name = "traceCall", blocking)]
     fn debug_trace_call(
         &self,
         request: TransactionRequest,

--- a/lib/rpc_api/src/debug.rs
+++ b/lib/rpc_api/src/debug.rs
@@ -128,9 +128,6 @@ pub trait DebugApi {
     /// Returns the code associated with a given hash at the specified block ID.
     /// If no block ID is provided, it defaults to the latest block.
     #[method(name = "codeByHash")]
-    fn debug_code_by_hash(
-        &self,
-        hash: B256,
-        block_id: Option<BlockId>,
-    ) -> RpcResult<Option<Bytes>>;
+    fn debug_code_by_hash(&self, hash: B256, block_id: Option<BlockId>)
+    -> RpcResult<Option<Bytes>>;
 }

--- a/lib/rpc_api/src/debug.rs
+++ b/lib/rpc_api/src/debug.rs
@@ -16,25 +16,25 @@ use jsonrpsee::proc_macros::rpc;
 pub trait DebugApi {
     /// Returns an RLP-encoded header.
     #[method(name = "getRawHeader")]
-    async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes>;
+    fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns an RLP-encoded block.
     #[method(name = "getRawBlock")]
-    async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
+    fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns a EIP-2718 binary-encoded transaction.
     ///
     /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[method(name = "getRawTransaction")]
-    async fn raw_transaction(&self, hash: TxHash) -> RpcResult<Option<Bytes>>;
+    fn raw_transaction(&self, hash: TxHash) -> RpcResult<Option<Bytes>>;
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [`BlockId`].
     #[method(name = "getRawTransactions")]
-    async fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
+    fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
 
     /// Returns an array of EIP-2718 binary-encoded receipts.
     #[method(name = "getRawReceipts")]
-    async fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
+    fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
 
     /// The `debug_traceBlock` method will return a full stack trace of all invoked opcodes of all
     /// transaction that were included in this block.
@@ -44,7 +44,7 @@ pub trait DebugApi {
     /// Note, the parent of this block must be present, or it will fail. For the second parameter
     /// see [`GethDebugTracingOptions`] reference.
     #[method(name = "traceBlock")]
-    async fn debug_trace_block(
+    fn debug_trace_block(
         &self,
         rlp_block: Bytes,
         opts: Option<GethDebugTracingOptions>,
@@ -54,7 +54,7 @@ pub trait DebugApi {
     /// the block that is already present in the database. For the second parameter see
     /// [`GethDebugTracingOptions`].
     #[method(name = "traceBlockByHash")]
-    async fn debug_trace_block_by_hash(
+    fn debug_trace_block_by_hash(
         &self,
         block: BlockHash,
         opts: Option<GethDebugTracingOptions>,
@@ -64,7 +64,7 @@ pub trait DebugApi {
     /// [`BlockNumberOrTag`] and will replay the block that is already present in the database.
     /// For the second parameter see [`GethDebugTracingOptions`].
     #[method(name = "traceBlockByNumber")]
-    async fn debug_trace_block_by_number(
+    fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
@@ -75,7 +75,7 @@ pub trait DebugApi {
     /// may have been executed prior to this one before it will finally attempt to execute the
     /// transaction that corresponds to the given hash.
     #[method(name = "traceTransaction")]
-    async fn debug_trace_transaction(
+    fn debug_trace_transaction(
         &self,
         tx_hash: TxHash,
         opts: Option<GethDebugTracingOptions>,
@@ -91,7 +91,7 @@ pub trait DebugApi {
     /// see [`GethDebugTracingOptions`]. The method returns the same output as
     /// `debug_traceTransaction`.
     #[method(name = "traceCall")]
-    async fn debug_trace_call(
+    fn debug_trace_call(
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
@@ -114,7 +114,7 @@ pub trait DebugApi {
     /// Where the length of the outer list is the number of bundles and the length of the inner list
     /// (`Vec<GethTrace>`) is the number of transactions in the bundle.
     #[method(name = "traceCallMany")]
-    async fn debug_trace_call_many(
+    fn debug_trace_call_many(
         &self,
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
@@ -123,12 +123,12 @@ pub trait DebugApi {
 
     /// Returns the current chain config.
     #[method(name = "chainConfig")]
-    async fn debug_chain_config(&self) -> RpcResult<ChainConfig>;
+    fn debug_chain_config(&self) -> RpcResult<ChainConfig>;
 
     /// Returns the code associated with a given hash at the specified block ID.
     /// If no block ID is provided, it defaults to the latest block.
     #[method(name = "codeByHash")]
-    async fn debug_code_by_hash(
+    fn debug_code_by_hash(
         &self,
         hash: B256,
         block_id: Option<BlockId>,

--- a/lib/rpc_api/src/eth.rs
+++ b/lib/rpc_api/src/eth.rs
@@ -79,7 +79,7 @@ pub trait EthApi {
     ) -> RpcResult<Option<U256>>;
 
     /// Returns all transaction receipts for a given block.
-    #[method(name = "getBlockReceipts")]
+    #[method(name = "getBlockReceipts", blocking)]
     fn block_receipts(&self, block_id: BlockId) -> RpcResult<Option<Vec<ZkTransactionReceipt>>>;
 
     /// Returns an uncle block of the given block and index.
@@ -196,7 +196,7 @@ pub trait EthApi {
     ) -> RpcResult<Vec<SimulatedBlock>>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
-    #[method(name = "call")]
+    #[method(name = "call", blocking)]
     fn call(
         &self,
         request: TransactionRequest,
@@ -239,7 +239,7 @@ pub trait EthApi {
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
-    #[method(name = "estimateGas")]
+    #[method(name = "estimateGas", blocking)]
     fn estimate_gas(
         &self,
         request: TransactionRequest,
@@ -272,7 +272,7 @@ pub trait EthApi {
     /// can be a subsection of the requested range if not all blocks are available.
     ///
     /// The L2 pubdata price history is also included in the response.
-    #[method(name = "feeHistory")]
+    #[method(name = "feeHistory", blocking)]
     fn fee_history(
         &self,
         block_count: U64,

--- a/lib/rpc_api/src/eth.rs
+++ b/lib/rpc_api/src/eth.rs
@@ -22,7 +22,7 @@ use jsonrpsee::proc_macros::rpc;
 pub trait EthApi {
     /// Returns the protocol version encoded as a string.
     #[method(name = "protocolVersion")]
-    async fn protocol_version(&self) -> RpcResult<String>;
+    fn protocol_version(&self) -> RpcResult<String>;
 
     /// Returns an object with data about the sync status or false.
     #[method(name = "syncing")]
@@ -30,7 +30,7 @@ pub trait EthApi {
 
     /// Returns the client coinbase address.
     #[method(name = "coinbase")]
-    async fn author(&self) -> RpcResult<Address>;
+    fn author(&self) -> RpcResult<Address>;
 
     /// Returns a list of addresses owned by client.
     #[method(name = "accounts")]
@@ -42,15 +42,15 @@ pub trait EthApi {
 
     /// Returns the chain ID of the current network.
     #[method(name = "chainId")]
-    async fn chain_id(&self) -> RpcResult<Option<U64>>;
+    fn chain_id(&self) -> RpcResult<Option<U64>>;
 
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]
-    async fn block_by_hash(&self, hash: B256, full: bool) -> RpcResult<Option<ZkApiBlock>>;
+    fn block_by_hash(&self, hash: B256, full: bool) -> RpcResult<Option<ZkApiBlock>>;
 
     /// Returns information about a block by number.
     #[method(name = "getBlockByNumber")]
-    async fn block_by_number(
+    fn block_by_number(
         &self,
         number: BlockNumberOrTag,
         full: bool,
@@ -58,36 +58,33 @@ pub trait EthApi {
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
     #[method(name = "getBlockTransactionCountByHash")]
-    async fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
+    fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
 
     /// Returns the number of transactions in a block matching the given block number.
     #[method(name = "getBlockTransactionCountByNumber")]
-    async fn block_transaction_count_by_number(
+    fn block_transaction_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>>;
 
     /// Returns the number of uncles in a block from a block matching the given block hash.
     #[method(name = "getUncleCountByBlockHash")]
-    async fn block_uncles_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
+    fn block_uncles_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
 
     /// Returns the number of uncles in a block with given block number.
     #[method(name = "getUncleCountByBlockNumber")]
-    async fn block_uncles_count_by_number(
+    fn block_uncles_count_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>>;
 
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts")]
-    async fn block_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> RpcResult<Option<Vec<ZkTransactionReceipt>>>;
+    fn block_receipts(&self, block_id: BlockId) -> RpcResult<Option<Vec<ZkTransactionReceipt>>>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockHashAndIndex")]
-    async fn uncle_by_block_hash_and_index(
+    fn uncle_by_block_hash_and_index(
         &self,
         hash: B256,
         index: Index,
@@ -95,7 +92,7 @@ pub trait EthApi {
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockNumberAndIndex")]
-    async fn uncle_by_block_number_and_index(
+    fn uncle_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
         index: Index,
@@ -105,15 +102,15 @@ pub trait EthApi {
     ///
     /// If this is a EIP-4844 transaction that is in the pool it will include the sidecar.
     #[method(name = "getRawTransactionByHash")]
-    async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>>;
+    fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>>;
 
     /// Returns the information about a transaction requested by transaction hash.
     #[method(name = "getTransactionByHash")]
-    async fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<ZkApiTransaction>>;
+    fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<ZkApiTransaction>>;
 
     /// Returns information about a raw transaction by block hash and transaction index position.
     #[method(name = "getRawTransactionByBlockHashAndIndex")]
-    async fn raw_transaction_by_block_hash_and_index(
+    fn raw_transaction_by_block_hash_and_index(
         &self,
         hash: B256,
         index: Index,
@@ -121,7 +118,7 @@ pub trait EthApi {
 
     /// Returns information about a transaction by block hash and transaction index position.
     #[method(name = "getTransactionByBlockHashAndIndex")]
-    async fn transaction_by_block_hash_and_index(
+    fn transaction_by_block_hash_and_index(
         &self,
         hash: B256,
         index: Index,
@@ -130,7 +127,7 @@ pub trait EthApi {
     /// Returns information about a raw transaction by block number and transaction index
     /// position.
     #[method(name = "getRawTransactionByBlockNumberAndIndex")]
-    async fn raw_transaction_by_block_number_and_index(
+    fn raw_transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
         index: Index,
@@ -138,7 +135,7 @@ pub trait EthApi {
 
     /// Returns information about a transaction by block number and transaction index position.
     #[method(name = "getTransactionByBlockNumberAndIndex")]
-    async fn transaction_by_block_number_and_index(
+    fn transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
         index: Index,
@@ -146,7 +143,7 @@ pub trait EthApi {
 
     /// Returns information about a transaction by sender and nonce.
     #[method(name = "getTransactionBySenderAndNonce")]
-    async fn transaction_by_sender_and_nonce(
+    fn transaction_by_sender_and_nonce(
         &self,
         address: Address,
         nonce: U64,
@@ -154,15 +151,15 @@ pub trait EthApi {
 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
-    async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<ZkTransactionReceipt>>;
+    fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<ZkTransactionReceipt>>;
 
     /// Returns the balance of the account of given address.
     #[method(name = "getBalance")]
-    async fn balance(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256>;
+    fn balance(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns the value from a storage position at a given address
     #[method(name = "getStorageAt")]
-    async fn storage_at(
+    fn storage_at(
         &self,
         address: Address,
         key: JsonStorageKey,
@@ -171,7 +168,7 @@ pub trait EthApi {
 
     /// Returns the number of transactions sent from an address at given block number.
     #[method(name = "getTransactionCount")]
-    async fn transaction_count(
+    fn transaction_count(
         &self,
         address: Address,
         block_id: Option<BlockId>,
@@ -179,21 +176,20 @@ pub trait EthApi {
 
     /// Returns code at a given address at given block number.
     #[method(name = "getCode")]
-    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes>;
+    fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes>;
 
     /// Returns the block's header at given number.
     #[method(name = "getHeaderByNumber")]
-    async fn header_by_number(&self, block_number: BlockNumberOrTag)
-    -> RpcResult<Option<ZkHeader>>;
+    fn header_by_number(&self, block_number: BlockNumberOrTag) -> RpcResult<Option<ZkHeader>>;
 
     /// Returns the block's header at given hash.
     #[method(name = "getHeaderByHash")]
-    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<ZkHeader>>;
+    fn header_by_hash(&self, hash: B256) -> RpcResult<Option<ZkHeader>>;
 
     /// `eth_simulateV1` executes an arbitrary number of transactions on top of the requested state.
     /// The transactions are packed into individual blocks. Overrides can be provided.
     #[method(name = "simulateV1")]
-    async fn simulate_v1(
+    fn simulate_v1(
         &self,
         opts: SimulatePayload,
         block_number: Option<BlockId>,
@@ -201,7 +197,7 @@ pub trait EthApi {
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
     #[method(name = "call")]
-    async fn call(
+    fn call(
         &self,
         request: TransactionRequest,
         block_number: Option<BlockId>,
@@ -212,7 +208,7 @@ pub trait EthApi {
     /// Simulate arbitrary number of transactions at an arbitrary blockchain index, with the
     /// optionality of state overrides
     #[method(name = "callMany")]
-    async fn call_many(
+    fn call_many(
         &self,
         bundles: Vec<Bundle>,
         state_context: Option<StateContext>,
@@ -234,7 +230,7 @@ pub trait EthApi {
     /// not necessary result in lower gas usage compared to a transaction without an access
     /// list.
     #[method(name = "createAccessList")]
-    async fn create_access_list(
+    fn create_access_list(
         &self,
         request: TransactionRequest,
         block_number: Option<BlockId>,
@@ -244,7 +240,7 @@ pub trait EthApi {
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
     #[method(name = "estimateGas")]
-    async fn estimate_gas(
+    fn estimate_gas(
         &self,
         request: TransactionRequest,
         block_number: Option<BlockId>,
@@ -253,20 +249,19 @@ pub trait EthApi {
 
     /// Returns the current price per gas in wei.
     #[method(name = "gasPrice")]
-    async fn gas_price(&self) -> RpcResult<U256>;
+    fn gas_price(&self) -> RpcResult<U256>;
 
     /// Returns the account details by specifying an address and a block number/tag
     #[method(name = "getAccount")]
-    async fn get_account(&self, address: Address, block: BlockId)
-    -> RpcResult<Option<TrieAccount>>;
+    fn get_account(&self, address: Address, block: BlockId) -> RpcResult<Option<TrieAccount>>;
 
     /// Introduced in EIP-1559, returns suggestion for the priority for dynamic fee transactions.
     #[method(name = "maxPriorityFeePerGas")]
-    async fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
+    fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 
     /// Introduced in EIP-4844, returns the current blob base fee in wei.
     #[method(name = "blobBaseFee")]
-    async fn blob_base_fee(&self) -> RpcResult<U256>;
+    fn blob_base_fee(&self) -> RpcResult<U256>;
 
     /// Returns the Transaction fee history
     ///
@@ -278,7 +273,7 @@ pub trait EthApi {
     ///
     /// The L2 pubdata price history is also included in the response.
     #[method(name = "feeHistory")]
-    async fn fee_history(
+    fn fee_history(
         &self,
         block_count: U64,
         newest_block: BlockNumberOrTag,
@@ -288,7 +283,7 @@ pub trait EthApi {
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
     #[method(name = "sendTransaction")]
-    async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<B256>;
+    fn send_transaction(&self, request: TransactionRequest) -> RpcResult<B256>;
 
     /// Sends signed transaction, returning its hash.
     #[method(name = "sendRawTransaction")]
@@ -305,21 +300,21 @@ pub trait EthApi {
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
     #[method(name = "sign")]
-    async fn sign(&self, address: Address, message: Bytes) -> RpcResult<Bytes>;
+    fn sign(&self, address: Address, message: Bytes) -> RpcResult<Bytes>;
 
     /// Signs a transaction that can be submitted to the network at a later time using with
     /// `sendRawTransaction.`
     #[method(name = "signTransaction")]
-    async fn sign_transaction(&self, transaction: TransactionRequest) -> RpcResult<Bytes>;
+    fn sign_transaction(&self, transaction: TransactionRequest) -> RpcResult<Bytes>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
     #[method(name = "signTypedData")]
-    async fn sign_typed_data(&self, address: Address, data: TypedData) -> RpcResult<Bytes>;
+    fn sign_typed_data(&self, address: Address, data: TypedData) -> RpcResult<Bytes>;
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.
     #[method(name = "getProof")]
-    async fn get_proof(
+    fn get_proof(
         &self,
         address: Address,
         keys: Vec<JsonStorageKey>,
@@ -330,5 +325,5 @@ pub trait EthApi {
     ///
     /// This is similar to `eth_getAccount` but does not return the storage root.
     #[method(name = "getAccountInfo")]
-    async fn get_account_info(&self, address: Address, block: BlockId) -> RpcResult<AccountInfo>;
+    fn get_account_info(&self, address: Address, block: BlockId) -> RpcResult<AccountInfo>;
 }

--- a/lib/rpc_api/src/eth.rs
+++ b/lib/rpc_api/src/eth.rs
@@ -73,10 +73,7 @@ pub trait EthApi {
 
     /// Returns the number of uncles in a block with given block number.
     #[method(name = "getUncleCountByBlockNumber")]
-    fn block_uncles_count_by_number(
-        &self,
-        number: BlockNumberOrTag,
-    ) -> RpcResult<Option<U256>>;
+    fn block_uncles_count_by_number(&self, number: BlockNumberOrTag) -> RpcResult<Option<U256>>;
 
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts", blocking)]
@@ -168,11 +165,7 @@ pub trait EthApi {
 
     /// Returns the number of transactions sent from an address at given block number.
     #[method(name = "getTransactionCount")]
-    fn transaction_count(
-        &self,
-        address: Address,
-        block_id: Option<BlockId>,
-    ) -> RpcResult<U256>;
+    fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns code at a given address at given block number.
     #[method(name = "getCode")]

--- a/lib/rpc_api/src/filter.rs
+++ b/lib/rpc_api/src/filter.rs
@@ -29,10 +29,7 @@ pub trait EthFilterApi {
 
     /// Returns all filter changes since last poll.
     #[method(name = "getFilterChanges", blocking)]
-    fn filter_changes(
-        &self,
-        id: FilterId,
-    ) -> RpcResult<FilterChanges<Transaction<L2Envelope>>>;
+    fn filter_changes(&self, id: FilterId) -> RpcResult<FilterChanges<Transaction<L2Envelope>>>;
 
     /// Returns all logs matching given filter (in a range 'from' - 'to').
     #[method(name = "getFilterLogs", blocking)]

--- a/lib/rpc_api/src/filter.rs
+++ b/lib/rpc_api/src/filter.rs
@@ -35,7 +35,7 @@ pub trait EthFilterApi {
     ) -> RpcResult<FilterChanges<Transaction<L2Envelope>>>;
 
     /// Returns all logs matching given filter (in a range 'from' - 'to').
-    #[method(name = "getFilterLogs")]
+    #[method(name = "getFilterLogs", blocking)]
     fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>>;
 
     /// Uninstalls filter.
@@ -43,6 +43,6 @@ pub trait EthFilterApi {
     fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool>;
 
     /// Returns logs matching given filter object.
-    #[method(name = "getLogs")]
+    #[method(name = "getLogs", blocking)]
     fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
 }

--- a/lib/rpc_api/src/filter.rs
+++ b/lib/rpc_api/src/filter.rs
@@ -14,15 +14,15 @@ use zksync_os_types::L2Envelope;
 pub trait EthFilterApi {
     /// Creates a new filter and returns its id.
     #[method(name = "newFilter")]
-    async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId>;
+    fn new_filter(&self, filter: Filter) -> RpcResult<FilterId>;
 
     /// Creates a new block filter and returns its id.
     #[method(name = "newBlockFilter")]
-    async fn new_block_filter(&self) -> RpcResult<FilterId>;
+    fn new_block_filter(&self) -> RpcResult<FilterId>;
 
     /// Creates a pending transaction filter and returns its id.
     #[method(name = "newPendingTransactionFilter")]
-    async fn new_pending_transaction_filter(
+    fn new_pending_transaction_filter(
         &self,
         kind: Option<PendingTransactionFilterKind>,
     ) -> RpcResult<FilterId>;
@@ -36,13 +36,13 @@ pub trait EthFilterApi {
 
     /// Returns all logs matching given filter (in a range 'from' - 'to').
     #[method(name = "getFilterLogs")]
-    async fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>>;
+    fn filter_logs(&self, id: FilterId) -> RpcResult<Vec<Log>>;
 
     /// Uninstalls filter.
     #[method(name = "uninstallFilter")]
-    async fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool>;
+    fn uninstall_filter(&self, id: FilterId) -> RpcResult<bool>;
 
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+    fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
 }

--- a/lib/rpc_api/src/filter.rs
+++ b/lib/rpc_api/src/filter.rs
@@ -28,8 +28,8 @@ pub trait EthFilterApi {
     ) -> RpcResult<FilterId>;
 
     /// Returns all filter changes since last poll.
-    #[method(name = "getFilterChanges")]
-    async fn filter_changes(
+    #[method(name = "getFilterChanges", blocking)]
+    fn filter_changes(
         &self,
         id: FilterId,
     ) -> RpcResult<FilterChanges<Transaction<L2Envelope>>>;

--- a/lib/rpc_api/src/net.rs
+++ b/lib/rpc_api/src/net.rs
@@ -8,5 +8,5 @@ use jsonrpsee::proc_macros::rpc;
 pub trait NetApi {
     /// Returns the chain ID of the current network.
     #[method(name = "version")]
-    async fn version(&self) -> RpcResult<Option<U64>>;
+    fn version(&self) -> RpcResult<Option<U64>>;
 }

--- a/lib/rpc_api/src/ots.rs
+++ b/lib/rpc_api/src/ots.rs
@@ -58,10 +58,7 @@ pub trait OtsApi {
     /// Tailor-made and expanded version of `eth_getBlockByNumber` for block details page in
     /// Otterscan.
     #[method(name = "getBlockDetails", blocking)]
-    fn get_block_details(
-        &self,
-        block_number: LenientBlockNumberOrTag,
-    ) -> RpcResult<BlockDetails>;
+    fn get_block_details(&self, block_number: LenientBlockNumberOrTag) -> RpcResult<BlockDetails>;
 
     /// Tailor-made and expanded version of `eth_getBlockByHash` for block details page in
     /// Otterscan.

--- a/lib/rpc_api/src/ots.rs
+++ b/lib/rpc_api/src/ots.rs
@@ -57,7 +57,7 @@ pub trait OtsApi {
 
     /// Tailor-made and expanded version of `eth_getBlockByNumber` for block details page in
     /// Otterscan.
-    #[method(name = "getBlockDetails")]
+    #[method(name = "getBlockDetails", blocking)]
     fn get_block_details(
         &self,
         block_number: LenientBlockNumberOrTag,
@@ -65,11 +65,11 @@ pub trait OtsApi {
 
     /// Tailor-made and expanded version of `eth_getBlockByHash` for block details page in
     /// Otterscan.
-    #[method(name = "getBlockDetailsByHash")]
+    #[method(name = "getBlockDetailsByHash", blocking)]
     fn get_block_details_by_hash(&self, block_hash: BlockHash) -> RpcResult<BlockDetails>;
 
     /// Get paginated transactions for a certain block. Also remove some verbose fields like logs.
-    #[method(name = "getBlockTransactions")]
+    #[method(name = "getBlockTransactions", blocking)]
     fn get_block_transactions(
         &self,
         block_number: LenientBlockNumberOrTag,
@@ -78,7 +78,7 @@ pub trait OtsApi {
     ) -> RpcResult<OtsBlockTransactions<ZkApiTransaction>>;
 
     /// Gets paginated inbound/outbound transaction calls for a certain address.
-    #[method(name = "searchTransactionsBefore")]
+    #[method(name = "searchTransactionsBefore", blocking)]
     fn search_transactions_before(
         &self,
         address: Address,
@@ -87,7 +87,7 @@ pub trait OtsApi {
     ) -> RpcResult<TransactionsWithReceipts<ZkApiTransaction>>;
 
     /// Gets paginated inbound/outbound transaction calls for a certain address.
-    #[method(name = "searchTransactionsAfter")]
+    #[method(name = "searchTransactionsAfter", blocking)]
     fn search_transactions_after(
         &self,
         address: Address,

--- a/lib/rpc_api/src/ots.rs
+++ b/lib/rpc_api/src/ots.rs
@@ -23,14 +23,14 @@ pub trait OtsApi {
     ///
     /// Ref: <https://github.com/otterscan/otterscan/blob/071d8c55202badf01804f6f8d53ef9311d4a9e47/src/useProvider.ts#L71>
     #[method(name = "getHeaderByNumber", aliases = ["erigon_getHeaderByNumber"])]
-    async fn get_header_by_number(
+    fn get_header_by_number(
         &self,
         block_number: LenientBlockNumberOrTag,
     ) -> RpcResult<Option<Header>>;
 
     /// Check if a certain address contains a deployed code.
     #[method(name = "hasCode")]
-    async fn has_code(
+    fn has_code(
         &self,
         address: Address,
         block_id: Option<LenientBlockNumberOrTag>,
@@ -40,25 +40,25 @@ pub trait OtsApi {
     /// incremented. This allows for Otterscan to check if the node contains all API it
     /// needs.
     #[method(name = "getApiLevel")]
-    async fn get_api_level(&self) -> RpcResult<u64>;
+    fn get_api_level(&self) -> RpcResult<u64>;
 
     /// Return the internal ETH transfers inside a transaction.
     #[method(name = "getInternalOperations")]
-    async fn get_internal_operations(&self, tx_hash: TxHash) -> RpcResult<Vec<InternalOperation>>;
+    fn get_internal_operations(&self, tx_hash: TxHash) -> RpcResult<Vec<InternalOperation>>;
 
     /// Given a transaction hash, returns its raw revert reason.
     #[method(name = "getTransactionError")]
-    async fn get_transaction_error(&self, tx_hash: TxHash) -> RpcResult<Option<Bytes>>;
+    fn get_transaction_error(&self, tx_hash: TxHash) -> RpcResult<Option<Bytes>>;
 
     /// Extract all variations of calls, contract creation and self-destructs and returns a call
     /// tree.
     #[method(name = "traceTransaction")]
-    async fn trace_transaction(&self, tx_hash: TxHash) -> RpcResult<Option<Vec<TraceEntry>>>;
+    fn trace_transaction(&self, tx_hash: TxHash) -> RpcResult<Option<Vec<TraceEntry>>>;
 
     /// Tailor-made and expanded version of `eth_getBlockByNumber` for block details page in
     /// Otterscan.
     #[method(name = "getBlockDetails")]
-    async fn get_block_details(
+    fn get_block_details(
         &self,
         block_number: LenientBlockNumberOrTag,
     ) -> RpcResult<BlockDetails>;
@@ -66,11 +66,11 @@ pub trait OtsApi {
     /// Tailor-made and expanded version of `eth_getBlockByHash` for block details page in
     /// Otterscan.
     #[method(name = "getBlockDetailsByHash")]
-    async fn get_block_details_by_hash(&self, block_hash: BlockHash) -> RpcResult<BlockDetails>;
+    fn get_block_details_by_hash(&self, block_hash: BlockHash) -> RpcResult<BlockDetails>;
 
     /// Get paginated transactions for a certain block. Also remove some verbose fields like logs.
     #[method(name = "getBlockTransactions")]
-    async fn get_block_transactions(
+    fn get_block_transactions(
         &self,
         block_number: LenientBlockNumberOrTag,
         page_number: usize,
@@ -79,7 +79,7 @@ pub trait OtsApi {
 
     /// Gets paginated inbound/outbound transaction calls for a certain address.
     #[method(name = "searchTransactionsBefore")]
-    async fn search_transactions_before(
+    fn search_transactions_before(
         &self,
         address: Address,
         block_number: LenientBlockNumberOrTag,
@@ -88,7 +88,7 @@ pub trait OtsApi {
 
     /// Gets paginated inbound/outbound transaction calls for a certain address.
     #[method(name = "searchTransactionsAfter")]
-    async fn search_transactions_after(
+    fn search_transactions_after(
         &self,
         address: Address,
         block_number: LenientBlockNumberOrTag,
@@ -97,7 +97,7 @@ pub trait OtsApi {
 
     /// Gets the transaction hash for a certain sender address, given its nonce.
     #[method(name = "getTransactionBySenderAndNonce")]
-    async fn get_transaction_by_sender_and_nonce(
+    fn get_transaction_by_sender_and_nonce(
         &self,
         sender: Address,
         nonce: u64,
@@ -105,5 +105,5 @@ pub trait OtsApi {
 
     /// Gets the transaction hash and the address who created a contract.
     #[method(name = "getContractCreator")]
-    async fn get_contract_creator(&self, address: Address) -> RpcResult<Option<ContractCreator>>;
+    fn get_contract_creator(&self, address: Address) -> RpcResult<Option<ContractCreator>>;
 }

--- a/lib/rpc_api/src/txpool.rs
+++ b/lib/rpc_api/src/txpool.rs
@@ -15,19 +15,19 @@ pub trait TxpoolApi {
     ///
     /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_inspect>.
     #[method(name = "inspect")]
-    async fn inspect(&self) -> RpcResult<TxpoolInspect>;
+    fn inspect(&self) -> RpcResult<TxpoolInspect>;
 
     /// Returns the exact details of all transactions currently pending for inclusion in the next
     /// block(s), as well as the ones that are being scheduled for future execution only.
     ///
     /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_content>.
     #[method(name = "content")]
-    async fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>>;
+    fn content(&self) -> RpcResult<TxpoolContent<ZkApiTransaction>>;
 
     /// Returns the number of transactions currently pending for inclusion in the next block(s), as
     /// well as the ones that are being scheduled for future execution only.
     ///
     /// See <https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_status>.
     #[method(name = "status")]
-    async fn status(&self) -> RpcResult<TxpoolStatus>;
+    fn status(&self) -> RpcResult<TxpoolStatus>;
 }

--- a/lib/rpc_api/src/unstable.rs
+++ b/lib/rpc_api/src/unstable.rs
@@ -9,6 +9,6 @@ pub trait UnstableApi {
     #[method(name = "getBatchByBlockNumber")]
     fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<PersistedBatch>;
 
-    #[method(name = "getLocalRoot")]
+    #[method(name = "getLocalRoot", blocking)]
     fn get_local_root(&self, batch_number: u64) -> RpcResult<B256>;
 }

--- a/lib/rpc_api/src/unstable.rs
+++ b/lib/rpc_api/src/unstable.rs
@@ -7,8 +7,8 @@ use zksync_os_storage_api::PersistedBatch;
 #[cfg_attr(feature = "server", rpc(server, client, namespace = "unstable"))]
 pub trait UnstableApi {
     #[method(name = "getBatchByBlockNumber")]
-    async fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<PersistedBatch>;
+    fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<PersistedBatch>;
 
     #[method(name = "getLocalRoot")]
-    async fn get_local_root(&self, batch_number: u64) -> RpcResult<B256>;
+    fn get_local_root(&self, batch_number: u64) -> RpcResult<B256>;
 }

--- a/lib/rpc_api/src/web3.rs
+++ b/lib/rpc_api/src/web3.rs
@@ -11,7 +11,7 @@ use jsonrpsee::proc_macros::rpc;
 pub trait Web3Api {
     /// Returns current client version.
     #[method(name = "clientVersion")]
-    async fn client_version(&self) -> RpcResult<String>;
+    fn client_version(&self) -> RpcResult<String>;
 
     /// Returns sha3 of the given data.
     #[method(name = "sha3")]

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -30,10 +30,7 @@ pub trait ZksApi {
     async fn get_genesis(&self) -> RpcResult<GenesisInput>;
 
     #[method(name = "getBlockMetadataByNumber")]
-    fn get_block_metadata_by_number(
-        &self,
-        block_number: u64,
-    ) -> RpcResult<Option<BlockMetadata>>;
+    fn get_block_metadata_by_number(&self, block_number: u64) -> RpcResult<Option<BlockMetadata>>;
 
     #[method(name = "getProof", blocking)]
     fn get_proof(

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -9,10 +9,10 @@ use zksync_os_genesis::GenesisInput;
 #[cfg_attr(feature = "server", rpc(server, client, namespace = "zks"))]
 pub trait ZksApi {
     #[method(name = "getBridgehubContract")]
-    async fn get_bridgehub_contract(&self) -> RpcResult<Address>;
+    fn get_bridgehub_contract(&self) -> RpcResult<Address>;
 
     #[method(name = "getBytecodeSupplierContract")]
-    async fn get_bytecode_supplier_contract(&self) -> RpcResult<Address>;
+    fn get_bytecode_supplier_contract(&self) -> RpcResult<Address>;
 
     /// Returns the merkle proof for an L2->L1 log emitted in a given transaction.
     ///
@@ -30,13 +30,13 @@ pub trait ZksApi {
     async fn get_genesis(&self) -> RpcResult<GenesisInput>;
 
     #[method(name = "getBlockMetadataByNumber")]
-    async fn get_block_metadata_by_number(
+    fn get_block_metadata_by_number(
         &self,
         block_number: u64,
     ) -> RpcResult<Option<BlockMetadata>>;
 
     #[method(name = "getProof")]
-    async fn get_proof(
+    fn get_proof(
         &self,
         account: Address,
         keys: Vec<B256>,

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -35,7 +35,7 @@ pub trait ZksApi {
         block_number: u64,
     ) -> RpcResult<Option<BlockMetadata>>;
 
-    #[method(name = "getProof")]
+    #[method(name = "getProof", blocking)]
     fn get_proof(
         &self,
         account: Address,


### PR DESCRIPTION
## Summary

RPC handlers that do heavy synchronous work (VM execution, block scans, debug traces) were running on tokio worker threads, blocking them for tens to hundreds of milliseconds and starving other tasks.

Fix: mark those handlers with jsonrpsee's `#[method(blocking)]` so they run on the blocking thread pool. As a prerequisite, removed needless `async fn` from the ~70 handlers that had no `.await` in their bodies. Also switched `PendingTransactionsReceiver` from `tokio::sync::Mutex` to `std::sync::Mutex` (the lock was never held across an await) to make `eth_getFilterChanges` blocking too.

Blocking methods: `eth_call`, `eth_estimateGas`, `eth_getBlockReceipts`, `eth_feeHistory`, `eth_getFilterChanges`, `eth_getFilterLogs`, `eth_getLogs`, all `debug_trace*`, `ots_getBlockDetails`, `ots_getBlockDetailsByHash`, `ots_getBlockTransactions`, `ots_searchTransactionsBefore`, `ots_searchTransactionsAfter`, `unstable_getLocalRoot`, `zks_getProof`.

Replaced the per-method `TaskMonitor` list with a single `RPC_TASK_MONITOR` covering all requests — per-method metrics were only useful for detecting worker starvation, which is now prevented structurally.