### PR TITLE
fix: Reduce logging verbosity

### DIFF
--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -104,7 +104,7 @@ pub async fn execute_block_in_vm<V: ViewState>(
                     break reason;
                 }
 
-                tracing::info!(
+                tracing::debug!(
                     block_number=command.block_context.block_number,
                     "Executing transaction {:?} ({:?}) in block {} at index {} signer {:?} nonce {} with gas limit {} and cumulative gas used {cumulative_gas_used}...",
                     tx.hash(),
@@ -147,7 +147,7 @@ pub async fn execute_block_in_vm<V: ViewState>(
                         EXECUTION_METRICS.transaction_pubdata_used.observe(res.pubdata_used);
                         let status_str = if res.status  {"success"} else {"failure"};
                         EXECUTION_METRICS.transaction_status[&status_str].inc();
-                        tracing::info!(
+                        tracing::debug!(
                             block_number=command.block_context.block_number,
                             output=?res,
                             "Transaction {:?} executed with status {status_str} in block {}",
@@ -404,7 +404,7 @@ pub async fn execute_block_in_vm<V: ViewState>(
         output.pubdata.len(),
     );
 
-    tracing::info!(
+    tracing::debug!(
         output = ?BlockOutputDebug(&output),
         block_number = output.header.number,
         "Full block {} output",

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -199,8 +199,23 @@ impl PipelineComponent for ExternalNodeCommandSource {
     ) -> anyhow::Result<()> {
         while let Some(record) = self.replays_for_sequencer.recv().await {
             let block_number = record.block_context.block_number;
+            let txs = record.transactions.len();
+            let force_preimages = record.force_preimages.len();
+            let force_preimage_bytes = record
+                .force_preimages
+                .iter()
+                .map(|(_, value)| value.len())
+                .sum::<usize>();
+            let protocol_version = record.protocol_version.to_string();
+            let starting_l1_priority_id = record.starting_cursors.l1_priority_id;
             let command = BlockCommand::Replay(Box::new(record));
-            tracing::info!(?command, "Received block command from main node");
+            tracing::info!(
+                "Received replay block command from main node: block_number: {block_number}, \
+                 txs: {txs}, force_preimages: {force_preimages}, \
+                 force_preimage_bytes: {force_preimage_bytes}, protocol_version: {protocol_version}, \
+                 starting_l1_priority_id: {starting_l1_priority_id}"
+            );
+            tracing::debug!(?command, "Received replay block command from main node");
 
             if let Some(up_to_block) = self.up_to_block
                 && block_number > up_to_block


### PR DESCRIPTION
This PR gets rid of printing the entire block command & moves tx logging to debug. External Nodes on high traffic could generate up to 50GB of logs for a full sync.
