### PR TITLE
chore(security): suppress hickory-proto advisories until reth upgrade

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,12 @@ ignore = [
     # `rand` unsoundness with custom logger using `rand::rng()`. Too many
     # transitive deps still pin 0.8.5, so upgrading is not feasible right now.
     "RUSTSEC-2026-0097",
+    # hickory-proto 0.25.2 is pulled in transitively via reth-dns-discovery.
+    # DNS discovery is explicitly disabled in our network config, so neither
+    # code path is reachable. Proper fix requires upgrading reth to v2.2.0+
+    # which is a significant effort (alloy 1.x → 2.x migration).
+    "RUSTSEC-2026-0118",
+    "RUSTSEC-2026-0119",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Suppress hickory-proto advisories until reth upgrade.

## Why?

RUSTSEC-2026-0118 and RUSTSEC-2026-0119 affect hickory-proto 0.25.2, pulled in transitively via reth-dns-discovery. DNS discovery is explicitly disabled in our network config so neither code path is reachable at runtime. The proper fix (reth v2.2.0+) requires an alloy 1.x → 2.x migration and is tracked as a follow-up.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

