### PR TITLE
feat(observability): Expose hosted chain config metrics

### DIFF
--- a/lib/observability/src/metrics.rs
+++ b/lib/observability/src/metrics.rs
@@ -73,6 +73,81 @@ pub struct GeneralMetrics {
     pub rpc_gas_price_scale_factor: Gauge<f64>,
     /// RPC: pubdata price multiplier used during gas limit estimation (`eth_estimateGas`).
     pub rpc_estimate_gas_pubdata_price_factor: Gauge<f64>,
+
+    // -- Fee policy (from `FeeConfig`) -------------------------------------------------------
+    /// Fee policy: configured USD price for one native resource unit.
+    pub fee_native_price_usd: Gauge<f64>,
+    /// Fee policy: native resource units equivalent to one gas unit.
+    pub fee_native_per_gas: Gauge<u64>,
+    /// Fee policy: whether `fee.base_fee_override` is configured.
+    pub fee_base_fee_override_enabled: Gauge<u64>,
+    /// Fee policy: configured base fee override, in base token units.
+    pub fee_base_fee_override_wei: Gauge<f64>,
+    /// Fee policy: whether `fee.native_price_override` is configured.
+    pub fee_native_price_override_enabled: Gauge<u64>,
+    /// Fee policy: configured native price override, in base token units.
+    pub fee_native_price_override_wei: Gauge<f64>,
+    /// Fee policy: whether `fee.pubdata_price_override` is configured.
+    pub fee_pubdata_price_override_enabled: Gauge<u64>,
+    /// Fee policy: configured pubdata price override, in base token units.
+    pub fee_pubdata_price_override_wei: Gauge<f64>,
+    /// Fee policy: whether `fee.pubdata_price_cap` is configured.
+    pub fee_pubdata_price_cap_enabled: Gauge<u64>,
+    /// Fee policy: configured pubdata price cap, in base token units.
+    pub fee_pubdata_price_cap_wei: Gauge<f64>,
+
+    // -- Proving policy (from `ProverApiConfig`) ---------------------------------------------
+    /// Proving policy: whether in-process fake FRI provers are enabled.
+    pub proving_fake_fri_provers_enabled: Gauge<u64>,
+    /// Proving policy: whether in-process fake SNARK provers are enabled.
+    pub proving_fake_snark_provers_enabled: Gauge<u64>,
+
+    // -- L1 submission policy (from `L1SenderConfig`) ----------------------------------------
+    /// L1 submission policy: max fee per gas, in wei.
+    pub l1_sender_max_fee_per_gas_wei: Gauge<f64>,
+    /// L1 submission policy: max priority fee per gas, in wei.
+    pub l1_sender_max_priority_fee_per_gas_wei: Gauge<f64>,
+    /// L1 submission policy: max fee per blob gas, in wei.
+    pub l1_sender_max_fee_per_blob_gas_wei: Gauge<f64>,
+
+    // -- Transaction admission policy --------------------------------------------------------
+    /// Tx admission policy: max pending mempool transactions.
+    pub mempool_max_pending_txs: Gauge<usize>,
+    /// Tx admission policy: max pending mempool size.
+    #[metrics(unit = Unit::Bytes)]
+    pub mempool_max_pending_size: Gauge<usize>,
+    /// Tx admission policy: minimal protocol base fee accepted by mempool.
+    pub mempool_minimal_protocol_basefee: Gauge<u64>,
+    /// Tx admission policy: max transaction input size accepted by the validator.
+    #[metrics(unit = Unit::Bytes)]
+    pub tx_validator_max_input_bytes: Gauge<usize>,
+
+    // -- Price source policy -----------------------------------------------------------------
+    /// Price source policy: selected external price source. Gauge is always set to one.
+    #[metrics(labels = ["source"])]
+    pub external_price_api_source: LabeledFamily<&'static str, Gauge, 1>,
+    /// Price source policy: number of configured fallback token prices.
+    pub base_token_price_fallback_prices_count: Gauge<usize>,
+    /// Price source policy: whether base token address override is configured.
+    pub base_token_price_base_token_addr_override_enabled: Gauge<u64>,
+    /// Price source policy: configured base token address override. Gauge is always set to one.
+    #[metrics(labels = ["address"])]
+    pub base_token_price_base_token_addr_override: LabeledFamily<&'static str, Gauge, 1>,
+    /// Price source policy: whether base token decimals override is configured.
+    pub base_token_price_base_token_decimals_override_enabled: Gauge<u64>,
+    /// Price source policy: configured base token decimals override.
+    pub base_token_price_base_token_decimals_override: Gauge<u64>,
+    /// Price source policy: whether gateway base token address override is configured.
+    pub base_token_price_gateway_base_token_addr_override_enabled: Gauge<u64>,
+    /// Price source policy: configured gateway base token address override. Gauge is always set to one.
+    #[metrics(labels = ["address"])]
+    pub base_token_price_gateway_base_token_addr_override: LabeledFamily<&'static str, Gauge, 1>,
+
+    // -- Batch verification policy -----------------------------------------------------------
+    /// Batch verification policy: whether the main-node verification server is enabled.
+    pub batch_verification_server_enabled: Gauge<u64>,
+    /// Batch verification policy: whether the external-node verification client is enabled.
+    pub batch_verification_client_enabled: Gauge<u64>,
 }
 
 #[vise::register]

