### PR TITLE
feat(rpc): Implement eth_simulateV1

### DIFF
--- a/integration-tests/test-contracts/src/Counter.sol
+++ b/integration-tests/test-contracts/src/Counter.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.13;
 
 /// Sample contract with storage state.
 contract Counter {
-    uint256 counter;
+    uint256 public counter;
 
     function increment(uint256 _by) public {
         counter += _by;

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -4,5 +4,6 @@ mod debug;
 mod deployment_filter;
 mod filter;
 mod pubsub;
+mod simulate;
 mod storage_proof;
 mod transactions;

--- a/integration-tests/tests/rpc/simulate.rs
+++ b/integration-tests/tests/rpc/simulate.rs
@@ -2,6 +2,8 @@ use alloy::primitives::U256;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy::rpc::types::simulate::{SimBlock, SimulatePayload};
+use alloy::sol_types::{SolCall, SolEvent};
+use zksync_os_integration_tests::contracts::EventEmitter::TestEvent;
 use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
 use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
 
@@ -69,41 +71,63 @@ async fn simulate_multiple_txs_in_one_block(tester: Tester) -> anyhow::Result<()
         assert!(call.gas_used > 0, "call {i} gas used should be non-zero");
     }
 
+    // First two calls must have emitted exactly one TestEvent each, with numbers 1 and 2 in
+    // that order. This proves that logs (and their ordering) are reported per-call.
+    for (i, expected_number) in [1u64, 2u64].iter().enumerate() {
+        let logs = &block.calls[i].logs;
+        assert_eq!(logs.len(), 1, "call {i} should have one log");
+        let decoded = TestEvent::decode_log(&logs[0].inner)
+            .unwrap_or_else(|e| panic!("call {i} log is not a TestEvent: {e}"));
+        assert_eq!(decoded.number, U256::from(*expected_number));
+    }
+    // The plain ETH transfer should not have produced any logs.
+    assert!(
+        block.calls[2].logs.is_empty(),
+        "transfer should emit no logs"
+    );
+
     Ok(())
 }
 
-/// Simulate two blocks in sequence and verify that state changes from the first block carry over.
+/// Simulate three blocks in sequence and verify that state changes from earlier blocks carry over.
 #[test_multisetup([CURRENT_TO_L1])]
 async fn simulate_state_carries_across_blocks(tester: Tester) -> anyhow::Result<()> {
-    // Deploy a Counter and increment it in block 1. In block 2, read it via eth_call to confirm
-    // the simulated write is visible.
+    // Deploy a Counter, increment by 7 in block 1, by 3 in block 2, then read the counter in
+    // block 3 and confirm it equals 10. Without state carry-over, the read would return 0.
     let counter = Counter::deploy(tester.l2_provider.clone()).await?;
 
     let increment_call = counter.increment(U256::from(7)).into_transaction_request();
-    // A second increment in block 2 — if state did not carry over, this would fail or return wrong data.
     let increment_call_2 = counter.increment(U256::from(3)).into_transaction_request();
+    let read_call = counter.counter().into_transaction_request();
 
     let payload = SimulatePayload {
         block_state_calls: vec![
             SimBlock::default().call(increment_call),
             SimBlock::default().call(increment_call_2),
+            SimBlock::default().call(read_call),
         ],
         ..Default::default()
     };
 
     let results = tester.l2_provider.simulate(&payload).await?;
 
-    assert_eq!(results.len(), 2, "expected two simulated blocks");
+    assert_eq!(results.len(), 3, "expected three simulated blocks");
     assert_eq!(results[0].calls.len(), 1);
     assert_eq!(results[1].calls.len(), 1);
+    assert_eq!(results[2].calls.len(), 1);
 
     let first_call = &results[0].calls[0];
     let second_call = &results[1].calls[0];
+    let read_result = &results[2].calls[0];
 
     assert!(first_call.status, "first increment should succeed");
     assert!(second_call.status, "second increment should succeed");
+    assert!(read_result.status, "read should succeed");
     assert!(first_call.gas_used > 0);
     assert!(second_call.gas_used > 0);
+
+    let observed = Counter::counterCall::abi_decode_returns(&read_result.return_data)?;
+    assert_eq!(observed, U256::from(10), "counter should be 7 + 3 = 10");
 
     Ok(())
 }

--- a/integration-tests/tests/rpc/simulate.rs
+++ b/integration-tests/tests/rpc/simulate.rs
@@ -1,0 +1,109 @@
+use alloy::primitives::U256;
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use alloy::rpc::types::simulate::{SimBlock, SimulatePayload};
+use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
+use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+
+/// Simulate a single ETH transfer in one block and verify that gas was consumed.
+#[test_multisetup([CURRENT_TO_L1])]
+async fn simulate_eth_transfer_gas_used(tester: Tester) -> anyhow::Result<()> {
+    let sender = tester.l2_wallet.default_signer().address();
+    let recipient = alloy::primitives::address!("000000000000000000000000000000000000dead");
+    let value = U256::from(1_000u64);
+
+    let payload = SimulatePayload {
+        block_state_calls: vec![
+            SimBlock::default().call(
+                TransactionRequest::default()
+                    .from(sender)
+                    .to(recipient)
+                    .value(value),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let results = tester.l2_provider.simulate(&payload).await?;
+
+    assert_eq!(results.len(), 1, "expected one simulated block");
+    let block = &results[0];
+    assert_eq!(block.calls.len(), 1, "expected one call result");
+
+    let call = &block.calls[0];
+    assert!(call.status, "transfer should succeed");
+    assert!(call.gas_used > 0, "gas used should be non-zero");
+
+    Ok(())
+}
+
+/// Simulate three transactions in the same block and verify all succeed with non-zero gas.
+#[test_multisetup([CURRENT_TO_L1])]
+async fn simulate_multiple_txs_in_one_block(tester: Tester) -> anyhow::Result<()> {
+    let sender = tester.l2_wallet.default_signer().address();
+    let emitter = EventEmitter::deploy(tester.l2_provider.clone()).await?;
+    let recipient = alloy::primitives::address!("000000000000000000000000000000000000dead");
+
+    let payload = SimulatePayload {
+        block_state_calls: vec![
+            SimBlock::default()
+                .call(emitter.emitEvent(U256::from(1)).into_transaction_request())
+                .call(emitter.emitEvent(U256::from(2)).into_transaction_request())
+                .call(
+                    TransactionRequest::default()
+                        .from(sender)
+                        .to(recipient)
+                        .value(U256::from(1u64)),
+                ),
+        ],
+        ..Default::default()
+    };
+
+    let results = tester.l2_provider.simulate(&payload).await?;
+
+    assert_eq!(results.len(), 1);
+    let block = &results[0];
+    assert_eq!(block.calls.len(), 3, "expected three call results");
+    for (i, call) in block.calls.iter().enumerate() {
+        assert!(call.status, "call {i} should succeed");
+        assert!(call.gas_used > 0, "call {i} gas used should be non-zero");
+    }
+
+    Ok(())
+}
+
+/// Simulate two blocks in sequence and verify that state changes from the first block carry over.
+#[test_multisetup([CURRENT_TO_L1])]
+async fn simulate_state_carries_across_blocks(tester: Tester) -> anyhow::Result<()> {
+    // Deploy a Counter and increment it in block 1. In block 2, read it via eth_call to confirm
+    // the simulated write is visible.
+    let counter = Counter::deploy(tester.l2_provider.clone()).await?;
+
+    let increment_call = counter.increment(U256::from(7)).into_transaction_request();
+    // A second increment in block 2 — if state did not carry over, this would fail or return wrong data.
+    let increment_call_2 = counter.increment(U256::from(3)).into_transaction_request();
+
+    let payload = SimulatePayload {
+        block_state_calls: vec![
+            SimBlock::default().call(increment_call),
+            SimBlock::default().call(increment_call_2),
+        ],
+        ..Default::default()
+    };
+
+    let results = tester.l2_provider.simulate(&payload).await?;
+
+    assert_eq!(results.len(), 2, "expected two simulated blocks");
+    assert_eq!(results[0].calls.len(), 1);
+    assert_eq!(results[1].calls.len(), 1);
+
+    let first_call = &results[0].calls[0];
+    let second_call = &results[1].calls[0];
+
+    assert!(first_call.status, "first increment should succeed");
+    assert!(second_call.status, "second increment should succeed");
+    assert!(first_call.gas_used > 0);
+    assert!(second_call.gas_used > 0);
+
+    Ok(())
+}

--- a/lib/rpc/src/config.rs
+++ b/lib/rpc/src/config.rs
@@ -10,6 +10,11 @@ pub struct RpcConfig {
     /// Gas limit of transactions executed via eth_call
     pub eth_call_gas: usize,
 
+    /// Maximum block gas limit accepted for an `eth_simulateV1` block override. Applies only
+    /// when the caller explicitly overrides `blockOverrides.gasLimit`; unset overrides fall
+    /// back to the executing block's own gas limit.
+    pub eth_simulate_block_gas_limit: u64,
+
     /// Number of concurrent API connections (passed to jsonrpsee, default value there is 128)
     pub max_connections: u32,
 

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -19,11 +19,14 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
+use zksync_os_interface::tracing::{NopTracer, NopValidator};
+use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
     types::{BlockContext, ExecutionResult},
 };
+use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
     BlockOverlay, RepositoryError, StateError, ViewState,
@@ -771,15 +774,14 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         for sim_block in block_state_calls {
             block_context.mix_hash = U256::ZERO;
-            let header_overrides = match sim_block.block_overrides {
-                Some(block_overrides) => simulation_utils::apply_simulate_block_overrides(
+            if let Some(block_overrides) = sim_block.block_overrides {
+                simulation_utils::apply_simulate_block_overrides(
                     &mut block_context,
                     block_overrides,
                     previous_block_number,
                     previous_timestamp,
-                )?,
-                None => simulation_utils::SimulateHeaderOverrides::default(),
-            };
+                )?;
+            }
 
             // `validation=false` disables fee validation for execution, but the returned block
             // still reports the requested/header-overridden base fee.
@@ -806,12 +808,22 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 execution_context,
                 overridden_view.clone(),
             )?;
-            let block_output =
-                simulation_utils::run_simulation_block(execution_context, overridden_view, &txs)?;
+            let tx_source = TxListSource {
+                transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
+            };
+            let block_output = run_block(
+                execution_context,
+                overridden_view.clone(),
+                overridden_view,
+                tx_source,
+                NoopTxCallback,
+                &mut NopTracer,
+                &mut NopValidator,
+            )
+            .map_err(EthCallError::ForwardSubsystemError)?;
 
             let simulated_block = simulation_utils::build_simulated_block_response(
                 response_context,
-                header_overrides,
                 txs,
                 block_output,
                 return_full_transactions,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -827,7 +827,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             )
             .map_err(EthCallError::ForwardSubsystemError)?;
 
-            let simulated_block = simulation_utils::build_simulated_block_response(
+            let (simulated_block, block_overlay) = simulation_utils::build_simulated_block_response(
                 response_context,
                 txs,
                 block_output,
@@ -838,7 +838,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             let mut overlay = state_overrides;
             // State overrides seed this simulated block; actual VM writes take precedence for
             // subsequent simulated blocks.
-            overlay.extend(simulated_block.overlay);
+            overlay.extend(block_overlay);
             Arc::get_mut(&mut overlays)
                 .ok_or_else(|| {
                     EthCallError::ForwardSubsystemError(anyhow::anyhow!(
@@ -848,10 +848,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 .insert(block_context.block_number, overlay);
             previous_block_number = block_context.block_number;
             previous_timestamp = block_context.timestamp;
-            simulated_blocks.push(SimulatedBlock {
-                inner: simulated_block.inner,
-                calls: simulated_block.calls,
-            });
+            simulated_blocks.push(simulated_block);
 
             block_context = simulation_utils::next_block_context(block_context, next_hash);
         }

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -727,7 +727,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     /// Spec limitations: this backend does not expose reth's `TransferInspector` equivalent, so
     /// `traceTransfers=true` is rejected instead of returning partial transfer logs. The backend
     /// also cannot remap precompiles for a single simulated block, so `movePrecompileToAddress` is
-    /// validated for self/duplicate references and then rejected as unsupported.
+    /// rejected as unsupported.
     pub fn simulate_v1_impl(
         &self,
         opts: SimulatePayload,
@@ -796,7 +796,12 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
             let state_overrides = match sim_block.state_overrides {
                 Some(state_overrides) => {
-                    simulation_utils::validate_state_overrides_for_simulate(&state_overrides)?;
+                    if state_overrides
+                        .values()
+                        .any(|account| account.move_precompile_to.is_some())
+                    {
+                        return Err(EthCallError::SimulateMovePrecompileNotSupported);
+                    }
                     build_state_override_maps(&simulation_view, state_overrides)
                 }
                 None => BlockOverlay::default(),
@@ -965,10 +970,6 @@ pub enum EthCallError {
     SimulateBlockTimestampInvalid { got: u64, parent: u64 },
     #[error("block gas limit exceeded by the block's transactions")]
     SimulateBlockGasLimitExceeded,
-    #[error("MovePrecompileToAddress referenced itself")]
-    SimulatePrecompileSelfReference,
-    #[error("multiple MovePrecompileToAddress values reference the same replacement address")]
-    SimulatePrecompileDuplicateAddress,
     #[error("movePrecompileToAddress is not supported by this execution backend")]
     SimulateMovePrecompileNotSupported,
     // todo(EIP-4844)

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -779,6 +779,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let mut previous_timestamp = parent_timestamp;
 
         for sim_block in block_state_calls {
+            // Per the eth_simulateV1 spec, prevrandao defaults to zero for simulated blocks
+            // unless explicitly overridden via `blockOverrides.random`.
             block_context.mix_hash = U256::ZERO;
             if let Some(block_overrides) = sim_block.block_overrides {
                 simulation_utils::apply_simulate_block_overrides(
@@ -786,7 +788,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     block_overrides,
                     previous_block_number,
                     previous_timestamp,
-                    self.config.eth_call_gas as u64,
+                    self.config.eth_simulate_block_gas_limit,
                 )?;
             }
 
@@ -909,8 +911,11 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         block_context: BlockContext,
         mut state_view: V,
     ) -> Result<Vec<ZkTransaction>, EthCallError> {
-        let default_gas_limit =
-            simulation_utils::simulation_default_gas_limit(&calls, block_context.gas_limit)?;
+        let default_gas_limit = simulation_utils::simulation_default_gas_limit(
+            &calls,
+            block_context.gas_limit,
+            self.config.eth_call_gas as u64,
+        )?;
         let mut next_nonces = HashMap::new();
 
         calls

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -736,6 +736,10 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     ///   its block context; use `blockOverrides.random` (prevrandao) instead.
     /// - `blockOverrides.parentBeaconBlockRoot`: silently ignored. There is no corresponding
     ///   field in `BlockContext`.
+    /// - `validation=false` nonce relaxation: partially unsupported. The basefee is zeroed as
+    ///   the spec requires, but nonce checks are not disabled. Transactions without an explicit
+    ///   nonce are auto-filled from state (the common case works), but an explicitly supplied
+    ///   stale nonce will be rejected by the VM.
     pub fn simulate_v1_impl(
         &self,
         opts: SimulatePayload,
@@ -791,8 +795,11 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 )?;
             }
 
-            // `validation=false` disables fee validation for execution, but the returned block
-            // still reports the requested/header-overridden base fee.
+            // `validation=false` is supposed to disable both fee and nonce validation. We zero
+            // the basefee to satisfy fee checks, but nonce checks are not disabled — the VM still
+            // enforces them. Callers that rely on sending transactions with arbitrary nonces when
+            // `validation=false` will see unexpected failures. Nonces without an explicit value are
+            // auto-filled from state, so the common case works correctly.
             let response_context = block_context;
             let mut execution_context = response_context;
             if !validation {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -29,8 +29,8 @@ use zksync_os_interface::{
 use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
-    OwnedOverrides, RepositoryError, StateError, ViewState,
-    state_override_view::{OverriddenStateView, build_state_override_maps},
+    RepositoryError, StateError, ViewState,
+    state_override_view::{OverriddenStateView, OwnedOverrides, build_state_override_maps},
 };
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -4,6 +4,7 @@ use crate::js_tracer;
 use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute};
+use crate::simulation_utils;
 use alloy::consensus::transaction::Recovered;
 use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxType};
 use alloy::eips::BlockId;
@@ -38,9 +39,6 @@ use zksync_os_types::{
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType, ZkEnvelope,
     ZkTransaction, ZkTxType,
 };
-
-#[path = "simulation_utils.rs"]
-mod simulation_utils;
 
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
 #[derive(Clone, Debug)]
@@ -792,6 +790,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     block_overrides,
                     previous_block_number,
                     previous_timestamp,
+                    self.config.eth_call_gas as u64,
                 )?;
             }
 
@@ -919,11 +918,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         block_context: BlockContext,
         mut state_view: V,
     ) -> Result<Vec<ZkTransaction>, EthCallError> {
-        let default_gas_limit = simulation_utils::simulation_default_gas_limit(
-            &calls,
-            block_context.gas_limit,
-            self.config.eth_call_gas as u64,
-        )?;
+        let default_gas_limit =
+            simulation_utils::simulation_default_gas_limit(&calls, block_context.gas_limit)?;
         let mut next_nonces = HashMap::new();
 
         calls

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -1,38 +1,29 @@
 use crate::call_fees::{CallFees, CallFeesError};
 use crate::config::RpcConfig;
-use crate::eth_impl::{build_api_log, build_api_tx};
 use crate::js_tracer;
 use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute};
-use alloy::consensus::Transaction as _;
-use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy::consensus::transaction::Recovered;
 use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxType};
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
-use alloy::network::primitives::BlockTransactions;
-use alloy::primitives::{Address, B256, Bloom, Bytes, Signature, TxKind, U256};
-use alloy::rpc::types::simulate::{
-    MAX_SIMULATE_BLOCKS, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock,
-};
+use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+use alloy::rpc::types::simulate::{MAX_SIMULATE_BLOCKS, SimulatePayload, SimulatedBlock};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::trace::geth::{CallConfig, GethTrace};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use serde_json::Value as JsonValue;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
-use zksync_os_interface::tracing::{NopTracer, NopValidator};
-use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
-use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
+use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
-    types::{BlockContext, BlockOutput, ExecutionResult},
+    types::{BlockContext, ExecutionResult},
 };
-use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
     BlockOverlay, RepositoryError, StateError, ViewState,
@@ -42,8 +33,11 @@ use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
     L1_TX_MINIMAL_GAS_LIMIT, L1Envelope, L1PriorityTxType, L1Tx, L1TxType, L2Envelope,
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType, ZkEnvelope,
-    ZkReceipt, ZkReceiptEnvelope, ZkTransaction, ZkTxType,
+    ZkTransaction, ZkTxType,
 };
+
+#[path = "simulation_utils.rs"]
+mod simulation_utils;
 
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
 #[derive(Clone, Debug)]
@@ -432,131 +426,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         Ok(tracer_output.results.pop().unwrap_or(JsonValue::Null))
     }
 
-    /// Implements `eth_simulateV1` using the same high-level model as reth: execute the requested
-    /// blocks linearly, carry an overlay of simulated writes into subsequent blocks, and use a
-    /// separate execution context when `validation=false` so fee validation does not leak into the
-    /// returned header.
-    ///
-    /// Spec limitations: this backend does not expose reth's `TransferInspector` equivalent, so
-    /// `traceTransfers=true` is rejected instead of returning partial transfer logs. The backend
-    /// also cannot remap precompiles for a single simulated block, so `movePrecompileToAddress` is
-    /// validated for self/duplicate references and then rejected as unsupported.
-    pub fn simulate_v1_impl(
-        &self,
-        opts: SimulatePayload,
-        block: Option<BlockId>,
-    ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
-        let SimulatePayload {
-            block_state_calls,
-            trace_transfers,
-            validation,
-            return_full_transactions,
-        } = opts;
-
-        if block_state_calls.is_empty() {
-            return Err(EthCallError::SimulateInvalidParams(
-                "calls are empty".to_string(),
-            ));
-        }
-        if block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
-            return Err(EthCallError::SimulateInvalidParams(
-                "too many blocks".to_string(),
-            ));
-        }
-
-        if trace_transfers {
-            // Reth implements this with `TransferInspector`, which records all native value moves,
-            // including internal CALL/CREATE/SELFDESTRUCT. The ZKsync OS VM path used here does not
-            // expose an equivalent transfer stream, so fail explicitly rather than returning a
-            // partial trace.
-            return Err(EthCallError::SimulateInvalidParams(
-                "traceTransfers is not implemented".to_string(),
-            ));
-        }
-
-        let SimulationStartContext {
-            mut block_context,
-            parent_block_number,
-            parent_timestamp,
-        } = self.resolve_simulation_start_context(block)?;
-        let base_state = self.storage.state_view_at(parent_block_number)?;
-        let mut overlays = Arc::new(BTreeMap::new());
-        let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
-        let mut previous_block_number = parent_block_number;
-        let mut previous_timestamp = parent_timestamp;
-
-        for sim_block in block_state_calls {
-            block_context.mix_hash = U256::ZERO;
-            let header_overrides = match sim_block.block_overrides {
-                Some(block_overrides) => apply_simulate_block_overrides(
-                    &mut block_context,
-                    block_overrides,
-                    previous_block_number,
-                    previous_timestamp,
-                )?,
-                None => SimulateHeaderOverrides::default(),
-            };
-
-            // `validation=false` disables fee validation for execution, but the returned block
-            // still reports the requested/header-overridden base fee.
-            let response_context = block_context;
-            let mut execution_context = response_context;
-            if !validation {
-                execution_context.eip1559_basefee = U256::ZERO;
-            }
-
-            let simulation_view =
-                OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
-
-            let state_overrides = match sim_block.state_overrides {
-                Some(state_overrides) => {
-                    validate_state_overrides_for_simulate(&state_overrides)?;
-                    build_state_override_maps(&simulation_view, state_overrides)
-                }
-                None => BlockOverlay::default(),
-            };
-            let overridden_view =
-                OverriddenStateView::new(simulation_view, state_overrides.clone());
-            let txs = self.create_simulation_txs(
-                sim_block.calls,
-                execution_context,
-                overridden_view.clone(),
-            )?;
-            let block_output = run_simulation_block(execution_context, overridden_view, &txs)?;
-
-            let simulated_block = build_simulated_block_response(
-                response_context,
-                header_overrides,
-                txs,
-                block_output,
-                return_full_transactions,
-            )?;
-            let next_hash = simulated_block.inner.header.hash;
-
-            let mut overlay = state_overrides;
-            // State overrides seed this simulated block; actual VM writes take precedence for
-            // subsequent simulated blocks.
-            overlay.extend(simulated_block.overlay);
-            Arc::get_mut(&mut overlays)
-                .ok_or_else(|| {
-                    EthCallError::ForwardSubsystemError(anyhow::anyhow!(
-                        "simulation overlay still borrowed during mutation"
-                    ))
-                })?
-                .insert(block_context.block_number, overlay);
-            previous_block_number = block_context.block_number;
-            previous_timestamp = block_context.timestamp;
-            simulated_blocks.push(SimulatedBlock {
-                inner: simulated_block.inner,
-                calls: simulated_block.calls,
-            });
-
-            block_context = next_block_context(block_context, next_hash);
-        }
-
-        Ok(simulated_blocks)
-    }
-
     pub fn estimate_gas_impl(
         &self,
         request: TransactionRequest,
@@ -583,100 +452,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             ),
             None => self.estimate_gas_with_view(request, block_context, storage_view),
         }
-    }
-
-    fn resolve_simulation_start_context(
-        &self,
-        block: Option<BlockId>,
-    ) -> Result<SimulationStartContext, EthCallError> {
-        let block = block.unwrap_or_default();
-        if block.is_latest() || block.is_pending() {
-            let parent_block = self.storage.replay_storage().latest_record();
-            let parent_context = self
-                .storage
-                .replay_storage()
-                .get_context(parent_block)
-                .ok_or(RpcStorageError::BlockNotFound(block))?;
-            return Ok(SimulationStartContext {
-                block_context: self.build_pending_block_context(),
-                parent_block_number: parent_block,
-                parent_timestamp: parent_context.timestamp,
-            });
-        }
-
-        let parent_block = self
-            .storage
-            .resolve_block_number(block)?
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let parent_context = self
-            .storage
-            .replay_storage()
-            .get_context(parent_block)
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let parent = self
-            .storage
-            .get_block_by_id(block)?
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let block_context = next_block_context(parent_context, parent.hash());
-
-        Ok(SimulationStartContext {
-            block_context,
-            parent_block_number: parent_block,
-            parent_timestamp: parent_context.timestamp,
-        })
-    }
-
-    fn create_simulation_txs<V: ViewState>(
-        &self,
-        calls: Vec<TransactionRequest>,
-        block_context: BlockContext,
-        mut state_view: V,
-    ) -> Result<Vec<ZkTransaction>, EthCallError> {
-        let default_gas_limit = simulation_default_gas_limit(
-            &calls,
-            block_context.gas_limit,
-            self.config.eth_call_gas as u64,
-        )?;
-        let mut next_nonces = HashMap::new();
-
-        calls
-            .into_iter()
-            .map(|mut request| {
-                if request.gas.is_none() {
-                    request.set_gas_limit(default_gas_limit);
-                }
-
-                let from = request.from.unwrap_or_default();
-                let state_nonce = next_nonces.entry(from).or_insert_with(|| {
-                    state_view
-                        .get_account(from)
-                        .as_ref()
-                        .map(get_nonce)
-                        .unwrap_or_default()
-                });
-                if let Some(nonce) = request.nonce {
-                    if nonce >= *state_nonce {
-                        *state_nonce =
-                            nonce
-                                .checked_add(1)
-                                .ok_or(EthCallError::SimulateInvalidParams(
-                                    "nonce has max value".to_string(),
-                                ))?;
-                    }
-                } else {
-                    let nonce = *state_nonce;
-                    request.set_nonce(nonce);
-                    *state_nonce =
-                        nonce
-                            .checked_add(1)
-                            .ok_or(EthCallError::SimulateInvalidParams(
-                                "nonce has max value".to_string(),
-                            ))?;
-                }
-
-                self.create_tx_from_request(request, &block_context, false)
-            })
-            .collect()
     }
 }
 
@@ -893,442 +668,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     }
 }
 
