### PR TITLE
fix(observability): align tokio metrics sampling interval with Prometheus scrape interval

### DIFF
--- a/lib/observability/src/prometheus.rs
+++ b/lib/observability/src/prometheus.rs
@@ -55,7 +55,7 @@ impl PrometheusExporterConfig {
 
     /// Runs the exporter. This future should be spawned in a separate Tokio task.
     pub async fn run(self, shutdown: GracefulShutdown) -> anyhow::Result<()> {
-        tokio_runtime::spawn_monitor();
+        tokio_runtime::register_monitor();
         let registry = MetricsCollection::lazy().collect();
         let metrics_exporter =
             MetricsExporter::new(registry.into()).with_graceful_shutdown(shutdown.ignore_guard());

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -5,13 +5,11 @@
 //! synchronous code running on async worker threads starves other tasks without necessarily
 //! saturating CPU (e.g. blocking storage reads block the thread but do no compute).
 
-use std::time::Duration;
+use std::sync::Mutex;
 
 use tokio::runtime::Handle;
-use tokio::spawn;
-use tokio::time::sleep;
 use tokio_metrics::RuntimeMonitor;
-use vise::{Gauge, Global, Metrics, Unit};
+use vise::{Collector, Gauge, Metrics, Unit};
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "tokio_runtime")]
@@ -39,42 +37,35 @@ struct TokioRuntimeMetrics {
 }
 
 #[vise::register]
-static METRICS: Global<TokioRuntimeMetrics> = Global::new();
+static METRICS: Collector<TokioRuntimeMetrics> = Collector::new();
 
-/// Spawns a background task that samples Tokio runtime metrics once per scrape interval.
+/// Registers a Prometheus collector that samples Tokio runtime metrics on each scrape.
 ///
+/// The sampling window exactly matches the scrape interval — no hardcoded sleep needed.
 /// Must be called from within a Tokio runtime context.
-pub fn spawn_monitor() {
+pub fn register_monitor() {
     let handle = Handle::current();
-    spawn(async move {
-        let monitor = RuntimeMonitor::new(&handle);
-        let mut intervals = monitor.intervals();
-        loop {
-            sleep(Duration::from_secs(30)).await;
-            let interval = intervals.next().expect("infinite iterator");
-            METRICS.worker_busy_ratio.set(interval.busy_ratio());
-            METRICS.workers_count.set(interval.workers_count as u64);
-            METRICS
-                .global_queue_depth
-                .set(interval.global_queue_depth as u64);
-            METRICS
-                .live_tasks_count
-                .set(interval.live_tasks_count as u64);
-            METRICS
-                .total_local_queue_depth
+    let intervals = Mutex::new(RuntimeMonitor::new(&handle).intervals());
+
+    METRICS
+        .before_scrape(move || {
+            let interval = intervals.lock().unwrap().next().expect("infinite iterator");
+            let m = TokioRuntimeMetrics::default();
+            m.worker_busy_ratio.set(interval.busy_ratio());
+            m.workers_count.set(interval.workers_count as u64);
+            m.global_queue_depth.set(interval.global_queue_depth as u64);
+            m.live_tasks_count.set(interval.live_tasks_count as u64);
+            m.total_local_queue_depth
                 .set(interval.total_local_queue_depth as u64);
-            METRICS
-                .blocking_queue_depth
+            m.blocking_queue_depth
                 .set(interval.blocking_queue_depth as u64);
-            METRICS
-                .blocking_threads_count
+            m.blocking_threads_count
                 .set(interval.blocking_threads_count as u64);
-            METRICS
-                .idle_blocking_threads_count
+            m.idle_blocking_threads_count
                 .set(interval.idle_blocking_threads_count as u64);
-            METRICS
-                .mean_poll_duration
+            m.mean_poll_duration
                 .set(interval.mean_poll_duration.as_secs_f64());
-        }
-    });
+            m
+        })
+        .expect("tokio runtime monitor already registered");
 }

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -67,5 +67,5 @@ pub fn register_monitor() {
                 .set(interval.mean_poll_duration.as_secs_f64());
             m
         })
