### PR TITLE
feat: track finalized executed batches and blocks

### DIFF
--- a/.github/scripts/test-configs.sh
+++ b/.github/scripts/test-configs.sh
@@ -64,7 +64,7 @@ for entry in "${CONFIGS[@]}"; do
   gzip -dfk "${CUR_STATE}.gz"
 
   echo "Starting anvil..."
-  anvil --load-state "${CUR_STATE}" --port 8545 --block-time 0.25 --mixed-mining > anvil.log 2>&1 &
+  anvil --load-state "${CUR_STATE}" --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10 > anvil.log 2>&1 &
   ANVIL_PID=$!
 
   echo "Starting server..."

--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -152,7 +152,7 @@ jobs:
           anvil --load-state "${L1_STATE_JSON}" \
             --port 8545 \
             --block-time 0.25 \
-            --mixed-mining > anvil.log.txt 2>&1 &
+            --mixed-mining --slots-in-an-epoch 10 > anvil.log.txt 2>&1 &
           ./${ZKSYNC_OS_SERVER_BIN} > ${SERVER_LOGFILE} 2>&1 &
           elapsed=0
           while ! nc -z localhost ${PORT}; do

--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -177,7 +177,7 @@ jobs:
         run: gzip -dfk ./local-chains/v30.2/l1-state.json.gz
 
       - name: Run anvil L1
-        run: anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining &
+        run: anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10 &
 
       - name: Build server
         run: cargo build --release --bin zksync-os-server

