### PR TITLE
chore(security): suppress hickory-proto advisories in audit ci

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 'RUSTSEC-2025-0055' todo: waiting for ark-relations to release a patch https://github.com/arkworks-rs/snark/issues/413
-          ignore: 'RUSTSEC-2025-0055'
+          # 'RUSTSEC-2026-0118', 'RUSTSEC-2026-0119': hickory-proto 0.25.2 via reth-dns-discovery; DNS discovery
+          # is disabled in our network config so neither path is reachable. Fix requires reth v2.2.0+ (alloy 1.x→2.x).
+          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0118,RUSTSEC-2026-0119'
   cargo-deny:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Suppress hickory-proto advisories in audit ci.

## Why?

Follow-up after https://github.com/matter-labs/zksync-os-server/pull/1249 propagating deny into audit as well.

By some reason, it was a delay - deny found issues 1 day earlier, audit was clean.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

