### PR TITLE
feat: add zks protocol v4

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,7 +4,7 @@ slow-timeout = { period = "1m", terminate-after = 20 }
 # Global timeout for the entire test run. Test runs will be terminated if they take longer than this timeout.
 global-timeout = "1h"
 # Do not stop the test run on the first failure, but continue to run all tests.
-fail-fast = false
+fail-fast = fals
 
 [profile.default.junit]
 # Save junit report to the project root.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,7 +4,7 @@ slow-timeout = { period = "1m", terminate-after = 20 }
 # Global timeout for the entire test run. Test runs will be terminated if they take longer than this timeout.
 global-timeout = "1h"
 # Do not stop the test run on the first failure, but continue to run all tests.
-fail-fast = fals
+fail-fast = false
 
 [profile.default.junit]
 # Save junit report to the project root.

--- a/lib/network/src/version.rs
+++ b/lib/network/src/version.rs
@@ -1,7 +1,7 @@
 //! Support for representing the version of the `zks` protocol.
 
 use crate::wire::message::ZksMessageId;
-use crate::wire::replays::{WireReplayRecord, v0, v1, v2};
+use crate::wire::replays::{WireReplayRecord, v0, v1, v2, v3};
 use alloy::primitives::bytes::BufMut;
 use alloy::rlp::{Decodable, Encodable, Error as RlpError};
 use std::fmt::Debug;
@@ -58,6 +58,16 @@ impl ZksProtocolVersionSpec for ZksProtocolV3 {
     const VERSION: ZksVersion = ZksVersion::Zks3;
 }
 
+/// Protocol version 4 keeps the replay transport from v3 but upgrades the replay record encoding.
+#[derive(Debug, Clone)]
+pub struct ZksProtocolV4;
+
+impl ZksProtocolVersionSpec for ZksProtocolV4 {
+    type Record = v3::ReplayRecord;
+
+    const VERSION: ZksVersion = ZksVersion::Zks4;
+}
+
 /// Error thrown when failed to parse a valid [`ZksVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("Unknown zks protocol version: {0}")]
@@ -75,14 +85,17 @@ pub enum ZksVersion {
     Zks2 = 2,
     /// The `zks` protocol version 3.
     Zks3 = 3,
+    /// The `zks` protocol version 4.
+    Zks4 = 4,
 }
 
 impl ZksVersion {
     /// The latest known zks version
-    pub const LATEST: Self = Self::Zks3;
+    pub const LATEST: Self = Self::Zks4;
 
     /// All known zks versions
-    pub const ALL_VERSIONS: &'static [Self] = &[Self::Zks0, Self::Zks1, Self::Zks2, Self::Zks3];
+    pub const ALL_VERSIONS: &'static [Self] =
+        &[Self::Zks0, Self::Zks1, Self::Zks2, Self::Zks3, Self::Zks4];
 
     /// Returns the max message id for the given version.
     const fn max_message_id(&self) -> u8 {
@@ -91,6 +104,7 @@ impl ZksVersion {
             ZksVersion::Zks1 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks2 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks3 => ZksMessageId::VerifyBatchResult as u8,
+            ZksVersion::Zks4 => ZksMessageId::VerifyBatchResult as u8,
         }
     }
 
@@ -164,6 +178,7 @@ impl From<ZksVersion> for &'static str {
             ZksVersion::Zks1 => "1",
             ZksVersion::Zks2 => "2",
             ZksVersion::Zks3 => "3",
+            ZksVersion::Zks4 => "4",
         }
     }
 }

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -18,7 +18,8 @@ use zksync_os_network::protocol::{
     MainNodeProtocolConfig, ProtocolEvent, ZksProtocolHandler,
 };
 use zksync_os_network::version::{
-    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4, ZksProtocolVersionSpec, ZksVersion,
+    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4,
+    ZksProtocolVersionSpec, ZksVersion,
 };
 use zksync_os_network::{PeerVerifyBatchResult, VerifyBatchOutcome, VerifyBatchResult};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -18,7 +18,7 @@ use zksync_os_network::protocol::{
     MainNodeProtocolConfig, ProtocolEvent, ZksProtocolHandler,
 };
 use zksync_os_network::version::{
-    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolVersionSpec, ZksVersion,
+    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4, ZksProtocolVersionSpec, ZksVersion,
 };
 use zksync_os_network::{PeerVerifyBatchResult, VerifyBatchOutcome, VerifyBatchResult};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};
@@ -270,6 +270,7 @@ async fn send_replay_record_matching_version(version: ZksVersion) {
         ZksVersion::Zks1 => test_inner::<ZksProtocolV1>().await,
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
         ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
+        ZksVersion::Zks4 => test_inner::<ZksProtocolV4>().await,
     }
 }
 
@@ -759,6 +760,7 @@ async fn send_replay_record_different_versions(version: ZksVersion) {
         ZksVersion::Zks1 => test_inner::<ZksProtocolV1>().await,
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
         ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
+        ZksVersion::Zks4 => test_inner::<ZksProtocolV4>().await,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `ZksProtocolV4` that uses `v3::ReplayRecord`. `ZksProtocolV3` mistakenly uses `v2::ReplayRecord` that doesn't contain some important changes for v31

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

