### PR TITLE
feat(rpc): track gas used per eth_call

### DIFF
--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -1,6 +1,7 @@
 use crate::call_fees::{CallFees, CallFeesError};
 use crate::config::RpcConfig;
 use crate::js_tracer;
+use crate::metrics::API_METRICS;
 use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute};
@@ -302,25 +303,25 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> Result<Bytes, EthCallError> {
         let mut execution_env = self.prepare_execution_env(request, block, block_overrides)?;
+        execution_env.block_context.eip1559_basefee = U256::from(0);
+
         let storage_view = self
             .storage
             .state_at_block_number_or_latest(execution_env.block_context.block_number)?;
+        let state_view = OverriddenStateView::with_state_overrides(
+            storage_view,
+            state_overrides.unwrap_or_default(),
+        );
 
-        execution_env.block_context.eip1559_basefee = U256::from(0);
-        let res = match state_overrides {
-            Some(overrides) => execute(
-                execution_env.transaction,
-                execution_env.block_context,
-                OverriddenStateView::with_state_overrides(storage_view, overrides),
-            ),
-            None => execute(
-                execution_env.transaction,
-                execution_env.block_context,
-                storage_view,
-            ),
-        }
+        let res = execute(
+            execution_env.transaction,
+            execution_env.block_context,
+            state_view,
+        )
         .map_err(EthCallError::ForwardSubsystemError)?
         .map_err(EthCallError::InvalidTransaction)?;
+
+        API_METRICS.call_gas_used[&"eth_call".to_string()].observe(res.gas_used);
 
         match res.execution_result {
             ExecutionResult::Success(

--- a/lib/rpc/src/metrics.rs
+++ b/lib/rpc/src/metrics.rs
@@ -11,6 +11,20 @@ use vise::{
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.000001..=32.0, 2.0);
 const BLOCK_COUNTS: Buckets = Buckets::exponential(1.0..=100000.0, 10.0);
 const BYTES_BUCKETS: Buckets = Buckets::exponential(1.0..=10485760.0, 2.0); // 1B .. 10MB
+const GAS_BUCKETS: Buckets = Buckets::values(&[
+    20_000.0,
+    50_000.0,
+    100_000.0,
+    200_000.0,
+    500_000.0,
+    1_000_000.0,
+    2_000_000.0,
+    5_000_000.0,
+    10_000_000.0,
+    20_000_000.0,
+    50_000_000.0,
+    100_000_000.0,
+]);
 const RATIO_BUCKETS: Buckets = Buckets::values(&[
     0.0, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
 ]);
@@ -92,6 +106,10 @@ pub struct Api {
     pub cancelled: LabeledFamily<String, Counter>,
     #[metrics(labels = ["method"])]
     pub panicked: LabeledFamily<String, Counter>,
+    /// Gas consumed by methods whose execution cost scales with gas (eth_call, eth_estimateGas,
+    /// debug_traceTransaction, debug_traceCall). Always recorded, including on revert.
+    #[metrics(labels = ["method"], buckets = GAS_BUCKETS)]
+    pub call_gas_used: LabeledFamily<String, Histogram<u64>>,
 }
 
 #[vise::register]


### PR DESCRIPTION
## Summary

- Adds `api_call_gas_used{method="eth_call"}` histogram with round gas buckets (20k, 50k, 100k, 200k, 500k, 1M, 2M, 5M, 10M, 20M, 50M, 100M, +Inf) to the existing `Api` metrics struct
- Records gas from `TxOutput.gas_used` after every `eth_call` execution, including reverts — only skipped on pre-execution failures (`InvalidTransaction`) and VM crashes (`ForwardSubsystemError`) where no `TxOutput` is available
- Consolidates the `state_overrides` match into a single `OverriddenStateView` construction (empty overrides are a no-op pass-through, so no behaviour change)

Motivation: when clients spam heavy `eth_call`s the existing `api_response_time_seconds` histogram shows latency but not why. `api_call_gas_used` lets you correlate slow calls with actual EVM work, alert on p99 gas, and compute total gas throughput per second.

Example queries:
```promql
# p99 gas per eth_call
histogram_quantile(0.99, rate(api_call_gas_used_bucket{method="eth_call"}[5m]))

# total gas load from eth_call per second
rate(api_call_gas_used_sum{method="eth_call"}[5m])
```

## Test plan

- [ ] Build passes (`cargo build -p zksync_os_rpc`)
- [ ] Existing RPC tests pass (`cargo nextest run -p zksync_os_rpc`)
- [ ] Verify metric appears in Prometheus scrape after an `eth_call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)