### PR TITLE
feat: Make block replay size configurable

### DIFF
--- a/lib/network/src/protocol/config.rs
+++ b/lib/network/src/protocol/config.rs
@@ -21,6 +21,8 @@ pub struct ExternalNodeProtocolConfig {
     pub starting_block: Arc<RwLock<BlockNumber>>,
     /// All overrides to pass through when requesting records.
     pub record_overrides: Vec<RecordOverride>,
+    /// Maximum replay records requested per `BlockReplays` response message.
+    pub max_blocks_per_message: u64,
     /// Channel used to forward replay records into the local sequencer.
     pub replay_sender: mpsc::Sender<ReplayRecord>,
     /// Optional verifier configuration. When absent, this EN only participates in replay sync.

--- a/lib/network/src/protocol/en.rs
+++ b/lib/network/src/protocol/en.rs
@@ -29,6 +29,7 @@ pub(super) async fn run_en_connection<P: ZksProtocolVersionSpec>(
     let ExternalNodeProtocolConfig {
         starting_block,
         record_overrides,
+        max_blocks_per_message,
         replay_sender,
         verification: verifier,
     } = config;
@@ -39,9 +40,14 @@ pub(super) async fn run_en_connection<P: ZksProtocolVersionSpec>(
         return;
     }
 
-    if send_replay_request::<P>(&outbound_tx, &starting_block, record_overrides)
-        .await
-        .is_err()
+    if send_replay_request::<P>(
+        &outbound_tx,
+        &starting_block,
+        record_overrides,
+        max_blocks_per_message,
+    )
+    .await
+    .is_err()
     {
         return;
     }
@@ -114,12 +120,13 @@ async fn send_replay_request<P: ZksProtocolVersionSpec>(
     outbound_tx: &mpsc::Sender<BytesMut>,
     starting_block: &Arc<RwLock<BlockNumber>>,
     record_overrides: Vec<RecordOverride>,
+    max_blocks_per_message: u64,
 ) -> Result<(), ()> {
     let next_block = *starting_block.read().unwrap();
     tracing::info!(next_block, "requesting block replays from main node");
     let max_blocks_per_message = P::VERSION
         .supports_message(ZksMessageId::VerifierRoleRequest)
-        .then_some(MAX_BLOCKS_PER_MESSAGE);
+        .then_some(max_blocks_per_message.clamp(1, MAX_BLOCKS_PER_MESSAGE));
     let msg =
         ZksMessage::<P>::get_block_replays(next_block, max_blocks_per_message, record_overrides);
     outbound_tx.send(msg.encoded()).await.map_err(|_| ())

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -206,6 +206,7 @@ where
                     ExternalNodeProtocolConfig {
                         starting_block: Arc::new(RwLock::new(starting_block)),
                         record_overrides: vec![],
+                        max_blocks_per_message: 64,
                         replay_sender: replay_tx,
                         verification,
                     },

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -636,6 +636,10 @@ pub struct SequencerConfig {
     #[config(default)]
     pub en_sync_up_to_block: Option<u64>,
 
+    /// Maximum replay records requested per p2p replay response message by an external node.
+    #[config(default_t = 1)]
+    pub en_max_blocks_per_replay_message: u64,
+
     #[config(default, with = Serde![*])]
     /// List of (block_number, db_key) pairs to override when downloading replay records.
     pub en_replay_record_overrides: Vec<(u64, Bytes)>,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -458,6 +458,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 ZksProtocolConfig::ExternalNode(ExternalNodeProtocolConfig {
                     starting_block: Arc::new(RwLock::new(starting_block)),
                     record_overrides,
+                    max_blocks_per_message: config
+                        .sequencer_config
+                        .en_max_blocks_per_replay_message,
                     replay_sender,
                     verification: config.batch_verification_config.client_enabled.then(|| {
                         ExternalNodeVerifierConfig {


### PR DESCRIPTION
Previously, this used to be 1. With introduction of p2p, we allowed configuration to between 1 and 64, but the value has been hardcoded to 64.

This PR does 2 things:
1. add a configuration that allows each node runner to decide on the value
2. changes default value from 64 to 1

In all observations, the overhead of the messages is minor. In practice, with relaible internet, there's barely any visible difference between syncing 1 by 1 or 64 by 64. On the other hand, having 64 in the buffer at one time increases the general memory usage (not by a lot, but it is unnecessary and we want ENs to be as thin as possible). This can become more problematic if said replay records are massive and the heap allocator is lazy (i.e. glibc).

This change makes the default saner and more customer friendly, allowing node runners to decide on their own if they'd like to change the configuration (i.e. if they have poor/unstable network).