-fn run_simulation_block<State>(
-    block_context: BlockContext,
-    state_view: State,
-    txs: &[ZkTransaction],
-) -> Result<BlockOutput, EthCallError>
-where
-    State: ViewState,
-{
-    let tx_source = TxListSource {
-        transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
-    };
-
-    run_block(
-        block_context,
-        state_view.clone(),
-        state_view,
-        tx_source,
-        NoopTxCallback,
-        &mut NopTracer,
-        &mut NopValidator,
-    )
-    .map_err(EthCallError::ForwardSubsystemError)
-}
-
-#[derive(Debug)]
-struct SimulationStartContext {
-    block_context: BlockContext,
-    parent_block_number: u64,
-    parent_timestamp: u64,
-}
-
-#[derive(Debug)]
-struct SimulatedBlockResponse {
-    inner: ZkApiBlock,
-    calls: Vec<SimCallResult>,
-    overlay: BlockOverlay,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-struct SimulateHeaderOverrides {
-    difficulty: Option<U256>,
-}
-
-fn build_simulated_block_response(
-    block_context: BlockContext,
-    header_overrides: SimulateHeaderOverrides,
-    txs: Vec<ZkTransaction>,
-    block_output: BlockOutput,
-    return_full_transactions: bool,
-) -> Result<SimulatedBlockResponse, EthCallError> {
-    let BlockOutput {
-        header: sealed_header,
-        tx_results,
-        storage_writes,
-        published_preimages,
-        ..
-    } = block_output;
-
-    let mut block_bloom = Bloom::default();
-    let mut number_of_logs_before_this_tx = 0;
-    let mut cumulative_gas_used = 0;
-    let mut receipts = Vec::with_capacity(tx_results.len());
-    let mut simulated_txs = Vec::with_capacity(tx_results.len());
-    let mut executed_tx_index = 0;
-
-    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results).enumerate() {
-        let simulated_tx = match result {
-            Ok(tx_output) => {
-                let receipt = build_simulated_receipt(&tx, &tx_output, cumulative_gas_used);
-                block_bloom.accrue_bloom(receipt.logs_bloom());
-                cumulative_gas_used += tx_output.gas_used;
-                let simulated_tx = SimulatedTx {
-                    tx,
-                    tx_index_in_block: executed_tx_index,
-                    number_of_logs_before_this_tx,
-                    result: SimulatedTxResult::Executed {
-                        output: tx_output,
-                        receipt: Box::new(receipt.clone()),
-                    },
-                };
-                executed_tx_index += 1;
-                number_of_logs_before_this_tx += receipt.logs().len() as u64;
-                receipts.push(receipt);
-                simulated_tx
-            }
-            Err(err) => SimulatedTx {
-                tx,
-                tx_index_in_block: call_index as u64,
-                number_of_logs_before_this_tx,
-                result: SimulatedTxResult::Invalid(err),
-            },
-        };
-        simulated_txs.push(simulated_tx);
-    }
-
-    let mut header = sealed_header.unseal();
-    header.base_fee_per_gas = Some(block_context.eip1559_basefee.saturating_to());
-    header.logs_bloom = block_bloom;
-    header.gas_used = cumulative_gas_used;
-    let executed_envelopes = simulated_txs
-        .iter()
-        .filter(|tx| tx.is_executed())
-        .map(|tx| tx.tx.envelope())
-        .collect::<Vec<_>>();
-    header.transactions_root = calculate_transaction_root(&executed_envelopes);
-    header.receipts_root = calculate_receipt_root(&receipts);
-    if let Some(difficulty) = header_overrides.difficulty {
-        header.difficulty = difficulty;
-    }
-
-    let header = alloy::rpc::types::Header::new(header);
-    let block_hash = header.hash;
-    let calls = simulated_txs
-        .iter()
-        .map(|tx| tx.to_call_result(block_hash, block_context))
-        .collect();
-    let transactions = if return_full_transactions {
-        BlockTransactions::Full(
-            simulated_txs
-                .iter()
-                .filter(|tx| tx.is_executed())
-                .map(|tx| tx.to_api_tx(block_hash, block_context))
-                .collect(),
-        )
-    } else {
-        BlockTransactions::Hashes(
-            simulated_txs
-                .iter()
-                .filter(|tx| tx.is_executed())
-                .map(|tx| *tx.tx.hash())
-                .collect(),
-        )
-    };
-    let inner = ZkApiBlock::new(header, transactions);
-
-    Ok(SimulatedBlockResponse {
-        inner,
-        calls,
-        overlay: BlockOverlay {
-            storage_writes: storage_writes
-                .into_iter()
-                .map(|write| (write.key, write.value))
-                .collect(),
-            preimages: published_preimages.into_iter().collect(),
-        },
-    })
-}
-
-fn build_simulated_receipt(
-    tx: &ZkTransaction,
-    tx_output: &TxOutput,
-    cumulative_gas_used_before_this_tx: u64,
-) -> ZkReceiptEnvelope {
-    let l2_to_l1_logs = tx_output
-        .l2_to_l1_logs
-        .iter()
-        .map(|l2_to_l1_log| l2_to_l1_log.log.clone().into())
-        .collect();
-
-    ZkReceiptEnvelope::from_typed(
-        tx.tx_type(),
-        ZkReceipt {
-            status: matches!(tx_output.execution_result, ExecutionResult::Success(_)).into(),
-            cumulative_gas_used: cumulative_gas_used_before_this_tx + tx_output.gas_used,
-            logs: tx_output.logs.clone(),
-            l2_to_l1_logs,
-        },
-    )
-}
-
-fn next_block_context(mut block_context: BlockContext, parent_hash: B256) -> BlockContext {
-    block_context.block_number += 1;
-    block_context.timestamp += 1;
-    block_context.block_hashes.0.rotate_left(1);
-    block_context.block_hashes.0[255] = U256::from_be_bytes(parent_hash.0);
-    block_context
-}
-
-fn apply_simulate_block_overrides(
-    block_context: &mut BlockContext,
-    overrides: BlockOverrides,
-    previous_block_number: u64,
-    previous_timestamp: u64,
-) -> Result<SimulateHeaderOverrides, EthCallError> {
-    let mut header_overrides = SimulateHeaderOverrides::default();
-
-    if let Some(number) = overrides.number {
-        let number = u64::try_from(number)
-            .map_err(|_| EthCallError::SimulateInvalidBlockOverride("number"))?;
-        if number <= previous_block_number {
-            return Err(EthCallError::SimulateBlockNumberInvalid {
-                got: number,
-                parent: previous_block_number,
-            });
-        }
-        let skipped_blocks = number.saturating_sub(block_context.block_number);
-        if skipped_blocks >= 256 {
-            block_context.block_hashes.0 = [U256::ZERO; 256];
-        } else if skipped_blocks > 0 {
-            let skipped_blocks = skipped_blocks as usize;
-            block_context
-                .block_hashes
-                .0
-                .copy_within(skipped_blocks.., 0);
-            block_context.block_hashes.0[256 - skipped_blocks..].fill(U256::ZERO);
-        }
-        block_context.block_number = number;
-    }
-    if let Some(time) = overrides.time {
-        if time <= previous_timestamp {
-            return Err(EthCallError::SimulateBlockTimestampInvalid {
-                got: time,
-                parent: previous_timestamp,
-            });
-        }
-        block_context.timestamp = time;
-    }
-    if let Some(gas_limit) = overrides.gas_limit {
-        block_context.gas_limit = gas_limit;
-    }
-    if let Some(coinbase) = overrides.coinbase {
-        block_context.coinbase = coinbase;
-    }
-    if let Some(random) = overrides.random {
-        block_context.mix_hash = U256::from_be_bytes(random.0);
-    } else {
-        block_context.mix_hash = U256::ZERO;
-    }
-    if let Some(base_fee) = overrides.base_fee {
-        block_context.eip1559_basefee = base_fee;
-    }
-    if let Some(blob_base_fee) = overrides.blob_base_fee {
-        block_context.blob_fee = blob_base_fee;
-    }
-    if let Some(difficulty) = overrides.difficulty {
-        header_overrides.difficulty = Some(difficulty);
-    }
-    if let Some(block_hash_overrides) = overrides.block_hash {
-        for (block_number, block_hash) in block_hash_overrides {
-            if block_number >= block_context.block_number {
-                continue;
-            }
-            let distance = block_context.block_number - block_number;
-            if distance == 0 || distance > 256 {
-                continue;
-            }
-
-            let index = 256 - distance as usize;
-            block_context.block_hashes.0[index] = U256::from_be_bytes(block_hash.0);
-        }
-    }
-
-    Ok(header_overrides)
-}
-
-fn validate_state_overrides_for_simulate(
-    state_overrides: &StateOverride,
-) -> Result<(), EthCallError> {
-    let mut destinations = HashSet::new();
-    let mut has_precompile_move = false;
-    for (source, account) in state_overrides {
-        let Some(destination) = account.move_precompile_to else {
-            continue;
-        };
-        has_precompile_move = true;
-        if *source == destination {
-            return Err(EthCallError::SimulatePrecompileSelfReference);
-        }
-        if !destinations.insert(destination) {
-            return Err(EthCallError::SimulatePrecompileDuplicateAddress);
-        }
-    }
-    if has_precompile_move {
-        // Spec note: `movePrecompileToAddress` is part of eth_simulateV1 state overrides. The
-        // current ZKsync OS execution backend does not expose a way to remap its precompile table
-        // for a single simulated block, so reject it explicitly after the spec validation checks
-        // above.
-        return Err(EthCallError::SimulateMovePrecompileNotSupported);
-    }
-    Ok(())
-}
-
-fn simulation_default_gas_limit(
-    calls: &[TransactionRequest],
-    block_gas_limit: u64,
-    call_gas_limit: u64,
-) -> Result<u64, EthCallError> {
-    let total_specified_gas =
-        calls
-            .iter()
-            .filter_map(|call| call.gas)
-            .try_fold(0_u64, |sum, gas| {
-                sum.checked_add(gas)
-                    .ok_or(EthCallError::SimulateBlockGasLimitExceeded)
-            })?;
-    if total_specified_gas > block_gas_limit {
-        return Err(EthCallError::SimulateBlockGasLimitExceeded);
-    }
-
-    let calls_without_gas = calls.iter().filter(|call| call.gas.is_none()).count() as u64;
-    if calls_without_gas == 0 {
-        return Ok(0);
-    }
-
-    let gas_per_call = (block_gas_limit - total_specified_gas) / calls_without_gas;
-    Ok(if call_gas_limit == 0 {
-        gas_per_call
-    } else {
-        gas_per_call.min(call_gas_limit)
-    })
-}
-
-struct SimulatedTx {
-    tx: ZkTransaction,
-    tx_index_in_block: u64,
-    number_of_logs_before_this_tx: u64,
-    result: SimulatedTxResult,
-}
-
-enum SimulatedTxResult {
-    Executed {
-        output: TxOutput,
-        receipt: Box<ZkReceiptEnvelope>,
-    },
-    Invalid(InvalidTransaction),
-}
-
-impl SimulatedTx {
-    fn is_executed(&self) -> bool {
-        matches!(&self.result, SimulatedTxResult::Executed { .. })
-    }
-
-    fn to_call_result(&self, block_hash: B256, block_context: BlockContext) -> SimCallResult {
-        match &self.result {
-            SimulatedTxResult::Executed { output, receipt } => {
-                let logs = self.api_logs(block_hash, block_context, receipt);
-                let (return_data, status, error) = match &output.execution_result {
-                    ExecutionResult::Success(
-                        ExecutionOutput::Call(return_bytes)
-                        | ExecutionOutput::Create(return_bytes, _),
-                    ) => (Bytes::from(return_bytes.clone()), true, None),
-                    ExecutionResult::Revert(return_bytes) => {
-                        let return_data = Bytes::from(return_bytes.clone());
-                        (
-                            return_data.clone(),
-                            false,
-                            Some(SimulateError {
-                                code: -32000,
-                                message: RevertError::new(return_data).to_string(),
-                            }),
-                        )
-                    }
-                };
-
-                SimCallResult {
-                    return_data,
-                    logs,
-                    gas_used: output.gas_used,
-                    status,
-                    error,
-                }
-            }
-            SimulatedTxResult::Invalid(err) => SimCallResult {
-                return_data: Bytes::default(),
-                logs: vec![],
-                gas_used: 0,
-                status: false,
-                error: Some(SimulateError {
-                    code: -32015,
-                    message: format!("vm execution error: {err}"),
-                }),
-            },
-        }
-    }
-
-    fn to_api_tx(
-        &self,
-        block_hash: B256,
-        block_context: BlockContext,
-    ) -> zksync_os_rpc_api::types::ZkApiTransaction {
-        build_api_tx(
-            self.tx.clone(),
-            Some(&self.tx_meta(block_hash, block_context, self.gas_used())),
-        )
-    }
-
-    fn api_logs(
-        &self,
-        block_hash: B256,
-        block_context: BlockContext,
-        receipt: &ZkReceiptEnvelope,
-    ) -> Vec<alloy::rpc::types::Log> {
-        let tx_hash = *self.tx.hash();
-        let meta = self.tx_meta(block_hash, block_context, self.gas_used());
-        receipt
-            .logs()
-            .iter()
-            .cloned()
-            .enumerate()
-            .map(|(i, log)| build_api_log(tx_hash, log, meta.clone(), i as u64))
-            .collect()
-    }
-
-    fn tx_meta(
-        &self,
-        block_hash: B256,
-        block_context: BlockContext,
-        gas_used: u64,
-    ) -> zksync_os_storage_api::TxMeta {
-        zksync_os_storage_api::TxMeta {
-            block_hash,
-            block_number: block_context.block_number,
-            block_timestamp: block_context.timestamp,
-            tx_index_in_block: self.tx_index_in_block,
-            effective_gas_price: self
-                .tx
-                .inner
-                .inner()
-                .effective_gas_price(Some(block_context.eip1559_basefee.saturating_to())),
-            number_of_logs_before_this_tx: self.number_of_logs_before_this_tx,
-            gas_used,
-            contract_address: match &self.result {
-                SimulatedTxResult::Executed { output, .. } => output.contract_address,
-                SimulatedTxResult::Invalid(_) => None,
-            },
-        }
-    }
-
-    fn gas_used(&self) -> u64 {
-        match &self.result {
-            SimulatedTxResult::Executed { output, .. } => output.gas_used,
-            SimulatedTxResult::Invalid(_) => 0,
-        }
-    }
-}
-
 fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
     match tx.inner.inner_mut() {
         ZkEnvelope::System(_) => {
@@ -1374,6 +713,228 @@ pub fn update_estimated_gas_range(
     };
 
     Ok(())
+}
+
+impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
+    /// Implements `eth_simulateV1` using the same high-level model as reth: execute the requested
+    /// blocks linearly, carry an overlay of simulated writes into subsequent blocks, and use a
+    /// separate execution context when `validation=false` so fee validation does not leak into the
+    /// returned header.
+    ///
+    /// Spec limitations: this backend does not expose reth's `TransferInspector` equivalent, so
+    /// `traceTransfers=true` is rejected instead of returning partial transfer logs. The backend
+    /// also cannot remap precompiles for a single simulated block, so `movePrecompileToAddress` is
+    /// validated for self/duplicate references and then rejected as unsupported.
+    pub fn simulate_v1_impl(
+        &self,
+        opts: SimulatePayload,
+        block: Option<BlockId>,
+    ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
+        let SimulatePayload {
+            block_state_calls,
+            trace_transfers,
+            validation,
+            return_full_transactions,
+        } = opts;
+
+        if block_state_calls.is_empty() {
+            return Err(EthCallError::SimulateInvalidParams(
+                "calls are empty".to_string(),
+            ));
+        }
+        if block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
+            return Err(EthCallError::SimulateInvalidParams(
+                "too many blocks".to_string(),
+            ));
+        }
+
+        if trace_transfers {
+            // Reth implements this with `TransferInspector`, which records all native value moves,
+            // including internal CALL/CREATE/SELFDESTRUCT. The ZKsync OS VM path used here does not
+            // expose an equivalent transfer stream, so fail explicitly rather than returning a
+            // partial trace.
+            return Err(EthCallError::SimulateInvalidParams(
+                "traceTransfers is not implemented".to_string(),
+            ));
+        }
+
+        let simulation_utils::SimulationStartContext {
+            mut block_context,
+            parent_block_number,
+            parent_timestamp,
+        } = self.resolve_simulation_start_context(block)?;
+        let base_state = self.storage.state_view_at(parent_block_number)?;
+        let mut overlays = Arc::new(BTreeMap::new());
+        let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
+        let mut previous_block_number = parent_block_number;
+        let mut previous_timestamp = parent_timestamp;
+
+        for sim_block in block_state_calls {
+            block_context.mix_hash = U256::ZERO;
+            let header_overrides = match sim_block.block_overrides {
+                Some(block_overrides) => simulation_utils::apply_simulate_block_overrides(
+                    &mut block_context,
+                    block_overrides,
+                    previous_block_number,
+                    previous_timestamp,
+                )?,
+                None => simulation_utils::SimulateHeaderOverrides::default(),
+            };
+
+            // `validation=false` disables fee validation for execution, but the returned block
+            // still reports the requested/header-overridden base fee.
+            let response_context = block_context;
+            let mut execution_context = response_context;
+            if !validation {
+                execution_context.eip1559_basefee = U256::ZERO;
+            }
+
+            let simulation_view =
+                OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
+
+            let state_overrides = match sim_block.state_overrides {
+                Some(state_overrides) => {
+                    simulation_utils::validate_state_overrides_for_simulate(&state_overrides)?;
+                    build_state_override_maps(&simulation_view, state_overrides)
+                }
+                None => BlockOverlay::default(),
+            };
+            let overridden_view =
+                OverriddenStateView::new(simulation_view, state_overrides.clone());
+            let txs = self.create_simulation_txs(
+                sim_block.calls,
+                execution_context,
+                overridden_view.clone(),
+            )?;
+            let block_output =
+                simulation_utils::run_simulation_block(execution_context, overridden_view, &txs)?;
+
+            let simulated_block = simulation_utils::build_simulated_block_response(
+                response_context,
+                header_overrides,
+                txs,
+                block_output,
+                return_full_transactions,
+            )?;
+            let next_hash = simulated_block.inner.header.hash;
+
+            let mut overlay = state_overrides;
+            // State overrides seed this simulated block; actual VM writes take precedence for
+            // subsequent simulated blocks.
+            overlay.extend(simulated_block.overlay);
+            Arc::get_mut(&mut overlays)
+                .ok_or_else(|| {
+                    EthCallError::ForwardSubsystemError(anyhow::anyhow!(
+                        "simulation overlay still borrowed during mutation"
+                    ))
+                })?
+                .insert(block_context.block_number, overlay);
+            previous_block_number = block_context.block_number;
+            previous_timestamp = block_context.timestamp;
+            simulated_blocks.push(SimulatedBlock {
+                inner: simulated_block.inner,
+                calls: simulated_block.calls,
+            });
+
+            block_context = simulation_utils::next_block_context(block_context, next_hash);
+        }
+
+        Ok(simulated_blocks)
+    }
+
+    fn resolve_simulation_start_context(
+        &self,
+        block: Option<BlockId>,
+    ) -> Result<simulation_utils::SimulationStartContext, EthCallError> {
+        let block = block.unwrap_or_default();
+        if block.is_latest() || block.is_pending() {
+            let parent_block = self.storage.replay_storage().latest_record();
+            let parent_context = self
+                .storage
+                .replay_storage()
+                .get_context(parent_block)
+                .ok_or(RpcStorageError::BlockNotFound(block))?;
+            return Ok(simulation_utils::SimulationStartContext {
+                block_context: self.build_pending_block_context(),
+                parent_block_number: parent_block,
+                parent_timestamp: parent_context.timestamp,
+            });
+        }
+
+        let parent_block = self
+            .storage
+            .resolve_block_number(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let parent_context = self
+            .storage
+            .replay_storage()
+            .get_context(parent_block)
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let parent = self
+            .storage
+            .get_block_by_id(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let block_context = simulation_utils::next_block_context(parent_context, parent.hash());
+
+        Ok(simulation_utils::SimulationStartContext {
+            block_context,
+            parent_block_number: parent_block,
+            parent_timestamp: parent_context.timestamp,
+        })
+    }
+
+    fn create_simulation_txs<V: ViewState>(
+        &self,
+        calls: Vec<TransactionRequest>,
+        block_context: BlockContext,
+        mut state_view: V,
+    ) -> Result<Vec<ZkTransaction>, EthCallError> {
+        let default_gas_limit = simulation_utils::simulation_default_gas_limit(
+            &calls,
+            block_context.gas_limit,
+            self.config.eth_call_gas as u64,
+        )?;
+        let mut next_nonces = HashMap::new();
+
+        calls
+            .into_iter()
+            .map(|mut request| {
+                if request.gas.is_none() {
+                    request.set_gas_limit(default_gas_limit);
+                }
+
+                let from = request.from.unwrap_or_default();
+                let state_nonce = next_nonces.entry(from).or_insert_with(|| {
+                    state_view
+                        .get_account(from)
+                        .as_ref()
+                        .map(get_nonce)
+                        .unwrap_or_default()
+                });
+                if let Some(nonce) = request.nonce {
+                    if nonce >= *state_nonce {
+                        *state_nonce =
+                            nonce
+                                .checked_add(1)
+                                .ok_or(EthCallError::SimulateInvalidParams(
+                                    "nonce has max value".to_string(),
+                                ))?;
+                    }
+                } else {
+                    let nonce = *state_nonce;
+                    request.set_nonce(nonce);
+                    *state_nonce =
+                        nonce
+                            .checked_add(1)
+                            .ok_or(EthCallError::SimulateInvalidParams(
+                                "nonce has max value".to_string(),
+                            ))?;
+                }
+
+                self.create_tx_from_request(request, &block_context, false)
+            })
+            .collect()
+    }
 }
 
 /// Error types returned by `eth_call` implementation
@@ -1440,145 +1001,4 @@ pub enum EthCallError {
     /// Error occurred during debug tracing
     #[error("Tracer error: {0:?}")]
     CallTracerError(anyhow::Error),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy::rpc::types::state::AccountOverride;
-
-    #[test]
-    fn simulation_default_gas_limit_splits_remaining_block_gas() {
-        let calls = vec![
-            TransactionRequest {
-                gas: Some(40),
-                ..Default::default()
-            },
-            TransactionRequest::default(),
-            TransactionRequest::default(),
-        ];
-
-        assert_eq!(simulation_default_gas_limit(&calls, 100, 0).unwrap(), 30);
-        assert_eq!(simulation_default_gas_limit(&calls, 100, 25).unwrap(), 25);
-    }
-
-    #[test]
-    fn simulation_default_gas_limit_rejects_block_gas_overflow() {
-        let calls = vec![TransactionRequest {
-            gas: Some(101),
-            ..Default::default()
-        }];
-
-        assert!(matches!(
-            simulation_default_gas_limit(&calls, 100, 0),
-            Err(EthCallError::SimulateBlockGasLimitExceeded)
-        ));
-    }
-
-    #[test]
-    fn simulate_block_overrides_reject_non_increasing_sequences() {
-        let mut context = BlockContext {
-            block_number: 11,
-            timestamp: 101,
-            ..Default::default()
-        };
-        let number_err = apply_simulate_block_overrides(
-            &mut context,
-            BlockOverrides {
-                number: Some(U256::from(10)),
-                ..Default::default()
-            },
-            10,
-            100,
-        )
-        .unwrap_err();
-        assert!(matches!(
-            number_err,
-            EthCallError::SimulateBlockNumberInvalid { .. }
-        ));
-
-        let time_err = apply_simulate_block_overrides(
-            &mut context,
-            BlockOverrides {
-                time: Some(100),
-                ..Default::default()
-            },
-            10,
-            100,
-        )
-        .unwrap_err();
-        assert!(matches!(
-            time_err,
-            EthCallError::SimulateBlockTimestampInvalid { .. }
-        ));
-    }
-
-    #[test]
-    fn simulate_block_override_number_jump_clears_gap_hashes() {
-        let mut hashes = [U256::ZERO; 256];
-        for (i, hash) in hashes.iter_mut().enumerate() {
-            *hash = U256::from(i + 1);
-        }
-        let mut context = BlockContext {
-            block_number: 11,
-            timestamp: 101,
-            block_hashes: BlockHashes(hashes),
-            ..Default::default()
-        };
-
-        apply_simulate_block_overrides(
-            &mut context,
-            BlockOverrides {
-                number: Some(U256::from(14)),
-                ..Default::default()
-            },
-            10,
-            100,
-        )
-        .unwrap();
-
-        assert_eq!(context.block_number, 14);
-        assert_eq!(context.block_hashes.0[252], U256::from(256));
-        assert_eq!(context.block_hashes.0[253], U256::ZERO);
-        assert_eq!(context.block_hashes.0[254], U256::ZERO);
-        assert_eq!(context.block_hashes.0[255], U256::ZERO);
-    }
-
-    #[test]
-    fn simulate_state_overrides_validate_precompile_moves() {
-        let source = Address::from([1; 20]);
-        let destination = Address::from([2; 20]);
-        let mut overrides = StateOverride::default();
-        overrides.insert(
-            source,
-            AccountOverride {
-                move_precompile_to: Some(source),
-                ..Default::default()
-            },
-        );
-        assert!(matches!(
-            validate_state_overrides_for_simulate(&overrides),
-            Err(EthCallError::SimulatePrecompileSelfReference)
-        ));
-
-        let mut overrides = StateOverride::default();
-        overrides.insert(
-            source,
-            AccountOverride {
-                move_precompile_to: Some(destination),
-                ..Default::default()
-            },
-        );
-        overrides.insert(
-            Address::from([3; 20]),
-            AccountOverride {
-                move_precompile_to: Some(destination),
-                ..Default::default()
-            },
-        );
-        assert!(matches!(
-            validate_state_overrides_for_simulate(&overrides),
-            Err(EthCallError::SimulatePrecompileDuplicateAddress)
-        ));
-    }
 }

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -29,7 +29,7 @@ use zksync_os_interface::{
 use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
-    BlockOverlay, RepositoryError, StateError, ViewState,
+    OwnedOverrides, RepositoryError, StateError, ViewState,
     state_override_view::{OverriddenStateView, build_state_override_maps},
 };
 use zksync_os_types::ZksyncOsEncode;
@@ -804,7 +804,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     }
                     build_state_override_maps(&simulation_view, state_overrides)
                 }
-                None => BlockOverlay::default(),
+                None => OwnedOverrides::default(),
             };
             let overridden_view =
                 OverriddenStateView::new(simulation_view, state_overrides.clone());

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -724,10 +724,18 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     /// separate execution context when `validation=false` so fee validation does not leak into the
     /// returned header.
     ///
-    /// Spec limitations: this backend does not expose reth's `TransferInspector` equivalent, so
-    /// `traceTransfers=true` is rejected instead of returning partial transfer logs. The backend
-    /// also cannot remap precompiles for a single simulated block, so `movePrecompileToAddress` is
-    /// rejected as unsupported.
+    /// # Spec limitations
+    ///
+    /// The following features from the `eth_simulateV1` spec are not supported:
+    ///
+    /// - `traceTransfers=true`: rejected with an error. ZKsync OS has no transfer-tracing
+    ///   inspector equivalent, so synthetic ERC-20 transfer logs cannot be generated.
+    /// - `movePrecompileToAddress`: rejected with an error. The VM does not support remapping
+    ///   precompile addresses on a per-block basis.
+    /// - `blockOverrides.difficulty`: silently ignored. ZKsync OS has no `difficulty` field in
+    ///   its block context; use `blockOverrides.random` (prevrandao) instead.
+    /// - `blockOverrides.parentBeaconBlockRoot`: silently ignored. There is no corresponding
+    ///   field in `BlockContext`.
     pub fn simulate_v1_impl(
         &self,
         opts: SimulatePayload,
@@ -827,12 +835,13 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             )
             .map_err(EthCallError::ForwardSubsystemError)?;
 
-            let (simulated_block, block_overlay) = simulation_utils::build_simulated_block_response(
-                response_context,
-                txs,
-                block_output,
-                return_full_transactions,
-            )?;
+            let (simulated_block, block_overlay) =
+                simulation_utils::build_simulated_block_response(
+                    response_context,
+                    txs,
+                    block_output,
+                    return_full_transactions,
+                )?;
             let next_hash = simulated_block.inner.header.hash;
 
             let mut overlay = state_overrides;

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -446,23 +446,24 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         opts: SimulatePayload,
         block: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
-        if opts.block_state_calls.is_empty() {
-            return Err(EthCallError::SimulateInvalidParams(
-                "calls are empty".to_string(),
-            ));
-        }
-        if opts.block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
-            return Err(EthCallError::SimulateInvalidParams(
-                "too many blocks".to_string(),
-            ));
-        }
-
         let SimulatePayload {
             block_state_calls,
             trace_transfers,
             validation,
             return_full_transactions,
         } = opts;