--- a/lib/observability/src/metrics.rs
+++ b/lib/observability/src/metrics.rs
@@ -1,5 +1,5 @@
 use crate::GenericComponentState;
-use vise::{Counter, Gauge, LabeledFamily, Metrics};
+use vise::{Counter, Gauge, LabeledFamily, Metrics, Unit};
 
 #[derive(Debug, Metrics)]
 pub struct GeneralMetrics {
@@ -26,6 +26,53 @@ pub struct GeneralMetrics {
 
     /// Number of blacklisted addresses in the internal config on server startup
     pub blacklisted_addresses_count: Gauge<usize>,
+
+    // -- Block seal criteria (from `SequencerConfig`) ----------------------------------------
+    /// Block seal criterion: deadline since first tx after which a block is sealed.
+    #[metrics(unit = Unit::Seconds)]
+    pub block_seal_block_time: Gauge<f64>,
+    /// Block seal criterion: max number of transactions per block.
+    pub block_seal_max_transactions_in_block: Gauge<u64>,
+    /// Block seal criterion: max gas used per block.
+    pub block_seal_block_gas_limit: Gauge<u64>,
+    /// Block seal criterion: max pubdata bytes per block.
+    #[metrics(unit = Unit::Bytes)]
+    pub block_seal_block_pubdata_limit: Gauge<u64>,
+
+    // -- Batch seal criteria (from `BatcherConfig`) ------------------------------------------
+    /// Batch seal criterion: max time a batch stays open before sealing.
+    #[metrics(unit = Unit::Seconds)]
+    pub batch_seal_batch_timeout: Gauge<f64>,
+    /// Batch seal criterion: max number of transactions per batch.
+    pub batch_seal_tx_per_batch_limit: Gauge<u64>,
+    /// Batch seal criterion: max number of interop roots per batch.
+    pub batch_seal_interop_roots_per_batch_limit: Gauge<u64>,
+
+    // -- RPC request limits (from `RpcConfig`) -----------------------------------------------
+    /// RPC limit: gas limit for transactions executed via `eth_call` / `eth_estimateGas`.
+    pub rpc_eth_call_gas: Gauge<u64>,
+    /// RPC limit: max concurrent API connections (HTTP and WS).
+    pub rpc_max_connections: Gauge<u64>,
+    /// RPC limit: max RPC request payload size for both HTTP and WS.
+    #[metrics(unit = Unit::Bytes)]
+    pub rpc_max_request_size: Gauge<u64>,
+    /// RPC limit: max RPC response payload size for both HTTP and WS.
+    #[metrics(unit = Unit::Bytes)]
+    pub rpc_max_response_size: Gauge<u64>,
+    /// RPC limit: max number of blocks that can be scanned per filter.
+    pub rpc_max_blocks_per_filter: Gauge<u64>,
+    /// RPC limit: max number of logs returned in a single response.
+    pub rpc_max_logs_per_response: Gauge<u64>,
+    /// RPC limit: duration since the last filter poll after which the filter is considered stale.
+    #[metrics(unit = Unit::Seconds)]
+    pub rpc_stale_filter_ttl: Gauge<f64>,
+    /// RPC limit: default timeout for `eth_sendRawTransactionSync`.
+    #[metrics(unit = Unit::Seconds)]
+    pub rpc_send_raw_transaction_sync_timeout: Gauge<f64>,
+    /// RPC: factor applied to the pending block base fee returned by `eth_gasPrice`.
+    pub rpc_gas_price_scale_factor: Gauge<f64>,
+    /// RPC: pubdata price multiplier used during gas limit estimation (`eth_estimateGas`).
+    pub rpc_estimate_gas_pubdata_price_factor: Gauge<f64>,
 }
 
 #[vise::register]

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -21,7 +21,8 @@ use crate::batch_sink::{BatchSink, NoOpSink, clear_failing_block_config_task};
 use crate::batcher::{Batcher, BatcherStartupConfig, util::load_genesis_stored_batch_info};
 use crate::command_source::{ConsensusNodeCommandSource, ExternalNodeCommandSource};
 use crate::config::{
-    Config, ProverApiConfig, base_token_price_updater_config, gas_adjuster_config,
+    Config, ExternalPriceApiClientConfig, ProverApiConfig, base_token_price_updater_config,
+    gas_adjuster_config,
 };
 use crate::en_remote_config::load_remote_config;
 use crate::node_state_on_startup::NodeStateOnStartup;
@@ -1394,11 +1395,20 @@ fn block_hashes_for_first_block(repositories: &dyn ReadRepository) -> BlockHashe
     block_hashes
 }
 