-        .expect("tokio runtime monitor already registered");
+        .ok();
 }

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -48,7 +48,10 @@ pub fn spawn_monitor() {
     let handle = Handle::current();
     spawn(async move {
         let monitor = RuntimeMonitor::new(&handle);
-        for interval in monitor.intervals() {
+        let mut intervals = monitor.intervals();
+        loop {
+            sleep(Duration::from_secs(30)).await;
+            let interval = intervals.next().expect("infinite iterator");
             METRICS.worker_busy_ratio.set(interval.busy_ratio());
             METRICS.workers_count.set(interval.workers_count as u64);
             METRICS
@@ -72,7 +75,6 @@ pub fn spawn_monitor() {
             METRICS
                 .mean_poll_duration
                 .set(interval.mean_poll_duration.as_secs_f64());
-            sleep(Duration::from_secs(30)).await;
         }
     });
 }

--- a/lib/observability/src/tokio_runtime.rs
+++ b/lib/observability/src/tokio_runtime.rs
@@ -41,7 +41,7 @@ struct TokioRuntimeMetrics {
 #[vise::register]
 static METRICS: Global<TokioRuntimeMetrics> = Global::new();
 
-/// Spawns a background task that samples Tokio runtime metrics once per second.
+/// Spawns a background task that samples Tokio runtime metrics once per scrape interval.
 ///
 /// Must be called from within a Tokio runtime context.
 pub fn spawn_monitor() {
@@ -72,7 +72,7 @@ pub fn spawn_monitor() {
             METRICS
                 .mean_poll_duration
                 .set(interval.mean_poll_duration.as_secs_f64());
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(30)).await;
         }
     });
 }

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     wait_for_db: impl Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
     tracing::info!("Starting JSON-RPC server at {}", config.address);
-    metrics::spawn_task_monitor();
+    metrics::register_task_monitor();
 
     let mut rpc = RpcModule::new(());
     let eth_call_handler = EthCallHandler::new(

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -213,5 +213,5 @@ pub fn register_task_monitor() {
             m.slow_polls_count.set(metrics.total_slow_poll_count);
             m
         })
-        .expect("RPC task monitor already registered");
+        .ok();
 }

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -1,12 +1,11 @@
 use alloy::rpc::types::Filter;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
-use tokio::spawn;
-use tokio::time::sleep;
+
 use tokio_metrics::TaskMonitor;
 use vise::{
-    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Global, Histogram,
-    LabeledFamily, Metrics, Unit,
+    Buckets, Collector, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Global,
+    Histogram, LabeledFamily, Metrics, Unit,
 };
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
@@ -195,27 +194,24 @@ struct RpcTaskMetrics {
 }
 
 #[vise::register]
-static RPC_TASK_METRICS: Global<RpcTaskMetrics> = Global::new();
+static RPC_TASK_METRICS: Collector<RpcTaskMetrics> = Collector::new();
 
-/// Spawns a background task that samples global RPC task metrics once per scrape interval.
+/// Registers a Prometheus collector that samples RPC task metrics on each scrape.
 ///
-/// Must be called from within a Tokio runtime context.
-pub fn spawn_task_monitor() {
-    let mut intervals = RPC_TASK_MONITOR.intervals();
+/// The sampling window exactly matches the scrape interval — no hardcoded sleep needed.
+pub fn register_task_monitor() {
+    let intervals = Mutex::new(RPC_TASK_MONITOR.intervals());
 
-    spawn(async move {
-        loop {
-            sleep(Duration::from_secs(30)).await;
-            let metrics = intervals.next().expect("infinite iterator");
-            RPC_TASK_METRICS
-                .mean_scheduled_duration
+    RPC_TASK_METRICS
+        .before_scrape(move || {
+            let metrics = intervals.lock().unwrap().next().expect("infinite iterator");
+            let m = RpcTaskMetrics::default();
+            m.mean_scheduled_duration
                 .set(metrics.mean_scheduled_duration().as_secs_f64());
-            RPC_TASK_METRICS
-                .mean_poll_duration
+            m.mean_poll_duration
                 .set(metrics.mean_poll_duration().as_secs_f64());
-            RPC_TASK_METRICS
-                .slow_polls_count
-                .set(metrics.total_slow_poll_count);
-        }
-    });
+            m.slow_polls_count.set(metrics.total_slow_poll_count);
+            m
+        })
+        .expect("RPC task monitor already registered");
 }

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -197,7 +197,7 @@ struct RpcTaskMetrics {
 #[vise::register]
 static RPC_TASK_METRICS: Global<RpcTaskMetrics> = Global::new();
 
-/// Spawns a background task that samples global RPC task metrics once per second.
+/// Spawns a background task that samples global RPC task metrics once per scrape interval.
 ///
 /// Must be called from within a Tokio runtime context.
 pub fn spawn_task_monitor() {
@@ -205,7 +205,7 @@ pub fn spawn_task_monitor() {
 
     spawn(async move {
         loop {
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(30)).await;
             let metrics = intervals.next().expect("infinite iterator");
             RPC_TASK_METRICS
                 .mean_scheduled_duration


### PR DESCRIPTION
## Summary

`tokio_metrics` intervals are window aggregates — the value of `busy_ratio`, `mean_poll_duration`, etc. depends on how long ago you last called `intervals.next()`. We were calling it every 1s from a background task, but Prometheus scrapes every 30s, so 29/30 samples were discarded and the one that landed captured a 1-second window.

Fix: use `vise::Collector::before_scrape()` to call `intervals.next()` at scrape time. The window now matches the actual scrape interval with no hardcoding.

Both `tokio_runtime` and `rpc_task` monitors updated. `spawn_monitor`/`spawn_task_monitor` renamed to `register_monitor`/`register_task_monitor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)