### PR TITLE
fix: register v4 subprotocol

### DIFF
--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
 };
 use crate::raft::protocol::RaftProtocolHandler;
 use crate::session::PeerSessionStore;
-use crate::version::{ZksProtocolV1, ZksProtocolV2, ZksProtocolV3};
+use crate::version::{ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4};
 use crate::wire::message::ZksMessage;
 use crate::{VerifyBatch, VerifyBatchResult};
 use alloy::eips::eip2124::Head;
@@ -332,6 +332,12 @@ impl NetworkService {
                 connection_registry.clone(),
             ))
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV3, _>::for_main_node(
+                replay.clone(),
+                protocol.clone(),
+                state.clone(),
+                connection_registry.clone(),
+            ))
+            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV4, _>::for_main_node(
                 replay,
                 protocol,
                 state,
@@ -361,6 +367,12 @@ impl NetworkService {
                 connection_registry.clone(),
             ))
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV3, _>::for_external_node(
+                replay.clone(),
+                protocol.clone(),
+                state.clone(),
+                connection_registry.clone(),
+            ))
+            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV4, _>::for_external_node(
                 replay,
                 protocol,
                 state,


### PR DESCRIPTION
## Summary

ZksProtocolV4 should be registered

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

