### PR TITLE
feat(interop): Allow inclusion of multiple interop roots in system tx

### DIFF
--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -581,8 +581,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let sl_chain_id_subpool = SlChainIdSubpool::default();
     let interop_fee_subpool = InteropFeeSubpool::new(next_cursors.interop_fee_number);
     let interop_roots_subpool = InteropRootsSubpool::new(
-        // todo: change to config.sequencer_config.interop_roots_per_tx when contracts are updated
-        1,
+        config.sequencer_config.interop_roots_per_tx
     );
 
     // If we start from the very first block, we should start by sending upgrade tx for genesis.

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -580,9 +580,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let upgrade_subpool = UpgradeSubpool::new(current_protocol_version.clone());
     let sl_chain_id_subpool = SlChainIdSubpool::default();
     let interop_fee_subpool = InteropFeeSubpool::new(next_cursors.interop_fee_number);
-    let interop_roots_subpool = InteropRootsSubpool::new(
-        config.sequencer_config.interop_roots_per_tx
-    );
+    let interop_roots_subpool =
+        InteropRootsSubpool::new(config.sequencer_config.interop_roots_per_tx);
 
     // If we start from the very first block, we should start by sending upgrade tx for genesis.
     if starting_block == 1 {


### PR DESCRIPTION
## Summary

Before we were including only one interop root in system tx, as the contracts on L1 were not supporting batches of them. Now as we test interop with working gateway - it's no longer a case