-/// Publishes static config limits (block seal / batch seal / RPC) as gauges so they're
-/// observable in Prometheus alongside the runtime metrics they bound. Set once at startup;
-/// values do not change at runtime.
+/// Publishes static config limits and hosted-chain policy values as gauges.
 fn report_static_config_limits(config: &Config) {
-    // Block seal criteria.
+    report_block_seal_config(config);
+    report_batch_seal_config(config);
+    report_rpc_config(config);
+    report_fee_policy_config(config);
+    report_proving_policy_config(config);
+    report_l1_submission_policy_config(config);
+    report_tx_admission_policy_config(config);
+    report_price_source_policy_config(config);
+    report_batch_verification_policy_config(config);
+}
+
+fn report_block_seal_config(config: &Config) {
     let sequencer = &config.sequencer_config;
     GENERAL_METRICS
         .block_seal_block_time
@@ -1412,8 +1422,9 @@ fn report_static_config_limits(config: &Config) {
     GENERAL_METRICS
         .block_seal_block_pubdata_limit
         .set(sequencer.block_pubdata_limit_bytes);
+}
 
-    // Batch seal criteria.
+fn report_batch_seal_config(config: &Config) {
     let batcher = &config.batcher_config;
     GENERAL_METRICS
         .batch_seal_batch_timeout
@@ -1424,8 +1435,9 @@ fn report_static_config_limits(config: &Config) {
     GENERAL_METRICS
         .batch_seal_interop_roots_per_batch_limit
         .set(batcher.interop_roots_per_batch_limit);
+}
 
-    // RPC request limits.
+fn report_rpc_config(config: &Config) {
     let rpc = &config.rpc_config;
     GENERAL_METRICS
         .rpc_eth_call_gas
@@ -1457,6 +1469,159 @@ fn report_static_config_limits(config: &Config) {
     GENERAL_METRICS
         .rpc_estimate_gas_pubdata_price_factor
         .set(rpc.estimate_gas_pubdata_price_factor);
+}
+
+fn report_fee_policy_config(config: &Config) {
+    let fee = &config.fee_config;
+    GENERAL_METRICS
+        .fee_native_price_usd
+        .set(fee.native_price_usd);
+    GENERAL_METRICS.fee_native_per_gas.set(fee.native_per_gas);
+    report_optional_f64_gauge(
+        fee.base_fee_override.map(u128_metric_value),
+        &GENERAL_METRICS.fee_base_fee_override_enabled,
+        &GENERAL_METRICS.fee_base_fee_override_wei,
+    );
+    report_optional_f64_gauge(
+        fee.native_price_override.map(u128_metric_value),
+        &GENERAL_METRICS.fee_native_price_override_enabled,
+        &GENERAL_METRICS.fee_native_price_override_wei,
+    );
+    report_optional_f64_gauge(
+        fee.pubdata_price_override.map(u128_metric_value),
+        &GENERAL_METRICS.fee_pubdata_price_override_enabled,
+        &GENERAL_METRICS.fee_pubdata_price_override_wei,
+    );
+    report_optional_f64_gauge(
+        fee.pubdata_price_cap.map(u128_metric_value),
+        &GENERAL_METRICS.fee_pubdata_price_cap_enabled,
+        &GENERAL_METRICS.fee_pubdata_price_cap_wei,
+    );
+}
+
+fn report_proving_policy_config(config: &Config) {
+    let fake_provers = &config.prover_api_config;
+    GENERAL_METRICS
+        .proving_fake_fri_provers_enabled
+        .set(bool_metric_value(fake_provers.fake_fri_provers.enabled));
+    GENERAL_METRICS
+        .proving_fake_snark_provers_enabled
+        .set(bool_metric_value(fake_provers.fake_snark_provers.enabled));
+}
+
+fn report_l1_submission_policy_config(config: &Config) {
+    let l1_sender = &config.l1_sender_config;
+    GENERAL_METRICS
+        .l1_sender_max_fee_per_gas_wei
+        .set(l1_sender.max_fee_per_gas.0 as f64);
+    GENERAL_METRICS
+        .l1_sender_max_priority_fee_per_gas_wei
+        .set(l1_sender.max_priority_fee_per_gas.0 as f64);
+    GENERAL_METRICS
+        .l1_sender_max_fee_per_blob_gas_wei
+        .set(l1_sender.max_fee_per_blob_gas.0 as f64);
+}
+
+fn report_tx_admission_policy_config(config: &Config) {
+    let mempool = &config.mempool_config;
+    GENERAL_METRICS
+        .mempool_max_pending_txs
+        .set(mempool.max_pending_txs);
+    GENERAL_METRICS
+        .mempool_max_pending_size
+        .set(mempool.max_pending_size);
+    GENERAL_METRICS
+        .mempool_minimal_protocol_basefee
+        .set(mempool.minimal_protocol_basefee);
+    GENERAL_METRICS
+        .tx_validator_max_input_bytes
+        .set(config.tx_validator_config.max_input_bytes);
+}
+
+fn report_price_source_policy_config(config: &Config) {
+    let price_updater = &config.base_token_price_updater_config;
+    let source = external_price_source_name(&config.external_price_api_client_config);
+    GENERAL_METRICS.external_price_api_source[&source].set(1);
+    GENERAL_METRICS
+        .base_token_price_fallback_prices_count
+        .set(price_updater.fallback_prices.len());
+    report_optional_address_override(
+        price_updater.base_token_addr_override,
+        &GENERAL_METRICS.base_token_price_base_token_addr_override_enabled,
+        |address| {
+            GENERAL_METRICS.base_token_price_base_token_addr_override[&address].set(1);
+        },
+    );
+    report_optional_u8_gauge(
+        price_updater.base_token_decimals_override,
+        &GENERAL_METRICS.base_token_price_base_token_decimals_override_enabled,
+        &GENERAL_METRICS.base_token_price_base_token_decimals_override,
+    );
+    report_optional_address_override(
+        price_updater.gateway_base_token_addr_override,
+        &GENERAL_METRICS.base_token_price_gateway_base_token_addr_override_enabled,
+        |address| {
+            GENERAL_METRICS.base_token_price_gateway_base_token_addr_override[&address].set(1);
+        },
+    );
+}
+
+fn report_batch_verification_policy_config(config: &Config) {
+    let batch_verification = &config.batch_verification_config;
+    GENERAL_METRICS
+        .batch_verification_server_enabled
+        .set(bool_metric_value(batch_verification.server_enabled));
+    GENERAL_METRICS
+        .batch_verification_client_enabled
+        .set(bool_metric_value(batch_verification.client_enabled));
+}
+
+fn report_optional_f64_gauge(
+    value: Option<f64>,
+    enabled_gauge: &vise::Gauge<u64>,
+    value_gauge: &vise::Gauge<f64>,
+) {
+    enabled_gauge.set(bool_metric_value(value.is_some()));
+    value_gauge.set(value.unwrap_or_default());
+}
+
+fn report_optional_u8_gauge(
+    value: Option<u8>,
+    enabled_gauge: &vise::Gauge<u64>,
+    value_gauge: &vise::Gauge<u64>,
+) {
+    enabled_gauge.set(bool_metric_value(value.is_some()));
+    value_gauge.set(u64::from(value.unwrap_or_default()));
+}
+
+fn report_optional_address_override(
+    value: Option<alloy::primitives::Address>,
+    enabled_gauge: &vise::Gauge<u64>,
+    report_label: impl FnOnce(&'static str),
+) {
+    enabled_gauge.set(bool_metric_value(value.is_some()));
+    if let Some(value) = value {
+        report_label(value.to_string().leak());
+    }
+}
+
+fn external_price_source_name(
+    external_price_api_client: &Option<ExternalPriceApiClientConfig>,
+) -> &'static str {
+    match external_price_api_client {
+        Some(ExternalPriceApiClientConfig::Forced { .. }) => "forced",
+        Some(ExternalPriceApiClientConfig::CoinGecko { .. }) => "coingecko",
+        Some(ExternalPriceApiClientConfig::CoinMarketCap { .. }) => "coinmarketcap",
+        None => "none",
+    }
+}
+
+fn u128_metric_value(value: alloy::primitives::U128) -> f64 {
+    value.to::<u128>() as f64
+}
+
+fn bool_metric_value(value: bool) -> u64 {
+    u64::from(value)
 }
 
 fn init_and_report_internal_config_manager(

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -188,6 +188,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         .leak();
     GENERAL_METRICS.fee_collector_address[&fee_collector_address].set(1);
     GENERAL_METRICS.chain_id.set(chain_id);
+    report_static_config_limits(&config);
 
     // This is the only place where we initialize L1 provider, every component shares the same
     // cloned provider.
@@ -1391,6 +1392,71 @@ fn block_hashes_for_first_block(repositories: &dyn ReadRepository) -> BlockHashe
         .expect("Missing genesis block in repositories");
     block_hashes.0[255] = U256::from_be_slice(genesis_block.hash().as_slice());
     block_hashes
+}
+
+/// Publishes static config limits (block seal / batch seal / RPC) as gauges so they're
+/// observable in Prometheus alongside the runtime metrics they bound. Set once at startup;
+/// values do not change at runtime.
+fn report_static_config_limits(config: &Config) {
+    // Block seal criteria.
+    let sequencer = &config.sequencer_config;
+    GENERAL_METRICS
+        .block_seal_block_time
+        .set(sequencer.block_time.as_secs_f64());
+    GENERAL_METRICS
+        .block_seal_max_transactions_in_block
+        .set(sequencer.max_transactions_in_block as u64);
+    GENERAL_METRICS
+        .block_seal_block_gas_limit
+        .set(sequencer.block_gas_limit);
+    GENERAL_METRICS
+        .block_seal_block_pubdata_limit
+        .set(sequencer.block_pubdata_limit_bytes);
+
+    // Batch seal criteria.
+    let batcher = &config.batcher_config;
+    GENERAL_METRICS
+        .batch_seal_batch_timeout
+        .set(batcher.batch_timeout.as_secs_f64());
+    GENERAL_METRICS
+        .batch_seal_tx_per_batch_limit
+        .set(batcher.tx_per_batch_limit);
+    GENERAL_METRICS
+        .batch_seal_interop_roots_per_batch_limit
+        .set(batcher.interop_roots_per_batch_limit);
+
+    // RPC request limits.
+    let rpc = &config.rpc_config;
+    GENERAL_METRICS
+        .rpc_eth_call_gas
+        .set(rpc.eth_call_gas as u64);
+    GENERAL_METRICS
+        .rpc_max_connections
+        .set(rpc.max_connections as u64);
+    GENERAL_METRICS
+        .rpc_max_request_size
+        .set((rpc.max_request_size as u64) * 1024 * 1024);
+    GENERAL_METRICS
+        .rpc_max_response_size
+        .set((rpc.max_response_size as u64) * 1024 * 1024);
+    GENERAL_METRICS
+        .rpc_max_blocks_per_filter
+        .set(rpc.max_blocks_per_filter);
+    GENERAL_METRICS
+        .rpc_max_logs_per_response
+        .set(rpc.max_logs_per_response as u64);
+    GENERAL_METRICS
+        .rpc_stale_filter_ttl
+        .set(rpc.stale_filter_ttl.as_secs_f64());
+    GENERAL_METRICS
+        .rpc_send_raw_transaction_sync_timeout
+        .set(rpc.send_raw_transaction_sync_timeout.as_secs_f64());
+    GENERAL_METRICS
+        .rpc_gas_price_scale_factor
+        .set(rpc.gas_price_scale_factor);
+    GENERAL_METRICS
+        .rpc_estimate_gas_pubdata_price_factor
+        .set(rpc.estimate_gas_pubdata_price_factor);
 }
 
 fn init_and_report_internal_config_manager(


### PR DESCRIPTION
## Summary

Surfaces startup-only configuration values that are useful when operating hosted chains as Prometheus gauges. The PR now covers the original block seal, batch seal and RPC limits, plus fee policy, fake prover mode, L1 submission caps, transaction admission limits, price source policy and batch verification mode.

All values are set once at startup from the loaded `Config`, alongside the existing `fee_collector_address` and `chain_id` metrics. Secret values and API keys are not exposed. Optional numeric values use a `*_enabled` gauge plus a value gauge set to zero when unset; optional address overrides are exposed as one-value label gauges only when configured.

### New metrics

**Block seal criteria** (from `SequencerConfig`):
- `block_seal_block_time_seconds`
- `block_seal_max_transactions_in_block`
- `block_seal_block_gas_limit`
- `block_seal_block_pubdata_limit_bytes`

**Batch seal criteria** (from `BatcherConfig`):
- `batch_seal_batch_timeout_seconds`
- `batch_seal_tx_per_batch_limit`
- `batch_seal_interop_roots_per_batch_limit`

**RPC request limits** (from `RpcConfig`):
- `rpc_eth_call_gas`
- `rpc_max_connections`
- `rpc_max_request_size_bytes`
- `rpc_max_response_size_bytes`
- `rpc_max_blocks_per_filter`
- `rpc_max_logs_per_response`
- `rpc_stale_filter_ttl_seconds`
- `rpc_send_raw_transaction_sync_timeout_seconds`
- `rpc_gas_price_scale_factor`
- `rpc_estimate_gas_pubdata_price_factor`

**Fee policy** (from `FeeConfig`):
- `fee_native_price_usd`
- `fee_native_per_gas`
- `fee_base_fee_override_enabled`
- `fee_base_fee_override_wei`
- `fee_native_price_override_enabled`
- `fee_native_price_override_wei`
- `fee_pubdata_price_override_enabled`
- `fee_pubdata_price_override_wei`
- `fee_pubdata_price_cap_enabled`
- `fee_pubdata_price_cap_wei`

**Proving mode** (from `ProverApiConfig`):
- `proving_fake_fri_provers_enabled`
- `proving_fake_snark_provers_enabled`

**L1 submission policy** (from `L1SenderConfig`):
- `l1_sender_max_fee_per_gas_wei`
- `l1_sender_max_priority_fee_per_gas_wei`
- `l1_sender_max_fee_per_blob_gas_wei`

**Transaction admission policy** (from `MempoolConfig` / `MempoolTxValidatorConfig`):
- `mempool_max_pending_txs`
- `mempool_max_pending_size_bytes`
- `mempool_minimal_protocol_basefee`
- `tx_validator_max_input_bytes`

**Price source policy** (from `ExternalPriceApiClientConfig` / `BaseTokenPriceUpdaterConfig`):
- `external_price_api_source{source=...}`
- `base_token_price_fallback_prices_count`
- `base_token_price_base_token_addr_override_enabled`
- `base_token_price_base_token_addr_override{address=...}`
- `base_token_price_base_token_decimals_override_enabled`
- `base_token_price_base_token_decimals_override`
- `base_token_price_gateway_base_token_addr_override_enabled`
- `base_token_price_gateway_base_token_addr_override{address=...}`

**Batch verification policy** (from `BatchVerificationConfig`):
- `batch_verification_server_enabled`
- `batch_verification_client_enabled`

Durations are reported in seconds and sizes in bytes, following Prometheus conventions and the units already used elsewhere in the codebase.

## Verification

- `cargo fmt --all -- --check`
- `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include CARGO_BUILD_JOBS=1 cargo check -p zksync_os_server`
