### PR TITLE
feat(mempool): stream interop txs only during gateway SL

### DIFF
--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -6,7 +6,7 @@ use crate::subpools::l2::{L2Subpool, L2TransactionsStreamMarker};
 use crate::subpools::sl_chain_id::SlChainIdSubpool;
 use crate::subpools::upgrade::{UpgradeSubpool, UpgradeTransactionsStream};
 use alloy::consensus::{Header, Sealed};
-use alloy::primitives::TxHash;
+use alloy::primitives::{ChainId, TxHash};
 use futures::stream::{BoxStream, PollNext};
 use futures::{Stream, StreamExt};
 use reth_execution_types::ChangedAccount;
@@ -55,10 +55,15 @@ impl<T: L2Subpool> Pool<T> {
     /// Also provides upgrade information is there is one (which is not necessarily accompanied by
     /// an upgrade transaction).
     ///
+    /// `include_interop_traffic` should be `false` whenever the chain currently settles on L1 --
+    /// in that case interop-root and interop-fee system txs are not valid downstream (they only
+    /// flow through Gateway settlement) and must not be included in produced blocks.
+    ///
     /// Returns `None` if all transaction sources are closed.
     pub async fn best_transactions_stream<'a>(
         &'a mut self,
         next_interop_tx_allowed_after: Instant,
+        include_interop_traffic: bool,
     ) -> Option<StreamOutcome<'a>> {
         let mut upgrade_info_stream = self.upgrade_subpool.upgrade_info_stream().await;
 
@@ -137,7 +142,7 @@ impl<T: L2Subpool> Pool<T> {
                         stream: MarkingTxStream::unmarkable(sl_chain_id_stream),
                     });
                 }
