### PR TITLE
perf: Default to jemalloc for mem allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11934,6 +11934,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15001,6 +15021,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,9 @@ bincode = { version = "2.0.1", features = ["serde"] }
 smart-config = { version = "0.4.0-pre.2" }
 smart-config-commands = { version = "0.4.0-pre.2" }
 thiserror = "2.0.12"
+tikv-jemallocator = { version = "0.6.1", features = [
+    "override_allocator_on_supported_platforms",
+] }
 clap = "4.2.2"
 insta = "1.29.0"
 jsonrpsee = { version = "0.26.0", default-features = false }

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -13,6 +13,10 @@ categories.workspace = true
 name = "zksync-os-server"
 path = "src/main.rs"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator"]
+
 [dependencies]
 zksync_os_l1_sender.workspace = true
 zksync_os_l1_watcher.workspace = true
@@ -106,3 +110,6 @@ sentry.workspace = true
 tempfile.workspace = true
 flate2.workspace = true
 tar.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }

--- a/node/bin/src/main.rs
+++ b/node/bin/src/main.rs
@@ -18,6 +18,10 @@ use zksync_os_server::{INTERNAL_CONFIG_FILE_NAME, run};
 use zksync_os_state::StateHandle;
 use zksync_os_state_full_diffs::FullDiffsState;
 
+#[cfg(all(feature = "jemalloc", target_family = "unix"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 const IMMEDIATE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
Enables jemalloc as the default allocator on Unix targets. It is feature gated (by default on), but one can opt out via `--no-default-features`.

All releases are running under Linux machines. As such the likely default choice is glibc. The problem with glibc is that it is lazy to release memory and under heavy pressure, it hogs memory for "later use". Another issue is that memory gets fragmented and glibc does an "average" job at reclaiming it properly (at least in use cases I've observed). Jemalloc is a better fit for long running, high concurrency processes.

For this repo, we have plenty of such cases (i.e. a mainnode under heavy load or a syncing EN).

I have tested EN sync scenario and it reduced overall potential memory usage from ~20GB (it might go higher than this, but didn't wait for a full sync, the data I got in a couple of runs in ~2h was enough to justify the change) to max ~11GB. I've ran multiple tests to compare EN memory and they are all positive.

I have high confidence that this will be operationally better for all nodes (including existing mainnodes with high load), albeit, didn't manage to test a a main node locally (i.e reproduce high load from an existing a main node locally).


