### PR TITLE
fix: InteropWatcher init

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -94,7 +94,7 @@ alloy::sol! {
 
         function addInteropRootsInBatch(InteropRoot[] calldata interopRootsInput);
 
-        uint256 public totalPublishedInteropRoots;
+        uint256 public interopRootLogId;
 
         function getChainTree(uint256 chainId) public view returns (Bytes32PushTree);
 
@@ -470,14 +470,14 @@ impl<P: Provider> MessageRoot<P> {
         self.instance.provider()
     }
 
-    pub async fn total_published_interop_roots(&self, block_id: BlockId) -> Result<u64> {
+    pub async fn interop_root_log_id(&self, block_id: BlockId) -> Result<u64> {
         self.instance
-            .totalPublishedInteropRoots()
+            .interopRootLogId()
             .block(block_id)
             .call()
             .await
             .map(|n| n.saturating_to())
-            .enrich("totalPublishedInteropRoots", Some(block_id))
+            .enrich("interopRootLogId", Some(block_id))
     }
 
     pub async fn code_exists_at_block(&self, block_id: BlockId) -> alloy::contract::Result<bool> {

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -275,7 +275,7 @@ pub async fn find_l1_execute_block_by_batch_number(
     .await
 }
 
-/// Finds the first L1 block where `totalPublishedInteropRoots >= next_interop_root_id`.
+/// Finds the first L1 block where `interopRootLogId >= next_interop_root_id`.
 /// Uses binary search for efficiency.
 pub async fn find_l1_block_by_interop_root_id(
     bridgehub: Bridgehub<DynProvider>,
@@ -305,9 +305,7 @@ pub async fn find_l1_block_by_interop_root_id(
             if !message_root.code_exists_at_block(block.into()).await? {
                 return Ok(false);
             }
-            let res = message_root
-                .total_published_interop_roots(block.into())
-                .await?;
+            let res = message_root.interop_root_log_id(block.into()).await?;
             Ok(res >= next_interop_root_id)
         };
 


### PR DESCRIPTION
## Summary

totalPublishedInteropRoots was replaced with interopRootLogId in contracts (see https://github.com/matter-labs/era-contracts/commit/416051563438fdf8d7ff222e324519704d5dbfe3#diff-3ab49649a79921a1d6ef95d0200a85f4a4c5e998e11924bc2a9c17d9a0247170)

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