--- a/docs/src/setup/local_run.md
+++ b/docs/src/setup/local_run.md
@@ -23,7 +23,7 @@ To run node locally, first decompress state and launch `anvil`:
 
 ```
 gzip -dfk ./local-chains/v30.2/l1-state.json.gz
-anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining
+anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10
 ```
 
 then launch the server:

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1200,6 +1200,8 @@ impl AnvilL1 {
         let locked_port = LockedPort::acquire_unused().await?;
         let address = format!("http://localhost:{}", locked_port.port);
 
+        // --slots-in-an-epoch defines what blocks are "finalized" in Anvil, last finalized block is `latest - 2 * slots_in_an_epoch`
+        // so we set block time to 0.25s and slots in epoch set to 10 and finalization delays is about 10*0.25s*2=5s which is reasonable for tests.
         let provider = ProviderBuilder::new().connect_anvil_with_wallet_and_config(|anvil| {
             anvil
                 .port(locked_port.port)

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1209,6 +1209,8 @@ impl AnvilL1 {
                 .arg("--mixed-mining")
                 .arg("--load-state")
                 .arg(l1_state_path)
+                .arg("--slots-in-an-epoch")
+                .arg("10")
         })?;
 
         let wallet = provider.wallet().clone();

--- a/lib/batch_verification/src/tests/mod.rs
+++ b/lib/batch_verification/src/tests/mod.rs
@@ -19,6 +19,8 @@ impl DummyFinality {
             last_committed_batch: 0,
             last_executed_block: 0,
             last_executed_batch: 0,
+            last_finalized_executed_block: 0,
+            last_finalized_executed_batch: 0,
         };
         let (tx, rx) = watch::channel(status.clone());
         let _ = tx;

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -289,6 +289,14 @@ async fn fetch_finalized_executed_batch(
         .context("failed to fetch finalized SL block number")?
         .context("failed to fetch finalized SL block number (`None` returned)")?;
 
+    if !zk_chain_sl
+        .code_exists_at_block(finalized_sl_block_number.into())
+        .await
+        .context("failed to check ZK chain contract code at finalized SL block")?
+    {
+        return Ok((finalized_sl_block_number, 0));
+    }
+
     let last_finalized_executed_batch = zk_chain_sl
         .get_total_batches_executed(finalized_sl_block_number.into())
         .await?;

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -282,25 +282,12 @@ impl L1State {
 async fn fetch_finalized_executed_batch(
     zk_chain_sl: &ZkChain<DynProvider>,
 ) -> anyhow::Result<(u64, u64)> {
-    let finalized_sl_block_number = {
-        let Some(finalized_sl_block_number) = zk_chain_sl
-            .provider()
-            .get_block_number_by_id(BlockId::finalized())
-            .await
-            .context("failed to fetch finalized SL block number")?
-        else {
-            return Ok((0, 0));
-        };
-        finalized_sl_block_number
-    };
-
-    if !zk_chain_sl
-        .code_exists_at_block(finalized_sl_block_number.into())
+    let finalized_sl_block_number = zk_chain_sl
+        .provider()
+        .get_block_number_by_id(BlockId::finalized())
         .await
-        .context("failed to check ZK chain contract code at finalized SL block")?
-    {
-        return Ok((finalized_sl_block_number, 0));
-    }
+        .context("failed to fetch finalized SL block number")?
+        .context("failed to fetch finalized SL block number (`None` returned)")?;
 
     let last_finalized_executed_batch = zk_chain_sl
         .get_total_batches_executed(finalized_sl_block_number.into())

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -35,8 +35,11 @@ pub struct L1State {
     pub last_committed_batch: u64,
     pub last_proved_batch: u64,
     pub last_executed_batch: u64,
+    pub last_finalized_executed_batch: u64,
     /// Block number on SL that was used to query `last_committed_batch`, `last_proved_batch`, `last_executed_batch`.
     pub sl_block_number: u64,
+    /// Finalized SL block number that was used to query `last_finalized_executed_batch`.
+    pub finalized_sl_block_number: u64,
     pub da_input_mode: BatchDaInputMode,
     pub l1_chain_id: u64,
     pub sl_chain_id: u64,
@@ -111,6 +114,8 @@ impl L1State {
         let last_executed_batch = diamond_proxy_sl
             .get_total_batches_executed(latest_sl_block_number.into())
             .await?;
+        let (finalized_sl_block_number, last_finalized_executed_batch) =
+            fetch_finalized_executed_batch(&diamond_proxy_sl).await?;
 
         let pubdata_pricing_mode = diamond_proxy_sl.get_pubdata_pricing_mode().await?;
         let da_input_mode = match pubdata_pricing_mode {
@@ -172,7 +177,9 @@ impl L1State {
             last_committed_batch,
             last_proved_batch,
             last_executed_batch,
+            last_finalized_executed_batch,
             sl_block_number: latest_sl_block_number,
+            finalized_sl_block_number,
             da_input_mode,
             l1_chain_id,
             sl_chain_id,
@@ -229,6 +236,8 @@ impl L1State {
             })
             .await
             .context("failed to fetch finalized batch state")?;
+        let (finalized_sl_block_number, last_finalized_executed_batch) =
+            fetch_finalized_executed_batch(zk_chain_sl).await?;
         Ok(Self {
             bridgehub_l1: this.bridgehub_l1,
             bridgehub_sl: this.bridgehub_sl,
@@ -239,7 +248,9 @@ impl L1State {
             last_committed_batch: batch_finality.last_committed_batch,
             last_proved_batch: batch_finality.last_proved_batch,
             last_executed_batch: batch_finality.last_executed_batch,
+            last_finalized_executed_batch,
             sl_block_number,
+            finalized_sl_block_number,
             da_input_mode: this.da_input_mode,
             l1_chain_id: this.l1_chain_id,
             sl_chain_id: this.sl_chain_id,
@@ -266,6 +277,35 @@ impl L1State {
         };
         L1_STATE_METRICS.da_input_mode[&da_input_mode].set(1);
     }
+}
+
+async fn fetch_finalized_executed_batch(
+    zk_chain_sl: &ZkChain<DynProvider>,
+) -> anyhow::Result<(u64, u64)> {
+    let finalized_sl_block_number = {
+        let Some(finalized_sl_block_number) = zk_chain_sl
+            .provider()
+            .get_block_number_by_id(BlockId::finalized())
+            .await
+            .context("failed to fetch finalized SL block number")?
+        else {
+            return Ok((0, 0));
+        };
+        finalized_sl_block_number
+    };
+
+    if !zk_chain_sl
+        .code_exists_at_block(finalized_sl_block_number.into())
+        .await
+        .context("failed to check ZK chain contract code at finalized SL block")?
+    {
+        return Ok((finalized_sl_block_number, 0));
+    }
+
+    let last_finalized_executed_batch = zk_chain_sl
+        .get_total_batches_executed(finalized_sl_block_number.into())
+        .await?;
+    Ok((finalized_sl_block_number, last_finalized_executed_batch))
 }
 
 /// Waits until the pending SL state matches the latest finalized SL block.

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -208,7 +208,12 @@ fn startup_batch_numbers(
     last_executed_batch: u64,
     last_finalized_executed_batch: u64,
 ) -> (Vec<u64>, Vec<u64>) {
-    let prioritized = [last_committed_batch, last_proved_batch, last_executed_batch, last_finalized_executed_batch];
+    let prioritized = [
+        last_committed_batch,
+        last_proved_batch,
+        last_executed_batch,
+        last_finalized_executed_batch,
+    ];
     let (prioritized_in_range, remaining_batch_numbers): (Vec<_>, Vec<_>) =
         (last_finalized_executed_batch.max(1)..=last_committed_batch)
             .partition(|batch_number| prioritized.contains(batch_number));

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -80,6 +80,7 @@ impl CommittedBatchProvider {
             l1_state.last_committed_batch,
             l1_state.last_proved_batch,
             l1_state.last_executed_batch,
+            l1_state.last_finalized_executed_batch,
         );
         provider
             .load_batch_numbers(max_l1_blocks_to_scan, prioritized_batch_numbers)
@@ -89,12 +90,14 @@ impl CommittedBatchProvider {
         let last_committed = l1_state.last_committed_batch;
         let last_proved = l1_state.last_proved_batch;
         let last_executed = l1_state.last_executed_batch;
+        let last_finalized_executed = l1_state.last_finalized_executed_batch;
         runtime.spawn_critical_task("committed batch provider init", async move {
             provider_for_init
                 .init(
                     last_committed,
                     last_proved,
                     last_executed,
+                    last_finalized_executed,
                     max_l1_blocks_to_scan,
                 )
                 .await
@@ -110,10 +113,15 @@ impl CommittedBatchProvider {
         last_committed_batch: u64,
         last_proved_batch: u64,
         last_executed_batch: u64,
+        last_finalized_executed_batch: u64,
         max_l1_blocks_to_scan: u64,
     ) -> anyhow::Result<()> {
-        let (_, remaining_batch_numbers) =
-            startup_batch_numbers(last_committed_batch, last_proved_batch, last_executed_batch);
+        let (_, remaining_batch_numbers) = startup_batch_numbers(
+            last_committed_batch,
+            last_proved_batch,
+            last_executed_batch,
+            last_finalized_executed_batch,
+        );
         self.load_batch_numbers(max_l1_blocks_to_scan, remaining_batch_numbers)
             .await?;
         Ok(())
@@ -192,18 +200,18 @@ impl Inner {
 
 /// Returns startup frontier batches first, then the remaining committed startup range.
 ///
-/// The prioritized vector preserves the bookkeeping order most likely to unblock startup:
-/// committed, proved, then executed.
+/// The prioritized vector contains every batch needed for immediate startup bookkeeping:
+/// committed, proved, operational executed, and finalized executed.
 fn startup_batch_numbers(
     last_committed_batch: u64,
     last_proved_batch: u64,
     last_executed_batch: u64,
+    last_finalized_executed_batch: u64,
 ) -> (Vec<u64>, Vec<u64>) {
-    let prioritized = [last_committed_batch, last_proved_batch, last_executed_batch];
+    let prioritized = [last_committed_batch, last_proved_batch, last_executed_batch, last_finalized_executed_batch];
     let (prioritized_in_range, remaining_batch_numbers): (Vec<_>, Vec<_>) =
-        (last_executed_batch.max(1)..=last_committed_batch)
+        (last_finalized_executed_batch.max(1)..=last_committed_batch)
             .partition(|batch_number| prioritized.contains(batch_number));
-
     (prioritized_in_range, remaining_batch_numbers)
 }
 
@@ -231,14 +239,14 @@ mod tests {
 
     #[test]
     fn prioritizes_frontier_batches_once() {
-        assert_eq!(startup_batch_numbers(10, 8, 8), (vec![8, 10], vec![9]));
+        assert_eq!(startup_batch_numbers(10, 8, 8, 8), (vec![8, 10], vec![9]));
     }
 
     #[test]
     fn excludes_prioritized_batches_from_remaining_range() {
         assert_eq!(
-            startup_batch_numbers(10, 8, 6),
-            (vec![6, 8, 10], vec![7, 9])
+            startup_batch_numbers(10, 8, 6, 4),
+            (vec![4, 6, 8, 10], vec![5, 7, 9])
         );
     }
 }

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -21,17 +21,18 @@ use zksync_os_storage_api::WriteFinality;
 /// - startup / replay code that reads executed finality to decide where block processing resumes;
 /// - RPC-facing storage initialization, which uses executed progress as part of node recovery.
 pub struct L1ExecuteWatcher<Finality> {
+    inner: ExecuteWatcherState<Finality>,
+}
+
+pub struct L1FinalizedExecuteWatcher<Finality> {
+    inner: ExecuteWatcherState<Finality>,
+}
+
+struct ExecuteWatcherState<Finality> {
     contract_address: Address,
     next_batch_number: u64,
     committed_batch_provider: CommittedBatchProvider,
     finality: Finality,
-    frontier: ExecuteFrontier,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum ExecuteFrontier {
-    Operational,
-    Finalized,
 }
 
 impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
@@ -58,11 +59,12 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         tracing::info!(last_l1_block, "resolved on L1");
 
         let this = Self {
-            contract_address: *zk_chain.address(),
-            next_batch_number: last_executed_batch + 1,
-            committed_batch_provider,
-            finality,
-            frontier: ExecuteFrontier::Operational,
+            inner: ExecuteWatcherState {
+                contract_address: *zk_chain.address(),
+                next_batch_number: last_executed_batch + 1,
+                committed_batch_provider,
+                finality,
+            },
         };
         let l1_watcher = L1Watcher::new(
             zk_chain.provider().clone(),
@@ -79,7 +81,9 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
 
         Ok(l1_watcher)
     }
+}
 
+impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
     pub async fn create_finalized_watcher(
         config: L1WatcherConfig,
         zk_chain: ZkChain<DynProvider>,
@@ -105,11 +109,12 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         tracing::info!(last_l1_block, "resolved on L1");
 
         let this = Self {
-            contract_address: *zk_chain.address(),
-            next_batch_number: last_finalized_executed_batch + 1,
-            committed_batch_provider,
-            finality,
-            frontier: ExecuteFrontier::Finalized,
+            inner: ExecuteWatcherState {
+                contract_address: *zk_chain.address(),
+                next_batch_number: last_finalized_executed_batch + 1,
+                committed_batch_provider,
+                finality,
+            },
         };
         Ok(L1Watcher::new_finalized(
             zk_chain.provider().clone(),
@@ -121,21 +126,12 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
     }
 }
 
-#[async_trait::async_trait]
-impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
-    const NAME: &'static str = "block_execution";
-
-    type SolEvent = BlockExecution;
-    type WatchedEvent = BlockExecution;
-
-    fn contract_address(&self) -> Address {
-        self.contract_address
-    }
-
-    async fn process_event(
+impl<Finality: WriteFinality> ExecuteWatcherState<Finality> {
+    async fn process_execution(
         &mut self,
         batch_execute: BlockExecution,
-        _log: Log,
+        update_finality: impl FnOnce(&Finality, u64, u64),
+        frontier: &'static str,
     ) -> Result<(), L1WatcherError> {
         let batch_number = batch_execute.batchNumber.to::<u64>();
         let batch_hash = batch_execute.batchHash;
@@ -145,6 +141,7 @@ impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
                 batch_number,
                 ?batch_hash,
                 ?batch_commitment,
+                frontier,
                 "skipping already processed executed batch",
             );
         } else {
@@ -153,42 +150,98 @@ impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
                 .wait_for_batch(batch_number)
                 .await;
             let last_executed_block = discovered_batch.last_block_number();
-            match self.frontier {
-                ExecuteFrontier::Operational => {
-                    self.finality.update_finality_status(|finality| {
-                        assert!(
-                            batch_number > finality.last_executed_batch,
-                            "non-monotonous executed batch"
-                        );
-                        assert!(
-                            last_executed_block > finality.last_executed_block,
-                            "non-monotonous executed block"
-                        );
-                        finality.last_executed_batch = batch_number;
-                        finality.last_executed_block = last_executed_block;
-                    });
-                }
-                ExecuteFrontier::Finalized => {
-                    self.finality.update_finality_status(|finality| {
-                        assert!(
-                            batch_number > finality.last_finalized_executed_batch,
-                            "non-monotonous finalized executed batch"
-                        );
-                        assert!(
-                            last_executed_block > finality.last_finalized_executed_block,
-                            "non-monotonous finalized executed block"
-                        );
-                        finality.last_finalized_executed_batch = batch_number;
-                        finality.last_finalized_executed_block = last_executed_block;
-                    });
-                }
-            }
+            update_finality(&self.finality, batch_number, last_executed_block);
             tracing::info!(
                 "discovered executed batch {batch_number}, hash {batch_hash:?}, commitment {batch_commitment:?},\
-                last_executed_block {last_executed_block}, frontier {:?}",
-                self.frontier
+                last_executed_block {last_executed_block}, frontier {frontier}",
             );
         }
         Ok(())
+    }
+}
+
+fn update_executed_finality<Finality: WriteFinality>(
+    finality: &Finality,
+    batch_number: u64,
+    last_executed_block: u64,
+) {
+    finality.update_finality_status(|finality| {
+        assert!(
+            batch_number > finality.last_executed_batch,
+            "non-monotonous executed batch"
+        );
+        assert!(
+            last_executed_block > finality.last_executed_block,
+            "non-monotonous executed block"
+        );
+        finality.last_executed_batch = batch_number;
+        finality.last_executed_block = last_executed_block;
+    });
+}
+
+fn update_finalized_executed_finality<Finality: WriteFinality>(
+    finality: &Finality,
+    batch_number: u64,
+    last_executed_block: u64,
+) {
+    finality.update_finality_status(|finality| {
+        assert!(
+            batch_number > finality.last_finalized_executed_batch,
+            "non-monotonous finalized executed batch"
+        );
+        assert!(
+            last_executed_block > finality.last_finalized_executed_block,
+            "non-monotonous finalized executed block"
+        );
+        finality.last_finalized_executed_batch = batch_number;
+        finality.last_finalized_executed_block = last_executed_block;
+    });
+}
+
+#[async_trait::async_trait]
+impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
+    const NAME: &'static str = "block_execution";
+
+    type SolEvent = BlockExecution;
+    type WatchedEvent = BlockExecution;
+
+    fn contract_address(&self) -> Address {
+        self.inner.contract_address
+    }
+
+    async fn process_event(
+        &mut self,
+        batch_execute: BlockExecution,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
+        self.inner
+            .process_execution(batch_execute, update_executed_finality, "normal")
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl<Finality: WriteFinality> ProcessL1Event for L1FinalizedExecuteWatcher<Finality> {
+    const NAME: &'static str = "finalized_block_execution";
+
+    type SolEvent = BlockExecution;
+    type WatchedEvent = BlockExecution;
+
+    fn contract_address(&self) -> Address {
+        self.inner.contract_address
+    }
+
+    async fn process_event(
+        &mut self,
+        batch_execute: BlockExecution,
+        _log: Log,
+    ) -> Result<(), L1WatcherError> {
+        self.inner
+            .process_execution(
+                batch_execute,
+                update_finalized_executed_finality,
+                "finalized",
+            )
+            .await
     }
 }

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -25,6 +25,13 @@ pub struct L1ExecuteWatcher<Finality> {
     next_batch_number: u64,
     committed_batch_provider: CommittedBatchProvider,
     finality: Finality,
+    frontier: ExecuteFrontier,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExecuteFrontier {
+    Operational,
+    Finalized,
 }
 
 impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
@@ -55,6 +62,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
             next_batch_number: last_executed_batch + 1,
             committed_batch_provider,
             finality,
+            frontier: ExecuteFrontier::Operational,
         };
         let l1_watcher = L1Watcher::new(
             zk_chain.provider().clone(),
@@ -70,6 +78,46 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         .await?;
 
         Ok(l1_watcher)
+    }
+
+    pub async fn create_finalized_watcher(
+        config: L1WatcherConfig,
+        zk_chain: ZkChain<DynProvider>,
+        committed_batch_provider: CommittedBatchProvider,
+        finality: Finality,
+    ) -> anyhow::Result<L1Watcher> {
+        let current_l1_block = zk_chain.provider().get_block_number().await?;
+        let last_finalized_executed_batch =
+            finality.get_finality_status().last_finalized_executed_batch;
+        tracing::info!(
+            current_l1_block,
+            last_finalized_executed_batch,
+            config.max_blocks_to_process,
+            ?config.poll_interval,
+            zk_chain_address = ?zk_chain.address(),
+            "initializing finalized L1 execute watcher"
+        );
+        let last_l1_block = util::find_l1_execute_block_by_batch_number(
+            zk_chain.clone(),
+            last_finalized_executed_batch,
+        )
+        .await?;
+        tracing::info!(last_l1_block, "resolved on L1");
+
+        let this = Self {
+            contract_address: *zk_chain.address(),
+            next_batch_number: last_finalized_executed_batch + 1,
+            committed_batch_provider,
+            finality,
+            frontier: ExecuteFrontier::Finalized,
+        };
+        Ok(L1Watcher::new_finalized(
+            zk_chain.provider().clone(),
+            last_l1_block,
+            config.max_blocks_to_process,
+            config.poll_interval,
+            this.into(),
+        ))
     }
 }
 
@@ -105,24 +153,40 @@ impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
                 .wait_for_batch(batch_number)
                 .await;
             let last_executed_block = discovered_batch.last_block_number();
-            self.finality.update_finality_status(|finality| {
-                assert!(
-                    batch_number > finality.last_executed_batch,
-                    "non-monotonous executed batch"
-                );
-                assert!(
-                    last_executed_block > finality.last_executed_block,
-                    "non-monotonous executed block"
-                );
-                finality.last_executed_batch = batch_number;
-                finality.last_executed_block = last_executed_block;
-            });
-            tracing::debug!(
-                batch_number,
-                ?batch_hash,
-                ?batch_commitment,
-                last_executed_block,
-                "discovered executed batch"
+            match self.frontier {
+                ExecuteFrontier::Operational => {
+                    self.finality.update_finality_status(|finality| {
+                        assert!(
+                            batch_number > finality.last_executed_batch,
+                            "non-monotonous executed batch"
+                        );
+                        assert!(
+                            last_executed_block > finality.last_executed_block,
+                            "non-monotonous executed block"
+                        );
+                        finality.last_executed_batch = batch_number;
+                        finality.last_executed_block = last_executed_block;
+                    });
+                }
+                ExecuteFrontier::Finalized => {
+                    self.finality.update_finality_status(|finality| {
+                        assert!(
+                            batch_number > finality.last_finalized_executed_batch,
+                            "non-monotonous finalized executed batch"
+                        );
+                        assert!(
+                            last_executed_block > finality.last_finalized_executed_block,
+                            "non-monotonous finalized executed block"
+                        );
+                        finality.last_finalized_executed_batch = batch_number;
+                        finality.last_finalized_executed_block = last_executed_block;
+                    });
+                }
+            }
+            tracing::info!(
+                "discovered executed batch {batch_number}, hash {batch_hash:?}, commitment {batch_commitment:?},\
+                last_executed_block {last_executed_block}, frontier {:?}",
+                self.frontier
             );
         }
         Ok(())

--- a/lib/l1_watcher/src/lib.rs
+++ b/lib/l1_watcher/src/lib.rs
@@ -10,7 +10,7 @@ mod commit_watcher;
 pub use commit_watcher::L1CommitWatcher;
 
 mod execute_watcher;
-pub use execute_watcher::L1ExecuteWatcher;
+pub use execute_watcher::{L1ExecuteWatcher, L1FinalizedExecuteWatcher};
 
 mod upgrade_tx_watcher;
 pub use upgrade_tx_watcher::L1UpgradeTxWatcher;

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -11,11 +11,13 @@ use zksync_os_contract_interface::IExecutor::{BlockExecution, ReportCommittedBat
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_storage_api::{PersistedBatch, WriteBatch};
 
-/// Watches commit and execute events together and persists only irreversibly executed batches.
+/// Watches finalized commit and execute events together and persists only irreversibly executed
+/// batches.
 ///
 /// This component keeps committed batches in memory until the matching `BlockExecution` event
-/// arrives, and only then writes a `PersistedBatch` through `WriteBatch`. That split avoids having
-/// to roll back persistent storage for batches that were committed but later reverted on L1.
+/// arrives in a finalized settlement-layer block, and only then writes a `PersistedBatch` through
+/// `WriteBatch`. That split avoids having to roll back persistent storage for batches that were
+/// committed or executed but later reverted on L1.
 ///
 /// Depended on by:
 /// - `ExecutedBatchStorage`, which is the concrete persistent store typically passed into this
@@ -35,7 +37,6 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
         config: L1WatcherConfig,
         zk_chain: ZkChain<DynProvider>,
         batch_storage: BatchStorage,
-        l1_chain_id: u64,
     ) -> anyhow::Result<L1Watcher> {
         let current_l1_block = zk_chain.provider().get_block_number().await?;
         let last_persisted_batch = batch_storage.latest_batch();
@@ -62,18 +63,15 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
             last_processed_commit_batch: last_persisted_batch,
             last_persisted_batch_on_start: last_persisted_batch,
         };
-        let l1_watcher = L1Watcher::new(
+        let l1_watcher = L1Watcher::new_finalized(
             zk_chain.provider().clone(),
             // We start from last L1 block as it may contain more committed batches apart from the last
             // one.
             last_l1_block,
             config.max_blocks_to_process,
-            config.confirmations,
-            l1_chain_id,
             config.poll_interval,
             Box::new(this),
-        )
-        .await?;
+        );
 
         Ok(l1_watcher)
     }
@@ -196,13 +194,6 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
                 self.process_commit(report, log).await?;
             }
             s if s == BlockExecution::SIGNATURE_HASH => {
-                // This logic is not totally resistant to reorgs. If `executeBatches` is reverted + the
-                // batch itself is reverted then the storage will persist an incorrect batch. The
-                // situation should be extremely rare but still possible. Two options here:
-                // 1. Trim batches that are no longer executed from the storage on start-up.
-                // 2. Track **finalized** executions along with regular (latest) ones. They cannot
-                //    be reorged and hence would be safe to depend on here.
-
                 let execute = BlockExecution::decode_log(&log.inner)?.data;
                 let batch_number = execute.batchNumber.to::<u64>();
                 if batch_number > self.last_persisted_batch_on_start {

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -1,5 +1,6 @@
 use crate::ProcessRawEvents;
 use crate::metrics::METRICS;
+use alloy::eips::BlockId;
 use alloy::primitives::BlockNumber;
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::{Filter, Log};
@@ -12,9 +13,14 @@ pub struct L1Watcher {
     provider: DynProvider,
     next_block: BlockNumber,
     max_blocks_to_process: u64,
-    confirmations: BlockNumber,
+    block_boundary: BlockBoundary,
     poll_interval: Duration,
     processor: Box<dyn ProcessRawEvents>,
+}
+
+enum BlockBoundary {
+    Confirmed { confirmations: BlockNumber },
+    Finalized,
 }
 
 impl L1Watcher {
@@ -36,10 +42,27 @@ impl L1Watcher {
             provider,
             next_block,
             max_blocks_to_process,
-            confirmations,
+            block_boundary: BlockBoundary::Confirmed { confirmations },
             poll_interval,
             processor,
         })
+    }
+
+    pub(crate) fn new_finalized(
+        provider: DynProvider,
+        next_block: BlockNumber,
+        max_blocks_to_process: u64,
+        poll_interval: Duration,
+        processor: Box<dyn ProcessRawEvents>,
+    ) -> Self {
+        Self {
+            provider,
+            next_block,
+            max_blocks_to_process,
+            block_boundary: BlockBoundary::Finalized,
+            poll_interval,
+            processor,
+        }
     }
 }
 
@@ -56,8 +79,27 @@ impl L1Watcher {
     }
 
     async fn poll(&mut self) -> Result<(), L1WatcherError> {
-        let latest_block = self.provider.get_block_number().await?;
-        let latest_confirmed_block = latest_block.saturating_sub(self.confirmations);
+        let latest_confirmed_block = match self.block_boundary {
+            BlockBoundary::Confirmed { confirmations } => self
+                .provider
+                .get_block_number()
+                .await?
+                .saturating_sub(confirmations),
+            BlockBoundary::Finalized => {
+                let Some(finalized_block) = self
+                    .provider
+                    .get_block_number_by_id(BlockId::finalized())
+                    .await?
+                else {
+                    tracing::debug!(
+                        event_name = &self.processor.name(),
+                        "no finalized L1 block available yet"
+                    );
+                    return Ok(());
+                };
+                finalized_block
+            }
+        };
 
         while self.next_block <= latest_confirmed_block {
             let from_block = self.next_block;

--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -337,7 +337,7 @@ impl<ReplayStorage: ReadReplay + Clone, Finality: ReadFinality + Clone>
                 return Ok(());
             };
             finality_receiver
-                .wait_for(|f| last_block_number <= f.last_executed_block)
+                .wait_for(|f| last_block_number <= f.last_finalized_executed_block)
                 .await
                 .context("failed to wait for executed block number")?;
 

--- a/lib/rpc/src/rpc_storage.rs
+++ b/lib/rpc/src/rpc_storage.rs
@@ -50,7 +50,7 @@ pub trait ReadRpcStorage: ReadStateHistory + Clone {
             BlockId::Number(BlockNumberOrTag::Finalized) => self
                 .finality()
                 .get_finality_status()
-                .last_executed_block
+                .last_finalized_executed_block
                 .into(),
             BlockId::Number(BlockNumberOrTag::Earliest) => {
                 self.repository().get_earliest_block().into()

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -110,4 +110,6 @@ pub struct FinalityStatus {
     pub last_committed_batch: u64,
     pub last_executed_block: u64,
     pub last_executed_batch: u64,
+    pub last_finalized_executed_block: u64,
+    pub last_finalized_executed_batch: u64,
 }

--- a/local-chains/README.md
+++ b/local-chains/README.md
@@ -57,7 +57,7 @@ L1 state snapshot for Anvil. Contains the deployed L1 contracts state. It can be
 
 ```bash
 gzip -dfk ./local-chains/v30.2/l1-state.json.gz
-anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining
+anvil --load-state ./local-chains/v30.2/l1-state.json --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10
 ```
 
 ### `config.yaml`

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -70,7 +70,7 @@ use zksync_os_l1_sender::pipeline_component::L1Sender;
 use zksync_os_l1_sender::upgrade_gatekeeper::UpgradeGatekeeper;
 use zksync_os_l1_watcher::{
     CommittedBatchProvider, GatewayMigrationWatcher, L1CommitWatcher, L1ExecuteWatcher,
-    L1TxWatcher, L1UpgradeTxWatcher,
+    L1FinalizedExecuteWatcher, L1TxWatcher, L1UpgradeTxWatcher,
 };
 use zksync_os_l1_watcher::{InteropWatcher, L1PersistBatchWatcher};
 use zksync_os_mempool::Pool;
@@ -528,7 +528,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     runtime.spawn_critical_task(
         "l1 finalized execute watcher",
-        L1ExecuteWatcher::create_finalized_watcher(
+        L1FinalizedExecuteWatcher::create_finalized_watcher(
             config.l1_watcher_config.clone().into(),
             node_startup_state.l1_state.diamond_proxy_sl.clone(),
             committed_batch_provider.clone(),

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -332,8 +332,12 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         config.tx_validator_config.clone().into(),
     );
 
-    let (last_l1_committed_block, last_l1_proved_block, last_l1_executed_block) =
-        commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider).await;
+    let (
+        last_l1_committed_block,
+        last_l1_proved_block,
+        last_l1_executed_block,
+        last_l1_finalized_executed_block,
+    ) = commit_proof_execute_block_numbers(&l1_state, &committed_batch_provider).await;
 
     let node_startup_state = NodeStateOnStartup {
         node_role,
@@ -370,6 +374,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         last_committed_batch: l1_state.last_committed_batch,
         last_executed_block: last_l1_executed_block,
         last_executed_batch: l1_state.last_executed_batch,
+        last_finalized_executed_block: last_l1_finalized_executed_block,
+        last_finalized_executed_batch: l1_state.last_finalized_executed_batch,
     });
 
     // `starting_block` - the block number to go through the pipeline.
@@ -517,6 +523,19 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         )
         .await
         .expect("failed to start L1 execute watcher")
+        .run(),
+    );
+
+    runtime.spawn_critical_task(
+        "l1 finalized execute watcher",
+        L1ExecuteWatcher::create_finalized_watcher(
+            config.l1_watcher_config.clone().into(),
+            node_startup_state.l1_state.diamond_proxy_sl.clone(),
+            committed_batch_provider.clone(),
+            finality_storage.clone(),
+        )
+        .await
+        .expect("failed to start finalized L1 execute watcher")
         .run(),
     );
 
@@ -781,7 +800,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             config.l1_watcher_config.clone().into(),
             node_startup_state.l1_state.diamond_proxy_sl.clone(),
             persistent_batch_storage.clone(),
-            node_startup_state.l1_state.l1_chain_id,
         )
         .await
         .expect("failed to start L1 batch persist watcher")
@@ -1366,7 +1384,7 @@ fn check_batch_verification_mismatch(
 async fn commit_proof_execute_block_numbers(
     l1_state: &L1State,
     committed_batch_provider: &CommittedBatchProvider,
-) -> (u64, u64, u64) {
+) -> (u64, u64, u64, u64) {
     let last_committed_block = if l1_state.last_committed_batch == 0 {
         0
     } else {
@@ -1394,7 +1412,20 @@ async fn commit_proof_execute_block_numbers(
             .expect("last_executed_batch is expected to be loaded")
             .last_block_number()
     };
-    (last_committed_block, last_proved_block, last_executed_block)
+    let last_finalized_executed_block = if l1_state.last_finalized_executed_batch == 0 {
+        0
+    } else {
+        committed_batch_provider
+            .get(l1_state.last_finalized_executed_batch)
+            .expect("last_finalized_executed_batch is expected to be loaded")
+            .last_block_number()
+    };
+    (
+        last_committed_block,
+        last_proved_block,
+        last_executed_block,
+        last_finalized_executed_block,
+    )
 }
 
 fn run_fake_snark_provers(

--- a/run_local.sh
+++ b/run_local.sh
@@ -151,10 +151,10 @@ echo -e "${GREEN}Build completed${NC}"
 echo -e "\n${GREEN}Starting Anvil...${NC}"
 if [ -n "$LOGS_DIR" ]; then
     ANVIL_LOG_FILE="$LOGS_DIR/anvil-$LOG_TIMESTAMP.log"
-    anvil --load-state "$L1_STATE_FILE" --port 8545 --block-time 0.25 --mixed-mining > "$ANVIL_LOG_FILE" 2>&1 &
+    anvil --load-state "$L1_STATE_FILE" --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10 > "$ANVIL_LOG_FILE" 2>&1 &
     echo -e "${GREEN}Anvil logs: $ANVIL_LOG_FILE${NC}"
 else
-    anvil --load-state "$L1_STATE_FILE" --port 8545 --block-time 0.25 --mixed-mining > /dev/null 2>&1 &
+    anvil --load-state "$L1_STATE_FILE" --port 8545 --block-time 0.25 --mixed-mining --slots-in-an-epoch 10 > /dev/null 2>&1 &
 fi
 ANVIL_PID=$!
 PIDS+=($ANVIL_PID)


### PR DESCRIPTION
## Summary

Adds BlockBoundary enum, that is passed to `L1Watcher::new`, most of the watchers use BlockBoundary::Confirmed, but those that need finalized events use BlockBoundary::Finalized. Two versions of `L1ExecuteWatcher`s are run, one with Confirmed and one with Finalized, they set the corresponding finality fields. 
`last_finalized_executed` is used in RPC for resolving "finalized" block tag and in priority tree persistence.
Also, L1PersistBatchWatcher now runs in `BlockBoundary::Finalized` mode.

For persistance use-cases we use "finalized" so that we're sure we don't have to revert storages in some exceptional cases. For RPC we use `last_finalized_executed` because only for these blocks/batches true finalization is guaranteed + this way L2 to L1 log proofs are always available for finalized blocks.

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