-                Some(_) = interop_related_stream.peek() => {
+                Some(_) = interop_related_stream.peek(), if include_interop_traffic => {
                     return Some(StreamOutcome {
                         upgrade_metadata,
                         stream: MarkingTxStream::unmarkable(interop_related_stream),
@@ -208,7 +213,7 @@ impl<T: L2Subpool> Pool<T> {
                     SystemTxType::SetInteropFee(_) => {
                         interop_fee_txs.push(system_tx);
                     }
-                    SystemTxType::SetSLChainId(_) => {
+                    SystemTxType::SetSLChainId(_, _) => {
                         sl_chain_id_txs.push(system_tx);
                     }
                 },
@@ -234,7 +239,7 @@ impl<T: L2Subpool> Pool<T> {
             .interop_fee_subpool
             .on_canonical_state_change(interop_fee_txs, strict_subpool_cleanup)
             .await;
-        let last_migration_number = self
+        let sl_chain_id_outcome = self
             .sl_chain_id_subpool
             .on_canonical_state_change(sl_chain_id_txs)
             .await;
@@ -269,7 +274,8 @@ impl<T: L2Subpool> Pool<T> {
         StateChangeOutcome {
             last_interop_log_id,
             last_l1_priority_id,
-            last_migration_number,
+            last_migration_number: sl_chain_id_outcome.map(|o| o.last_migration_number),
+            last_sl_chain_id_target: sl_chain_id_outcome.map(|o| o.last_sl_chain_id_target),
             last_interop_fee_number,
         }
     }
@@ -292,6 +298,9 @@ pub struct StateChangeOutcome {
     pub last_l1_priority_id: Option<L1TxSerialId>,
     /// Last migration number that was executed after canonical state change.
     pub last_migration_number: Option<u64>,
+    /// Target settlement-layer chain id of the last `SetSLChainId` system tx applied in the
+    /// block (excluding the `u64::MAX` upgrade placeholder).
+    pub last_sl_chain_id_target: Option<ChainId>,
     /// Last interop fee update number that was executed after canonical state change.
     pub last_interop_fee_number: Option<u64>,
 }

--- a/lib/mempool/src/subpools/sl_chain_id.rs
+++ b/lib/mempool/src/subpools/sl_chain_id.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::ChainId;
 use futures::{Stream, StreamExt};
 use std::collections::VecDeque;
 use std::pin::Pin;
@@ -6,6 +7,19 @@ use std::task::{Context, Poll, ready};
 use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_types::{SystemTxEnvelope, SystemTxType, ZkTransaction};
+
+/// Result of reconciling a block's transactions with the [`SlChainIdSubpool`].
+///
+/// Both fields refer to the most recent non-placeholder `SetSLChainId` system tx observed in
+/// the block (one block contains at most one such tx in practice — the subpool serves them
+/// individually).
+#[derive(Clone, Copy, Debug)]
+pub struct SlChainIdOutcome {
+    /// Migration number of the last observed `SetSLChainId` tx.
+    pub last_migration_number: u64,
+    /// Target settlement-layer chain id of that same tx.
+    pub last_sl_chain_id_target: ChainId,
+}
 
 #[derive(Clone)]
 pub struct SlChainIdSubpool {
@@ -49,7 +63,7 @@ impl SlChainIdSubpool {
 
     pub async fn insert(&self, tx: SystemTxEnvelope) {
         assert!(
-            matches!(tx.system_subtype(), SystemTxType::SetSLChainId(_)),
+            matches!(tx.system_subtype(), SystemTxType::SetSLChainId(_, _)),
             "tried to insert unrelated system tx ({:?}) into `SlChainIdSubpool`",
             tx.system_subtype()
         );
@@ -77,15 +91,18 @@ impl SlChainIdSubpool {
         }
     }
 
-    pub async fn on_canonical_state_change(&self, txs: Vec<&SystemTxEnvelope>) -> Option<u64> {
+    /// Returns the migration_number and the target SL chain id of the most recent
+    /// non-placeholder `SetSLChainId` tx observed across `txs`.
+    pub async fn on_canonical_state_change(
+        &self,
+        txs: Vec<&SystemTxEnvelope>,
+    ) -> Option<SlChainIdOutcome> {
         if txs.is_empty() {
             return None;
         }
 
-        let mut last_migration_number = None;
-
         for tx in txs {
-            if matches!(tx.system_subtype(), SystemTxType::SetSLChainId(u64::MAX)) {
+            if matches!(tx.system_subtype(), SystemTxType::SetSLChainId(_, u64::MAX)) {
                 // If we received a transaction with migration number `u64::MAX`, it means
                 // that this is the transaction we executed along with upgrade, so it is not present in the subpool and we should not expect it from the stream.
                 // The migration number should not be updated then, so we need to just skip the transaction.
@@ -95,11 +112,16 @@ impl SlChainIdSubpool {
             let pending_tx = self.pop_wait().await;
             assert_eq!(tx, &pending_tx);
 
-            if let SystemTxType::SetSLChainId(migration_number) = *tx.system_subtype() {
-                last_migration_number = Some(migration_number);
+            if let SystemTxType::SetSLChainId(target_sl_chain_id, migration_number) =
+                *tx.system_subtype()
+            {
+                return Some(SlChainIdOutcome {
+                    last_migration_number: migration_number,
+                    last_sl_chain_id_target: target_sl_chain_id,
+                });
             }
         }
-        last_migration_number
+        None
     }
 }
 

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -43,6 +43,11 @@ pub struct BlockContextProvider<Subpool> {
     /// Can change in runtime in case of upgrades.
     protocol_version: ProtocolSemanticVersion,
     sl_chain_id_at_startup: u64,
+    /// L2 chain id of the chain's currently-active settlement layer. Can change in runtime if there
+    /// is a migration in the process.
+    current_sl_chain_id: u64,
+    /// L1 chain id, fixed at startup.
+    l1_chain_id: u64,
     /// Whether the one-time `SetSLChainId` system transaction has already been included.
     /// Initialized to `true` on restart when already at v31+, since it must have been
     /// included in a prior run. Also set to `true` during replay when a v31 block is
@@ -71,6 +76,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
         service_block_delay: Duration,
         protocol_version: ProtocolSemanticVersion,
         sl_chain_id_at_startup: u64,
+        l1_chain_id: u64,
         fee_collector_address: Address,
         last_constructed_block_ctx_sender: watch::Sender<Option<BlockContext>>,
         fee_provider: FeeProvider,
@@ -96,11 +102,19 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
             next_interop_tx_allowed_after: Instant::now(),
             protocol_version,
             sl_chain_id_at_startup,
+            current_sl_chain_id: sl_chain_id_at_startup,
+            l1_chain_id,
             sl_chain_id_set,
             fee_collector_address,
             last_constructed_block_ctx_sender,
             fee_provider,
         }
+    }
+
+    /// `true` when the chain currently settles on a Gateway (i.e. its tracked SL chain id
+    /// differs from L1's).
+    fn settles_on_gateway(&self) -> bool {
+        self.current_sl_chain_id != self.l1_chain_id
     }
 
     pub fn next_block_number(&self) -> u64 {
@@ -122,7 +136,10 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                 // - L1 transactions first, then L2 transactions.
                 let best_txs = self
                     .pool
-                    .best_transactions_stream(self.next_interop_tx_allowed_after)
+                    .best_transactions_stream(
+                        self.next_interop_tx_allowed_after,
+                        self.settles_on_gateway(),
+                    )
                     .await
                     .context("mempool is closed")?;
 
@@ -413,6 +430,20 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
 
         if let Some(last_migration_number) = outcome.last_migration_number {
             self.next_cursors.migration_number = last_migration_number + 1;
+        }
+        if let Some(target_sl_chain_id) = outcome.last_sl_chain_id_target {
+            // Subsequent produced blocks will gate interop traffic on the new value (in particular:
+            // stop including interop-root / interop-fee txs once we've migrated back to L1).
+            // Otherwise, we will end up with blocks/batches that must be committed to L1 but
+            // include interop txs which leads to `CommitBasedInteropNotSupported` revert.
+            if self.current_sl_chain_id != target_sl_chain_id {
+                tracing::info!(
+                    previous_sl_chain_id = self.current_sl_chain_id,
+                    new_sl_chain_id = target_sl_chain_id,
+                    "applied SetSLChainId tx; updating runtime settlement layer pointer"
+                );
+                self.current_sl_chain_id = target_sl_chain_id;
+            }
         }
         if let Some(last_interop_fee_number) = outcome.last_interop_fee_number {
             self.next_cursors.interop_fee_number = last_interop_fee_number + 1;

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -251,7 +251,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                         matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
                             && matches!(
                                 window[1].as_system_tx_type(),
-                                Some(SystemTxType::SetSLChainId(_))
+                                Some(SystemTxType::SetSLChainId(_, _))
                             )
                     })
                     .is_some();
@@ -351,7 +351,7 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
                         matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
                             && matches!(
                                 window[1].as_system_tx_type(),
-                                Some(SystemTxType::SetSLChainId(_))
+                                Some(SystemTxType::SetSLChainId(_, _))
                             )
                     })
                     .is_some();

--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -196,7 +196,7 @@ pub async fn execute_block_in_vm<V: ViewState>(
                         }
 
                         // If the transaction provided is an SL chain id update transaction, we need to seal the block.
-                        if let Some(SystemTxType::SetSLChainId(_)) = executed_txs.last().unwrap().as_system_tx_type() {
+                        if let Some(SystemTxType::SetSLChainId(_, _)) = executed_txs.last().unwrap().as_system_tx_type() {
                             match &command.seal_policy {
                                 SealPolicy::Decide(..) | SealPolicy::UntilExhausted { allowed_to_finish_early: true } => {
                                     tracing::info!(block_number = ctx.block_number, "sealing block as chain id update tx was executed");

--- a/lib/types/src/transaction/system/mod.rs
+++ b/lib/types/src/transaction/system/mod.rs
@@ -127,8 +127,8 @@ impl SystemTxEnvelope {
                 SystemTxInput::ImportInteropRoots(roots) => {
                     SystemTxType::ImportInteropRoots(roots.len() as u64)
                 }
-                SystemTxInput::SetSLChainId(_, migration_number) => {
-                    SystemTxType::SetSLChainId(migration_number)
+                SystemTxInput::SetSLChainId(chain_id, migration_number) => {
+                    SystemTxType::SetSLChainId(chain_id, migration_number)
                 }
                 SystemTxInput::SetInteropFee(_, interop_fee_number) => {
                     SystemTxType::SetInteropFee(interop_fee_number)

--- a/lib/types/src/transaction/system/utils.rs
+++ b/lib/types/src/transaction/system/utils.rs
@@ -23,8 +23,10 @@ pub const SYSTEM_TX_TYPE_ID: u8 = 125;
 pub enum SystemTxType {
     /// Transaction subtype for importing interop roots, contains the number of interop roots imported
     ImportInteropRoots(u64),
-    /// Transaction subtype for setting the settlement layer chain id, contains migration number
-    SetSLChainId(u64),
+    /// Transaction subtype for setting the settlement layer chain id; carries the target SL
+    /// chain id and the migration number. The migration number is `u64::MAX` for the v31 upgrade
+    /// placeholder (which only initialises the field, not a real migration).
+    SetSLChainId(ChainId, u64),
     /// Transaction subtype for setting the interop fee, contains interop fee update number.
     SetInteropFee(u64),
 }

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -97,7 +97,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
     let set_sl_chain_id_migration_number = blocks.iter().find_map(|(_, replay_record, _, _)| {
         replay_record.transactions.iter().find_map(|tx| {
             if let ZkEnvelope::System(system_tx) = tx.envelope()
-                && let SystemTxType::SetSLChainId(n) = system_tx.system_subtype()
+                && let SystemTxType::SetSLChainId(_, n) = system_tx.system_subtype()
                 && *n != u64::MAX
             {
                 Some(*n)

--- a/node/bin/src/batcher/seal_criteria.rs
+++ b/node/bin/src/batcher/seal_criteria.rs
@@ -68,11 +68,12 @@ impl BatchInfoAccumulator {
             .sum::<u64>();
 
         // If there is a chain id update transaction not in the first block(note `self.block_count > 1`), we need to seal the batch for gateway migration(so it goes in the first block of the next batch)
-        if replay_record
-            .transactions
-            .iter()
-            .any(|tx| matches!(tx.as_system_tx_type(), Some(SystemTxType::SetSLChainId(_))))
-            && self.block_count > 1
+        if replay_record.transactions.iter().any(|tx| {
+            matches!(
+                tx.as_system_tx_type(),
+                Some(SystemTxType::SetSLChainId(_, _))
+            )
+        }) && self.block_count > 1
         {
             self.should_seal_for_gateway_migration = true;
         }
@@ -91,7 +92,7 @@ impl BatchInfoAccumulator {
                         && replay_record.protocol_version.minor == 31
                         && matches!(
                             replay_record.transactions[1].as_system_tx_type(),
-                            Some(SystemTxType::SetSLChainId(u64::MAX))
+                            Some(SystemTxType::SetSLChainId(_, u64::MAX))
                         )),
                 "upgrade tx must be the only tx in the block (or followed by a single SetSLChainId tx for v31): {replay_record:?}"
             );

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -810,6 +810,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         config.sequencer_config.service_block_delay,
         current_protocol_version.clone(),
         node_startup_state.l1_state.sl_chain_id,
+        node_startup_state.l1_state.l1_chain_id,
         config.sequencer_config.fee_collector_address,
         last_constructed_block_ctx_sender,
         fee_provider,


### PR DESCRIPTION
## Summary

Currently interop system transactions can bleed into L1 interval if we migrate from GW -> L1. This PR fixes it

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