+
+        if block_state_calls.is_empty() {
+            return Err(EthCallError::SimulateInvalidParams(
+                "calls are empty".to_string(),
+            ));
+        }
+        if block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
+            return Err(EthCallError::SimulateInvalidParams(
+                "too many blocks".to_string(),
+            ));
+        }
+
         if trace_transfers {
             // Reth implements this with `TransferInspector`, which records all native value moves,
             // including internal CALL/CREATE/SELFDESTRUCT. The ZKsync OS VM path used here does not
@@ -475,11 +476,10 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         let SimulationStartContext {
             mut block_context,
-            base_state_block,
             parent_block_number,
             parent_timestamp,
         } = self.resolve_simulation_start_context(block)?;
-        let base_state = self.storage.state_view_at(base_state_block)?;
+        let base_state = self.storage.state_view_at(parent_block_number)?;
         let mut overlays = Arc::new(BTreeMap::new());
         let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
         let mut previous_block_number = parent_block_number;
@@ -544,11 +544,14 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             let mut overlay = state_override_overlay;
             // State overrides seed this simulated block; actual VM writes take precedence for
             // subsequent simulated blocks.
-            overlay
-                .storage_writes
-                .extend(simulated_block.overlay.storage_writes);
-            overlay.preimages.extend(simulated_block.overlay.preimages);
-            Arc::make_mut(&mut overlays).insert(block_context.block_number, overlay);
+            overlay.extend(simulated_block.overlay);
+            Arc::get_mut(&mut overlays)
+                .ok_or_else(|| {
+                    EthCallError::ForwardSubsystemError(anyhow::anyhow!(
+                        "simulation overlay still borrowed during mutation"
+                    ))
+                })?
+                .insert(block_context.block_number, overlay);
             previous_block_number = block_context.block_number;
             previous_timestamp = block_context.timestamp;
             simulated_blocks.push(SimulatedBlock {
@@ -604,15 +607,15 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 .ok_or(RpcStorageError::BlockNotFound(block))?;
             return Ok(SimulationStartContext {
                 block_context: self.build_pending_block_context(),
-                base_state_block: parent_block,
                 parent_block_number: parent_block,
                 parent_timestamp: parent_context.timestamp,
             });
         }
 
-        let Some(parent_block) = self.storage.resolve_block_number(block)? else {
-            return Err(RpcStorageError::BlockNotFound(block).into());
-        };
+        let parent_block = self
+            .storage
+            .resolve_block_number(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
         let parent_context = self
             .storage
             .replay_storage()
@@ -626,15 +629,14 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         Ok(SimulationStartContext {
             block_context,
-            base_state_block: parent_block,
             parent_block_number: parent_block,
             parent_timestamp: parent_context.timestamp,
         })
     }
 
-    fn create_simulation_txs<V: ViewState + Clone>(
+    fn create_simulation_txs<V: ViewState>(
         &self,
-        mut calls: Vec<TransactionRequest>,
+        calls: Vec<TransactionRequest>,
         block_context: BlockContext,
         mut state_view: V,
     ) -> Result<Vec<ZkTransaction>, EthCallError> {
@@ -646,43 +648,41 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let mut next_nonces = HashMap::new();
 
         calls
-            .iter_mut()
-            .map(|request| {
+            .into_iter()
+            .map(|mut request| {
                 if request.gas.is_none() {
                     request.set_gas_limit(default_gas_limit);
                 }
 
                 let from = request.from.unwrap_or_default();
-                if request.nonce.is_none() {
-                    let nonce = *next_nonces.entry(from).or_insert_with(|| {
-                        state_view
-                            .get_account(from)
-                            .as_ref()
-                            .map(get_nonce)
-                            .unwrap_or_default()
-                    });
+                let state_nonce = next_nonces.entry(from).or_insert_with(|| {
+                    state_view
+                        .get_account(from)
+                        .as_ref()
+                        .map(get_nonce)
+                        .unwrap_or_default()
+                });
+                if let Some(nonce) = request.nonce {
+                    if nonce >= *state_nonce {
+                        *state_nonce =
+                            nonce
+                                .checked_add(1)
+                                .ok_or(EthCallError::SimulateInvalidParams(
+                                    "nonce has max value".to_string(),
+                                ))?;
+                    }
+                } else {
+                    let nonce = *state_nonce;
                     request.set_nonce(nonce);
-                    let next_nonce =
+                    *state_nonce =
                         nonce
                             .checked_add(1)
                             .ok_or(EthCallError::SimulateInvalidParams(
                                 "nonce has max value".to_string(),
                             ))?;
-                    next_nonces.insert(from, next_nonce);
-                } else if let Some(nonce) = request.nonce {
-                    let state_nonce = next_nonces.entry(from).or_insert_with(|| {
-                        state_view
-                            .get_account(from)
-                            .as_ref()
-                            .map(get_nonce)
-                            .unwrap_or_default()
-                    });
-                    if nonce >= *state_nonce {
-                        *state_nonce = nonce.saturating_add(1);
-                    }
                 }
 
-                self.create_tx_from_request(request.clone(), &block_context, false)
+                self.create_tx_from_request(request, &block_context, false)
             })
             .collect()
     }
@@ -928,7 +928,6 @@ where
 #[derive(Debug)]
 struct SimulationStartContext {
     block_context: BlockContext,
-    base_state_block: u64,
     parent_block_number: u64,
     parent_timestamp: u64,
 }
@@ -956,10 +955,8 @@ fn build_simulated_block_response(
         header: sealed_header,
         tx_results,
         storage_writes,
-        account_diffs: _,
         published_preimages,
-        pubdata: _,
-        computational_native_used: _,
+        ..
     } = block_output;
 
     let mut block_bloom = Bloom::default();
@@ -969,7 +966,7 @@ fn build_simulated_block_response(
     let mut simulated_txs = Vec::with_capacity(tx_results.len());
     let mut executed_tx_index = 0;
 
-    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results.into_iter()).enumerate() {
+    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results).enumerate() {
         let simulated_tx = match result {
             Ok(tx_output) => {
                 let receipt = build_simulated_receipt(&tx, &tx_output, cumulative_gas_used);
@@ -1003,13 +1000,12 @@ fn build_simulated_block_response(
     header.base_fee_per_gas = Some(block_context.eip1559_basefee.saturating_to());
     header.logs_bloom = block_bloom;
     header.gas_used = cumulative_gas_used;
-    header.transactions_root = calculate_transaction_root(
-        &simulated_txs
-            .iter()
-            .filter(|tx| tx.is_executed())
-            .map(|tx| tx.tx.envelope().clone())
-            .collect::<Vec<_>>(),
-    );
+    let executed_envelopes = simulated_txs
+        .iter()
+        .filter(|tx| tx.is_executed())
+        .map(|tx| tx.tx.envelope())
+        .collect::<Vec<_>>();
+    header.transactions_root = calculate_transaction_root(&executed_envelopes);
     header.receipts_root = calculate_receipt_root(&receipts);
     if let Some(difficulty) = header_overrides.difficulty {
         header.difficulty = difficulty;
@@ -1061,14 +1057,7 @@ fn build_simulated_receipt(
     let l2_to_l1_logs = tx_output
         .l2_to_l1_logs
         .iter()
-        .map(|l2_to_l1_log| zksync_os_types::L2ToL1Log {
-            l2_shard_id: l2_to_l1_log.log.l2_shard_id,
-            is_service: l2_to_l1_log.log.is_service,
-            tx_number_in_block: l2_to_l1_log.log.tx_number_in_block,
-            sender: l2_to_l1_log.log.sender,
-            key: l2_to_l1_log.log.key,
-            value: l2_to_l1_log.log.value,
-        })
+        .map(|l2_to_l1_log| l2_to_l1_log.log.clone().into())
         .collect();
 
     ZkReceiptEnvelope::from_typed(
@@ -1254,13 +1243,13 @@ impl SimulatedTx {
                         | ExecutionOutput::Create(return_bytes, _),
                     ) => (Bytes::from(return_bytes.clone()), true, None),
                     ExecutionResult::Revert(return_bytes) => {
-                        let revert = RevertError::new(Bytes::from(return_bytes.clone()));
+                        let return_data = Bytes::from(return_bytes.clone());
                         (
-                            Bytes::from(return_bytes.clone()),
+                            return_data.clone(),
                             false,
                             Some(SimulateError {
                                 code: -32000,
-                                message: revert.to_string(),
+                                message: RevertError::new(return_data).to_string(),
                             }),
                         )
                     }
@@ -1294,7 +1283,7 @@ impl SimulatedTx {
     ) -> zksync_os_rpc_api::types::ZkApiTransaction {
         build_api_tx(
             self.tx.clone(),
-            Some(&self.tx_meta(block_hash, block_context, 0)),
+            Some(&self.tx_meta(block_hash, block_context, self.gas_used())),
         )
     }
 
@@ -1305,11 +1294,7 @@ impl SimulatedTx {
         receipt: &ZkReceiptEnvelope,
     ) -> Vec<alloy::rpc::types::Log> {
         let tx_hash = *self.tx.hash();
-        let gas_used = match &self.result {
-            SimulatedTxResult::Executed { output, .. } => output.gas_used,
-            SimulatedTxResult::Invalid(_) => 0,
-        };
-        let meta = self.tx_meta(block_hash, block_context, gas_used);
+        let meta = self.tx_meta(block_hash, block_context, self.gas_used());
         receipt
             .logs()
             .iter()
@@ -1341,6 +1326,13 @@ impl SimulatedTx {
                 SimulatedTxResult::Executed { output, .. } => output.contract_address,
                 SimulatedTxResult::Invalid(_) => None,
             },
+        }
+    }
+
+    fn gas_used(&self) -> u64 {
+        match &self.result {
+            SimulatedTxResult::Executed { output, .. } => output.gas_used,
+            SimulatedTxResult::Invalid(_) => 0,
         }
     }
 }

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -762,10 +762,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         }
 
         if trace_transfers {
-            // Reth implements this with `TransferInspector`, which records all native value moves,
-            // including internal CALL/CREATE/SELFDESTRUCT. The ZKsync OS VM path used here does not
-            // expose an equivalent transfer stream, so fail explicitly rather than returning a
-            // partial trace.
             return Err(EthCallError::SimulateInvalidParams(
                 "traceTransfers is not implemented".to_string(),
             ));
@@ -794,11 +790,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 )?;
             }
 
-            // `validation=false` is supposed to disable both fee and nonce validation. We zero
-            // the basefee to satisfy fee checks, but nonce checks are not disabled — the VM still
-            // enforces them. Callers that rely on sending transactions with arbitrary nonces when
-            // `validation=false` will see unexpected failures. Nonces without an explicit value are
-            // auto-filled from state, so the common case works correctly.
             let response_context = block_context;
             let mut execution_context = response_context;
             if !validation {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -4,34 +4,25 @@ use crate::js_tracer;
 use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute};
-use crate::simulation_utils;
 use alloy::consensus::transaction::Recovered;
 use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxType};
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
-use alloy::rpc::types::simulate::{MAX_SIMULATE_BLOCKS, SimulatePayload, SimulatedBlock};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::trace::geth::{CallConfig, GethTrace};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use serde_json::Value as JsonValue;
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
-use zksync_os_interface::tracing::{NopTracer, NopValidator};
-use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
     types::{BlockContext, ExecutionResult},
 };
-use zksync_os_multivm::run_block;
-use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
-    RepositoryError, StateError, ViewState,
-    state_override_view::{OverriddenStateView, OwnedOverrides, build_state_override_maps},
+    RepositoryError, StateError, ViewState, state_override_view::OverriddenStateView,
 };
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
@@ -43,8 +34,8 @@ use zksync_os_types::{
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
 #[derive(Clone, Debug)]
 pub struct EthCallHandler<RpcStorage> {
-    config: RpcConfig,
-    storage: RpcStorage,
+    pub(crate) config: RpcConfig,
+    pub(crate) storage: RpcStorage,
     chain_id: u64,
     /// Last block context constructed by sequencer but not necessarily executed yet.
     last_constructed_block_context: watch::Receiver<Option<BlockContext>>,
@@ -70,7 +61,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         }
     }
 
-    fn create_tx_from_request(
+    pub(crate) fn create_tx_from_request(
         &self,
         request: TransactionRequest,
         block_context: &BlockContext,
@@ -215,7 +206,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     }
 
     /// Builds new block context for theoretical pending block using current system state.
-    fn build_pending_block_context(&self) -> BlockContext {
+    pub(crate) fn build_pending_block_context(&self) -> BlockContext {
         let latest_block_number = self.storage.replay_storage().latest_record();
         let latest_block = self
             .storage
@@ -714,249 +705,6 @@ pub fn update_estimated_gas_range(
     };
 
     Ok(())
-}
-
-impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
-    /// Implements `eth_simulateV1` using the same high-level model as reth: execute the requested
-    /// blocks linearly, carry an overlay of simulated writes into subsequent blocks, and use a
-    /// separate execution context when `validation=false` so fee validation does not leak into the
-    /// returned header.
-    ///
-    /// # Spec limitations
-    ///
-    /// The following features from the `eth_simulateV1` spec are not supported:
-    ///
-    /// - `traceTransfers=true`: rejected with an error. ZKsync OS has no transfer-tracing
-    ///   inspector equivalent, so synthetic ERC-20 transfer logs cannot be generated.
-    /// - `movePrecompileToAddress`: rejected with an error. The VM does not support remapping
-    ///   precompile addresses on a per-block basis.
-    /// - `blockOverrides.difficulty`: silently ignored. ZKsync OS has no `difficulty` field in
-    ///   its block context; use `blockOverrides.random` (prevrandao) instead.
-    /// - `blockOverrides.parentBeaconBlockRoot`: silently ignored. There is no corresponding
-    ///   field in `BlockContext`.
-    /// - `validation=false` nonce relaxation: partially unsupported. The basefee is zeroed as
-    ///   the spec requires, but nonce checks are not disabled. Transactions without an explicit
-    ///   nonce are auto-filled from state (the common case works), but an explicitly supplied
-    ///   stale nonce will be rejected by the VM.
-    pub fn simulate_v1_impl(
-        &self,
-        opts: SimulatePayload,
-        block: Option<BlockId>,
-    ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
-        let SimulatePayload {
-            block_state_calls,
-            trace_transfers,
-            validation,
-            return_full_transactions,
-        } = opts;
-
-        if block_state_calls.is_empty() {
-            return Err(EthCallError::SimulateInvalidParams(
-                "calls are empty".to_string(),
-            ));
-        }
-        if block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
-            return Err(EthCallError::SimulateInvalidParams(
-                "too many blocks".to_string(),
-            ));
-        }
-
-        if trace_transfers {
-            return Err(EthCallError::SimulateInvalidParams(
-                "traceTransfers is not implemented".to_string(),
-            ));
-        }
-
-        let simulation_utils::SimulationStartContext {
-            mut block_context,
-            parent_block_number,
-            parent_timestamp,
-        } = self.resolve_simulation_start_context(block)?;
-        let base_state = self.storage.state_view_at(parent_block_number)?;
-        let mut overlays = Arc::new(BTreeMap::new());
-        let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
-        let mut previous_block_number = parent_block_number;
-        let mut previous_timestamp = parent_timestamp;
-
-        for sim_block in block_state_calls {
-            // Per the eth_simulateV1 spec, prevrandao defaults to zero for simulated blocks
-            // unless explicitly overridden via `blockOverrides.random`.
-            block_context.mix_hash = U256::ZERO;
-            if let Some(block_overrides) = sim_block.block_overrides {
-                simulation_utils::apply_simulate_block_overrides(
-                    &mut block_context,
-                    block_overrides,
-                    previous_block_number,
-                    previous_timestamp,
-                    self.config.eth_simulate_block_gas_limit,
-                )?;
-            }
-
-            let response_context = block_context;
-            let mut execution_context = response_context;
-            if !validation {
-                execution_context.eip1559_basefee = U256::ZERO;
-            }
-
-            let simulation_view =
-                OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
-
-            let state_overrides = match sim_block.state_overrides {
-                Some(state_overrides) => {
-                    if state_overrides
-                        .values()
-                        .any(|account| account.move_precompile_to.is_some())
-                    {
-                        return Err(EthCallError::SimulateMovePrecompileNotSupported);
-                    }
-                    build_state_override_maps(&simulation_view, state_overrides)
-                }
-                None => OwnedOverrides::default(),
-            };
-            let overridden_view =
-                OverriddenStateView::new(simulation_view, state_overrides.clone());
-            let txs = self.create_simulation_txs(
-                sim_block.calls,
-                execution_context,
-                overridden_view.clone(),
-            )?;
-            let tx_source = TxListSource {
-                transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
-            };
-            let block_output = run_block(
-                execution_context,
-                overridden_view.clone(),
-                overridden_view,
-                tx_source,
-                NoopTxCallback,
-                &mut NopTracer,
-                &mut NopValidator,
-            )
-            .map_err(EthCallError::ForwardSubsystemError)?;
-
-            let (simulated_block, block_overlay) =
-                simulation_utils::build_simulated_block_response(
-                    response_context,
-                    txs,
-                    block_output,
-                    return_full_transactions,
-                )?;
-            let next_hash = simulated_block.inner.header.hash;
-
-            let mut overlay = state_overrides;
-            // State overrides seed this simulated block; actual VM writes take precedence for
-            // subsequent simulated blocks.
-            overlay.extend(block_overlay);
-            Arc::get_mut(&mut overlays)
-                .ok_or_else(|| {
-                    EthCallError::ForwardSubsystemError(anyhow::anyhow!(
-                        "simulation overlay still borrowed during mutation"
-                    ))
-                })?
-                .insert(block_context.block_number, overlay);
-            previous_block_number = block_context.block_number;
-            previous_timestamp = block_context.timestamp;
-            simulated_blocks.push(simulated_block);
-
-            block_context = simulation_utils::next_block_context(block_context, next_hash);
-        }
-
-        Ok(simulated_blocks)
-    }
-
-    fn resolve_simulation_start_context(
-        &self,
-        block: Option<BlockId>,
-    ) -> Result<simulation_utils::SimulationStartContext, EthCallError> {
-        let block = block.unwrap_or_default();
-        if block.is_latest() || block.is_pending() {
-            let parent_block = self.storage.replay_storage().latest_record();
-            let parent_context = self
-                .storage
-                .replay_storage()
-                .get_context(parent_block)
-                .ok_or(RpcStorageError::BlockNotFound(block))?;
-            return Ok(simulation_utils::SimulationStartContext {
-                block_context: self.build_pending_block_context(),
-                parent_block_number: parent_block,
-                parent_timestamp: parent_context.timestamp,
-            });
-        }
-
-        let parent_block = self
-            .storage
-            .resolve_block_number(block)?
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let parent_context = self
-            .storage
-            .replay_storage()
-            .get_context(parent_block)
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let parent = self
-            .storage
-            .get_block_by_id(block)?
-            .ok_or(RpcStorageError::BlockNotFound(block))?;
-        let block_context = simulation_utils::next_block_context(parent_context, parent.hash());
-
-        Ok(simulation_utils::SimulationStartContext {
-            block_context,
-            parent_block_number: parent_block,
-            parent_timestamp: parent_context.timestamp,
-        })
-    }
-
-    fn create_simulation_txs<V: ViewState>(
-        &self,
-        calls: Vec<TransactionRequest>,
-        block_context: BlockContext,
-        mut state_view: V,
-    ) -> Result<Vec<ZkTransaction>, EthCallError> {
-        let default_gas_limit = simulation_utils::simulation_default_gas_limit(
-            &calls,
-            block_context.gas_limit,
-            self.config.eth_call_gas as u64,
-        )?;
-        let mut next_nonces = HashMap::new();
-
-        calls
-            .into_iter()
-            .map(|mut request| {
-                if request.gas.is_none() {
-                    request.set_gas_limit(default_gas_limit);
-                }
-
-                let from = request.from.unwrap_or_default();
-                let state_nonce = next_nonces.entry(from).or_insert_with(|| {
-                    state_view
-                        .get_account(from)
-                        .as_ref()
-                        .map(get_nonce)
-                        .unwrap_or_default()
-                });
-                if let Some(nonce) = request.nonce {
-                    if nonce >= *state_nonce {
-                        *state_nonce =
-                            nonce
-                                .checked_add(1)
-                                .ok_or(EthCallError::SimulateInvalidParams(
-                                    "nonce has max value".to_string(),
-                                ))?;
-                    }
-                } else {
-                    let nonce = *state_nonce;
-                    request.set_nonce(nonce);
-                    *state_nonce =
-                        nonce
-                            .checked_add(1)
-                            .ok_or(EthCallError::SimulateInvalidParams(
-                                "nonce has max value".to_string(),
-                            ))?;
-                }
-
-                self.create_tx_from_request(request, &block_context, false)
-            })
-            .collect()
-    }
 }
 
 /// Error types returned by `eth_call` implementation

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -12,7 +12,7 @@ use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxTy
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
 use alloy::network::primitives::BlockTransactions;
-use alloy::primitives::{Address, B256, Bloom, Bytes, Log, Signature, TxKind, U256, b256};
+use alloy::primitives::{Address, B256, Bloom, Bytes, Signature, TxKind, U256};
 use alloy::rpc::types::simulate::{
     MAX_SIMULATE_BLOCKS, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock,
 };
@@ -25,11 +25,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
-use zksync_os_evm_errors::EvmError;
-use zksync_os_interface::tracing::{
-    AnyTracer, CallModifier, CallResult, EvmFrameInterface, EvmRequest, EvmResources, EvmTracer,
-    NopValidator,
-};
+use zksync_os_interface::tracing::{NopTracer, NopValidator};
 use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
 use zksync_os_interface::{
@@ -40,7 +36,7 @@ use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
     BlockOverlay, RepositoryError, StateError, ViewState,
-    state_override_view::{OverriddenStateView, build_state_override_maps},
+    state_override_view::{OverriddenStateView, OwnedOverrides, build_state_override_maps},
 };
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
@@ -50,9 +46,6 @@ use zksync_os_types::{
 };
 
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
-const TRANSFER_EVENT_TOPIC: B256 =
-    b256!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
-
 #[derive(Clone, Debug)]
 pub struct EthCallHandler<RpcStorage> {
     config: RpcConfig,
@@ -439,6 +432,15 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         Ok(tracer_output.results.pop().unwrap_or(JsonValue::Null))
     }
 
+    /// Implements `eth_simulateV1` using the same high-level model as reth: execute the requested
+    /// blocks linearly, carry an overlay of simulated writes into subsequent blocks, and use a
+    /// separate execution context when `validation=false` so fee validation does not leak into the
+    /// returned header.
+    ///
+    /// Spec limitations: this backend does not expose reth's `TransferInspector` equivalent, so
+    /// `traceTransfers=true` is rejected instead of returning partial transfer logs. The backend
+    /// also cannot remap precompiles for a single simulated block, so `movePrecompileToAddress` is
+    /// validated for self/duplicate references and then rejected as unsupported.
     pub fn simulate_v1_impl(
         &self,
         opts: SimulatePayload,
@@ -461,6 +463,15 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             validation,
             return_full_transactions,
         } = opts;
+        if trace_transfers {
+            // Reth implements this with `TransferInspector`, which records all native value moves,
+            // including internal CALL/CREATE/SELFDESTRUCT. The ZKsync OS VM path used here does not
+            // expose an equivalent transfer stream, so fail explicitly rather than returning a
+            // partial trace.
+            return Err(EthCallError::SimulateInvalidParams(
+                "traceTransfers is not implemented".to_string(),
+            ));
+        }
 
         let SimulationStartContext {
             mut block_context,
@@ -497,55 +508,35 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             let simulation_view =
                 OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
 
-            let (state_override_overlay, block_output, trace_entries, txs) =
-                match sim_block.state_overrides {
-                    Some(state_overrides) => {
-                        validate_state_overrides_for_simulate(&state_overrides)?;
-                        let state_overrides =
-                            build_state_override_maps(&simulation_view, state_overrides);
-                        let (storage_writes, preimages) = state_overrides.clone().into_parts();
-                        let state_override_overlay = BlockOverlay {
+            let (state_override_overlay, state_overrides) = match sim_block.state_overrides {
+                Some(state_overrides) => {
+                    validate_state_overrides_for_simulate(&state_overrides)?;
+                    let state_overrides =
+                        build_state_override_maps(&simulation_view, state_overrides);
+                    let (storage_writes, preimages) = state_overrides.clone().into_parts();
+                    (
+                        BlockOverlay {
                             storage_writes,
                             preimages,
-                        };
-                        let overridden_view =
-                            OverriddenStateView::new(simulation_view, state_overrides);
-                        let txs = self.create_simulation_txs(
-                            sim_block.calls,
-                            execution_context,
-                            overridden_view.clone(),
-                        )?;
-                        let (block_output, trace_entries) = run_simulation_block(
-                            execution_context,
-                            overridden_view,
-                            &txs,
-                            trace_transfers,
-                        )?;
-                        (state_override_overlay, block_output, trace_entries, txs)
-                    }
-                    None => {
-                        let txs = self.create_simulation_txs(
-                            sim_block.calls,
-                            execution_context,
-                            simulation_view.clone(),
-                        )?;
-                        let (block_output, trace_entries) = run_simulation_block(
-                            execution_context,
-                            simulation_view,
-                            &txs,
-                            trace_transfers,
-                        )?;
-                        (BlockOverlay::default(), block_output, trace_entries, txs)
-                    }
-                };
+                        },
+                        state_overrides,
+                    )
+                }
+                None => (BlockOverlay::default(), OwnedOverrides::default()),
+            };
+            let overridden_view = OverriddenStateView::new(simulation_view, state_overrides);
+            let txs = self.create_simulation_txs(
+                sim_block.calls,
+                execution_context,
+                overridden_view.clone(),
+            )?;
+            let block_output = run_simulation_block(execution_context, overridden_view, &txs)?;
 
             let simulated_block = build_simulated_block_response(
                 response_context,
                 header_overrides,
                 txs,
                 block_output,
-                trace_entries,
-                trace_transfers,
                 return_full_transactions,
             )?;
             let next_hash = simulated_block.inner.header.hash;
@@ -914,35 +905,24 @@ fn run_simulation_block<State>(
     block_context: BlockContext,
     state_view: State,
     txs: &[ZkTransaction],
-    trace_transfers: bool,
-) -> Result<(BlockOutput, Vec<Vec<TraceEntry>>), EthCallError>
+) -> Result<BlockOutput, EthCallError>
 where
     State: ViewState,
 {
     let tx_source = TxListSource {
         transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
     };
-    let mut tracer = TransferTrace::new(trace_transfers);
 
-    let block_output = run_block(
+    run_block(
         block_context,
         state_view.clone(),
         state_view,
         tx_source,
         NoopTxCallback,
-        &mut tracer,
+        &mut NopTracer,
         &mut NopValidator,
     )
-    .map_err(EthCallError::ForwardSubsystemError)?;
-
-    let mut trace_entries = if trace_transfers {
-        tracer.into_entries()
-    } else {
-        Vec::new()
-    };
-    trace_entries.resize_with(block_output.tx_results.len(), Vec::new);
-
-    Ok((block_output, trace_entries))
+    .map_err(EthCallError::ForwardSubsystemError)
 }
 
 #[derive(Debug)]
@@ -970,8 +950,6 @@ fn build_simulated_block_response(
     header_overrides: SimulateHeaderOverrides,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
-    tx_trace_entries: Vec<Vec<TraceEntry>>,
-    trace_transfers: bool,
     return_full_transactions: bool,
 ) -> Result<SimulatedBlockResponse, EthCallError> {
     let BlockOutput {
@@ -989,35 +967,33 @@ fn build_simulated_block_response(
     let mut cumulative_gas_used = 0;
     let mut receipts = Vec::with_capacity(tx_results.len());
     let mut simulated_txs = Vec::with_capacity(tx_results.len());
-    let mut tx_trace_entries = tx_trace_entries.into_iter();
+    let mut executed_tx_index = 0;
 
-    for (tx_index, (tx, result)) in txs.into_iter().zip(tx_results.into_iter()).enumerate() {
-        let trace_entries = trace_transfers.then(|| tx_trace_entries.next().unwrap_or_default());
+    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results.into_iter()).enumerate() {
         let simulated_tx = match result {
             Ok(tx_output) => {
-                let receipt =
-                    build_simulated_receipt(&tx, &tx_output, cumulative_gas_used, trace_entries);
+                let receipt = build_simulated_receipt(&tx, &tx_output, cumulative_gas_used);
                 block_bloom.accrue_bloom(receipt.logs_bloom());
                 cumulative_gas_used += tx_output.gas_used;
                 let simulated_tx = SimulatedTx {
                     tx,
-                    tx_index_in_block: tx_index as u64,
+                    tx_index_in_block: executed_tx_index,
                     number_of_logs_before_this_tx,
-                    tx_output: Some(tx_output),
-                    receipt: Some(receipt.clone()),
-                    invalid_tx_error: None,
+                    result: SimulatedTxResult::Executed {
+                        output: tx_output,
+                        receipt: Box::new(receipt.clone()),
+                    },
                 };
+                executed_tx_index += 1;
                 number_of_logs_before_this_tx += receipt.logs().len() as u64;
                 receipts.push(receipt);
                 simulated_tx
             }
             Err(err) => SimulatedTx {
                 tx,
-                tx_index_in_block: tx_index as u64,
+                tx_index_in_block: call_index as u64,
                 number_of_logs_before_this_tx,
-                tx_output: None,
-                receipt: None,
-                invalid_tx_error: Some(err),
+                result: SimulatedTxResult::Invalid(err),
             },
         };
         simulated_txs.push(simulated_tx);
@@ -1030,6 +1006,7 @@ fn build_simulated_block_response(
     header.transactions_root = calculate_transaction_root(
         &simulated_txs
             .iter()
+            .filter(|tx| tx.is_executed())
             .map(|tx| tx.tx.envelope().clone())
             .collect::<Vec<_>>(),
     );
@@ -1048,11 +1025,18 @@ fn build_simulated_block_response(
         BlockTransactions::Full(
             simulated_txs
                 .iter()
+                .filter(|tx| tx.is_executed())
                 .map(|tx| tx.to_api_tx(block_hash, block_context))
                 .collect(),
         )
     } else {
-        BlockTransactions::Hashes(simulated_txs.iter().map(|tx| *tx.tx.hash()).collect())
+        BlockTransactions::Hashes(
+            simulated_txs
+                .iter()
+                .filter(|tx| tx.is_executed())
+                .map(|tx| *tx.tx.hash())
+                .collect(),
+        )
     };
     let inner = ZkApiBlock::new(header, transactions);
 
@@ -1073,12 +1057,7 @@ fn build_simulated_receipt(
     tx: &ZkTransaction,
     tx_output: &TxOutput,
     cumulative_gas_used_before_this_tx: u64,
-    trace_entries: Option<Vec<TraceEntry>>,
 ) -> ZkReceiptEnvelope {
-    let logs = match trace_entries {
-        Some(entries) => trace_transfer_logs(tx, tx_output, entries),
-        None => tx_output.logs.clone(),
-    };
     let l2_to_l1_logs = tx_output
         .l2_to_l1_logs
         .iter()
@@ -1097,277 +1076,10 @@ fn build_simulated_receipt(
         ZkReceipt {
             status: matches!(tx_output.execution_result, ExecutionResult::Success(_)).into(),
             cumulative_gas_used: cumulative_gas_used_before_this_tx + tx_output.gas_used,
-            logs,
+            logs: tx_output.logs.clone(),
             l2_to_l1_logs,
         },
     )
-}
-
-fn trace_transfer_logs(
-    tx: &ZkTransaction,
-    tx_output: &TxOutput,
-    trace_entries: Vec<TraceEntry>,
-) -> Vec<Log> {
-    if !matches!(tx_output.execution_result, ExecutionResult::Success(_)) {
-        return tx_output.logs.clone();
-    }
-
-    let top_level_transfer = top_level_native_transfer(tx, tx_output);
-    let trace_event_count = trace_entries
-        .iter()
-        .filter(|entry| matches!(entry, TraceEntry::Event(_)))
-        .count();
-
-    if trace_event_count == tx_output.logs.len() {
-        let mut has_top_level_transfer = false;
-        let mut logs =
-            Vec::with_capacity(trace_entries.len() + usize::from(top_level_transfer.is_some()));
-        for entry in trace_entries {
-            match entry {
-                TraceEntry::Event(log) => logs.push(log),
-                TraceEntry::Transfer(transfer) => {
-                    if Some(transfer) == top_level_transfer {
-                        has_top_level_transfer = true;
-                    }
-                    logs.push(native_transfer_log(transfer));
-                }
-            }
-        }
-        if let Some(transfer) = top_level_transfer
-            && !has_top_level_transfer
-        {
-            logs.insert(0, native_transfer_log(transfer));
-        }
-        return logs;
-    }
-
-    let mut transfers = trace_entries
-        .into_iter()
-        .filter_map(|entry| match entry {
-            TraceEntry::Transfer(transfer) => Some(transfer),
-            TraceEntry::Event(_) => None,
-        })
-        .collect::<Vec<_>>();
-    if let Some(transfer) = top_level_transfer
-        && !transfers.contains(&transfer)
-    {
-        transfers.insert(0, transfer);
-    }
-
-    let mut logs = transfers
-        .into_iter()
-        .map(native_transfer_log)
-        .collect::<Vec<_>>();
-    logs.extend(tx_output.logs.clone());
-    logs
-}
-
-fn top_level_native_transfer(tx: &ZkTransaction, tx_output: &TxOutput) -> Option<NativeTransfer> {
-    if tx.value() == U256::ZERO
-        || !matches!(tx_output.execution_result, ExecutionResult::Success(_))
-    {
-        return None;
-    }
-
-    let to = tx.to().or(tx_output.contract_address)?;
-    Some(NativeTransfer {
-        from: tx.signer(),
-        to,
-        value: tx.value(),
-    })
-}
-
-fn native_transfer_log(transfer: NativeTransfer) -> Log {
-    let mut from_topic = B256::ZERO;
-    from_topic.0[12..].copy_from_slice(transfer.from.as_slice());
-    let mut to_topic = B256::ZERO;
-    to_topic.0[12..].copy_from_slice(transfer.to.as_slice());
-    let data = transfer.value.to_be_bytes::<32>();
-
-    Log::new_unchecked(
-        Address::repeat_byte(0xee),
-        vec![TRANSFER_EVENT_TOPIC, from_topic, to_topic],
-        Bytes::copy_from_slice(&data),
-    )
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct NativeTransfer {
-    from: Address,
-    to: Address,
-    value: U256,
-}
-
-#[derive(Clone, Debug)]
-enum TraceEntry {
-    Event(Log),
-    Transfer(NativeTransfer),
-}
-
-#[derive(Debug)]
-struct TraceFrame {
-    transfer: Option<NativeTransfer>,
-    entry_index: usize,
-}
-
-/// Minimal equivalent of reth's `TransferInspector` for the ZKsync OS tracer hooks.
-#[derive(Debug, Default)]
-struct TransferTrace {
-    enabled: bool,
-    current_tx_entries: Vec<TraceEntry>,
-    frame_stack: Vec<TraceFrame>,
-    tx_entries: Vec<Vec<TraceEntry>>,
-}
-
-impl TransferTrace {
-    fn new(enabled: bool) -> Self {
-        Self {
-            enabled,
-            ..Self::default()
-        }
-    }
-
-    fn into_entries(self) -> Vec<Vec<TraceEntry>> {
-        self.tx_entries
-    }
-}
-
-impl AnyTracer for TransferTrace {
-    fn as_evm(&mut self) -> Option<&mut impl EvmTracer> {
-        Some(self)
-    }
-}
-
-impl EvmTracer for TransferTrace {
-    fn on_new_execution_frame(&mut self, request: impl EvmRequest) {
-        if !self.enabled {
-            return;
-        }
-
-        let value = request.nominal_token_value();
-        let transfer = (value > U256::ZERO
-            && matches!(
-                request.modifier(),
-                CallModifier::NoModifier | CallModifier::Constructor
-            ))
-        .then_some(NativeTransfer {
-            from: request.caller(),
-            to: request.callee(),
-            value,
-        });
-        self.frame_stack.push(TraceFrame {
-            transfer,
-            entry_index: self.current_tx_entries.len(),
-        });
-    }
-
-    fn after_execution_frame_completed(&mut self, result: Option<(EvmResources, CallResult)>) {
-        if !self.enabled {
-            return;
-        }
-
-        let Some(frame) = self.frame_stack.pop() else {
-            return;
-        };
-        if matches!(result, Some((_, CallResult::Successful { .. }))) {
-            if let Some(transfer) = frame.transfer {
-                let index = frame.entry_index.min(self.current_tx_entries.len());
-                self.current_tx_entries
-                    .insert(index, TraceEntry::Transfer(transfer));
-            }
-        } else {
-            self.current_tx_entries.truncate(frame.entry_index);
-        }
-    }
-
-    fn on_storage_read(
-        &mut self,
-        _is_transient: bool,
-        _address: Address,
-        _key: B256,
-        _value: B256,
-    ) {
-    }
-
-    fn on_storage_write(
-        &mut self,
-        _is_transient: bool,
-        _address: Address,
-        _key: B256,
-        _value: B256,
-    ) {
-    }
-
-    fn on_bytecode_change(
-        &mut self,
-        _address: Address,
-        _new_raw_bytecode: Option<&[u8]>,
-        _new_internal_bytecode_hash: B256,
-        _new_observable_bytecode_length: u32,
-    ) {
-    }
-
-    fn on_event(&mut self, address: Address, topics: Vec<B256>, data: &[u8]) {
-        if self.enabled {
-            self.current_tx_entries
-                .push(TraceEntry::Event(Log::new_unchecked(
-                    address,
-                    topics,
-                    Bytes::copy_from_slice(data),
-                )));
-        }
-    }
-
-    fn begin_tx(&mut self, _calldata: &[u8]) {
-        if self.enabled {
-            self.current_tx_entries.clear();
-            self.frame_stack.clear();
-        }
-    }
-
-    fn finish_tx(&mut self) {
-        if self.enabled {
-            self.frame_stack.clear();
-            self.tx_entries
-                .push(std::mem::take(&mut self.current_tx_entries));
-        }
-    }
-
-    fn before_evm_interpreter_execution_step(
-        &mut self,
-        _opcode: u8,
-        _frame_state: impl EvmFrameInterface,
-    ) {
-    }
-
-    fn after_evm_interpreter_execution_step(
-        &mut self,
-        _opcode: u8,
-        _frame_state: impl EvmFrameInterface,
-    ) {
-    }
-
-    fn on_opcode_error(&mut self, _error: &EvmError, _frame_state: impl EvmFrameInterface) {}
-
-    fn on_call_error(&mut self, _error: &EvmError) {}
-
-    fn on_selfdestruct(
-        &mut self,
-        beneficiary: Address,
-        token_value: U256,
-        frame_state: impl EvmFrameInterface,
-    ) {
-        if self.enabled && token_value > U256::ZERO {
-            self.current_tx_entries
-                .push(TraceEntry::Transfer(NativeTransfer {
-                    from: frame_state.address(),
-                    to: beneficiary,
-                    value: token_value,
-                }));
-        }
-    }
-
-    fn on_create_request(&mut self, _is_create2: bool) {}
 }
 
 fn next_block_context(mut block_context: BlockContext, parent_hash: B256) -> BlockContext {
@@ -1394,6 +1106,17 @@ fn apply_simulate_block_overrides(
                 got: number,
                 parent: previous_block_number,
             });
+        }
+        let skipped_blocks = number.saturating_sub(block_context.block_number);
+        if skipped_blocks >= 256 {
+            block_context.block_hashes.0 = [U256::ZERO; 256];
+        } else if skipped_blocks > 0 {
+            let skipped_blocks = skipped_blocks as usize;
+            block_context
+                .block_hashes
+                .0
+                .copy_within(skipped_blocks.., 0);
+            block_context.block_hashes.0[256 - skipped_blocks..].fill(U256::ZERO);
         }
         block_context.block_number = number;
     }
@@ -1462,6 +1185,10 @@ fn validate_state_overrides_for_simulate(
         }
     }
     if has_precompile_move {
+        // Spec note: `movePrecompileToAddress` is part of eth_simulateV1 state overrides. The
+        // current ZKsync OS execution backend does not expose a way to remap its precompile table
+        // for a single simulated block, so reject it explicitly after the spec validation checks
+        // above.
         return Err(EthCallError::SimulateMovePrecompileNotSupported);
     }
     Ok(())
@@ -1501,43 +1228,53 @@ struct SimulatedTx {
     tx: ZkTransaction,
     tx_index_in_block: u64,
     number_of_logs_before_this_tx: u64,
-    tx_output: Option<TxOutput>,
-    receipt: Option<ZkReceiptEnvelope>,
-    invalid_tx_error: Option<InvalidTransaction>,
+    result: SimulatedTxResult,
+}
+
+enum SimulatedTxResult {
+    Executed {
+        output: TxOutput,
+        receipt: Box<ZkReceiptEnvelope>,
+    },
+    Invalid(InvalidTransaction),
 }
 
 impl SimulatedTx {
+    fn is_executed(&self) -> bool {
+        matches!(&self.result, SimulatedTxResult::Executed { .. })
+    }
+
     fn to_call_result(&self, block_hash: B256, block_context: BlockContext) -> SimCallResult {
-        match (&self.tx_output, &self.receipt, &self.invalid_tx_error) {
-            (Some(tx_output), Some(receipt), None) => {
+        match &self.result {
+            SimulatedTxResult::Executed { output, receipt } => {
                 let logs = self.api_logs(block_hash, block_context, receipt);
-                match &tx_output.execution_result {
+                let (return_data, status, error) = match &output.execution_result {
                     ExecutionResult::Success(
                         ExecutionOutput::Call(return_bytes)
                         | ExecutionOutput::Create(return_bytes, _),
-                    ) => SimCallResult {
-                        return_data: Bytes::from(return_bytes.clone()),
-                        logs,
-                        gas_used: tx_output.gas_used,
-                        status: true,
-                        error: None,
-                    },
+                    ) => (Bytes::from(return_bytes.clone()), true, None),
                     ExecutionResult::Revert(return_bytes) => {
                         let revert = RevertError::new(Bytes::from(return_bytes.clone()));
-                        SimCallResult {
-                            return_data: Bytes::from(return_bytes.clone()),
-                            logs,
-                            gas_used: tx_output.gas_used,
-                            status: false,
-                            error: Some(SimulateError {
+                        (
+                            Bytes::from(return_bytes.clone()),
+                            false,
+                            Some(SimulateError {
                                 code: -32000,
                                 message: revert.to_string(),
                             }),
-                        }
+                        )
                     }
+                };
+
+                SimCallResult {
+                    return_data,
+                    logs,
+                    gas_used: output.gas_used,
+                    status,
+                    error,
                 }
             }
-            (_, _, Some(err)) => SimCallResult {
+            SimulatedTxResult::Invalid(err) => SimCallResult {
                 return_data: Bytes::default(),
                 logs: vec![],
                 gas_used: 0,
@@ -1547,7 +1284,6 @@ impl SimulatedTx {
                     message: format!("vm execution error: {err}"),
                 }),
             },
-            _ => SimCallResult::default(),
         }
     }
 
@@ -1569,14 +1305,11 @@ impl SimulatedTx {
         receipt: &ZkReceiptEnvelope,
     ) -> Vec<alloy::rpc::types::Log> {
         let tx_hash = *self.tx.hash();
-        let meta = self.tx_meta(
-            block_hash,
-            block_context,
-            self.tx_output
-                .as_ref()
-                .map(|output| output.gas_used)
-                .unwrap_or_default(),
-        );
+        let gas_used = match &self.result {
+            SimulatedTxResult::Executed { output, .. } => output.gas_used,
+            SimulatedTxResult::Invalid(_) => 0,
+        };
+        let meta = self.tx_meta(block_hash, block_context, gas_used);
         receipt
             .logs()
             .iter()
@@ -1604,10 +1337,10 @@ impl SimulatedTx {
                 .effective_gas_price(Some(block_context.eip1559_basefee.saturating_to())),
             number_of_logs_before_this_tx: self.number_of_logs_before_this_tx,
             gas_used,
-            contract_address: self
-                .tx_output
-                .as_ref()
-                .and_then(|output| output.contract_address),
+            contract_address: match &self.result {
+                SimulatedTxResult::Executed { output, .. } => output.contract_address,
+                SimulatedTxResult::Invalid(_) => None,
+            },
         }
     }
 }
@@ -1794,6 +1527,37 @@ mod tests {
             time_err,
             EthCallError::SimulateBlockTimestampInvalid { .. }
         ));
+    }
+
+    #[test]
+    fn simulate_block_override_number_jump_clears_gap_hashes() {
+        let mut hashes = [U256::ZERO; 256];
+        for (i, hash) in hashes.iter_mut().enumerate() {
+            *hash = U256::from(i + 1);
+        }
+        let mut context = BlockContext {
+            block_number: 11,
+            timestamp: 101,
+            block_hashes: BlockHashes(hashes),
+            ..Default::default()
+        };
+
+        apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                number: Some(U256::from(14)),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(context.block_number, 14);
+        assert_eq!(context.block_hashes.0[252], U256::from(256));
+        assert_eq!(context.block_hashes.0[253], U256::ZERO);
+        assert_eq!(context.block_hashes.0[254], U256::ZERO);
+        assert_eq!(context.block_hashes.0[255], U256::ZERO);
     }
 
     #[test]

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -12,7 +12,7 @@ use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxTy
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
 use alloy::network::primitives::BlockTransactions;
-use alloy::primitives::{Address, B256, Bloom, Bytes, Log, Signature, TxKind, U256, keccak256};
+use alloy::primitives::{Address, B256, Bloom, Bytes, Log, Signature, TxKind, U256, b256};
 use alloy::rpc::types::simulate::{
     MAX_SIMULATE_BLOCKS, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock,
 };
@@ -25,7 +25,11 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
-use zksync_os_interface::tracing::{NopTracer, NopValidator};
+use zksync_os_evm_errors::EvmError;
+use zksync_os_interface::tracing::{
+    AnyTracer, CallModifier, CallResult, EvmFrameInterface, EvmRequest, EvmResources, EvmTracer,
+    NopValidator,
+};
 use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
 use zksync_os_interface::{
@@ -46,6 +50,8 @@ use zksync_os_types::{
 };
 
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
+const TRANSFER_EVENT_TOPIC: B256 =
+    b256!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
 
 #[derive(Clone, Debug)]
 pub struct EthCallHandler<RpcStorage> {
@@ -456,12 +462,17 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             return_full_transactions,
         } = opts;
 
-        let (mut block_context, base_state_block) = self.resolve_simulation_start_context(block)?;
+        let SimulationStartContext {
+            mut block_context,
+            base_state_block,
+            parent_block_number,
+            parent_timestamp,
+        } = self.resolve_simulation_start_context(block)?;
         let base_state = self.storage.state_view_at(base_state_block)?;
-        let mut overlays = BTreeMap::new();
+        let mut overlays = Arc::new(BTreeMap::new());
         let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
-        let mut previous_block_number = block_context.block_number.saturating_sub(1);
-        let mut previous_timestamp = block_context.timestamp.saturating_sub(1);
+        let mut previous_block_number = parent_block_number;
+        let mut previous_timestamp = parent_timestamp;
 
         for sim_block in block_state_calls {
             block_context.mix_hash = U256::ZERO;
@@ -475,60 +486,78 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 None => SimulateHeaderOverrides::default(),
             };
 
-            let simulation_view =
-                OverriddenStateView::new(base_state.clone(), Arc::new(overlays.clone()));
+            // `validation=false` disables fee validation for execution, but the returned block
+            // still reports the requested/header-overridden base fee.
+            let response_context = block_context;
+            let mut execution_context = response_context;
+            if !validation {
+                execution_context.eip1559_basefee = U256::ZERO;
+            }
 
-            let (state_override_overlay, block_output, txs) = match sim_block.state_overrides {
-                Some(state_overrides) => {
-                    validate_state_overrides_for_simulate(&state_overrides)?;
-                    let state_overrides =
-                        build_state_override_maps(&simulation_view, state_overrides);
-                    let (storage_writes, preimages) = state_overrides.clone().into_parts();
-                    let state_override_overlay = BlockOverlay {
-                        storage_writes,
-                        preimages,
-                    };
-                    let overridden_view =
-                        OverriddenStateView::new(simulation_view, state_overrides);
-                    let txs = self.create_simulation_txs(
-                        sim_block.calls,
-                        block_context,
-                        validation,
-                        overridden_view.clone(),
-                    )?;
-                    let block_output =
-                        run_simulation_block(block_context, overridden_view, txs.clone())?;
-                    (state_override_overlay, block_output, txs)
-                }
-                None => {
-                    let txs = self.create_simulation_txs(
-                        sim_block.calls,
-                        block_context,
-                        validation,
-                        simulation_view.clone(),
-                    )?;
-                    let block_output =
-                        run_simulation_block(block_context, simulation_view, txs.clone())?;
-                    (BlockOverlay::default(), block_output, txs)
-                }
-            };
+            let simulation_view =
+                OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
+
+            let (state_override_overlay, block_output, trace_entries, txs) =
+                match sim_block.state_overrides {
+                    Some(state_overrides) => {
+                        validate_state_overrides_for_simulate(&state_overrides)?;
+                        let state_overrides =
+                            build_state_override_maps(&simulation_view, state_overrides);
+                        let (storage_writes, preimages) = state_overrides.clone().into_parts();
+                        let state_override_overlay = BlockOverlay {
+                            storage_writes,
+                            preimages,
+                        };
+                        let overridden_view =
+                            OverriddenStateView::new(simulation_view, state_overrides);
+                        let txs = self.create_simulation_txs(
+                            sim_block.calls,
+                            execution_context,
+                            overridden_view.clone(),
+                        )?;
+                        let (block_output, trace_entries) = run_simulation_block(
+                            execution_context,
+                            overridden_view,
+                            &txs,
+                            trace_transfers,
+                        )?;
+                        (state_override_overlay, block_output, trace_entries, txs)
+                    }
+                    None => {
+                        let txs = self.create_simulation_txs(
+                            sim_block.calls,
+                            execution_context,
+                            simulation_view.clone(),
+                        )?;
+                        let (block_output, trace_entries) = run_simulation_block(
+                            execution_context,
+                            simulation_view,
+                            &txs,
+                            trace_transfers,
+                        )?;
+                        (BlockOverlay::default(), block_output, trace_entries, txs)
+                    }
+                };
 
             let simulated_block = build_simulated_block_response(
-                block_context,
+                response_context,
                 header_overrides,
                 txs,
                 block_output,
+                trace_entries,
                 trace_transfers,
                 return_full_transactions,
             )?;
             let next_hash = simulated_block.inner.header.hash;
 
             let mut overlay = state_override_overlay;
+            // State overrides seed this simulated block; actual VM writes take precedence for
+            // subsequent simulated blocks.
             overlay
                 .storage_writes
                 .extend(simulated_block.overlay.storage_writes);
             overlay.preimages.extend(simulated_block.overlay.preimages);
-            overlays.insert(block_context.block_number, overlay);
+            Arc::make_mut(&mut overlays).insert(block_context.block_number, overlay);
             previous_block_number = block_context.block_number;
             previous_timestamp = block_context.timestamp;
             simulated_blocks.push(SimulatedBlock {
@@ -573,11 +602,21 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     fn resolve_simulation_start_context(
         &self,
         block: Option<BlockId>,
-    ) -> Result<(BlockContext, u64), EthCallError> {
+    ) -> Result<SimulationStartContext, EthCallError> {
         let block = block.unwrap_or_default();
         if block.is_latest() || block.is_pending() {
             let parent_block = self.storage.replay_storage().latest_record();
-            return Ok((self.build_pending_block_context(), parent_block));
+            let parent_context = self
+                .storage
+                .replay_storage()
+                .get_context(parent_block)
+                .ok_or(RpcStorageError::BlockNotFound(block))?;
+            return Ok(SimulationStartContext {
+                block_context: self.build_pending_block_context(),
+                base_state_block: parent_block,
+                parent_block_number: parent_block,
+                parent_timestamp: parent_context.timestamp,
+            });
         }
 
         let Some(parent_block) = self.storage.resolve_block_number(block)? else {
@@ -594,14 +633,18 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             .ok_or(RpcStorageError::BlockNotFound(block))?;
         let block_context = next_block_context(parent_context, parent.hash());
 
-        Ok((block_context, parent_block))
+        Ok(SimulationStartContext {
+            block_context,
+            base_state_block: parent_block,
+            parent_block_number: parent_block,
+            parent_timestamp: parent_context.timestamp,
+        })
     }
 
     fn create_simulation_txs<V: ViewState + Clone>(
         &self,
         mut calls: Vec<TransactionRequest>,
         block_context: BlockContext,
-        validation: bool,
         mut state_view: V,
     ) -> Result<Vec<ZkTransaction>, EthCallError> {
         let default_gas_limit = simulation_default_gas_limit(
@@ -610,10 +653,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             self.config.eth_call_gas as u64,
         )?;
         let mut next_nonces = HashMap::new();
-        let mut tx_block_context = block_context;
-        if !validation {
-            tx_block_context.eip1559_basefee = U256::ZERO;
-        }
 
         calls
             .iter_mut()
@@ -652,7 +691,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     }
                 }
 
-                self.create_tx_from_request(request.clone(), &tx_block_context, false)
+                self.create_tx_from_request(request.clone(), &block_context, false)
             })
             .collect()
     }
@@ -874,25 +913,44 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 fn run_simulation_block<State>(
     block_context: BlockContext,
     state_view: State,
-    txs: Vec<ZkTransaction>,
-) -> Result<BlockOutput, EthCallError>
+    txs: &[ZkTransaction],
+    trace_transfers: bool,
+) -> Result<(BlockOutput, Vec<Vec<TraceEntry>>), EthCallError>
 where
     State: ViewState,
 {
     let tx_source = TxListSource {
-        transactions: txs.into_iter().map(|tx| tx.encode()).collect(),
+        transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
     };
+    let mut tracer = TransferTrace::new(trace_transfers);
 
-    run_block(
+    let block_output = run_block(
         block_context,
         state_view.clone(),
         state_view,
         tx_source,
         NoopTxCallback,
-        &mut NopTracer,
+        &mut tracer,
         &mut NopValidator,
     )
-    .map_err(EthCallError::ForwardSubsystemError)
+    .map_err(EthCallError::ForwardSubsystemError)?;
+
+    let mut trace_entries = if trace_transfers {
+        tracer.into_entries()
+    } else {
+        Vec::new()
+    };
+    trace_entries.resize_with(block_output.tx_results.len(), Vec::new);
+
+    Ok((block_output, trace_entries))
+}
+
+#[derive(Debug)]
+struct SimulationStartContext {
+    block_context: BlockContext,
+    base_state_block: u64,
+    parent_block_number: u64,
+    parent_timestamp: u64,
 }
 
 #[derive(Debug)]
@@ -912,6 +970,7 @@ fn build_simulated_block_response(
     header_overrides: SimulateHeaderOverrides,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
+    tx_trace_entries: Vec<Vec<TraceEntry>>,
     trace_transfers: bool,
     return_full_transactions: bool,
 ) -> Result<SimulatedBlockResponse, EthCallError> {
@@ -930,12 +989,14 @@ fn build_simulated_block_response(
     let mut cumulative_gas_used = 0;
     let mut receipts = Vec::with_capacity(tx_results.len());
     let mut simulated_txs = Vec::with_capacity(tx_results.len());
+    let mut tx_trace_entries = tx_trace_entries.into_iter();
 
     for (tx_index, (tx, result)) in txs.into_iter().zip(tx_results.into_iter()).enumerate() {
+        let trace_entries = trace_transfers.then(|| tx_trace_entries.next().unwrap_or_default());
         let simulated_tx = match result {
             Ok(tx_output) => {
                 let receipt =
-                    build_simulated_receipt(&tx, &tx_output, cumulative_gas_used, trace_transfers);
+                    build_simulated_receipt(&tx, &tx_output, cumulative_gas_used, trace_entries);
                 block_bloom.accrue_bloom(receipt.logs_bloom());
                 cumulative_gas_used += tx_output.gas_used;
                 let simulated_tx = SimulatedTx {
@@ -963,6 +1024,7 @@ fn build_simulated_block_response(
     }
 
     let mut header = sealed_header.unseal();
+    header.base_fee_per_gas = Some(block_context.eip1559_basefee.saturating_to());
     header.logs_bloom = block_bloom;
     header.gas_used = cumulative_gas_used;
     header.transactions_root = calculate_transaction_root(
@@ -1011,18 +1073,12 @@ fn build_simulated_receipt(
     tx: &ZkTransaction,
     tx_output: &TxOutput,
     cumulative_gas_used_before_this_tx: u64,
-    trace_transfers: bool,
+    trace_entries: Option<Vec<TraceEntry>>,
 ) -> ZkReceiptEnvelope {
-    let mut logs = tx_output.logs.clone();
-    if trace_transfers
-        && tx.value() > U256::ZERO
-        && matches!(tx_output.execution_result, ExecutionResult::Success(_))
-    {
-        logs.insert(
-            0,
-            native_transfer_log(tx.signer(), tx.to().unwrap_or_default(), tx.value()),
-        );
-    }
+    let logs = match trace_entries {
+        Some(entries) => trace_transfer_logs(tx, tx_output, entries),
+        None => tx_output.logs.clone(),
+    };
     let l2_to_l1_logs = tx_output
         .l2_to_l1_logs
         .iter()
@@ -1047,19 +1103,271 @@ fn build_simulated_receipt(
     )
 }
 
-fn native_transfer_log(from: Address, to: Address, value: U256) -> Log {
-    let transfer_topic = keccak256("Transfer(address,address,uint256)");
+fn trace_transfer_logs(
+    tx: &ZkTransaction,
+    tx_output: &TxOutput,
+    trace_entries: Vec<TraceEntry>,
+) -> Vec<Log> {
+    if !matches!(tx_output.execution_result, ExecutionResult::Success(_)) {
+        return tx_output.logs.clone();
+    }
+
+    let top_level_transfer = top_level_native_transfer(tx, tx_output);
+    let trace_event_count = trace_entries
+        .iter()
+        .filter(|entry| matches!(entry, TraceEntry::Event(_)))
+        .count();
+
+    if trace_event_count == tx_output.logs.len() {
+        let mut has_top_level_transfer = false;
+        let mut logs =
+            Vec::with_capacity(trace_entries.len() + usize::from(top_level_transfer.is_some()));
+        for entry in trace_entries {
+            match entry {
+                TraceEntry::Event(log) => logs.push(log),
+                TraceEntry::Transfer(transfer) => {
+                    if Some(transfer) == top_level_transfer {
+                        has_top_level_transfer = true;
+                    }
+                    logs.push(native_transfer_log(transfer));
+                }
+            }
+        }
+        if let Some(transfer) = top_level_transfer
+            && !has_top_level_transfer
+        {
+            logs.insert(0, native_transfer_log(transfer));
+        }
+        return logs;
+    }
+
+    let mut transfers = trace_entries
+        .into_iter()
+        .filter_map(|entry| match entry {
+            TraceEntry::Transfer(transfer) => Some(transfer),
+            TraceEntry::Event(_) => None,
+        })
+        .collect::<Vec<_>>();
+    if let Some(transfer) = top_level_transfer
+        && !transfers.contains(&transfer)
+    {
+        transfers.insert(0, transfer);
+    }
+
+    let mut logs = transfers
+        .into_iter()
+        .map(native_transfer_log)
+        .collect::<Vec<_>>();
+    logs.extend(tx_output.logs.clone());
+    logs
+}
+
+fn top_level_native_transfer(tx: &ZkTransaction, tx_output: &TxOutput) -> Option<NativeTransfer> {
+    if tx.value() == U256::ZERO
+        || !matches!(tx_output.execution_result, ExecutionResult::Success(_))
+    {
+        return None;
+    }
+
+    let to = tx.to().or(tx_output.contract_address)?;
+    Some(NativeTransfer {
+        from: tx.signer(),
+        to,
+        value: tx.value(),
+    })
+}
+
+fn native_transfer_log(transfer: NativeTransfer) -> Log {
     let mut from_topic = B256::ZERO;
-    from_topic.0[12..].copy_from_slice(from.as_slice());
+    from_topic.0[12..].copy_from_slice(transfer.from.as_slice());
     let mut to_topic = B256::ZERO;
-    to_topic.0[12..].copy_from_slice(to.as_slice());
-    let data = value.to_be_bytes::<32>();
+    to_topic.0[12..].copy_from_slice(transfer.to.as_slice());
+    let data = transfer.value.to_be_bytes::<32>();
 
     Log::new_unchecked(
         Address::repeat_byte(0xee),
-        vec![transfer_topic, from_topic, to_topic],
+        vec![TRANSFER_EVENT_TOPIC, from_topic, to_topic],
         Bytes::copy_from_slice(&data),
     )
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct NativeTransfer {
+    from: Address,
+    to: Address,
+    value: U256,
+}
+
+#[derive(Clone, Debug)]
+enum TraceEntry {
+    Event(Log),
+    Transfer(NativeTransfer),
+}
+
+#[derive(Debug)]
+struct TraceFrame {
+    transfer: Option<NativeTransfer>,
+    entry_index: usize,
+}
+
+/// Minimal equivalent of reth's `TransferInspector` for the ZKsync OS tracer hooks.
+#[derive(Debug, Default)]
+struct TransferTrace {
+    enabled: bool,
+    current_tx_entries: Vec<TraceEntry>,
+    frame_stack: Vec<TraceFrame>,
+    tx_entries: Vec<Vec<TraceEntry>>,
+}
+
+impl TransferTrace {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            ..Self::default()
+        }
+    }
+
+    fn into_entries(self) -> Vec<Vec<TraceEntry>> {
+        self.tx_entries
+    }
+}
+
+impl AnyTracer for TransferTrace {
+    fn as_evm(&mut self) -> Option<&mut impl EvmTracer> {
+        Some(self)
+    }
+}
+
+impl EvmTracer for TransferTrace {
+    fn on_new_execution_frame(&mut self, request: impl EvmRequest) {
+        if !self.enabled {
+            return;
+        }
+
+        let value = request.nominal_token_value();
+        let transfer = (value > U256::ZERO
+            && matches!(
+                request.modifier(),
+                CallModifier::NoModifier | CallModifier::Constructor
+            ))
+        .then_some(NativeTransfer {
+            from: request.caller(),
+            to: request.callee(),
+            value,
+        });
+        self.frame_stack.push(TraceFrame {
+            transfer,
+            entry_index: self.current_tx_entries.len(),
+        });
+    }
+
+    fn after_execution_frame_completed(&mut self, result: Option<(EvmResources, CallResult)>) {
+        if !self.enabled {
+            return;
+        }
+
+        let Some(frame) = self.frame_stack.pop() else {
+            return;
+        };
+        if matches!(result, Some((_, CallResult::Successful { .. }))) {
+            if let Some(transfer) = frame.transfer {
+                let index = frame.entry_index.min(self.current_tx_entries.len());
+                self.current_tx_entries
+                    .insert(index, TraceEntry::Transfer(transfer));
+            }
+        } else {
+            self.current_tx_entries.truncate(frame.entry_index);
+        }
+    }
+
+    fn on_storage_read(
+        &mut self,
+        _is_transient: bool,
+        _address: Address,
+        _key: B256,
+        _value: B256,
+    ) {
+    }
+
+    fn on_storage_write(
+        &mut self,
+        _is_transient: bool,
+        _address: Address,
+        _key: B256,
+        _value: B256,
+    ) {
+    }
+
+    fn on_bytecode_change(
+        &mut self,
+        _address: Address,
+        _new_raw_bytecode: Option<&[u8]>,
+        _new_internal_bytecode_hash: B256,
+        _new_observable_bytecode_length: u32,
+    ) {
+    }
+
+    fn on_event(&mut self, address: Address, topics: Vec<B256>, data: &[u8]) {
+        if self.enabled {
+            self.current_tx_entries
+                .push(TraceEntry::Event(Log::new_unchecked(
+                    address,
+                    topics,
+                    Bytes::copy_from_slice(data),
+                )));
+        }
+    }
+
+    fn begin_tx(&mut self, _calldata: &[u8]) {
+        if self.enabled {
+            self.current_tx_entries.clear();
+            self.frame_stack.clear();
+        }
+    }
+
+    fn finish_tx(&mut self) {
+        if self.enabled {
+            self.frame_stack.clear();
+            self.tx_entries
+                .push(std::mem::take(&mut self.current_tx_entries));
+        }
+    }
+
+    fn before_evm_interpreter_execution_step(
+        &mut self,
+        _opcode: u8,
+        _frame_state: impl EvmFrameInterface,
+    ) {
+    }
+
+    fn after_evm_interpreter_execution_step(
+        &mut self,
+        _opcode: u8,
+        _frame_state: impl EvmFrameInterface,
+    ) {
+    }
+
+    fn on_opcode_error(&mut self, _error: &EvmError, _frame_state: impl EvmFrameInterface) {}
+
+    fn on_call_error(&mut self, _error: &EvmError) {}
+
+    fn on_selfdestruct(
+        &mut self,
+        beneficiary: Address,
+        token_value: U256,
+        frame_state: impl EvmFrameInterface,
+    ) {
+        if self.enabled && token_value > U256::ZERO {
+            self.current_tx_entries
+                .push(TraceEntry::Transfer(NativeTransfer {
+                    from: frame_state.address(),
+                    to: beneficiary,
+                    value: token_value,
+                }));
+        }
+    }
+
+    fn on_create_request(&mut self, _is_create2: bool) {}
 }
 
 fn next_block_context(mut block_context: BlockContext, parent_hash: B256) -> BlockContext {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -1,35 +1,48 @@
 use crate::call_fees::{CallFees, CallFeesError};
 use crate::config::RpcConfig;
+use crate::eth_impl::{build_api_log, build_api_tx};
 use crate::js_tracer;
 use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute};
+use alloy::consensus::Transaction as _;
+use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy::consensus::transaction::Recovered;
 use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxType};
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
-use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+use alloy::network::primitives::BlockTransactions;
+use alloy::primitives::{Address, B256, Bloom, Bytes, Log, Signature, TxKind, U256, keccak256};
+use alloy::rpc::types::simulate::{
+    MAX_SIMULATE_BLOCKS, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock,
+};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::trace::geth::{CallConfig, GethTrace};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use serde_json::Value as JsonValue;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::{get_balance, get_nonce};
-use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
+use zksync_os_interface::tracing::{NopTracer, NopValidator};
+use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
+use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
-    types::{BlockContext, ExecutionResult},
+    types::{BlockContext, BlockOutput, ExecutionResult},
 };
-use zksync_os_storage_api::ViewState;
+use zksync_os_multivm::run_block;
+use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
-    RepositoryError, StateError, state_override_view::OverriddenStateView,
+    BlockOverlay, RepositoryError, StateError, ViewState,
+    state_override_view::{OverriddenStateView, build_state_override_maps},
 };
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
     L1_TX_MINIMAL_GAS_LIMIT, L1Envelope, L1PriorityTxType, L1Tx, L1TxType, L2Envelope,
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType, ZkEnvelope,
-    ZkTransaction, ZkTxType,
+    ZkReceipt, ZkReceiptEnvelope, ZkTransaction, ZkTxType,
 };
 
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
@@ -420,6 +433,115 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         Ok(tracer_output.results.pop().unwrap_or(JsonValue::Null))
     }
 
+    pub fn simulate_v1_impl(
+        &self,
+        opts: SimulatePayload,
+        block: Option<BlockId>,
+    ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
+        if opts.block_state_calls.is_empty() {
+            return Err(EthCallError::SimulateInvalidParams(
+                "calls are empty".to_string(),
+            ));
+        }
+        if opts.block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
+            return Err(EthCallError::SimulateInvalidParams(
+                "too many blocks".to_string(),
+            ));
+        }
+
+        let SimulatePayload {
+            block_state_calls,
+            trace_transfers,
+            validation,
+            return_full_transactions,
+        } = opts;
+
+        let (mut block_context, base_state_block) = self.resolve_simulation_start_context(block)?;
+        let base_state = self.storage.state_view_at(base_state_block)?;
+        let mut overlays = BTreeMap::new();
+        let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
+        let mut previous_block_number = block_context.block_number.saturating_sub(1);
+        let mut previous_timestamp = block_context.timestamp.saturating_sub(1);
+
+        for sim_block in block_state_calls {
+            block_context.mix_hash = U256::ZERO;
+            let header_overrides = match sim_block.block_overrides {
+                Some(block_overrides) => apply_simulate_block_overrides(
+                    &mut block_context,
+                    block_overrides,
+                    previous_block_number,
+                    previous_timestamp,
+                )?,
+                None => SimulateHeaderOverrides::default(),
+            };
+
+            let simulation_view =
+                OverriddenStateView::new(base_state.clone(), Arc::new(overlays.clone()));
+
+            let (state_override_overlay, block_output, txs) = match sim_block.state_overrides {
+                Some(state_overrides) => {
+                    validate_state_overrides_for_simulate(&state_overrides)?;
+                    let state_overrides =
+                        build_state_override_maps(&simulation_view, state_overrides);
+                    let (storage_writes, preimages) = state_overrides.clone().into_parts();
+                    let state_override_overlay = BlockOverlay {
+                        storage_writes,
+                        preimages,
+                    };
+                    let overridden_view =
+                        OverriddenStateView::new(simulation_view, state_overrides);
+                    let txs = self.create_simulation_txs(
+                        sim_block.calls,
+                        block_context,
+                        validation,
+                        overridden_view.clone(),
+                    )?;
+                    let block_output =
+                        run_simulation_block(block_context, overridden_view, txs.clone())?;
+                    (state_override_overlay, block_output, txs)
+                }
+                None => {
+                    let txs = self.create_simulation_txs(
+                        sim_block.calls,
+                        block_context,
+                        validation,
+                        simulation_view.clone(),
+                    )?;
+                    let block_output =
+                        run_simulation_block(block_context, simulation_view, txs.clone())?;
+                    (BlockOverlay::default(), block_output, txs)
+                }
+            };
+
+            let simulated_block = build_simulated_block_response(
+                block_context,
+                header_overrides,
+                txs,
+                block_output,
+                trace_transfers,
+                return_full_transactions,
+            )?;
+            let next_hash = simulated_block.inner.header.hash;
+
+            let mut overlay = state_override_overlay;
+            overlay
+                .storage_writes
+                .extend(simulated_block.overlay.storage_writes);
+            overlay.preimages.extend(simulated_block.overlay.preimages);
+            overlays.insert(block_context.block_number, overlay);
+            previous_block_number = block_context.block_number;
+            previous_timestamp = block_context.timestamp;
+            simulated_blocks.push(SimulatedBlock {
+                inner: simulated_block.inner,
+                calls: simulated_block.calls,
+            });
+
+            block_context = next_block_context(block_context, next_hash);
+        }
+
+        Ok(simulated_blocks)
+    }
+
     pub fn estimate_gas_impl(
         &self,
         request: TransactionRequest,
@@ -446,6 +568,93 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             ),
             None => self.estimate_gas_with_view(request, block_context, storage_view),
         }
+    }
+
+    fn resolve_simulation_start_context(
+        &self,
+        block: Option<BlockId>,
+    ) -> Result<(BlockContext, u64), EthCallError> {
+        let block = block.unwrap_or_default();
+        if block.is_latest() || block.is_pending() {
+            let parent_block = self.storage.replay_storage().latest_record();
+            return Ok((self.build_pending_block_context(), parent_block));
+        }
+
+        let Some(parent_block) = self.storage.resolve_block_number(block)? else {
+            return Err(RpcStorageError::BlockNotFound(block).into());
+        };
+        let parent_context = self
+            .storage
+            .replay_storage()
+            .get_context(parent_block)
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let parent = self
+            .storage
+            .get_block_by_id(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let block_context = next_block_context(parent_context, parent.hash());
+
+        Ok((block_context, parent_block))
+    }
+
+    fn create_simulation_txs<V: ViewState + Clone>(
+        &self,
+        mut calls: Vec<TransactionRequest>,
+        block_context: BlockContext,
+        validation: bool,
+        mut state_view: V,
+    ) -> Result<Vec<ZkTransaction>, EthCallError> {
+        let default_gas_limit = simulation_default_gas_limit(
+            &calls,
+            block_context.gas_limit,
+            self.config.eth_call_gas as u64,
+        )?;
+        let mut next_nonces = HashMap::new();
+        let mut tx_block_context = block_context;
+        if !validation {
+            tx_block_context.eip1559_basefee = U256::ZERO;
+        }
+
+        calls
+            .iter_mut()
+            .map(|request| {
+                if request.gas.is_none() {
+                    request.set_gas_limit(default_gas_limit);
+                }
+
+                let from = request.from.unwrap_or_default();
+                if request.nonce.is_none() {
+                    let nonce = *next_nonces.entry(from).or_insert_with(|| {
+                        state_view
+                            .get_account(from)
+                            .as_ref()
+                            .map(get_nonce)
+                            .unwrap_or_default()
+                    });
+                    request.set_nonce(nonce);
+                    let next_nonce =
+                        nonce
+                            .checked_add(1)
+                            .ok_or(EthCallError::SimulateInvalidParams(
+                                "nonce has max value".to_string(),
+                            ))?;
+                    next_nonces.insert(from, next_nonce);
+                } else if let Some(nonce) = request.nonce {
+                    let state_nonce = next_nonces.entry(from).or_insert_with(|| {
+                        state_view
+                            .get_account(from)
+                            .as_ref()
+                            .map(get_nonce)
+                            .unwrap_or_default()
+                    });
+                    if nonce >= *state_nonce {
+                        *state_nonce = nonce.saturating_add(1);
+                    }
+                }
+
+                self.create_tx_from_request(request.clone(), &tx_block_context, false)
+            })
+            .collect()
     }
 }
 
@@ -662,6 +871,439 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     }
 }
 
+fn run_simulation_block<State>(
+    block_context: BlockContext,
+    state_view: State,
+    txs: Vec<ZkTransaction>,
+) -> Result<BlockOutput, EthCallError>
+where
+    State: ViewState,
+{
+    let tx_source = TxListSource {
+        transactions: txs.into_iter().map(|tx| tx.encode()).collect(),
+    };
+
+    run_block(
+        block_context,
+        state_view.clone(),
+        state_view,
+        tx_source,
+        NoopTxCallback,
+        &mut NopTracer,
+        &mut NopValidator,
+    )
+    .map_err(EthCallError::ForwardSubsystemError)
+}
+
+#[derive(Debug)]
+struct SimulatedBlockResponse {
+    inner: ZkApiBlock,
+    calls: Vec<SimCallResult>,
+    overlay: BlockOverlay,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SimulateHeaderOverrides {
+    difficulty: Option<U256>,
+}
+
+fn build_simulated_block_response(
+    block_context: BlockContext,
+    header_overrides: SimulateHeaderOverrides,
+    txs: Vec<ZkTransaction>,
+    block_output: BlockOutput,
+    trace_transfers: bool,
+    return_full_transactions: bool,
+) -> Result<SimulatedBlockResponse, EthCallError> {
+    let BlockOutput {
+        header: sealed_header,
+        tx_results,
+        storage_writes,
+        account_diffs: _,
+        published_preimages,
+        pubdata: _,
+        computational_native_used: _,
+    } = block_output;
+
+    let mut block_bloom = Bloom::default();
+    let mut number_of_logs_before_this_tx = 0;
+    let mut cumulative_gas_used = 0;
+    let mut receipts = Vec::with_capacity(tx_results.len());
+    let mut simulated_txs = Vec::with_capacity(tx_results.len());
+
+    for (tx_index, (tx, result)) in txs.into_iter().zip(tx_results.into_iter()).enumerate() {
+        let simulated_tx = match result {
+            Ok(tx_output) => {
+                let receipt =
+                    build_simulated_receipt(&tx, &tx_output, cumulative_gas_used, trace_transfers);
+                block_bloom.accrue_bloom(receipt.logs_bloom());
+                cumulative_gas_used += tx_output.gas_used;
+                let simulated_tx = SimulatedTx {
+                    tx,
+                    tx_index_in_block: tx_index as u64,
+                    number_of_logs_before_this_tx,
+                    tx_output: Some(tx_output),
+                    receipt: Some(receipt.clone()),
+                    invalid_tx_error: None,
+                };
+                number_of_logs_before_this_tx += receipt.logs().len() as u64;
+                receipts.push(receipt);
+                simulated_tx
+            }
+            Err(err) => SimulatedTx {
+                tx,
+                tx_index_in_block: tx_index as u64,
+                number_of_logs_before_this_tx,
+                tx_output: None,
+                receipt: None,
+                invalid_tx_error: Some(err),
+            },
+        };
+        simulated_txs.push(simulated_tx);
+    }
+
+    let mut header = sealed_header.unseal();
+    header.logs_bloom = block_bloom;
+    header.gas_used = cumulative_gas_used;
+    header.transactions_root = calculate_transaction_root(
+        &simulated_txs
+            .iter()
+            .map(|tx| tx.tx.envelope().clone())
+            .collect::<Vec<_>>(),
+    );
+    header.receipts_root = calculate_receipt_root(&receipts);
+    if let Some(difficulty) = header_overrides.difficulty {
+        header.difficulty = difficulty;
+    }
+
+    let header = alloy::rpc::types::Header::new(header);
+    let block_hash = header.hash;
+    let calls = simulated_txs
+        .iter()
+        .map(|tx| tx.to_call_result(block_hash, block_context))
+        .collect();
+    let transactions = if return_full_transactions {
+        BlockTransactions::Full(
+            simulated_txs
+                .iter()
+                .map(|tx| tx.to_api_tx(block_hash, block_context))
+                .collect(),
+        )
+    } else {
+        BlockTransactions::Hashes(simulated_txs.iter().map(|tx| *tx.tx.hash()).collect())
+    };
+    let inner = ZkApiBlock::new(header, transactions);
+
+    Ok(SimulatedBlockResponse {
+        inner,
+        calls,
+        overlay: BlockOverlay {
+            storage_writes: storage_writes
+                .into_iter()
+                .map(|write| (write.key, write.value))
+                .collect(),
+            preimages: published_preimages.into_iter().collect(),
+        },
+    })
+}
+
+fn build_simulated_receipt(
+    tx: &ZkTransaction,
+    tx_output: &TxOutput,
+    cumulative_gas_used_before_this_tx: u64,
+    trace_transfers: bool,
+) -> ZkReceiptEnvelope {
+    let mut logs = tx_output.logs.clone();
+    if trace_transfers
+        && tx.value() > U256::ZERO
+        && matches!(tx_output.execution_result, ExecutionResult::Success(_))
+    {
+        logs.insert(
+            0,
+            native_transfer_log(tx.signer(), tx.to().unwrap_or_default(), tx.value()),
+        );
+    }
+    let l2_to_l1_logs = tx_output
+        .l2_to_l1_logs
+        .iter()
+        .map(|l2_to_l1_log| zksync_os_types::L2ToL1Log {
+            l2_shard_id: l2_to_l1_log.log.l2_shard_id,
+            is_service: l2_to_l1_log.log.is_service,
+            tx_number_in_block: l2_to_l1_log.log.tx_number_in_block,
+            sender: l2_to_l1_log.log.sender,
+            key: l2_to_l1_log.log.key,
+            value: l2_to_l1_log.log.value,
+        })
+        .collect();
+
+    ZkReceiptEnvelope::from_typed(
+        tx.tx_type(),
+        ZkReceipt {
+            status: matches!(tx_output.execution_result, ExecutionResult::Success(_)).into(),
+            cumulative_gas_used: cumulative_gas_used_before_this_tx + tx_output.gas_used,
+            logs,
+            l2_to_l1_logs,
+        },
+    )
+}
+
+fn native_transfer_log(from: Address, to: Address, value: U256) -> Log {
+    let transfer_topic = keccak256("Transfer(address,address,uint256)");
+    let mut from_topic = B256::ZERO;
+    from_topic.0[12..].copy_from_slice(from.as_slice());
+    let mut to_topic = B256::ZERO;
+    to_topic.0[12..].copy_from_slice(to.as_slice());
+    let data = value.to_be_bytes::<32>();
+
+    Log::new_unchecked(
+        Address::repeat_byte(0xee),
+        vec![transfer_topic, from_topic, to_topic],
+        Bytes::copy_from_slice(&data),
+    )
+}
+
+fn next_block_context(mut block_context: BlockContext, parent_hash: B256) -> BlockContext {
+    block_context.block_number += 1;
+    block_context.timestamp += 1;
+    block_context.block_hashes.0.rotate_left(1);
+    block_context.block_hashes.0[255] = U256::from_be_bytes(parent_hash.0);
+    block_context
+}
+
+fn apply_simulate_block_overrides(
+    block_context: &mut BlockContext,
+    overrides: BlockOverrides,
+    previous_block_number: u64,
+    previous_timestamp: u64,
+) -> Result<SimulateHeaderOverrides, EthCallError> {
+    let mut header_overrides = SimulateHeaderOverrides::default();
+
+    if let Some(number) = overrides.number {
+        let number = u64::try_from(number)
+            .map_err(|_| EthCallError::SimulateInvalidBlockOverride("number"))?;
+        if number <= previous_block_number {
+            return Err(EthCallError::SimulateBlockNumberInvalid {
+                got: number,
+                parent: previous_block_number,
+            });
+        }
+        block_context.block_number = number;
+    }
+    if let Some(time) = overrides.time {
+        if time <= previous_timestamp {
+            return Err(EthCallError::SimulateBlockTimestampInvalid {
+                got: time,
+                parent: previous_timestamp,
+            });
+        }
+        block_context.timestamp = time;
+    }
+    if let Some(gas_limit) = overrides.gas_limit {
+        block_context.gas_limit = gas_limit;
+    }
+    if let Some(coinbase) = overrides.coinbase {
+        block_context.coinbase = coinbase;
+    }
+    if let Some(random) = overrides.random {
+        block_context.mix_hash = U256::from_be_bytes(random.0);
+    } else {
+        block_context.mix_hash = U256::ZERO;
+    }
+    if let Some(base_fee) = overrides.base_fee {
+        block_context.eip1559_basefee = base_fee;
+    }
+    if let Some(blob_base_fee) = overrides.blob_base_fee {
+        block_context.blob_fee = blob_base_fee;
+    }
+    if let Some(difficulty) = overrides.difficulty {
+        header_overrides.difficulty = Some(difficulty);
+    }
+    if let Some(block_hash_overrides) = overrides.block_hash {
+        for (block_number, block_hash) in block_hash_overrides {
+            if block_number >= block_context.block_number {
+                continue;
+            }
+            let distance = block_context.block_number - block_number;
+            if distance == 0 || distance > 256 {
+                continue;
+            }
+
+            let index = 256 - distance as usize;
+            block_context.block_hashes.0[index] = U256::from_be_bytes(block_hash.0);
+        }
+    }
+
+    Ok(header_overrides)
+}
+
+fn validate_state_overrides_for_simulate(
+    state_overrides: &StateOverride,
+) -> Result<(), EthCallError> {
+    let mut destinations = HashSet::new();
+    let mut has_precompile_move = false;
+    for (source, account) in state_overrides {
+        let Some(destination) = account.move_precompile_to else {
+            continue;
+        };
+        has_precompile_move = true;
+        if *source == destination {
+            return Err(EthCallError::SimulatePrecompileSelfReference);
+        }
+        if !destinations.insert(destination) {
+            return Err(EthCallError::SimulatePrecompileDuplicateAddress);
+        }
+    }
+    if has_precompile_move {
+        return Err(EthCallError::SimulateMovePrecompileNotSupported);
+    }
+    Ok(())
+}
+
+fn simulation_default_gas_limit(
+    calls: &[TransactionRequest],
+    block_gas_limit: u64,
+    call_gas_limit: u64,
+) -> Result<u64, EthCallError> {
+    let total_specified_gas =
+        calls
+            .iter()
+            .filter_map(|call| call.gas)
+            .try_fold(0_u64, |sum, gas| {
+                sum.checked_add(gas)
+                    .ok_or(EthCallError::SimulateBlockGasLimitExceeded)
+            })?;
+    if total_specified_gas > block_gas_limit {
+        return Err(EthCallError::SimulateBlockGasLimitExceeded);
+    }
+
+    let calls_without_gas = calls.iter().filter(|call| call.gas.is_none()).count() as u64;
+    if calls_without_gas == 0 {
+        return Ok(0);
+    }
+
+    let gas_per_call = (block_gas_limit - total_specified_gas) / calls_without_gas;
+    Ok(if call_gas_limit == 0 {
+        gas_per_call
+    } else {
+        gas_per_call.min(call_gas_limit)
+    })
+}
+
+struct SimulatedTx {
+    tx: ZkTransaction,
+    tx_index_in_block: u64,
+    number_of_logs_before_this_tx: u64,
+    tx_output: Option<TxOutput>,
+    receipt: Option<ZkReceiptEnvelope>,
+    invalid_tx_error: Option<InvalidTransaction>,
+}
+
+impl SimulatedTx {
+    fn to_call_result(&self, block_hash: B256, block_context: BlockContext) -> SimCallResult {
+        match (&self.tx_output, &self.receipt, &self.invalid_tx_error) {
+            (Some(tx_output), Some(receipt), None) => {
+                let logs = self.api_logs(block_hash, block_context, receipt);
+                match &tx_output.execution_result {
+                    ExecutionResult::Success(
+                        ExecutionOutput::Call(return_bytes)
+                        | ExecutionOutput::Create(return_bytes, _),
+                    ) => SimCallResult {
+                        return_data: Bytes::from(return_bytes.clone()),
+                        logs,
+                        gas_used: tx_output.gas_used,
+                        status: true,
+                        error: None,
+                    },
+                    ExecutionResult::Revert(return_bytes) => {
+                        let revert = RevertError::new(Bytes::from(return_bytes.clone()));
+                        SimCallResult {
+                            return_data: Bytes::from(return_bytes.clone()),
+                            logs,
+                            gas_used: tx_output.gas_used,
+                            status: false,
+                            error: Some(SimulateError {
+                                code: -32000,
+                                message: revert.to_string(),
+                            }),
+                        }
+                    }
+                }
+            }
+            (_, _, Some(err)) => SimCallResult {
+                return_data: Bytes::default(),
+                logs: vec![],
+                gas_used: 0,
+                status: false,
+                error: Some(SimulateError {
+                    code: -32015,
+                    message: format!("vm execution error: {err}"),
+                }),
+            },
+            _ => SimCallResult::default(),
+        }
+    }
+
+    fn to_api_tx(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+    ) -> zksync_os_rpc_api::types::ZkApiTransaction {
+        build_api_tx(
+            self.tx.clone(),
+            Some(&self.tx_meta(block_hash, block_context, 0)),
+        )
+    }
+
+    fn api_logs(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+        receipt: &ZkReceiptEnvelope,
+    ) -> Vec<alloy::rpc::types::Log> {
+        let tx_hash = *self.tx.hash();
+        let meta = self.tx_meta(
+            block_hash,
+            block_context,
+            self.tx_output
+                .as_ref()
+                .map(|output| output.gas_used)
+                .unwrap_or_default(),
+        );
+        receipt
+            .logs()
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, log)| build_api_log(tx_hash, log, meta.clone(), i as u64))
+            .collect()
+    }
+
+    fn tx_meta(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+        gas_used: u64,
+    ) -> zksync_os_storage_api::TxMeta {
+        zksync_os_storage_api::TxMeta {
+            block_hash,
+            block_number: block_context.block_number,
+            block_timestamp: block_context.timestamp,
+            tx_index_in_block: self.tx_index_in_block,
+            effective_gas_price: self
+                .tx
+                .inner
+                .inner()
+                .effective_gas_price(Some(block_context.eip1559_basefee.saturating_to())),
+            number_of_logs_before_this_tx: self.number_of_logs_before_this_tx,
+            gas_used,
+            contract_address: self
+                .tx_output
+                .as_ref()
+                .and_then(|output| output.contract_address),
+        }
+    }
+}
+
 fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
     match tx.inner.inner_mut() {
         ZkEnvelope::System(_) => {
@@ -715,6 +1357,22 @@ pub enum EthCallError {
     // todo: temporary, needs to be supported eventually
     #[error("block overrides are not supported in `eth_call`")]
     BlockOverridesNotSupported,
+    #[error("invalid `eth_simulateV1` params: {0}")]
+    SimulateInvalidParams(String),
+    #[error("invalid block override in `eth_simulateV1`: {0}")]
+    SimulateInvalidBlockOverride(&'static str),
+    #[error("block numbers must be in order: {got} <= {parent}")]
+    SimulateBlockNumberInvalid { got: u64, parent: u64 },
+    #[error("block timestamps must be in order: {got} <= {parent}")]
+    SimulateBlockTimestampInvalid { got: u64, parent: u64 },
+    #[error("block gas limit exceeded by the block's transactions")]
+    SimulateBlockGasLimitExceeded,
+    #[error("MovePrecompileToAddress referenced itself")]
+    SimulatePrecompileSelfReference,
+    #[error("multiple MovePrecompileToAddress values reference the same replacement address")]
+    SimulatePrecompileDuplicateAddress,
+    #[error("movePrecompileToAddress is not supported by this execution backend")]
+    SimulateMovePrecompileNotSupported,
     // todo(EIP-4844)
     #[error("EIP-4844 transactions are not supported")]
     Eip4844NotSupported,
@@ -757,4 +1415,114 @@ pub enum EthCallError {
     /// Error occurred during debug tracing
     #[error("Tracer error: {0:?}")]
     CallTracerError(anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::rpc::types::state::AccountOverride;
+
+    #[test]
+    fn simulation_default_gas_limit_splits_remaining_block_gas() {
+        let calls = vec![
+            TransactionRequest {
+                gas: Some(40),
+                ..Default::default()
+            },
+            TransactionRequest::default(),
+            TransactionRequest::default(),
+        ];
+
+        assert_eq!(simulation_default_gas_limit(&calls, 100, 0).unwrap(), 30);
+        assert_eq!(simulation_default_gas_limit(&calls, 100, 25).unwrap(), 25);
+    }
+
+    #[test]
+    fn simulation_default_gas_limit_rejects_block_gas_overflow() {
+        let calls = vec![TransactionRequest {
+            gas: Some(101),
+            ..Default::default()
+        }];
+
+        assert!(matches!(
+            simulation_default_gas_limit(&calls, 100, 0),
+            Err(EthCallError::SimulateBlockGasLimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn simulate_block_overrides_reject_non_increasing_sequences() {
+        let mut context = BlockContext {
+            block_number: 11,
+            timestamp: 101,
+            ..Default::default()
+        };
+        let number_err = apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                number: Some(U256::from(10)),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            number_err,
+            EthCallError::SimulateBlockNumberInvalid { .. }
+        ));
+
+        let time_err = apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                time: Some(100),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            time_err,
+            EthCallError::SimulateBlockTimestampInvalid { .. }
+        ));
+    }
+
+    #[test]
+    fn simulate_state_overrides_validate_precompile_moves() {
+        let source = Address::from([1; 20]);
+        let destination = Address::from([2; 20]);
+        let mut overrides = StateOverride::default();
+        overrides.insert(
+            source,
+            AccountOverride {
+                move_precompile_to: Some(source),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            validate_state_overrides_for_simulate(&overrides),
+            Err(EthCallError::SimulatePrecompileSelfReference)
+        ));
+
+        let mut overrides = StateOverride::default();
+        overrides.insert(
+            source,
+            AccountOverride {
+                move_precompile_to: Some(destination),
+                ..Default::default()
+            },
+        );
+        overrides.insert(
+            Address::from([3; 20]),
+            AccountOverride {
+                move_precompile_to: Some(destination),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            validate_state_overrides_for_simulate(&overrides),
+            Err(EthCallError::SimulatePrecompileDuplicateAddress)
+        ));
+    }
 }

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -36,7 +36,7 @@ use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
 use zksync_os_storage_api::{
     BlockOverlay, RepositoryError, StateError, ViewState,
-    state_override_view::{OverriddenStateView, OwnedOverrides, build_state_override_maps},
+    state_override_view::{OverriddenStateView, build_state_override_maps},
 };
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
@@ -508,23 +508,15 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             let simulation_view =
                 OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
 
-            let (state_override_overlay, state_overrides) = match sim_block.state_overrides {
+            let state_overrides = match sim_block.state_overrides {
                 Some(state_overrides) => {
                     validate_state_overrides_for_simulate(&state_overrides)?;
-                    let state_overrides =
-                        build_state_override_maps(&simulation_view, state_overrides);
-                    let (storage_writes, preimages) = state_overrides.clone().into_parts();
-                    (
-                        BlockOverlay {
-                            storage_writes,
-                            preimages,
-                        },
-                        state_overrides,
-                    )
+                    build_state_override_maps(&simulation_view, state_overrides)
                 }
-                None => (BlockOverlay::default(), OwnedOverrides::default()),
+                None => BlockOverlay::default(),
             };
-            let overridden_view = OverriddenStateView::new(simulation_view, state_overrides);
+            let overridden_view =
+                OverriddenStateView::new(simulation_view, state_overrides.clone());
             let txs = self.create_simulation_txs(
                 sim_block.calls,
                 execution_context,
@@ -541,7 +533,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             )?;
             let next_hash = simulated_block.inner.header.hash;
 
-            let mut overlay = state_override_overlay;
+            let mut overlay = state_overrides;
             // State overrides seed this simulated block; actual VM writes take precedence for
             // subsequent simulated blocks.
             overlay.extend(simulated_block.overlay);

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -680,11 +680,12 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
 
     fn simulate_v1(
         &self,
-        _opts: SimulatePayload,
-        _block_number: Option<BlockId>,
-    ) -> RpcResult<Vec<SimulatedBlock>> {
-        // todo(#51): implement
-        Err(unimplemented_rpc_err())
+        opts: SimulatePayload,
+        block_number: Option<BlockId>,
+    ) -> RpcResult<Vec<SimulatedBlock<ZkApiBlock>>> {
+        self.eth_call_handler
+            .simulate_v1_impl(opts, block_number)
+            .to_rpc_result()
     }
 
     fn call(

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -15,7 +15,7 @@ mod metrics;
 mod ots_impl;
 mod result;
 mod rpc_storage;
-mod simulation_utils;
+mod simulate;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
 pub mod js_tracer;

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -15,6 +15,7 @@ mod metrics;
 mod ots_impl;
 mod result;
 mod rpc_storage;
+mod simulation_utils;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
 pub mod js_tracer;

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -125,12 +125,6 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
             EthCallError::SimulateBlockGasLimitExceeded => {
                 rpc_error_with_code(-38015, err.to_string())
             }
-            EthCallError::SimulatePrecompileSelfReference => {
-                rpc_error_with_code(-38022, err.to_string())
-            }
-            EthCallError::SimulatePrecompileDuplicateAddress => {
-                rpc_error_with_code(-38023, err.to_string())
-            }
             EthCallError::SimulateMovePrecompileNotSupported => {
                 invalid_params_rpc_err(err.to_string())
             }

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -116,6 +116,7 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
             | EthCallError::SimulateInvalidBlockOverride(_) => {
                 invalid_params_rpc_err(err.to_string())
             }
+            // Error codes -380xx follow the reth implementation of the eth_simulateV1 spec.
             EthCallError::SimulateBlockNumberInvalid { .. } => {
                 rpc_error_with_code(-38020, err.to_string())
             }

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -112,6 +112,28 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
                 revert.to_string(),
                 revert.output.as_ref().map(|out| out.as_ref()),
             ),
+            EthCallError::SimulateInvalidParams(_)
+            | EthCallError::SimulateInvalidBlockOverride(_) => {
+                invalid_params_rpc_err(err.to_string())
+            }
+            EthCallError::SimulateBlockNumberInvalid { .. } => {
+                rpc_error_with_code(-38020, err.to_string())
+            }
+            EthCallError::SimulateBlockTimestampInvalid { .. } => {
+                rpc_error_with_code(-38021, err.to_string())
+            }
+            EthCallError::SimulateBlockGasLimitExceeded => {
+                rpc_error_with_code(-38015, err.to_string())
+            }
+            EthCallError::SimulatePrecompileSelfReference => {
+                rpc_error_with_code(-38022, err.to_string())
+            }
+            EthCallError::SimulatePrecompileDuplicateAddress => {
+                rpc_error_with_code(-38023, err.to_string())
+            }
+            EthCallError::SimulateMovePrecompileNotSupported => {
+                invalid_params_rpc_err(err.to_string())
+            }
             err => internal_rpc_err(err.to_string()),
         })
     }

--- a/lib/rpc/src/simulate.rs
+++ b/lib/rpc/src/simulate.rs
@@ -1,28 +1,285 @@
-use crate::eth_call_handler::EthCallError;
+use crate::eth_call_handler::{EthCallError, EthCallHandler};
 use crate::eth_impl::{build_api_log, build_api_tx};
 use crate::result::RevertError;
+use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use alloy::consensus::Transaction as _;
 use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
+use alloy::eips::BlockId;
 use alloy::network::primitives::BlockTransactions;
 use alloy::primitives::{B256, Bloom, Bytes, U256};
-use alloy::rpc::types::simulate::{SimCallResult, SimulateError, SimulatedBlock};
+use alloy::rpc::types::simulate::{
+    MAX_SIMULATE_BLOCKS, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock,
+};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use zk_os_api::helpers::get_nonce;
 use zksync_os_interface::error::InvalidTransaction;
+use zksync_os_interface::tracing::{NopTracer, NopValidator};
+use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{
     BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
 };
+use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
-use zksync_os_storage_api::state_override_view::OwnedOverrides;
-use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction};
+use zksync_os_storage_api::ViewState;
+use zksync_os_storage_api::state_override_view::{
+    OverriddenStateView, OwnedOverrides, build_state_override_maps,
+};
+use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction, ZksyncOsEncode};
 
-#[derive(Debug)]
-pub(crate) struct SimulationStartContext {
-    pub(crate) block_context: BlockContext,
-    pub(crate) parent_block_number: u64,
-    pub(crate) parent_timestamp: u64,
+impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
+    /// Implements `eth_simulateV1` using the same high-level model as reth: execute the requested
+    /// blocks linearly, carry an overlay of simulated writes into subsequent blocks, and use a
+    /// separate execution context when `validation=false` so fee validation does not leak into the
+    /// returned header.
+    ///
+    /// # Spec limitations
+    ///
+    /// The following features from the `eth_simulateV1` spec are not supported:
+    ///
+    /// - `traceTransfers=true`: rejected with an error. ZKsync OS has no transfer-tracing
+    ///   inspector equivalent, so synthetic ERC-20 transfer logs cannot be generated.
+    /// - `movePrecompileToAddress`: rejected with an error. The VM does not support remapping
+    ///   precompile addresses on a per-block basis.
+    /// - `blockOverrides.difficulty`: silently ignored. ZKsync OS has no `difficulty` field in
+    ///   its block context; use `blockOverrides.random` (prevrandao) instead.
+    /// - `blockOverrides.parentBeaconBlockRoot`: silently ignored. There is no corresponding
+    ///   field in `BlockContext`.
+    /// - `validation=false` nonce relaxation: partially unsupported. The basefee is zeroed as
+    ///   the spec requires, but nonce checks are not disabled. Transactions without an explicit
+    ///   nonce are auto-filled from state (the common case works), but an explicitly supplied
+    ///   stale nonce will be rejected by the VM.
+    pub fn simulate_v1_impl(
+        &self,
+        opts: SimulatePayload,
+        block: Option<BlockId>,
+    ) -> Result<Vec<SimulatedBlock<ZkApiBlock>>, EthCallError> {
+        let SimulatePayload {
+            block_state_calls,
+            trace_transfers,
+            validation,
+            return_full_transactions,
+        } = opts;
+
+        if block_state_calls.is_empty() {
+            return Err(EthCallError::SimulateInvalidParams(
+                "calls are empty".to_string(),
+            ));
+        }
+        if block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
+            return Err(EthCallError::SimulateInvalidParams(
+                "too many blocks".to_string(),
+            ));
+        }
+
+        if trace_transfers {
+            return Err(EthCallError::SimulateInvalidParams(
+                "traceTransfers is not implemented".to_string(),
+            ));
+        }
+
+        let SimulationStartContext {
+            mut block_context,
+            parent_block_number,
+            parent_timestamp,
+        } = self.resolve_simulation_start_context(block)?;
+        let base_state = self.storage.state_view_at(parent_block_number)?;
+        let mut overlays = Arc::new(BTreeMap::new());
+        let mut simulated_blocks = Vec::with_capacity(block_state_calls.len());
+        let mut previous_block_number = parent_block_number;
+        let mut previous_timestamp = parent_timestamp;
+
+        for sim_block in block_state_calls {
+            // Per the eth_simulateV1 spec, prevrandao defaults to zero for simulated blocks
+            // unless explicitly overridden via `blockOverrides.random`.
+            block_context.mix_hash = U256::ZERO;
+            if let Some(block_overrides) = sim_block.block_overrides {
+                apply_simulate_block_overrides(
+                    &mut block_context,
+                    block_overrides,
+                    previous_block_number,
+                    previous_timestamp,
+                    self.config.eth_simulate_block_gas_limit,
+                )?;
+            }
+
+            let response_context = block_context;
+            let mut execution_context = response_context;
+            if !validation {
+                execution_context.eip1559_basefee = U256::ZERO;
+            }
+
+            let simulation_view =
+                OverriddenStateView::new(base_state.clone(), Arc::clone(&overlays));
+
+            let state_overrides = match sim_block.state_overrides {
+                Some(state_overrides) => {
+                    if state_overrides
+                        .values()
+                        .any(|account| account.move_precompile_to.is_some())
+                    {
+                        return Err(EthCallError::SimulateMovePrecompileNotSupported);
+                    }
+                    build_state_override_maps(&simulation_view, state_overrides)
+                }
+                None => OwnedOverrides::default(),
+            };
+            let overridden_view =
+                OverriddenStateView::new(simulation_view, state_overrides.clone());
+            let txs = self.create_simulation_txs(
+                sim_block.calls,
+                execution_context,
+                overridden_view.clone(),
+            )?;
+            let tx_source = TxListSource {
+                transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
+            };
+            let block_output = run_block(
+                execution_context,
+                overridden_view.clone(),
+                overridden_view,
+                tx_source,
+                NoopTxCallback,
+                &mut NopTracer,
+                &mut NopValidator,
+            )
+            .map_err(EthCallError::ForwardSubsystemError)?;
+
+            let (simulated_block, block_overlay) = build_simulated_block_response(
+                response_context,
+                txs,
+                block_output,
+                return_full_transactions,
+            )?;
+            let next_hash = simulated_block.inner.header.hash;
+
+            let mut overlay = state_overrides;
+            // State overrides seed this simulated block; actual VM writes take precedence for
+            // subsequent simulated blocks.
+            overlay.extend(block_overlay);
+            Arc::get_mut(&mut overlays)
+                .ok_or_else(|| {
+                    EthCallError::ForwardSubsystemError(anyhow::anyhow!(
+                        "simulation overlay still borrowed during mutation"
+                    ))
+                })?
+                .insert(block_context.block_number, overlay);
+            previous_block_number = block_context.block_number;
+            previous_timestamp = block_context.timestamp;
+            simulated_blocks.push(simulated_block);
+
+            block_context = next_block_context(block_context, next_hash);
+        }
+
+        Ok(simulated_blocks)
+    }
+
+    fn resolve_simulation_start_context(
+        &self,
+        block: Option<BlockId>,
+    ) -> Result<SimulationStartContext, EthCallError> {
+        let block = block.unwrap_or_default();
+        if block.is_latest() || block.is_pending() {
+            let parent_block = self.storage.replay_storage().latest_record();
+            let parent_context = self
+                .storage
+                .replay_storage()
+                .get_context(parent_block)
+                .ok_or(RpcStorageError::BlockNotFound(block))?;
+            return Ok(SimulationStartContext {
+                block_context: self.build_pending_block_context(),
+                parent_block_number: parent_block,
+                parent_timestamp: parent_context.timestamp,
+            });
+        }
+
+        let parent_block = self
+            .storage
+            .resolve_block_number(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let parent_context = self
+            .storage
+            .replay_storage()
+            .get_context(parent_block)
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let parent = self
+            .storage
+            .get_block_by_id(block)?
+            .ok_or(RpcStorageError::BlockNotFound(block))?;
+        let block_context = next_block_context(parent_context, parent.hash());
+
+        Ok(SimulationStartContext {
+            block_context,
+            parent_block_number: parent_block,
+            parent_timestamp: parent_context.timestamp,
+        })
+    }
+
+    fn create_simulation_txs<V: ViewState>(
+        &self,
+        calls: Vec<TransactionRequest>,
+        block_context: BlockContext,
+        mut state_view: V,
+    ) -> Result<Vec<ZkTransaction>, EthCallError> {
+        let default_gas_limit = simulation_default_gas_limit(
+            &calls,
+            block_context.gas_limit,
+            self.config.eth_call_gas as u64,
+        )?;
+        let mut next_nonces = HashMap::new();
+
+        calls
+            .into_iter()
+            .map(|mut request| {
+                use alloy::network::TransactionBuilder;
+
+                if request.gas.is_none() {
+                    request.set_gas_limit(default_gas_limit);
+                }
+
+                let from = request.from.unwrap_or_default();
+                let state_nonce = next_nonces.entry(from).or_insert_with(|| {
+                    state_view
+                        .get_account(from)
+                        .as_ref()
+                        .map(get_nonce)
+                        .unwrap_or_default()
+                });
+                if let Some(nonce) = request.nonce {
+                    if nonce >= *state_nonce {
+                        *state_nonce =
+                            nonce
+                                .checked_add(1)
+                                .ok_or(EthCallError::SimulateInvalidParams(
+                                    "nonce has max value".to_string(),
+                                ))?;
+                    }
+                } else {
+                    let nonce = *state_nonce;
+                    request.set_nonce(nonce);
+                    *state_nonce =
+                        nonce
+                            .checked_add(1)
+                            .ok_or(EthCallError::SimulateInvalidParams(
+                                "nonce has max value".to_string(),
+                            ))?;
+                }
+
+                self.create_tx_from_request(request, &block_context, false)
+            })
+            .collect()
+    }
 }
 
-pub(crate) fn build_simulated_block_response(
+#[derive(Debug)]
+struct SimulationStartContext {
+    block_context: BlockContext,
+    parent_block_number: u64,
+    parent_timestamp: u64,
+}
+
+fn build_simulated_block_response(
     block_context: BlockContext,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
@@ -144,10 +401,7 @@ fn build_simulated_receipt(
     )
 }
 
-pub(crate) fn next_block_context(
-    mut block_context: BlockContext,
-    parent_hash: B256,
-) -> BlockContext {
+fn next_block_context(mut block_context: BlockContext, parent_hash: B256) -> BlockContext {
     block_context.block_number += 1;
     block_context.timestamp += 1;
     block_context.block_hashes.0.rotate_left(1);
@@ -155,7 +409,7 @@ pub(crate) fn next_block_context(
     block_context
 }
 
-pub(crate) fn apply_simulate_block_overrides(
+fn apply_simulate_block_overrides(
     block_context: &mut BlockContext,
     overrides: BlockOverrides,
     previous_block_number: u64,
@@ -175,8 +429,6 @@ pub(crate) fn apply_simulate_block_overrides(
         block_hash,
         // ZKsync OS uses mix_hash for prevrandao and has no separate difficulty field; ignored.
         difficulty: _,
-        // No corresponding field in BlockContext; ignored.
-        beacon_root: _,
     } = overrides;
 
     if let Some(number) = number {
@@ -242,7 +494,7 @@ pub(crate) fn apply_simulate_block_overrides(
     Ok(())
 }
 
-pub(crate) fn simulation_default_gas_limit(
+fn simulation_default_gas_limit(
     calls: &[TransactionRequest],
     block_gas_limit: u64,
     per_call_gas_cap: u64,

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -213,8 +213,8 @@ pub(crate) fn apply_simulate_block_overrides(
     if let Some(blob_base_fee) = overrides.blob_base_fee {
         block_context.blob_fee = blob_base_fee;
     }
-    // TODO: difficulty override is not propagated to BlockContext (ZKsync OS uses mix_hash
-    // for prevrandao), so it is silently ignored.
+    // Note: difficulty override is silently ignored — ZKsync OS uses mix_hash for prevrandao
+    // and has no separate difficulty field in BlockContext.
     if let Some(block_hash_overrides) = overrides.block_hash {
         let range_start = block_context.block_number.saturating_sub(256);
         for (block_number, block_hash) in

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -5,7 +5,7 @@ use alloy::consensus::Transaction as _;
 use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy::network::primitives::BlockTransactions;
 use alloy::primitives::{B256, Bloom, Bytes, U256};
-use alloy::rpc::types::simulate::{SimCallResult, SimulateError};
+use alloy::rpc::types::simulate::{SimCallResult, SimulateError, SimulatedBlock};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::types::{
@@ -22,18 +22,12 @@ pub(super) struct SimulationStartContext {
     pub(super) parent_timestamp: u64,
 }
 
-pub(super) struct SimulatedBlockResponse {
-    pub(super) inner: ZkApiBlock,
-    pub(super) calls: Vec<SimCallResult>,
-    pub(super) overlay: OwnedOverrides,
-}
-
 pub(super) fn build_simulated_block_response(
     block_context: BlockContext,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
     return_full_transactions: bool,
-) -> Result<SimulatedBlockResponse, EthCallError> {
+) -> Result<(SimulatedBlock<ZkApiBlock>, OwnedOverrides), EthCallError> {
     let BlockOutput {
         header: sealed_header,
         tx_results,
@@ -116,17 +110,16 @@ pub(super) fn build_simulated_block_response(
     };
     let inner = ZkApiBlock::new(header, transactions);
 
-    Ok(SimulatedBlockResponse {
-        inner,
-        calls,
-        overlay: OwnedOverrides::new(
+    Ok((
+        SimulatedBlock { inner, calls },
+        OwnedOverrides::new(
             storage_writes
                 .into_iter()
                 .map(|write| (write.key, write.value))
                 .collect(),
             published_preimages.into_iter().collect(),
         ),
-    })
+    ))
 }
 
 fn build_simulated_receipt(

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -12,7 +12,7 @@ use zksync_os_interface::types::{
     BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
 };
 use zksync_os_rpc_api::types::ZkApiBlock;
-use zksync_os_storage_api::OwnedOverrides;
+use zksync_os_storage_api::state_override_view::OwnedOverrides;
 use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction};
 
 #[derive(Debug)]

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -10,39 +10,12 @@ use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use std::collections::HashSet;
 use zksync_os_interface::error::InvalidTransaction;
-use zksync_os_interface::tracing::{NopTracer, NopValidator};
-use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{
     BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
 };
-use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::ZkApiBlock;
-use zksync_os_storage_api::{BlockOverlay, ViewState};
-use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction, ZksyncOsEncode};
-
-pub(super) fn run_simulation_block<State>(
-    block_context: BlockContext,
-    state_view: State,
-    txs: &[ZkTransaction],
-) -> Result<BlockOutput, EthCallError>
-where
-    State: ViewState,
-{
-    let tx_source = TxListSource {
-        transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
-    };
-
-    run_block(
-        block_context,
-        state_view.clone(),
-        state_view,
-        tx_source,
-        NoopTxCallback,
-        &mut NopTracer,
-        &mut NopValidator,
-    )
-    .map_err(EthCallError::ForwardSubsystemError)
-}
+use zksync_os_storage_api::BlockOverlay;
+use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction};
 
 #[derive(Debug)]
 pub(super) struct SimulationStartContext {
@@ -57,14 +30,8 @@ pub(super) struct SimulatedBlockResponse {
     pub(super) overlay: BlockOverlay,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-pub(super) struct SimulateHeaderOverrides {
-    pub(super) difficulty: Option<U256>,
-}
-
 pub(super) fn build_simulated_block_response(
     block_context: BlockContext,
-    header_overrides: SimulateHeaderOverrides,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
     return_full_transactions: bool,
@@ -125,9 +92,6 @@ pub(super) fn build_simulated_block_response(
         .collect::<Vec<_>>();
     header.transactions_root = calculate_transaction_root(&executed_envelopes);
     header.receipts_root = calculate_receipt_root(&receipts);
-    if let Some(difficulty) = header_overrides.difficulty {
-        header.difficulty = difficulty;
-    }
 
     let header = alloy::rpc::types::Header::new(header);
     let block_hash = header.hash;
@@ -205,9 +169,7 @@ pub(super) fn apply_simulate_block_overrides(
     overrides: BlockOverrides,
     previous_block_number: u64,
     previous_timestamp: u64,
-) -> Result<SimulateHeaderOverrides, EthCallError> {
-    let mut header_overrides = SimulateHeaderOverrides::default();
-
+) -> Result<(), EthCallError> {
     if let Some(number) = overrides.number {
         let number = u64::try_from(number)
             .map_err(|_| EthCallError::SimulateInvalidBlockOverride("number"))?;
@@ -256,9 +218,8 @@ pub(super) fn apply_simulate_block_overrides(
     if let Some(blob_base_fee) = overrides.blob_base_fee {
         block_context.blob_fee = blob_base_fee;
     }
-    if let Some(difficulty) = overrides.difficulty {
-        header_overrides.difficulty = Some(difficulty);
-    }
+    // TODO: difficulty override is not propagated to BlockContext (ZKsync OS uses mix_hash
+    // for prevrandao), so it is silently ignored.
     if let Some(block_hash_overrides) = overrides.block_hash {
         for (block_number, block_hash) in block_hash_overrides {
             if block_number >= block_context.block_number {
@@ -274,7 +235,7 @@ pub(super) fn apply_simulate_block_overrides(
         }
     }
 
-    Ok(header_overrides)
+    Ok(())
 }
 
 pub(super) fn validate_state_overrides_for_simulate(

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -1,0 +1,602 @@
+use super::EthCallError;
+use crate::eth_impl::{build_api_log, build_api_tx};
+use crate::result::RevertError;
+use alloy::consensus::Transaction as _;
+use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
+use alloy::network::primitives::BlockTransactions;
+use alloy::primitives::{B256, Bloom, Bytes, U256};
+use alloy::rpc::types::simulate::{SimCallResult, SimulateError};
+use alloy::rpc::types::state::StateOverride;
+use alloy::rpc::types::{BlockOverrides, TransactionRequest};
+use std::collections::HashSet;
+use zksync_os_interface::error::InvalidTransaction;
+use zksync_os_interface::tracing::{NopTracer, NopValidator};
+use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
+use zksync_os_interface::types::{
+    BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
+};
+use zksync_os_multivm::run_block;
+use zksync_os_rpc_api::types::ZkApiBlock;
+use zksync_os_storage_api::{BlockOverlay, ViewState};
+use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction, ZksyncOsEncode};
+
+pub(super) fn run_simulation_block<State>(
+    block_context: BlockContext,
+    state_view: State,
+    txs: &[ZkTransaction],
+) -> Result<BlockOutput, EthCallError>
+where
+    State: ViewState,
+{
+    let tx_source = TxListSource {
+        transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
+    };
+
+    run_block(
+        block_context,
+        state_view.clone(),
+        state_view,
+        tx_source,
+        NoopTxCallback,
+        &mut NopTracer,
+        &mut NopValidator,
+    )
+    .map_err(EthCallError::ForwardSubsystemError)
+}
+
+#[derive(Debug)]
+pub(super) struct SimulationStartContext {
+    pub(super) block_context: BlockContext,
+    pub(super) parent_block_number: u64,
+    pub(super) parent_timestamp: u64,
+}
+
+pub(super) struct SimulatedBlockResponse {
+    pub(super) inner: ZkApiBlock,
+    pub(super) calls: Vec<SimCallResult>,
+    pub(super) overlay: BlockOverlay,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct SimulateHeaderOverrides {
+    pub(super) difficulty: Option<U256>,
+}
+
+pub(super) fn build_simulated_block_response(
+    block_context: BlockContext,
+    header_overrides: SimulateHeaderOverrides,
+    txs: Vec<ZkTransaction>,
+    block_output: BlockOutput,
+    return_full_transactions: bool,
+) -> Result<SimulatedBlockResponse, EthCallError> {
+    let BlockOutput {
+        header: sealed_header,
+        tx_results,
+        storage_writes,
+        published_preimages,
+        ..
+    } = block_output;
+
+    let mut block_bloom = Bloom::default();
+    let mut number_of_logs_before_this_tx = 0;
+    let mut cumulative_gas_used = 0;
+    let mut receipts = Vec::with_capacity(tx_results.len());
+    let mut simulated_txs = Vec::with_capacity(tx_results.len());
+    let mut executed_tx_index = 0;
+
+    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results).enumerate() {
+        let simulated_tx = match result {
+            Ok(tx_output) => {
+                let receipt = build_simulated_receipt(&tx, &tx_output, cumulative_gas_used);
+                block_bloom.accrue_bloom(receipt.logs_bloom());
+                cumulative_gas_used += tx_output.gas_used;
+                let simulated_tx = SimulatedTx {
+                    tx,
+                    tx_index_in_block: executed_tx_index,
+                    number_of_logs_before_this_tx,
+                    result: SimulatedTxResult::Executed {
+                        output: tx_output,
+                        receipt: Box::new(receipt.clone()),
+                    },
+                };
+                executed_tx_index += 1;
+                number_of_logs_before_this_tx += receipt.logs().len() as u64;
+                receipts.push(receipt);
+                simulated_tx
+            }
+            Err(err) => SimulatedTx {
+                tx,
+                tx_index_in_block: call_index as u64,
+                number_of_logs_before_this_tx,
+                result: SimulatedTxResult::Invalid(err),
+            },
+        };
+        simulated_txs.push(simulated_tx);
+    }
+
+    let mut header = sealed_header.unseal();
+    header.base_fee_per_gas = Some(block_context.eip1559_basefee.saturating_to());
+    header.logs_bloom = block_bloom;
+    header.gas_used = cumulative_gas_used;
+    let executed_envelopes = simulated_txs
+        .iter()
+        .filter(|tx| tx.is_executed())
+        .map(|tx| tx.tx.envelope())
+        .collect::<Vec<_>>();
+    header.transactions_root = calculate_transaction_root(&executed_envelopes);
+    header.receipts_root = calculate_receipt_root(&receipts);
+    if let Some(difficulty) = header_overrides.difficulty {
+        header.difficulty = difficulty;
+    }
+
+    let header = alloy::rpc::types::Header::new(header);
+    let block_hash = header.hash;
+    let calls = simulated_txs
+        .iter()
+        .map(|tx| tx.to_call_result(block_hash, block_context))
+        .collect();
+    let transactions = if return_full_transactions {
+        BlockTransactions::Full(
+            simulated_txs
+                .iter()
+                .filter(|tx| tx.is_executed())
+                .map(|tx| tx.to_api_tx(block_hash, block_context))
+                .collect(),
+        )
+    } else {
+        BlockTransactions::Hashes(
+            simulated_txs
+                .iter()
+                .filter(|tx| tx.is_executed())
+                .map(|tx| *tx.tx.hash())
+                .collect(),
+        )
+    };
+    let inner = ZkApiBlock::new(header, transactions);
+
+    Ok(SimulatedBlockResponse {
+        inner,
+        calls,
+        overlay: BlockOverlay {
+            storage_writes: storage_writes
+                .into_iter()
+                .map(|write| (write.key, write.value))
+                .collect(),
+            preimages: published_preimages.into_iter().collect(),
+        },
+    })
+}
+
+fn build_simulated_receipt(
+    tx: &ZkTransaction,
+    tx_output: &TxOutput,
+    cumulative_gas_used_before_this_tx: u64,
+) -> ZkReceiptEnvelope {
+    let l2_to_l1_logs = tx_output
+        .l2_to_l1_logs
+        .iter()
+        .map(|l2_to_l1_log| l2_to_l1_log.log.clone().into())
+        .collect();
+
+    ZkReceiptEnvelope::from_typed(
+        tx.tx_type(),
+        ZkReceipt {
+            status: matches!(tx_output.execution_result, ExecutionResult::Success(_)).into(),
+            cumulative_gas_used: cumulative_gas_used_before_this_tx + tx_output.gas_used,
+            logs: tx_output.logs.clone(),
+            l2_to_l1_logs,
+        },
+    )
+}
+
+pub(super) fn next_block_context(
+    mut block_context: BlockContext,
+    parent_hash: B256,
+) -> BlockContext {
+    block_context.block_number += 1;
+    block_context.timestamp += 1;
+    block_context.block_hashes.0.rotate_left(1);
+    block_context.block_hashes.0[255] = U256::from_be_bytes(parent_hash.0);
+    block_context
+}
+
+pub(super) fn apply_simulate_block_overrides(
+    block_context: &mut BlockContext,
+    overrides: BlockOverrides,
+    previous_block_number: u64,
+    previous_timestamp: u64,
+) -> Result<SimulateHeaderOverrides, EthCallError> {
+    let mut header_overrides = SimulateHeaderOverrides::default();
+
+    if let Some(number) = overrides.number {
+        let number = u64::try_from(number)
+            .map_err(|_| EthCallError::SimulateInvalidBlockOverride("number"))?;
+        if number <= previous_block_number {
+            return Err(EthCallError::SimulateBlockNumberInvalid {
+                got: number,
+                parent: previous_block_number,
+            });
+        }
+        let skipped_blocks = number.saturating_sub(block_context.block_number);
+        if skipped_blocks >= 256 {
+            block_context.block_hashes.0 = [U256::ZERO; 256];
+        } else if skipped_blocks > 0 {
+            let skipped_blocks = skipped_blocks as usize;
+            block_context
+                .block_hashes
+                .0
+                .copy_within(skipped_blocks.., 0);
+            block_context.block_hashes.0[256 - skipped_blocks..].fill(U256::ZERO);
+        }
+        block_context.block_number = number;
+    }
+    if let Some(time) = overrides.time {
+        if time <= previous_timestamp {
+            return Err(EthCallError::SimulateBlockTimestampInvalid {
+                got: time,
+                parent: previous_timestamp,
+            });
+        }
+        block_context.timestamp = time;
+    }
+    if let Some(gas_limit) = overrides.gas_limit {
+        block_context.gas_limit = gas_limit;
+    }
+    if let Some(coinbase) = overrides.coinbase {
+        block_context.coinbase = coinbase;
+    }
+    if let Some(random) = overrides.random {
+        block_context.mix_hash = U256::from_be_bytes(random.0);
+    } else {
+        block_context.mix_hash = U256::ZERO;
+    }
+    if let Some(base_fee) = overrides.base_fee {
+        block_context.eip1559_basefee = base_fee;
+    }
+    if let Some(blob_base_fee) = overrides.blob_base_fee {
+        block_context.blob_fee = blob_base_fee;
+    }
+    if let Some(difficulty) = overrides.difficulty {
+        header_overrides.difficulty = Some(difficulty);
+    }
+    if let Some(block_hash_overrides) = overrides.block_hash {
+        for (block_number, block_hash) in block_hash_overrides {
+            if block_number >= block_context.block_number {
+                continue;
+            }
+            let distance = block_context.block_number - block_number;
+            if distance == 0 || distance > 256 {
+                continue;
+            }
+
+            let index = 256 - distance as usize;
+            block_context.block_hashes.0[index] = U256::from_be_bytes(block_hash.0);
+        }
+    }
+
+    Ok(header_overrides)
+}
+
+pub(super) fn validate_state_overrides_for_simulate(
+    state_overrides: &StateOverride,
+) -> Result<(), EthCallError> {
+    let mut destinations = HashSet::new();
+    let mut has_precompile_move = false;
+    for (source, account) in state_overrides {
+        let Some(destination) = account.move_precompile_to else {
+            continue;
+        };
+        has_precompile_move = true;
+        if *source == destination {
+            return Err(EthCallError::SimulatePrecompileSelfReference);
+        }
+        if !destinations.insert(destination) {
+            return Err(EthCallError::SimulatePrecompileDuplicateAddress);
+        }
+    }
+    if has_precompile_move {
+        // Spec note: `movePrecompileToAddress` is part of eth_simulateV1 state overrides. The
+        // current ZKsync OS execution backend does not expose a way to remap its precompile table
+        // for a single simulated block, so reject it explicitly after the spec validation checks
+        // above.
+        return Err(EthCallError::SimulateMovePrecompileNotSupported);
+    }
+    Ok(())
+}
+
+pub(super) fn simulation_default_gas_limit(
+    calls: &[TransactionRequest],
+    block_gas_limit: u64,
+    call_gas_limit: u64,
+) -> Result<u64, EthCallError> {
+    let total_specified_gas =
+        calls
+            .iter()
+            .filter_map(|call| call.gas)
+            .try_fold(0_u64, |sum, gas| {
+                sum.checked_add(gas)
+                    .ok_or(EthCallError::SimulateBlockGasLimitExceeded)
+            })?;
+    if total_specified_gas > block_gas_limit {
+        return Err(EthCallError::SimulateBlockGasLimitExceeded);
+    }
+
+    let calls_without_gas = calls.iter().filter(|call| call.gas.is_none()).count() as u64;
+    if calls_without_gas == 0 {
+        return Ok(0);
+    }
+
+    let gas_per_call = (block_gas_limit - total_specified_gas) / calls_without_gas;
+    Ok(if call_gas_limit == 0 {
+        gas_per_call
+    } else {
+        gas_per_call.min(call_gas_limit)
+    })
+}
+
+struct SimulatedTx {
+    tx: ZkTransaction,
+    tx_index_in_block: u64,
+    number_of_logs_before_this_tx: u64,
+    result: SimulatedTxResult,
+}
+
+enum SimulatedTxResult {
+    Executed {
+        output: TxOutput,
+        receipt: Box<ZkReceiptEnvelope>,
+    },
+    Invalid(InvalidTransaction),
+}
+
+impl SimulatedTx {
+    fn is_executed(&self) -> bool {
+        matches!(&self.result, SimulatedTxResult::Executed { .. })
+    }
+
+    fn to_call_result(&self, block_hash: B256, block_context: BlockContext) -> SimCallResult {
+        match &self.result {
+            SimulatedTxResult::Executed { output, receipt } => {
+                let logs = self.api_logs(block_hash, block_context, receipt);
+                let (return_data, status, error) = match &output.execution_result {
+                    ExecutionResult::Success(
+                        ExecutionOutput::Call(return_bytes)
+                        | ExecutionOutput::Create(return_bytes, _),
+                    ) => (Bytes::from(return_bytes.clone()), true, None),
+                    ExecutionResult::Revert(return_bytes) => {
+                        let return_data = Bytes::from(return_bytes.clone());
+                        (
+                            return_data.clone(),
+                            false,
+                            Some(SimulateError {
+                                code: -32000,
+                                message: RevertError::new(return_data).to_string(),
+                            }),
+                        )
+                    }
+                };
+
+                SimCallResult {
+                    return_data,
+                    logs,
+                    gas_used: output.gas_used,
+                    status,
+                    error,
+                }
+            }
+            SimulatedTxResult::Invalid(err) => SimCallResult {
+                return_data: Bytes::default(),
+                logs: vec![],
+                gas_used: 0,
+                status: false,
+                error: Some(SimulateError {
+                    code: -32015,
+                    message: format!("vm execution error: {err}"),
+                }),
+            },
+        }
+    }
+
+    fn to_api_tx(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+    ) -> zksync_os_rpc_api::types::ZkApiTransaction {
+        build_api_tx(
+            self.tx.clone(),
+            Some(&self.tx_meta(block_hash, block_context, self.gas_used())),
+        )
+    }
+
+    fn api_logs(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+        receipt: &ZkReceiptEnvelope,
+    ) -> Vec<alloy::rpc::types::Log> {
+        let tx_hash = *self.tx.hash();
+        let meta = self.tx_meta(block_hash, block_context, self.gas_used());
+        receipt
+            .logs()
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, log)| build_api_log(tx_hash, log, meta.clone(), i as u64))
+            .collect()
+    }
+
+    fn tx_meta(
+        &self,
+        block_hash: B256,
+        block_context: BlockContext,
+        gas_used: u64,
+    ) -> zksync_os_storage_api::TxMeta {
+        zksync_os_storage_api::TxMeta {
+            block_hash,
+            block_number: block_context.block_number,
+            block_timestamp: block_context.timestamp,
+            tx_index_in_block: self.tx_index_in_block,
+            effective_gas_price: self
+                .tx
+                .inner
+                .inner()
+                .effective_gas_price(Some(block_context.eip1559_basefee.saturating_to())),
+            number_of_logs_before_this_tx: self.number_of_logs_before_this_tx,
+            gas_used,
+            contract_address: match &self.result {
+                SimulatedTxResult::Executed { output, .. } => output.contract_address,
+                SimulatedTxResult::Invalid(_) => None,
+            },
+        }
+    }
+
+    fn gas_used(&self) -> u64 {
+        match &self.result {
+            SimulatedTxResult::Executed { output, .. } => output.gas_used,
+            SimulatedTxResult::Invalid(_) => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+    use alloy::rpc::types::state::AccountOverride;
+    use zksync_os_interface::types::BlockHashes;
+
+    #[test]
+    fn simulation_default_gas_limit_splits_remaining_block_gas() {
+        let calls = vec![
+            TransactionRequest {
+                gas: Some(40),
+                ..Default::default()
+            },
+            TransactionRequest::default(),
+            TransactionRequest::default(),
+        ];
+
+        assert_eq!(simulation_default_gas_limit(&calls, 100, 0).unwrap(), 30);
+        assert_eq!(simulation_default_gas_limit(&calls, 100, 25).unwrap(), 25);
+    }
+
+    #[test]
+    fn simulation_default_gas_limit_rejects_block_gas_overflow() {
+        let calls = vec![TransactionRequest {
+            gas: Some(101),
+            ..Default::default()
+        }];
+
+        assert!(matches!(
+            simulation_default_gas_limit(&calls, 100, 0),
+            Err(EthCallError::SimulateBlockGasLimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn simulate_block_overrides_reject_non_increasing_sequences() {
+        let mut context = BlockContext {
+            block_number: 11,
+            timestamp: 101,
+            ..Default::default()
+        };
+        let number_err = apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                number: Some(U256::from(10)),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            number_err,
+            EthCallError::SimulateBlockNumberInvalid { .. }
+        ));
+
+        let time_err = apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                time: Some(100),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            time_err,
+            EthCallError::SimulateBlockTimestampInvalid { .. }
+        ));
+    }
+
+    #[test]
+    fn simulate_block_override_number_jump_clears_gap_hashes() {
+        let mut hashes = [U256::ZERO; 256];
+        for (i, hash) in hashes.iter_mut().enumerate() {
+            *hash = U256::from(i + 1);
+        }
+        let mut context = BlockContext {
+            block_number: 11,
+            timestamp: 101,
+            block_hashes: BlockHashes(hashes),
+            ..Default::default()
+        };
+
+        apply_simulate_block_overrides(
+            &mut context,
+            BlockOverrides {
+                number: Some(U256::from(14)),
+                ..Default::default()
+            },
+            10,
+            100,
+        )
+        .unwrap();
+
+        assert_eq!(context.block_number, 14);
+        assert_eq!(context.block_hashes.0[252], U256::from(256));
+        assert_eq!(context.block_hashes.0[253], U256::ZERO);
+        assert_eq!(context.block_hashes.0[254], U256::ZERO);
+        assert_eq!(context.block_hashes.0[255], U256::ZERO);
+    }
+
+    #[test]
+    fn simulate_state_overrides_validate_precompile_moves() {
+        let source = Address::from([1; 20]);
+        let destination = Address::from([2; 20]);
+        let mut overrides = StateOverride::default();
+        overrides.insert(
+            source,
+            AccountOverride {
+                move_precompile_to: Some(source),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            validate_state_overrides_for_simulate(&overrides),
+            Err(EthCallError::SimulatePrecompileSelfReference)
+        ));
+
+        let mut overrides = StateOverride::default();
+        overrides.insert(
+            source,
+            AccountOverride {
+                move_precompile_to: Some(destination),
+                ..Default::default()
+            },
+        );
+        overrides.insert(
+            Address::from([3; 20]),
+            AccountOverride {
+                move_precompile_to: Some(destination),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(
+            validate_state_overrides_for_simulate(&overrides),
+            Err(EthCallError::SimulatePrecompileDuplicateAddress)
+        ));
+    }
+}

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -162,7 +162,24 @@ pub(crate) fn apply_simulate_block_overrides(
     previous_timestamp: u64,
     max_block_gas_limit: u64,
 ) -> Result<(), EthCallError> {
-    if let Some(number) = overrides.number {
+    // Destructure to force a compile error when alloy adds new override fields, so we
+    // explicitly decide whether to support or ignore each one.
+    let BlockOverrides {
+        number,
+        time,
+        gas_limit,
+        coinbase,
+        random,
+        base_fee,
+        blob_base_fee,
+        block_hash,
+        // ZKsync OS uses mix_hash for prevrandao and has no separate difficulty field; ignored.
+        difficulty: _,
+        // No corresponding field in BlockContext; ignored.
+        beacon_root: _,
+    } = overrides;
+
+    if let Some(number) = number {
         let number = u64::try_from(number)
             .map_err(|_| EthCallError::SimulateInvalidBlockOverride("number"))?;
         if number <= previous_block_number {
@@ -184,7 +201,7 @@ pub(crate) fn apply_simulate_block_overrides(
         }
         block_context.block_number = number;
     }
-    if let Some(time) = overrides.time {
+    if let Some(time) = time {
         if time <= previous_timestamp {
             return Err(EthCallError::SimulateBlockTimestampInvalid {
                 got: time,
@@ -193,29 +210,25 @@ pub(crate) fn apply_simulate_block_overrides(
         }
         block_context.timestamp = time;
     }
-    if let Some(gas_limit) = overrides.gas_limit {
+    if let Some(gas_limit) = gas_limit {
         if max_block_gas_limit != 0 && gas_limit > max_block_gas_limit {
             return Err(EthCallError::SimulateBlockGasLimitExceeded);
         }
         block_context.gas_limit = gas_limit;
     }
-    if let Some(coinbase) = overrides.coinbase {
+    if let Some(coinbase) = coinbase {
         block_context.coinbase = coinbase;
     }
-    if let Some(random) = overrides.random {
+    if let Some(random) = random {
         block_context.mix_hash = U256::from_be_bytes(random.0);
-    } else {
-        block_context.mix_hash = U256::ZERO;
     }
-    if let Some(base_fee) = overrides.base_fee {
+    if let Some(base_fee) = base_fee {
         block_context.eip1559_basefee = base_fee;
     }
-    if let Some(blob_base_fee) = overrides.blob_base_fee {
+    if let Some(blob_base_fee) = blob_base_fee {
         block_context.blob_fee = blob_base_fee;
     }
-    // Note: difficulty override is silently ignored — ZKsync OS uses mix_hash for prevrandao
-    // and has no separate difficulty field in BlockContext.
-    if let Some(block_hash_overrides) = overrides.block_hash {
+    if let Some(block_hash_overrides) = block_hash {
         let range_start = block_context.block_number.saturating_sub(256);
         for (block_number, block_hash) in
             block_hash_overrides.range(range_start..block_context.block_number)
@@ -232,6 +245,7 @@ pub(crate) fn apply_simulate_block_overrides(
 pub(crate) fn simulation_default_gas_limit(
     calls: &[TransactionRequest],
     block_gas_limit: u64,
+    per_call_gas_cap: u64,
 ) -> Result<u64, EthCallError> {
     let total_specified_gas =
         calls
@@ -250,7 +264,9 @@ pub(crate) fn simulation_default_gas_limit(
         return Ok(0);
     }
 
-    Ok((block_gas_limit - total_specified_gas) / calls_without_gas)
+    // Cap the per-call default at `per_call_gas_cap` to avoid handing a single call the entire
+    // block's gas when the block limit is large and few calls specify gas explicitly.
+    Ok(((block_gas_limit - total_specified_gas) / calls_without_gas).min(per_call_gas_cap))
 }
 
 struct SimulatedTx {

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -389,34 +389,6 @@ mod tests {
     use zksync_os_interface::types::BlockHashes;
 
     #[test]
-    fn simulation_default_gas_limit_splits_remaining_block_gas() {
-        let calls = vec![
-            TransactionRequest {
-                gas: Some(40),
-                ..Default::default()
-            },
-            TransactionRequest::default(),
-            TransactionRequest::default(),
-        ];
-
-        assert_eq!(simulation_default_gas_limit(&calls, 100, 0).unwrap(), 30);
-        assert_eq!(simulation_default_gas_limit(&calls, 100, 25).unwrap(), 25);
-    }
-
-    #[test]
-    fn simulation_default_gas_limit_rejects_block_gas_overflow() {
-        let calls = vec![TransactionRequest {
-            gas: Some(101),
-            ..Default::default()
-        }];
-
-        assert!(matches!(
-            simulation_default_gas_limit(&calls, 100, 0),
-            Err(EthCallError::SimulateBlockGasLimitExceeded)
-        ));
-    }
-
-    #[test]
     fn simulate_block_overrides_reject_non_increasing_sequences() {
         let mut context = BlockContext {
             block_number: 11,

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -6,9 +6,7 @@ use alloy::consensus::proofs::{calculate_receipt_root, calculate_transaction_roo
 use alloy::network::primitives::BlockTransactions;
 use alloy::primitives::{B256, Bloom, Bytes, U256};
 use alloy::rpc::types::simulate::{SimCallResult, SimulateError};
-use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
-use std::collections::HashSet;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::types::{
     BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
@@ -226,7 +224,7 @@ pub(super) fn apply_simulate_block_overrides(
                 continue;
             }
             let distance = block_context.block_number - block_number;
-            if distance == 0 || distance > 256 {
+            if distance > 256 {
                 continue;
             }
 
@@ -235,33 +233,6 @@ pub(super) fn apply_simulate_block_overrides(
         }
     }
 
-    Ok(())
-}
-
-pub(super) fn validate_state_overrides_for_simulate(
-    state_overrides: &StateOverride,
-) -> Result<(), EthCallError> {
-    let mut destinations = HashSet::new();
-    let mut has_precompile_move = false;
-    for (source, account) in state_overrides {
-        let Some(destination) = account.move_precompile_to else {
-            continue;
-        };
-        has_precompile_move = true;
-        if *source == destination {
-            return Err(EthCallError::SimulatePrecompileSelfReference);
-        }
-        if !destinations.insert(destination) {
-            return Err(EthCallError::SimulatePrecompileDuplicateAddress);
-        }
-    }
-    if has_precompile_move {
-        // Spec note: `movePrecompileToAddress` is part of eth_simulateV1 state overrides. The
-        // current ZKsync OS execution backend does not expose a way to remap its precompile table
-        // for a single simulated block, so reject it explicitly after the spec validation checks
-        // above.
-        return Err(EthCallError::SimulateMovePrecompileNotSupported);
-    }
     Ok(())
 }
 

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -12,7 +12,7 @@ use zksync_os_interface::types::{
     BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
 };
 use zksync_os_rpc_api::types::ZkApiBlock;
-use zksync_os_storage_api::BlockOverlay;
+use zksync_os_storage_api::OwnedOverrides;
 use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction};
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ pub(super) struct SimulationStartContext {
 pub(super) struct SimulatedBlockResponse {
     pub(super) inner: ZkApiBlock,
     pub(super) calls: Vec<SimCallResult>,
-    pub(super) overlay: BlockOverlay,
+    pub(super) overlay: OwnedOverrides,
 }
 
 pub(super) fn build_simulated_block_response(
@@ -119,13 +119,13 @@ pub(super) fn build_simulated_block_response(
     Ok(SimulatedBlockResponse {
         inner,
         calls,
-        overlay: BlockOverlay {
-            storage_writes: storage_writes
+        overlay: OwnedOverrides::new(
+            storage_writes
                 .into_iter()
                 .map(|write| (write.key, write.value))
                 .collect(),
-            preimages: published_preimages.into_iter().collect(),
-        },
+            published_preimages.into_iter().collect(),
+        ),
     })
 }
 
@@ -393,8 +393,6 @@ impl SimulatedTx {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::Address;
-    use alloy::rpc::types::state::AccountOverride;
     use zksync_os_interface::types::BlockHashes;
 
     #[test]
@@ -492,43 +490,5 @@ mod tests {
         assert_eq!(context.block_hashes.0[253], U256::ZERO);
         assert_eq!(context.block_hashes.0[254], U256::ZERO);
         assert_eq!(context.block_hashes.0[255], U256::ZERO);
-    }
-
-    #[test]
-    fn simulate_state_overrides_validate_precompile_moves() {
-        let source = Address::from([1; 20]);
-        let destination = Address::from([2; 20]);
-        let mut overrides = StateOverride::default();
-        overrides.insert(
-            source,
-            AccountOverride {
-                move_precompile_to: Some(source),
-                ..Default::default()
-            },
-        );
-        assert!(matches!(
-            validate_state_overrides_for_simulate(&overrides),
-            Err(EthCallError::SimulatePrecompileSelfReference)
-        ));
-
-        let mut overrides = StateOverride::default();
-        overrides.insert(
-            source,
-            AccountOverride {
-                move_precompile_to: Some(destination),
-                ..Default::default()
-            },
-        );
-        overrides.insert(
-            Address::from([3; 20]),
-            AccountOverride {
-                move_precompile_to: Some(destination),
-                ..Default::default()
-            },
-        );
-        assert!(matches!(
-            validate_state_overrides_for_simulate(&overrides),
-            Err(EthCallError::SimulatePrecompileDuplicateAddress)
-        ));
     }
 }

--- a/lib/rpc/src/simulation_utils.rs
+++ b/lib/rpc/src/simulation_utils.rs
@@ -1,4 +1,4 @@
-use super::EthCallError;
+use crate::eth_call_handler::EthCallError;
 use crate::eth_impl::{build_api_log, build_api_tx};
 use crate::result::RevertError;
 use alloy::consensus::Transaction as _;
@@ -16,13 +16,13 @@ use zksync_os_storage_api::state_override_view::OwnedOverrides;
 use zksync_os_types::{ZkReceipt, ZkReceiptEnvelope, ZkTransaction};
 
 #[derive(Debug)]
-pub(super) struct SimulationStartContext {
-    pub(super) block_context: BlockContext,
-    pub(super) parent_block_number: u64,
-    pub(super) parent_timestamp: u64,
+pub(crate) struct SimulationStartContext {
+    pub(crate) block_context: BlockContext,
+    pub(crate) parent_block_number: u64,
+    pub(crate) parent_timestamp: u64,
 }
 
-pub(super) fn build_simulated_block_response(
+pub(crate) fn build_simulated_block_response(
     block_context: BlockContext,
     txs: Vec<ZkTransaction>,
     block_output: BlockOutput,
@@ -144,7 +144,7 @@ fn build_simulated_receipt(
     )
 }
 
-pub(super) fn next_block_context(
+pub(crate) fn next_block_context(
     mut block_context: BlockContext,
     parent_hash: B256,
 ) -> BlockContext {
@@ -155,11 +155,12 @@ pub(super) fn next_block_context(
     block_context
 }
 
-pub(super) fn apply_simulate_block_overrides(
+pub(crate) fn apply_simulate_block_overrides(
     block_context: &mut BlockContext,
     overrides: BlockOverrides,
     previous_block_number: u64,
     previous_timestamp: u64,
+    max_block_gas_limit: u64,
 ) -> Result<(), EthCallError> {
     if let Some(number) = overrides.number {
         let number = u64::try_from(number)
@@ -193,6 +194,9 @@ pub(super) fn apply_simulate_block_overrides(
         block_context.timestamp = time;
     }
     if let Some(gas_limit) = overrides.gas_limit {
+        if max_block_gas_limit != 0 && gas_limit > max_block_gas_limit {
+            return Err(EthCallError::SimulateBlockGasLimitExceeded);
+        }
         block_context.gas_limit = gas_limit;
     }
     if let Some(coinbase) = overrides.coinbase {
@@ -212,15 +216,11 @@ pub(super) fn apply_simulate_block_overrides(
     // TODO: difficulty override is not propagated to BlockContext (ZKsync OS uses mix_hash
     // for prevrandao), so it is silently ignored.
     if let Some(block_hash_overrides) = overrides.block_hash {
-        for (block_number, block_hash) in block_hash_overrides {
-            if block_number >= block_context.block_number {
-                continue;
-            }
+        let range_start = block_context.block_number.saturating_sub(256);
+        for (block_number, block_hash) in
+            block_hash_overrides.range(range_start..block_context.block_number)
+        {
             let distance = block_context.block_number - block_number;
-            if distance > 256 {
-                continue;
-            }
-
             let index = 256 - distance as usize;
             block_context.block_hashes.0[index] = U256::from_be_bytes(block_hash.0);
         }
@@ -229,10 +229,9 @@ pub(super) fn apply_simulate_block_overrides(
     Ok(())
 }
 
-pub(super) fn simulation_default_gas_limit(
+pub(crate) fn simulation_default_gas_limit(
     calls: &[TransactionRequest],
     block_gas_limit: u64,
-    call_gas_limit: u64,
 ) -> Result<u64, EthCallError> {
     let total_specified_gas =
         calls
@@ -251,12 +250,7 @@ pub(super) fn simulation_default_gas_limit(
         return Ok(0);
     }
 
-    let gas_per_call = (block_gas_limit - total_specified_gas) / calls_without_gas;
-    Ok(if call_gas_limit == 0 {
-        gas_per_call
-    } else {
-        gas_per_call.min(call_gas_limit)
-    })
+    Ok((block_gas_limit - total_specified_gas) / calls_without_gas)
 }
 
 struct SimulatedTx {
@@ -283,16 +277,15 @@ impl SimulatedTx {
         match &self.result {
             SimulatedTxResult::Executed { output, receipt } => {
                 let logs = self.api_logs(block_hash, block_context, receipt);
-                let (return_data, status, error) = match &output.execution_result {
+                let (return_data, error) = match &output.execution_result {
                     ExecutionResult::Success(
                         ExecutionOutput::Call(return_bytes)
                         | ExecutionOutput::Create(return_bytes, _),
-                    ) => (Bytes::from(return_bytes.clone()), true, None),
+                    ) => (Bytes::from(return_bytes.clone()), None),
                     ExecutionResult::Revert(return_bytes) => {
                         let return_data = Bytes::from(return_bytes.clone());
                         (
                             return_data.clone(),
-                            false,
                             Some(SimulateError {
                                 code: -32000,
                                 message: RevertError::new(return_data).to_string(),
@@ -305,7 +298,7 @@ impl SimulatedTx {
                     return_data,
                     logs,
                     gas_used: output.gas_used,
-                    status,
+                    status: error.is_none(),
                     error,
                 }
             }
@@ -329,7 +322,7 @@ impl SimulatedTx {
     ) -> zksync_os_rpc_api::types::ZkApiTransaction {
         build_api_tx(
             self.tx.clone(),
-            Some(&self.tx_meta(block_hash, block_context, self.gas_used())),
+            Some(&self.tx_meta(block_hash, block_context)),
         )
     }
 
@@ -340,7 +333,7 @@ impl SimulatedTx {
         receipt: &ZkReceiptEnvelope,
     ) -> Vec<alloy::rpc::types::Log> {
         let tx_hash = *self.tx.hash();
-        let meta = self.tx_meta(block_hash, block_context, self.gas_used());
+        let meta = self.tx_meta(block_hash, block_context);
         receipt
             .logs()
             .iter()
@@ -354,7 +347,6 @@ impl SimulatedTx {
         &self,
         block_hash: B256,
         block_context: BlockContext,
-        gas_used: u64,
     ) -> zksync_os_storage_api::TxMeta {
         zksync_os_storage_api::TxMeta {
             block_hash,
@@ -367,7 +359,7 @@ impl SimulatedTx {
                 .inner()
                 .effective_gas_price(Some(block_context.eip1559_basefee.saturating_to())),
             number_of_logs_before_this_tx: self.number_of_logs_before_this_tx,
-            gas_used,
+            gas_used: self.gas_used(),
             contract_address: match &self.result {
                 SimulatedTxResult::Executed { output, .. } => output.contract_address,
                 SimulatedTxResult::Invalid(_) => None,
@@ -403,6 +395,7 @@ mod tests {
             },
             10,
             100,
+            0,
         )
         .unwrap_err();
         assert!(matches!(
@@ -418,6 +411,7 @@ mod tests {
             },
             10,
             100,
+            0,
         )
         .unwrap_err();
         assert!(matches!(
@@ -447,6 +441,7 @@ mod tests {
             },
             10,
             100,
+            0,
         )
         .unwrap();
 

--- a/lib/rpc_api/src/eth.rs
+++ b/lib/rpc_api/src/eth.rs
@@ -186,7 +186,7 @@ pub trait EthApi {
         &self,
         opts: SimulatePayload,
         block_number: Option<BlockId>,
-    ) -> RpcResult<Vec<SimulatedBlock>>;
+    ) -> RpcResult<Vec<SimulatedBlock<ZkApiBlock>>>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
     #[method(name = "call", blocking)]

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -29,4 +29,4 @@ pub use state_override_view::OverriddenStateView;
 mod read_multichain_root;
 pub use read_multichain_root::read_multichain_root;
 mod overlay_buffer;
-pub use overlay_buffer::{BlockOverlay, OverlayBuffer};
+pub use overlay_buffer::OverlayBuffer;

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -24,9 +24,9 @@ mod state;
 pub use state::{ReadStateHistory, StateError, StateResult, ViewState, WriteState};
 
 pub mod state_override_view;
-pub use state_override_view::OverriddenStateView;
+pub use state_override_view::{BlockOverlay, OverriddenStateView};
 
 mod read_multichain_root;
 pub use read_multichain_root::read_multichain_root;
 mod overlay_buffer;
-pub use overlay_buffer::{BlockOverlay, OverlayBuffer};
+pub use overlay_buffer::OverlayBuffer;

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -24,9 +24,9 @@ mod state;
 pub use state::{ReadStateHistory, StateError, StateResult, ViewState, WriteState};
 
 pub mod state_override_view;
-pub use state_override_view::{OverriddenStateView, OwnedOverrides};
+pub use state_override_view::OverriddenStateView;
 
 mod read_multichain_root;
 pub use read_multichain_root::read_multichain_root;
 mod overlay_buffer;
-pub use overlay_buffer::OverlayBuffer;
+pub use overlay_buffer::{BlockOverlay, OverlayBuffer};

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -24,7 +24,7 @@ mod state;
 pub use state::{ReadStateHistory, StateError, StateResult, ViewState, WriteState};
 
 pub mod state_override_view;
-pub use state_override_view::{BlockOverlay, OverriddenStateView};
+pub use state_override_view::{OverriddenStateView, OwnedOverrides};
 
 mod read_multichain_root;
 pub use read_multichain_root::read_multichain_root;

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -134,9 +134,8 @@ impl OverlayBuffer {
     }
 }
 
-/// Implement OverrideProvider directly on BTreeMap<BlockNumber, BlockOverlay>.
-/// Searches through overlays in reverse order (most recent first) with O(1) HashMap lookups per block
-impl OverrideProvider for BTreeMap<BlockNumber, BlockOverlay> {
+/// Searches through overlays in reverse order (most recent first) with O(1) HashMap lookups per block.
+impl OverrideProvider for Arc<BTreeMap<BlockNumber, BlockOverlay>> {
     fn get_storage_override(&self, key: &B256) -> Option<B256> {
         for (_, overlay) in self.iter().rev() {
             if let Some(value) = overlay.get_storage_override(key) {

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -8,7 +8,7 @@ use zksync_os_interface::types::StorageWrite;
 use crate::state_override_view::OverrideProvider;
 use crate::{OverriddenStateView, ReadStateHistory, ViewState};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BlockOverlay {
     pub storage_writes: HashMap<B256, B256>,
     pub preimages: HashMap<B256, Vec<u8>>,

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -5,8 +5,10 @@ use alloy::primitives::{B256, BlockNumber};
 use anyhow::bail;
 use zksync_os_interface::types::StorageWrite;
 
-use crate::state_override_view::OverrideProvider;
-use crate::{BlockOverlay, OverriddenStateView, ReadStateHistory, ViewState};
+use crate::state_override_view::{OverrideProvider, OwnedOverrides};
+use crate::{OverriddenStateView, ReadStateHistory, ViewState};
+
+type BlockOverlay = OwnedOverrides;
 
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {
@@ -26,7 +28,7 @@ impl OverlayBuffer {
         base: &'a S,
         block_number_to_execute: BlockNumber,
     ) -> anyhow::Result<
-        OverriddenStateView<impl ViewState + 'a, Arc<BTreeMap<BlockNumber, BlockOverlay>>>,
+        OverriddenStateView<impl ViewState + 'a, Arc<BTreeMap<BlockNumber, OwnedOverrides>>>,
     >
     where
         S: ReadStateHistory + 'a,
@@ -137,7 +139,7 @@ impl OverlayBuffer {
 impl OverrideProvider for BTreeMap<BlockNumber, BlockOverlay> {
     fn get_storage_override(&self, key: &B256) -> Option<B256> {
         for (_, overlay) in self.iter().rev() {
-            if let Some(&value) = overlay.storage_writes.get(key) {
+            if let Some(value) = overlay.get_storage_override(key) {
                 return Some(value);
             }
         }
@@ -146,8 +148,8 @@ impl OverrideProvider for BTreeMap<BlockNumber, BlockOverlay> {
 
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
         for (_, overlay) in self.iter().rev() {
-            if let Some(bytes) = overlay.preimages.get(hash) {
-                return Some(bytes.clone());
+            if let Some(bytes) = overlay.get_preimage_override(hash) {
+                return Some(bytes);
             }
         }
         None

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -8,7 +8,7 @@ use zksync_os_interface::types::StorageWrite;
 use crate::state_override_view::{OverrideProvider, OwnedOverrides};
 use crate::{OverriddenStateView, ReadStateHistory, ViewState};
 
-pub type BlockOverlay = OwnedOverrides;
+pub(crate) type BlockOverlay = OwnedOverrides;
 
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -14,6 +14,13 @@ pub struct BlockOverlay {
     pub preimages: HashMap<B256, Vec<u8>>,
 }
 
+impl BlockOverlay {
+    pub fn extend(&mut self, changes: Self) {
+        self.storage_writes.extend(changes.storage_writes);
+        self.preimages.extend(changes.preimages);
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {
     overlays: Arc<BTreeMap<BlockNumber, BlockOverlay>>,
@@ -143,9 +150,9 @@ impl OverlayBuffer {
     }
 }
 
-/// Implement OverrideProvider directly on Arc<BTreeMap<BlockNumber, BlockOverlay>>.
+/// Implement OverrideProvider directly on BTreeMap<BlockNumber, BlockOverlay>.
 /// Searches through overlays in reverse order (most recent first) with O(1) HashMap lookups per block
-impl OverrideProvider for Arc<BTreeMap<BlockNumber, BlockOverlay>> {
+impl OverrideProvider for BTreeMap<BlockNumber, BlockOverlay> {
     fn get_storage_override(&self, key: &B256) -> Option<B256> {
         for (_, overlay) in self.iter().rev() {
             if let Some(&value) = overlay.storage_writes.get(key) {

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -6,20 +6,7 @@ use anyhow::bail;
 use zksync_os_interface::types::StorageWrite;
 
 use crate::state_override_view::OverrideProvider;
-use crate::{OverriddenStateView, ReadStateHistory, ViewState};
-
-#[derive(Debug, Clone, Default)]
-pub struct BlockOverlay {
-    pub storage_writes: HashMap<B256, B256>,
-    pub preimages: HashMap<B256, Vec<u8>>,
-}
-
-impl BlockOverlay {
-    pub fn extend(&mut self, changes: Self) {
-        self.storage_writes.extend(changes.storage_writes);
-        self.preimages.extend(changes.preimages);
-    }
-}
+use crate::{BlockOverlay, OverriddenStateView, ReadStateHistory, ViewState};
 
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {
@@ -118,13 +105,8 @@ impl OverlayBuffer {
             1,
             "Arc refcount > 1 during mutation - this would cause expensive clone!"
         );
-        Arc::make_mut(&mut self.overlays).insert(
-            block_number,
-            BlockOverlay {
-                storage_writes: storage_map,
-                preimages: preimage_map,
-            },
-        );
+        Arc::make_mut(&mut self.overlays)
+            .insert(block_number, BlockOverlay::new(storage_map, preimage_map));
         Ok(())
     }
 

--- a/lib/storage_api/src/overlay_buffer.rs
+++ b/lib/storage_api/src/overlay_buffer.rs
@@ -8,7 +8,7 @@ use zksync_os_interface::types::StorageWrite;
 use crate::state_override_view::{OverrideProvider, OwnedOverrides};
 use crate::{OverriddenStateView, ReadStateHistory, ViewState};
 
-type BlockOverlay = OwnedOverrides;
+pub type BlockOverlay = OwnedOverrides;
 
 #[derive(Debug, Default, Clone)]
 pub struct OverlayBuffer {
@@ -28,7 +28,7 @@ impl OverlayBuffer {
         base: &'a S,
         block_number_to_execute: BlockNumber,
     ) -> anyhow::Result<
-        OverriddenStateView<impl ViewState + 'a, Arc<BTreeMap<BlockNumber, OwnedOverrides>>>,
+        OverriddenStateView<impl ViewState + 'a, Arc<BTreeMap<BlockNumber, BlockOverlay>>>,
     >
     where
         S: ReadStateHistory + 'a,

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -12,22 +12,21 @@ use zk_os_basic_system::system_implementation::flat_storage_model::{
 };
 use zksync_os_interface::traits::{PreimageSource, ReadStorage};
 
+/// Owned HashMap-based override provider.
+/// Used for RPC calls with `StateOverride` and for in-memory block overlays.
 #[derive(Debug, Clone, Default)]
-pub struct BlockOverlay {
-    pub storage_writes: HashMap<B256, B256>,
-    pub preimages: HashMap<B256, Vec<u8>>,
+pub struct OwnedOverrides {
+    storage: HashMap<B256, B256>,
+    preimages: HashMap<B256, Vec<u8>>,
 }
 
-impl BlockOverlay {
-    pub fn new(storage_writes: HashMap<B256, B256>, preimages: HashMap<B256, Vec<u8>>) -> Self {
-        Self {
-            storage_writes,
-            preimages,
-        }
+impl OwnedOverrides {
+    pub fn new(storage: HashMap<B256, B256>, preimages: HashMap<B256, Vec<u8>>) -> Self {
+        Self { storage, preimages }
     }
 
     pub fn extend(&mut self, changes: Self) {
-        self.storage_writes.extend(changes.storage_writes);
+        self.storage.extend(changes.storage);
         self.preimages.extend(changes.preimages);
     }
 }
@@ -53,9 +52,9 @@ impl<T: OverrideProvider> OverrideProvider for Arc<T> {
     }
 }
 
-impl OverrideProvider for BlockOverlay {
+impl OverrideProvider for OwnedOverrides {
     fn get_storage_override(&self, key: &B256) -> Option<B256> {
-        self.storage_writes.get(key).copied()
+        self.storage.get(key).copied()
     }
 
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
@@ -79,7 +78,7 @@ impl<V: ViewState, O: OverrideProvider> OverriddenStateView<V, O> {
 }
 
 // Convenience constructors for common cases
-impl<V: ViewState> OverriddenStateView<V, BlockOverlay> {
+impl<V: ViewState> OverriddenStateView<V, OwnedOverrides> {
     /// Create from RPC StateOverride.
     pub fn with_state_overrides(inner: V, state_overrides: StateOverride) -> Self {
         let overrides = build_state_override_maps(&inner, state_overrides);
@@ -92,7 +91,7 @@ impl<V: ViewState> OverriddenStateView<V, BlockOverlay> {
             .iter()
             .cloned()
             .collect::<HashMap<B256, Vec<u8>>>();
-        Self::new(inner, BlockOverlay::new(HashMap::new(), preimages))
+        Self::new(inner, OwnedOverrides::new(HashMap::new(), preimages))
     }
 }
 
@@ -120,7 +119,7 @@ impl<V: ViewState, O: OverrideProvider> PreimageSource for OverriddenStateView<V
 pub fn build_state_override_maps<V: ViewState>(
     inner: &V,
     state_overrides: StateOverride,
-) -> BlockOverlay {
+) -> OwnedOverrides {
     let mut storage: HashMap<B256, B256> = HashMap::new();
     let mut preimages: HashMap<B256, Vec<u8>> = HashMap::new();
 
@@ -177,5 +176,5 @@ pub fn build_state_override_maps<V: ViewState>(
         }
     }
 
-    BlockOverlay::new(storage, preimages)
+    OwnedOverrides::new(storage, preimages)
 }

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::ViewState;
 use alloy::primitives::B256;
@@ -20,6 +21,16 @@ pub trait OverrideProvider: 'static {
 
     /// Look up a preimage override by hash.
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>>;
+}
+
+impl<T: OverrideProvider> OverrideProvider for Arc<T> {
+    fn get_storage_override(&self, key: &B256) -> Option<B256> {
+        self.as_ref().get_storage_override(key)
+    }
+
+    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
+        self.as_ref().get_preimage_override(hash)
+    }
 }
 
 /// Owned HashMap-based override provider.

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -12,8 +12,19 @@ use zk_os_basic_system::system_implementation::flat_storage_model::{
 };
 use zksync_os_interface::traits::{PreimageSource, ReadStorage};
 
+/// Trait for providing storage and preimage overrides.
+/// Allows different implementations: owned HashMaps for RPC calls, or shared data for sequencer.
+/// Requires 'static because it's used in types that implement ReadStorage/PreimageSource.
+pub trait OverrideProvider: 'static {
+    /// Look up a storage override by key.
+    fn get_storage_override(&self, key: &B256) -> Option<B256>;
+
+    /// Look up a preimage override by hash.
+    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>>;
+}
+
 /// Owned HashMap-based override provider.
-/// Used for RPC calls with `StateOverride` and for in-memory block overlays.
+/// Used for RPC calls with StateOverride, where we own the override data.
 #[derive(Debug, Clone, Default)]
 pub struct OwnedOverrides {
     storage: HashMap<B256, B256>,
@@ -31,15 +42,14 @@ impl OwnedOverrides {
     }
 }
 
-/// Trait for providing storage and preimage overrides.
-/// Allows different implementations: owned HashMaps for RPC calls, or shared data for sequencer.
-/// Requires 'static because it's used in types that implement ReadStorage/PreimageSource.
-pub trait OverrideProvider: 'static {
-    /// Look up a storage override by key.
-    fn get_storage_override(&self, key: &B256) -> Option<B256>;
+impl OverrideProvider for OwnedOverrides {
+    fn get_storage_override(&self, key: &B256) -> Option<B256> {
+        self.storage.get(key).copied()
+    }
 
-    /// Look up a preimage override by hash.
-    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>>;
+    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
+        self.preimages.get(hash).cloned()
+    }
 }
 
 impl<T: OverrideProvider> OverrideProvider for Arc<T> {
@@ -49,16 +59,6 @@ impl<T: OverrideProvider> OverrideProvider for Arc<T> {
 
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
         self.as_ref().get_preimage_override(hash)
-    }
-}
-
-impl OverrideProvider for OwnedOverrides {
-    fn get_storage_override(&self, key: &B256) -> Option<B256> {
-        self.storage.get(key).copied()
-    }
-
-    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
-        self.preimages.get(hash).cloned()
     }
 }
 
@@ -115,7 +115,7 @@ impl<V: ViewState, O: OverrideProvider> PreimageSource for OverriddenStateView<V
     }
 }
 
-/// Converts RPC `StateOverride` into an owned override provider.
+/// Converts RPC `StateOverride` into an `OwnedOverrides` provider.
 pub fn build_state_override_maps<V: ViewState>(
     inner: &V,
     state_overrides: StateOverride,

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -34,6 +34,10 @@ impl OwnedOverrides {
     pub fn new(storage: HashMap<B256, B256>, preimages: HashMap<B256, Vec<u8>>) -> Self {
         Self { storage, preimages }
     }
+
+    pub fn into_parts(self) -> (HashMap<B256, B256>, HashMap<B256, Vec<u8>>) {
+        (self.storage, self.preimages)
+    }
 }
 
 impl OverrideProvider for OwnedOverrides {
@@ -100,7 +104,7 @@ impl<V: ViewState, O: OverrideProvider> PreimageSource for OverriddenStateView<V
 }
 
 /// Converts RPC `StateOverride` into an `OwnedOverrides` provider.
-fn build_state_override_maps<V: ViewState>(
+pub fn build_state_override_maps<V: ViewState>(
     inner: &V,
     state_overrides: StateOverride,
 ) -> OwnedOverrides {

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::ViewState;
 use alloy::primitives::B256;
@@ -49,16 +48,6 @@ impl OverrideProvider for OwnedOverrides {
 
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
         self.preimages.get(hash).cloned()
-    }
-}
-
-impl<T: OverrideProvider> OverrideProvider for Arc<T> {
-    fn get_storage_override(&self, key: &B256) -> Option<B256> {
-        self.as_ref().get_storage_override(key)
-    }
-
-    fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
-        self.as_ref().get_preimage_override(hash)
     }
 }
 

--- a/lib/storage_api/src/state_override_view.rs
+++ b/lib/storage_api/src/state_override_view.rs
@@ -12,6 +12,26 @@ use zk_os_basic_system::system_implementation::flat_storage_model::{
 };
 use zksync_os_interface::traits::{PreimageSource, ReadStorage};
 
+#[derive(Debug, Clone, Default)]
+pub struct BlockOverlay {
+    pub storage_writes: HashMap<B256, B256>,
+    pub preimages: HashMap<B256, Vec<u8>>,
+}
+
+impl BlockOverlay {
+    pub fn new(storage_writes: HashMap<B256, B256>, preimages: HashMap<B256, Vec<u8>>) -> Self {
+        Self {
+            storage_writes,
+            preimages,
+        }
+    }
+
+    pub fn extend(&mut self, changes: Self) {
+        self.storage_writes.extend(changes.storage_writes);
+        self.preimages.extend(changes.preimages);
+    }
+}
+
 /// Trait for providing storage and preimage overrides.
 /// Allows different implementations: owned HashMaps for RPC calls, or shared data for sequencer.
 /// Requires 'static because it's used in types that implement ReadStorage/PreimageSource.
@@ -33,27 +53,9 @@ impl<T: OverrideProvider> OverrideProvider for Arc<T> {
     }
 }
 
-/// Owned HashMap-based override provider.
-/// Used for RPC calls with StateOverride, where we own the override data.
-#[derive(Debug, Clone, Default)]
-pub struct OwnedOverrides {
-    storage: HashMap<B256, B256>,
-    preimages: HashMap<B256, Vec<u8>>,
-}
-
-impl OwnedOverrides {
-    pub fn new(storage: HashMap<B256, B256>, preimages: HashMap<B256, Vec<u8>>) -> Self {
-        Self { storage, preimages }
-    }
-
-    pub fn into_parts(self) -> (HashMap<B256, B256>, HashMap<B256, Vec<u8>>) {
-        (self.storage, self.preimages)
-    }
-}
-
-impl OverrideProvider for OwnedOverrides {
+impl OverrideProvider for BlockOverlay {
     fn get_storage_override(&self, key: &B256) -> Option<B256> {
-        self.storage.get(key).copied()
+        self.storage_writes.get(key).copied()
     }
 
     fn get_preimage_override(&self, hash: &B256) -> Option<Vec<u8>> {
@@ -77,7 +79,7 @@ impl<V: ViewState, O: OverrideProvider> OverriddenStateView<V, O> {
 }
 
 // Convenience constructors for common cases
-impl<V: ViewState> OverriddenStateView<V, OwnedOverrides> {
+impl<V: ViewState> OverriddenStateView<V, BlockOverlay> {
     /// Create from RPC StateOverride.
     pub fn with_state_overrides(inner: V, state_overrides: StateOverride) -> Self {
         let overrides = build_state_override_maps(&inner, state_overrides);
@@ -90,7 +92,7 @@ impl<V: ViewState> OverriddenStateView<V, OwnedOverrides> {
             .iter()
             .cloned()
             .collect::<HashMap<B256, Vec<u8>>>();
-        Self::new(inner, OwnedOverrides::new(HashMap::new(), preimages))
+        Self::new(inner, BlockOverlay::new(HashMap::new(), preimages))
     }
 }
 
@@ -114,11 +116,11 @@ impl<V: ViewState, O: OverrideProvider> PreimageSource for OverriddenStateView<V
     }
 }
 
-/// Converts RPC `StateOverride` into an `OwnedOverrides` provider.
+/// Converts RPC `StateOverride` into an owned override provider.
 pub fn build_state_override_maps<V: ViewState>(
     inner: &V,
     state_overrides: StateOverride,
-) -> OwnedOverrides {
+) -> BlockOverlay {
     let mut storage: HashMap<B256, B256> = HashMap::new();
     let mut preimages: HashMap<B256, Vec<u8>> = HashMap::new();
 
@@ -175,5 +177,5 @@ pub fn build_state_override_maps<V: ViewState>(
         }
     }
 
-    OwnedOverrides::new(storage, preimages)
+    BlockOverlay::new(storage, preimages)
 }

--- a/lib/types/src/log.rs
+++ b/lib/types/src/log.rs
@@ -51,6 +51,19 @@ pub struct L2ToL1Log {
     pub value: B256,
 }
 
+impl From<zksync_os_interface::types::L2ToL1Log> for L2ToL1Log {
+    fn from(log: zksync_os_interface::types::L2ToL1Log) -> Self {
+        Self {
+            l2_shard_id: log.l2_shard_id,
+            is_service: log.is_service,
+            tx_number_in_block: log.tx_number_in_block,
+            sender: log.sender,
+            key: log.key,
+            value: log.value,
+        }
+    }
+}
+
 impl L2ToL1Log {
     ///
     /// Encode L2 to l1 log using solidity abi packed encoding.

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -679,6 +679,10 @@ pub struct RpcConfig {
     #[config(default_t = 10000000)]
     pub eth_call_gas: usize,
 
+    /// Maximum block gas limit accepted for an `eth_simulateV1` block override.
+    #[config(default_t = 100_000_000)]
+    pub eth_simulate_block_gas_limit: u64,
+
     /// Number of concurrent API connections (passed to jsonrpsee, default value there is 128)
     #[config(default_t = 1000)]
     pub max_connections: u32,
@@ -1284,6 +1288,7 @@ impl From<RpcConfig> for zksync_os_rpc::RpcConfig {
         Self {
             address: c.address,
             eth_call_gas: c.eth_call_gas,
+            eth_simulate_block_gas_limit: c.eth_simulate_block_gas_limit,
             max_connections: c.max_connections,
             max_request_size: c.max_request_size,
             max_response_size: c.max_response_size,


### PR DESCRIPTION
## Summary                                                                                                                                                                   
                                                                                                                                                                               
  Implements the `eth_simulateV1` RPC method ([spec](https://github.com/ethereum/execution-apis/pull/484)).
                                                                                                                                                                               
  Executes the requested blocks linearly against a base state, carrying an overlay of storage writes from each simulated block forward into subsequent ones. State overrides   
  per block are seeded into that overlay before execution, with actual VM writes taking precedence. When `validation=false`, the base fee is zeroed for execution while the    
  returned block header still reflects the requested/overridden fee.                                                                                                           
                                                                     
  **Not supported:**                                

  - `traceTransfers=true` — rejected with an error. ZKsync OS VM does not expose a transfer stream equivalent to reth's `TransferInspector`, so native value moves from        
  internal `CALL`/`CREATE`/`SELFDESTRUCT` cannot be captured.
  - `movePrecompileToAddress` (state override) — rejected with an error. The execution backend has no mechanism to remap the precompile table for a single simulated block.    
  - `difficulty` (block override) — silently ignored. ZKsync OS uses `mix_hash` for `PREVRANDAO`; the `random` block override maps to that correctly.                          
  - `beacon_root` (block override) — silently ignored. There is no corresponding field in `BlockContext`
  - `validation=false` - works partially since VM can still check explicitly assigned nonces and fail if they are stale, so nonce checks are still present in some way