### PR TITLE
refactor(rpc): refactor estimate_gas_with_view for clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "bytestring",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
@@ -131,7 +131,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash 0.1.5",
  "futures-core",
@@ -340,7 +340,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -368,7 +368,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -442,7 +442,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "itoa",
  "serde",
  "serde_json",
@@ -526,7 +526,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "serde",
  "serde_with",
@@ -551,7 +551,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "serde",
  "serde_with",
@@ -572,7 +572,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "revm",
  "thiserror 2.0.17",
  "tracing",
@@ -666,7 +666,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -719,7 +719,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.17.1",
@@ -918,7 +918,7 @@ checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
 ]
@@ -934,7 +934,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 2.0.4",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -1199,7 +1199,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
@@ -1258,7 +1258,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "derive_arbitrary",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "nybbles",
  "proptest",
  "proptest-derive 0.7.0",
@@ -3478,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -4108,7 +4108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4208,11 +4208,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.0.1",
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -4229,13 +4229,14 @@ dependencies = [
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -8992,7 +8993,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "metrics",
  "parking_lot",
  "pin-project",
@@ -9026,7 +9027,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -9084,7 +9085,7 @@ version = "2.2.0"
 source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4b231f55daeb2e00#ff8afdc5dbc253019df5b68f4b231f55daeb2e00"
 dependencies = [
  "alloy-primitives",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "eyre",
  "libc",
  "metrics",
@@ -9117,7 +9118,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "metrics",
  "modular-bitfield",
  "proptest",
@@ -9180,7 +9181,7 @@ source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -9292,7 +9293,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures",
  "pin-project",
  "reth-codecs",
@@ -9323,7 +9324,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -9385,7 +9386,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures-util",
  "rayon",
  "reth-execution-errors",
@@ -9440,7 +9441,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -9468,7 +9469,7 @@ dependencies = [
  "byteorder",
  "crossbeam-queue",
  "dashmap",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -9532,7 +9533,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -9588,7 +9589,7 @@ dependencies = [
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "enr",
  "futures",
  "reth-eth-wire-types",
@@ -9611,7 +9612,7 @@ dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures",
  "parking_lot",
  "reth-consensus",
@@ -9661,7 +9662,7 @@ source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
  "reth-fs-util",
@@ -9736,7 +9737,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "dashmap",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
  "proptest",
@@ -9805,7 +9806,7 @@ source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
@@ -9861,7 +9862,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",
@@ -9946,7 +9947,7 @@ version = "2.2.0"
 source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4b231f55daeb2e00#ff8afdc5dbc253019df5b68f4b231f55daeb2e00"
 dependencies = [
  "alloy-primitives",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "fixed-map",
  "reth-stages-types",
  "serde",
@@ -9986,7 +9987,7 @@ dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-prune-types",
@@ -10128,7 +10129,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "hash-db",
  "itertools 0.14.0",
  "nybbles",
@@ -10830,7 +10831,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11728,7 +11729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15175,6 +15176,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "dashmap",
+ "derive_more 2.1.1",
  "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ tikv-jemallocator = { version = "0.6.1", features = [
 ] }
 tikv-jemalloc-ctl = "0.6.1"
 clap = "4.2.2"
+derive_more = "2.1.1"
 insta = "1.29.0"
 jsonrpsee = { version = "0.26.0", default-features = false }
 leb128 = "0.2.5"

--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -1,5 +1,5 @@
 use alloy::eips::Encodable2718;
-use alloy::network::TransactionBuilder;
+use alloy::network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy::primitives::{Address, TxKind, U256, utils::parse_ether};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -39,6 +39,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 blake2.workspace = true
 dashmap.workspace = true
+derive_more.workspace = true
 futures.workspace = true
 jsonrpsee = { workspace = true, default-features = false, features = ["macros", "client"] }
 roaring.workspace = true

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -532,7 +532,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135>
         const GAS_STIPEND: u64 = 2_300;
         let optimistic_gas_limit = (gas_used + res.gas_refunded + GAS_STIPEND) * 64 / 63;
-        if optimistic_gas_limit < range.highest {
+        if optimistic_gas_limit > range.lowest && optimistic_gas_limit < range.highest {
             range.apply_probe(
                 run_at(optimistic_gas_limit)?,
                 Probe::Optimistic(optimistic_gas_limit),

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -485,41 +485,14 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         let mut highest_gas_limit = request.gas.unwrap_or(block_gas_limit).min(block_gas_limit);
 
-        // Check funds of the sender (only useful to check if transaction gas price is more than 0).
-        //
-        // The caller allowance is check by doing `(account.balance - tx.value) / tx.gas_price`
-        if request
+        let effective_gas_price = request
             .gas_price
             .or(request.max_fee_per_gas)
-            .unwrap_or_default()
-            > 0
-        {
-            let balance = storage_view
-                .get_account(request.from.unwrap_or_default())
-                .as_ref()
-                .map(get_balance)
-                .unwrap_or_default();
-
-            let value = request.value.unwrap_or_default();
-            // Subtract transferred value from the caller balance. Return error if the caller has
-            // insufficient funds.
-            let balance = balance
-                .checked_sub(value)
-                .ok_or(EthCallError::InvalidTransaction(
-                    InvalidTransaction::LackOfFundForMaxFee {
-                        fee: value,
-                        balance,
-                    },
-                ))?;
-            // Cap the highest gas limit by max gas caller can afford with given gas price
-            highest_gas_limit = highest_gas_limit.min(
-                // Calculate the amount of gas the caller can afford with the specified gas price.
-                balance
-                    .checked_div(block_context.eip1559_basefee)
-                    // This will be 0 if gas price is 0. It is fine, because we check it before.
-                    .unwrap_or_default()
-                    .saturating_to(),
-            );
+            .unwrap_or_default();
+        if effective_gas_price > 0 {
+            let gas_limit_from_balance =
+                max_gas_from_balance(&request, block_context.eip1559_basefee, &mut storage_view)?;
+            highest_gas_limit = highest_gas_limit.min(gas_limit_from_balance);
         }
         request.set_gas_limit(highest_gas_limit);
         let tx = self.create_tx_from_request(request, &block_context, true)?;
@@ -752,6 +725,34 @@ pub fn update_estimated_gas_range(
             *lowest_gas_limit = tx_gas_limit;
         }
     }
+}
+
+/// Returns how much gas the sender can afford: `(balance - value) / gas_price`.
+fn max_gas_from_balance<V: ViewState>(
+    request: &TransactionRequest,
+    gas_price: U256,
+    storage_view: &mut V,
+) -> Result<u64, EthCallError> {
+    let balance = storage_view
+        .get_account(request.from.unwrap_or_default())
+        .as_ref()
+        .map(get_balance)
+        .unwrap_or_default();
+
+    let value = request.value.unwrap_or_default();
+    let balance = balance
+        .checked_sub(value)
+        .ok_or(EthCallError::InvalidTransaction(
+            InvalidTransaction::LackOfFundForMaxFee {
+                fee: value,
+                balance,
+            },
+        ))?;
+
+    Ok(balance
+        .checked_div(gas_price)
+        .unwrap_or_default()
+        .saturating_to())
 }
 
 /// Error types returned by `eth_call` implementation

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -480,9 +480,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // original geth logic. Source:
         // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
 
-        // the gas limit of the corresponding block
         let block_gas_limit = block_context.gas_limit;
-
         let mut highest_gas_limit = request.gas.unwrap_or(block_gas_limit).min(block_gas_limit);
 
         let effective_gas_price = request
@@ -505,117 +503,73 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         };
 
         // Execute the transaction with the highest possible gas limit.
-        let mut res = try_at(highest_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
+        let res = try_at(tx.gas_limit())?.map_err(EthCallError::InvalidTransaction)?;
         tracing::trace!(
-            "Executed tx in estimate_gas with highest gas limit {highest_gas_limit}, result {res:?}"
+            "Executed tx in estimate_gas with highest gas limit {}, result {res:?}",
+            tx.gas_limit()
         );
-        match res.execution_result {
-            ExecutionResult::Success(_) => {
-                // Transaction succeeded with the highest possible gas limit, we can proceed with
-                // binary search
-            }
-            ExecutionResult::Revert(output) => {
-                let error = RevertError::new(Bytes::from(output));
-                return Err(EthCallError::Revert(error));
-            }
+        if let ExecutionResult::Revert(output) = res.execution_result {
+            return Err(EthCallError::Revert(RevertError::new(Bytes::from(output))));
         }
-
-        // we know the tx succeeded with the configured gas limit, so we can use that as the
-        // highest, in case we applied a gas cap due to caller allowance above
-        highest_gas_limit = tx.gas_limit();
 
         // NOTE: this is the gas the transaction used, which is less than the
         // transaction requires to succeed.
         let mut gas_used = res.gas_used;
-        // the lowest value is capped by the gas used by the unconstrained transaction
-        let mut lowest_gas_limit = gas_used.saturating_sub(1);
+        let mut range = GasRange::new(gas_used.saturating_sub(1), tx.gas_limit());
 
         // As stated in Geth, there is a good chance that the transaction will pass if we set the
-        // gas limit to the execution gas used plus the gas refund, so we check this first
-        // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135
-        //
-        // Calculate the optimistic gas limit by adding gas used and gas refund,
-        // then applying a 64/63 multiplier to account for gas forwarding rules.
+        // gas limit to the execution gas used plus the gas refund, so we check this first.
+        // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135>
+        // The 64/63 multiplier accounts for gas forwarding rules (EIP-150).
         let optimistic_gas_limit = (gas_used + res.gas_refunded + 2_300) * 64 / 63;
-        if optimistic_gas_limit < highest_gas_limit {
-            res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
+        if optimistic_gas_limit < range.highest {
+            let res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
             tracing::trace!(
                 "Executed tx in estimate_gas with optimistic gas limit {optimistic_gas_limit}, result {res:?}"
             );
-
-            // Update the gas used based on the new result.
             gas_used = res.gas_used;
-            // Update the gas limit estimates (highest and lowest) based on the execution result.
-            update_estimated_gas_range(
-                res.execution_result,
-                optimistic_gas_limit,
-                &mut highest_gas_limit,
-                &mut lowest_gas_limit,
-            );
-        };
+            range.update(res.execution_result, optimistic_gas_limit);
+        }
 
         if tx.tx_type() == ZkTxType::L1 {
             // L1 contracts enforce a higher minimal limit for extra security
             gas_used = gas_used.max(L1_TX_MINIMAL_GAS_LIMIT);
-            lowest_gas_limit = lowest_gas_limit.max(L1_TX_MINIMAL_GAS_LIMIT);
-            highest_gas_limit = highest_gas_limit.max(L1_TX_MINIMAL_GAS_LIMIT);
+            range.apply_floor(L1_TX_MINIMAL_GAS_LIMIT);
         }
-
-        // Pick a point that's close to the estimated gas
-        let mut mid_gas_limit = std::cmp::min(
-            gas_used * 3,
-            ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64,
-        );
 
         // Binary search narrows the range to find the minimum gas limit needed for the transaction
         // to succeed.
-        while lowest_gas_limit + 1 < highest_gas_limit {
-            // An estimation error is allowed once the current gas limit range used in the binary
-            // search is small enough (less than 1.5% of the highest gas limit)
-            // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152
-            if (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64)
-                < ESTIMATE_GAS_ERROR_RATIO
-            {
+        // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152>
+        let mut mid = range.biased_midpoint(gas_used);
+        while !range.is_empty() {
+            // Stop once error is within 1.5% of the highest gas limit.
+            if range.is_narrow_enough() {
                 break;
-            };
+            }
+            tracing::trace!("trying to simulate transaction with gas_limit {mid}");
 
-            tracing::trace!("trying to simulate transaction with gas_limit {mid_gas_limit}");
-
-            // Execute transaction and handle potential gas errors, adjusting limits accordingly.
-            match try_at(mid_gas_limit)? {
+            match try_at(mid)? {
                 Err(InvalidTransaction::CallerGasLimitMoreThanBlock) => {
-                    // Decrease the highest gas limit if gas is too high
-                    highest_gas_limit = mid_gas_limit;
+                    range.highest = mid;
                 }
                 Err(
                     InvalidTransaction::CallGasCostMoreThanGasLimit
                     | InvalidTransaction::OutOfGasDuringValidation
                     | InvalidTransaction::OutOfNativeResourcesDuringValidation,
                 ) => {
-                    // Increase the lowest gas limit if gas is too low
-                    lowest_gas_limit = mid_gas_limit;
+                    range.lowest = mid;
                 }
-                // Handle other cases, including successful transactions.
                 ethres => {
-                    // Unpack the result and environment if the transaction was successful.
-                    res = ethres.map_err(EthCallError::InvalidTransaction)?;
+                    let res = ethres.map_err(EthCallError::InvalidTransaction)?;
                     tracing::trace!(
-                        "Executed tx in estimate_gas with gas limit {mid_gas_limit}, result {res:?}"
+                        "Executed tx in estimate_gas with gas limit {mid}, result {res:?}"
                     );
-                    // Update the estimated gas range based on the transaction result.
-                    update_estimated_gas_range(
-                        res.execution_result,
-                        mid_gas_limit,
-                        &mut highest_gas_limit,
-                        &mut lowest_gas_limit,
-                    );
+                    range.update(res.execution_result, mid);
                 }
             }
-
-            // New midpoint
-            mid_gas_limit = ((highest_gas_limit as u128 + lowest_gas_limit as u128) / 2) as u64;
+            mid = range.midpoint();
         }
-        tracing::trace!("Estimated gas limit: {highest_gas_limit}");
+        tracing::trace!("Estimated gas limit: {}", range.highest);
 
         // Re-execute the resolved gas limit once with the validator wired in.
         // The binary search runs without the validator (one round-trip per
@@ -626,7 +580,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             && tx_type_runs_policy(tx.tx_type())
         {
             let mut judged_tx = tx.clone();
-            set_gas_limit(&mut judged_tx, highest_gas_limit);
+            set_gas_limit(&mut judged_tx, range.highest);
             let mut policy_session = policy_client.session(AccessType::Write);
             simulate_with_optional_policy(
                 judged_tx,
@@ -638,7 +592,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             .map_err(map_simulate_invalid_to_call_error)?;
         }
 
-        Ok(U256::from(highest_gas_limit))
+        Ok(U256::from(range.highest))
     }
 
     pub fn last_constructed_block_context(&self) -> Option<BlockContext> {
@@ -682,6 +636,45 @@ fn tx_type_runs_policy(tx_type: ZkTxType) -> bool {
     }
 }
 
+struct GasRange {
+    lowest: u64,
+    highest: u64,
+}
+
+impl GasRange {
+    fn new(lowest: u64, highest: u64) -> Self {
+        Self { lowest, highest }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lowest + 1 >= self.highest
+    }
+
+    fn is_narrow_enough(&self) -> bool {
+        (self.highest - self.lowest) as f64 / (self.highest as f64) < ESTIMATE_GAS_ERROR_RATIO
+    }
+
+    fn midpoint(&self) -> u64 {
+        ((self.highest as u128 + self.lowest as u128) / 2) as u64
+    }
+
+    fn biased_midpoint(&self, gas_used: u64) -> u64 {
+        (gas_used * 3).min(self.midpoint())
+    }
+
+    fn apply_floor(&mut self, floor: u64) {
+        self.lowest = self.lowest.max(floor);
+        self.highest = self.highest.max(floor);
+    }
+
+    fn update(&mut self, result: ExecutionResult, at: u64) {
+        match result {
+            ExecutionResult::Success(_) => self.highest = at,
+            ExecutionResult::Revert(_) => self.lowest = at,
+        }
+    }
+}
+
 fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
     match tx.inner.inner_mut() {
         ZkEnvelope::System(_) => {
@@ -698,32 +691,6 @@ fn set_gas_limit(tx: &mut ZkTransaction, gas_limit: u64) {
             tx.to_mint = tx.value + U256::from(tx.max_fee_per_gas) * U256::from(gas_limit);
         }
         ZkEnvelope::Upgrade(envelope) => envelope.inner.gas_limit = gas_limit,
-    }
-}
-
-#[inline]
-pub fn update_estimated_gas_range(
-    result: ExecutionResult,
-    tx_gas_limit: u64,
-    highest_gas_limit: &mut u64,
-    lowest_gas_limit: &mut u64,
-) {
-    match result {
-        ExecutionResult::Success { .. } => {
-            // Cap the highest gas limit with the succeeding gas limit.
-            *highest_gas_limit = tx_gas_limit;
-        }
-        ExecutionResult::Revert { .. } => {
-            // We know that transaction succeeded with a higher gas limit before, so any failure
-            // means that we need to increase it.
-            //
-            // We are ignoring all halts here, and not just OOG errors because there are cases when
-            // non-OOG halt might flag insufficient gas limit as well.
-            //
-            // Common usage of invalid opcode in OpenZeppelin:
-            // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/94697be8a3f0dfcd95dfb13ffbd39b5973f5c65d/contracts/metatx/ERC2771Forwarder.sol#L360-L367>
-            *lowest_gas_limit = tx_gas_limit;
-        }
     }
 }
 

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -516,11 +516,10 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let mut gas_used = res.gas_used;
         let mut range = GasRange::new(gas_used.saturating_sub(1), tx.gas_limit());
 
-        // As stated in Geth, there is a good chance that the transaction will pass if we set the
-        // gas limit to the execution gas used plus the gas refund, so we check this first.
+        // Optimistic check: tx likely passes at gas_used + refund + stipend, scaled by 64/63 (EIP-150).
         // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135>
-        // The 64/63 multiplier accounts for gas forwarding rules (EIP-150).
-        let optimistic_gas_limit = (gas_used + res.gas_refunded + 2_300) * 64 / 63;
+        const GAS_STIPEND: u64 = 2_300;
+        let optimistic_gas_limit = (gas_used + res.gas_refunded + GAS_STIPEND) * 64 / 63;
         if optimistic_gas_limit < range.highest {
             let res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
             tracing::trace!(

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -660,7 +660,7 @@ impl GasRange {
     }
 
     fn midpoint(&self) -> u64 {
-        ((self.highest as u128 + self.lowest as u128) / 2) as u64
+        u64::midpoint(self.lowest, self.highest)
     }
 
     fn biased_midpoint(&self) -> u64 {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -503,7 +503,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         let tx = self.build_estimate_tx(request, &block_context, &mut storage_view)?;
 
-        let try_at = |gas_limit: u64| {
+        let run_at = |gas_limit: u64| {
             let mut attempt = tx.clone();
             set_gas_limit(&mut attempt, gas_limit);
             execute(attempt, block_context, storage_view.clone())
@@ -511,7 +511,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         };
 
         // Execute the transaction with the highest possible gas limit.
-        let res = try_at(tx.gas_limit())?.map_err(EthCallError::InvalidTransaction)?;
+        let res = run_at(tx.gas_limit())?.map_err(EthCallError::InvalidTransaction)?;
         tracing::trace!(
             "Executed tx in eth_estimateGas with gas limit: {}, result {res:?}",
             Probe::Highest(tx.gas_limit())
@@ -534,7 +534,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let optimistic_gas_limit = (gas_used + res.gas_refunded + GAS_STIPEND) * 64 / 63;
         if optimistic_gas_limit < range.highest {
             range.apply_probe(
-                try_at(optimistic_gas_limit)?,
+                run_at(optimistic_gas_limit)?,
                 Probe::Optimistic(optimistic_gas_limit),
             )?;
         }
@@ -549,7 +549,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 break;
             }
             tracing::trace!("Trying to simulate transaction with gas_limit {mid}");
-            range.apply_probe(try_at(mid)?, Probe::Midpoint(mid))?;
+            range.apply_probe(run_at(mid)?, Probe::Midpoint(mid))?;
             mid = range.midpoint();
         }
         tracing::trace!("Estimated gas limit: {}", range.highest);

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -521,12 +521,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                     .saturating_to(),
             );
         }
-        request.set_gas_limit(
-            request
-                .gas
-                .unwrap_or(highest_gas_limit)
-                .min(highest_gas_limit),
-        );
+        request.set_gas_limit(highest_gas_limit);
         let tx = self.create_tx_from_request(request, &block_context, true)?;
 
         let try_at = |gas_limit: u64| {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -13,7 +13,7 @@ use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::trace::geth::{CallConfig, GethTrace};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
-use derive_more::{Deref, Display};
+use derive_more::Deref;
 use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
@@ -513,7 +513,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // Execute the transaction with the highest possible gas limit.
         let res = run_at(tx.gas_limit())?.map_err(EthCallError::InvalidTransaction)?;
         tracing::trace!(
-            "Executed tx in eth_estimateGas with gas limit: {}, result {res:?}",
+            "Executed tx in eth_estimateGas with gas limit: {:?}, result {res:?}",
             Probe::Highest(tx.gas_limit())
         );
         if let ExecutionResult::Revert(output) = res.execution_result {
@@ -615,13 +615,10 @@ fn tx_type_runs_policy(tx_type: ZkTxType) -> bool {
     }
 }
 
-#[derive(Debug, Deref, Display)]
+#[derive(Debug, Deref)]
 enum Probe {
-    #[display("Midpoint({_0})")]
     Midpoint(u64),
-    #[display("Highest({_0})")]
     Highest(u64),
-    #[display("Optimistic({_0})")]
     Optimistic(u64),
 }
 
@@ -674,7 +671,7 @@ impl GasRange {
             return Ok(());
         }
         let res = result.map_err(EthCallError::InvalidTransaction)?;
-        tracing::trace!("Executed tx in eth_estimateGas with gas limit: {probe}, result {res:?}");
+        tracing::trace!("Executed tx in eth_estimateGas with gas limit: {probe:?}, result {res:?}");
         match res.execution_result {
             ExecutionResult::Success(_) => self.highest = *probe,
             ExecutionResult::Revert(_) => self.lowest = *probe,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -16,7 +16,7 @@ use alloy::rpc::types::{BlockOverrides, TransactionRequest};
 use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
-use zk_os_api::helpers::{get_balance, get_nonce};
+use zk_os_api::helpers::get_nonce;
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
@@ -733,11 +733,7 @@ fn max_gas_from_balance<V: ViewState>(
     gas_price: U256,
     storage_view: &mut V,
 ) -> Result<u64, EthCallError> {
-    let balance = storage_view
-        .get_account(request.from.unwrap_or_default())
-        .as_ref()
-        .map(get_balance)
-        .unwrap_or_default();
+    let balance = storage_view.balance(request.from.unwrap_or_default());
 
     let value = request.value.unwrap_or_default();
     let balance = balance

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -540,14 +540,16 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         );
         let tx = self.create_tx_from_request(request, &block_context, true)?;
 
+        let try_at = |gas_limit: u64| {
+            let mut attempt = tx.clone();
+            set_gas_limit(&mut attempt, gas_limit);
+            execute(attempt, block_context, storage_view.clone())
+                .map_err(EthCallError::ForwardSubsystemError)
+        };
+
         // Execute the transaction with the highest possible gas limit.
-        let mut res = execute(tx.clone(), block_context, storage_view.clone())
-            .map_err(EthCallError::ForwardSubsystemError)?
-            .map_err(EthCallError::InvalidTransaction)?;
-        tracing::trace!(
-            "Executed tx in estimate_gas with highest gas limit {}, result {res:?}",
-            tx.gas_limit(),
-        );
+        let mut res = try_at(highest_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
+        tracing::trace!("Executed tx in estimate_gas with highest gas limit {highest_gas_limit}, result {res:?}");
         match res.execution_result {
             ExecutionResult::Success(_) => {
                 // Transaction succeeded with the highest possible gas limit, we can proceed with
@@ -577,19 +579,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // then applying a 64/63 multiplier to account for gas forwarding rules.
         let optimistic_gas_limit = (gas_used + res.gas_refunded + 2_300) * 64 / 63;
         if optimistic_gas_limit < highest_gas_limit {
-            // Set the transaction's gas limit to the calculated optimistic gas limit.
-            let mut optimistic_tx = tx.clone();
-            set_gas_limit(&mut optimistic_tx, optimistic_gas_limit);
-
-            // Re-execute the transaction with the new gas limit and update the result and
-            // environment.
-            res = execute(optimistic_tx, block_context, storage_view.clone())
-                .map_err(EthCallError::ForwardSubsystemError)?
-                .map_err(EthCallError::InvalidTransaction)?;
-            tracing::trace!(
-                "Executed tx in estimate_gas with optimistic gas limit {}, result {res:?}",
-                tx.gas_limit()
-            );
+            res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
+            tracing::trace!("Executed tx in estimate_gas with optimistic gas limit {optimistic_gas_limit}, result {res:?}");
 
             // Update the gas used based on the new result.
             gas_used = res.gas_used;
@@ -627,17 +618,10 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 break;
             };
 
-            let mut mid_tx = tx.clone();
-            set_gas_limit(&mut mid_tx, mid_gas_limit);
-            tracing::trace!(
-                "trying to simulate transaction with gas_limit {}",
-                mid_tx.gas_limit()
-            );
+            tracing::trace!("trying to simulate transaction with gas_limit {mid_gas_limit}");
 
             // Execute transaction and handle potential gas errors, adjusting limits accordingly.
-            match execute(mid_tx, block_context, storage_view.clone())
-                .map_err(EthCallError::ForwardSubsystemError)?
-            {
+            match try_at(mid_gas_limit)? {
                 Err(InvalidTransaction::CallerGasLimitMoreThanBlock) => {
                     // Decrease the highest gas limit if gas is too high
                     highest_gas_limit = mid_gas_limit;
@@ -654,10 +638,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 ethres => {
                     // Unpack the result and environment if the transaction was successful.
                     res = ethres.map_err(EthCallError::InvalidTransaction)?;
-                    tracing::trace!(
-                        "Executed tx in estimate_gas with gas limit {}, result {res:?}",
-                        tx.gas_limit(),
-                    );
+                    tracing::trace!("Executed tx in estimate_gas with gas limit {mid_gas_limit}, result {res:?}");
                     // Update the estimated gas range based on the transaction result.
                     update_estimated_gas_range(
                         res.execution_result,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -469,16 +469,12 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 }
 
 impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
-    // The flow was heavily borrowed from reth, which in turn closely follows the original geth logic. Source:
-    // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
-    fn estimate_gas_with_view<V: ViewState + Clone>(
+    fn build_estimate_tx<V: ViewState>(
         &self,
         mut request: TransactionRequest,
-        block_context: BlockContext,
-        mut storage_view: V,
-    ) -> Result<U256, EthCallError> {
-        tracing::trace!("Estimating gas with block context {block_context:?}");
-
+        block_context: &BlockContext,
+        storage_view: &mut V,
+    ) -> Result<ZkTransaction, EthCallError> {
         let block_gas_limit = block_context.gas_limit;
         let mut highest_gas_limit = request.gas.unwrap_or(block_gas_limit).min(block_gas_limit);
 
@@ -488,11 +484,24 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             .unwrap_or_default();
         if effective_gas_price > 0 {
             let gas_limit_from_balance =
-                max_gas_from_balance(&request, block_context.eip1559_basefee, &mut storage_view)?;
+                max_gas_from_balance(&request, block_context.eip1559_basefee, storage_view)?;
             highest_gas_limit = highest_gas_limit.min(gas_limit_from_balance);
         }
         request.set_gas_limit(highest_gas_limit);
-        let tx = self.create_tx_from_request(request, &block_context, true)?;
+        self.create_tx_from_request(request, block_context, true)
+    }
+
+    // The flow was heavily borrowed from reth, which in turn closely follows the original geth logic. Source:
+    // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+    fn estimate_gas_with_view<V: ViewState + Clone>(
+        &self,
+        request: TransactionRequest,
+        block_context: BlockContext,
+        mut storage_view: V,
+    ) -> Result<U256, EthCallError> {
+        tracing::trace!("Estimating gas with block context {block_context:?}");
+
+        let tx = self.build_estimate_tx(request, &block_context, &mut storage_view)?;
 
         let try_at = |gas_limit: u64| {
             let mut attempt = tx.clone();

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -483,18 +483,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // the gas limit of the corresponding block
         let block_gas_limit = block_context.gas_limit;
 
-        // Determine the highest possible gas limit, considering both the request's specified limit
-        // and the block's limit.
-        let mut highest_gas_limit = request
-            .gas
-            .map(|mut tx_gas_limit| {
-                if block_gas_limit < tx_gas_limit {
-                    // requested gas limit is higher than the allowed gas limit, capping
-                    tx_gas_limit = block_gas_limit;
-                }
-                tx_gas_limit
-            })
-            .unwrap_or(block_gas_limit);
+        let mut highest_gas_limit = request.gas.unwrap_or(block_gas_limit).min(block_gas_limit);
 
         // Check funds of the sender (only useful to check if transaction gas price is more than 0).
         //

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -13,14 +13,15 @@ use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::trace::geth::{CallConfig, GethTrace};
 use alloy::rpc::types::{BlockOverrides, TransactionRequest};
+use derive_more::{Deref, Display};
 use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zk_os_api::helpers::get_nonce;
-use zksync_os_interface::types::{BlockHashes, ExecutionOutput, TxOutput};
+use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
-    types::{BlockContext, ExecutionResult},
+    types::{BlockContext, ExecutionResult, TxOutput},
 };
 use zksync_os_storage_api::{
     RepositoryError, StateError, ViewState, state_override_view::OverriddenStateView,
@@ -468,6 +469,8 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 }
 
 impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
+    // The flow was heavily borrowed from reth, which in turn closely follows the original geth logic. Source:
+    // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
     fn estimate_gas_with_view<V: ViewState + Clone>(
         &self,
         mut request: TransactionRequest,
@@ -475,9 +478,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         mut storage_view: V,
     ) -> Result<U256, EthCallError> {
         tracing::trace!("Estimating gas with block context {block_context:?}");
-        // Rest of the flow was heavily borrowed from reth, which in turn closely follows the
-        // original geth logic. Source:
-        // https://github.com/paradigmxyz/reth/blob/5bc8589162b6e23b07919d82a57eee14353f2862/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
 
         let block_gas_limit = block_context.gas_limit;
         let mut highest_gas_limit = request.gas.unwrap_or(block_gas_limit).min(block_gas_limit);
@@ -504,67 +504,43 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // Execute the transaction with the highest possible gas limit.
         let res = try_at(tx.gas_limit())?.map_err(EthCallError::InvalidTransaction)?;
         tracing::trace!(
-            "Executed tx in estimate_gas with highest gas limit {}, result {res:?}",
-            tx.gas_limit()
+            "Executed tx in eth_estimateGas with gas limit: {}, result {res:?}",
+            Probe::Highest(tx.gas_limit())
         );
         if let ExecutionResult::Revert(output) = res.execution_result {
             return Err(EthCallError::Revert(RevertError::new(Bytes::from(output))));
         }
 
-        // NOTE: this is the gas the transaction used, which is less than the
-        // transaction requires to succeed.
-        let mut gas_used = res.gas_used;
+        // NOTE: this is the gas the transaction used, which is less than the transaction requires to succeed.
+        let gas_used = res.gas_used;
         let mut range = GasRange::new(gas_used.saturating_sub(1), tx.gas_limit());
+
+        if tx.tx_type() == ZkTxType::L1 {
+            range.apply_floor(L1_TX_MINIMAL_GAS_LIMIT);
+        }
 
         // Optimistic check: tx likely passes at gas_used + refund + stipend, scaled by 64/63 (EIP-150).
         // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135>
         const GAS_STIPEND: u64 = 2_300;
         let optimistic_gas_limit = (gas_used + res.gas_refunded + GAS_STIPEND) * 64 / 63;
         if optimistic_gas_limit < range.highest {
-            let res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
-            tracing::trace!(
-                "Executed tx in estimate_gas with optimistic gas limit {optimistic_gas_limit}, result {res:?}"
-            );
-            gas_used = res.gas_used;
-            range.update(res.execution_result, optimistic_gas_limit);
-        }
-
-        if tx.tx_type() == ZkTxType::L1 {
-            // L1 contracts enforce a higher minimal limit for extra security
-            gas_used = gas_used.max(L1_TX_MINIMAL_GAS_LIMIT);
-            range.apply_floor(L1_TX_MINIMAL_GAS_LIMIT);
+            range.apply_probe(
+                try_at(optimistic_gas_limit)?,
+                Probe::Optimistic(optimistic_gas_limit),
+            )?;
         }
 
         // Binary search narrows the range to find the minimum gas limit needed for the transaction
         // to succeed.
         // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152>
-        let mut mid = range.biased_midpoint(gas_used);
+        let mut mid = range.biased_midpoint();
         while !range.is_empty() {
             // Stop once error is within 1.5% of the highest gas limit.
             if range.is_narrow_enough() {
                 break;
             }
-            tracing::trace!("trying to simulate transaction with gas_limit {mid}");
-
-            match try_at(mid)? {
-                Err(InvalidTransaction::CallerGasLimitMoreThanBlock) => {
-                    range.highest = mid;
-                }
-                Err(
-                    InvalidTransaction::CallGasCostMoreThanGasLimit
-                    | InvalidTransaction::OutOfGasDuringValidation
-                    | InvalidTransaction::OutOfNativeResourcesDuringValidation,
-                ) => {
-                    range.lowest = mid;
-                }
-                ethres => {
-                    let res = ethres.map_err(EthCallError::InvalidTransaction)?;
-                    tracing::trace!(
-                        "Executed tx in estimate_gas with gas limit {mid}, result {res:?}"
-                    );
-                    range.update(res.execution_result, mid);
-                }
-            }
+            tracing::trace!("Trying to simulate transaction with gas_limit {mid}");
+            range.apply_probe(try_at(mid)?, Probe::Midpoint(mid))?;
             mid = range.midpoint();
         }
         tracing::trace!("Estimated gas limit: {}", range.highest);
@@ -634,7 +610,26 @@ fn tx_type_runs_policy(tx_type: ZkTxType) -> bool {
     }
 }
 
+#[derive(Debug, Deref, Display)]
+enum Probe {
+    #[display("Midpoint({_0})")]
+    Midpoint(u64),
+    #[display("Highest({_0})")]
+    Highest(u64),
+    #[display("Optimistic({_0})")]
+    Optimistic(u64),
+}
+
 const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
+
+fn is_out_of_gas(err: &InvalidTransaction) -> bool {
+    matches!(
+        err,
+        InvalidTransaction::CallGasCostMoreThanGasLimit
+            | InvalidTransaction::OutOfGasDuringValidation
+            | InvalidTransaction::OutOfNativeResourcesDuringValidation
+    )
+}
 
 // Invariant: tx fails at `lowest` (false), tx succeeds at `highest` (true).
 struct GasRange {
@@ -659,8 +654,8 @@ impl GasRange {
         ((self.highest as u128 + self.lowest as u128) / 2) as u64
     }
 
-    fn biased_midpoint(&self, gas_used: u64) -> u64 {
-        (gas_used * 3).min(self.midpoint())
+    fn biased_midpoint(&self) -> u64 {
+        (self.lowest * 3).min(self.midpoint())
     }
 
     fn apply_floor(&mut self, floor: u64) {
@@ -668,11 +663,22 @@ impl GasRange {
         self.highest = self.highest.max(floor);
     }
 
-    fn update(&mut self, result: ExecutionResult, at: u64) {
-        match result {
-            ExecutionResult::Success(_) => self.highest = at,
-            ExecutionResult::Revert(_) => self.lowest = at,
+    fn apply_probe(
+        &mut self,
+        result: Result<TxOutput, InvalidTransaction>,
+        probe: Probe,
+    ) -> Result<(), EthCallError> {
+        if result.as_ref().is_err_and(is_out_of_gas) {
+            self.lowest = *probe;
+            return Ok(());
         }
+        let res = result.map_err(EthCallError::InvalidTransaction)?;
+        tracing::trace!("Executed tx in eth_estimateGas with gas limit: {probe}, result {res:?}");
+        match res.execution_result {
+            ExecutionResult::Success(_) => self.highest = *probe,
+            ExecutionResult::Revert(_) => self.lowest = *probe,
+        }
+        Ok(())
     }
 }
 

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -33,7 +33,6 @@ use zksync_os_types::{
     ZkTransaction, ZkTxType,
 };
 
-const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
 #[derive(Clone, Debug)]
 pub struct EthCallHandler<RpcStorage> {
     pub(crate) config: RpcConfig,
@@ -636,6 +635,9 @@ fn tx_type_runs_policy(tx_type: ZkTxType) -> bool {
     }
 }
 
+const ESTIMATE_GAS_ERROR_RATIO: f64 = 0.015;
+
+// Invariant: tx fails at `lowest` (false), tx succeeds at `highest` (true).
 struct GasRange {
     lowest: u64,
     highest: u64,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -543,11 +543,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         // to succeed.
         // <https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L152>
         let mut mid = range.biased_midpoint();
-        while !range.is_empty() {
-            // Stop once error is within 1.5% of the highest gas limit.
-            if range.is_narrow_enough() {
-                break;
-            }
+        while !range.is_narrow_enough() {
             tracing::trace!("Trying to simulate transaction with gas_limit {mid}");
             range.apply_probe(run_at(mid)?, Probe::Midpoint(mid))?;
             mid = range.midpoint();
@@ -649,10 +645,6 @@ struct GasRange {
 impl GasRange {
     fn new(lowest: u64, highest: u64) -> Self {
         Self { lowest, highest }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.lowest + 1 >= self.highest
     }
 
     fn is_narrow_enough(&self) -> bool {

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -549,7 +549,9 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
         // Execute the transaction with the highest possible gas limit.
         let mut res = try_at(highest_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
-        tracing::trace!("Executed tx in estimate_gas with highest gas limit {highest_gas_limit}, result {res:?}");
+        tracing::trace!(
+            "Executed tx in estimate_gas with highest gas limit {highest_gas_limit}, result {res:?}"
+        );
         match res.execution_result {
             ExecutionResult::Success(_) => {
                 // Transaction succeeded with the highest possible gas limit, we can proceed with
@@ -580,7 +582,9 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let optimistic_gas_limit = (gas_used + res.gas_refunded + 2_300) * 64 / 63;
         if optimistic_gas_limit < highest_gas_limit {
             res = try_at(optimistic_gas_limit)?.map_err(EthCallError::InvalidTransaction)?;
-            tracing::trace!("Executed tx in estimate_gas with optimistic gas limit {optimistic_gas_limit}, result {res:?}");
+            tracing::trace!(
+                "Executed tx in estimate_gas with optimistic gas limit {optimistic_gas_limit}, result {res:?}"
+            );
 
             // Update the gas used based on the new result.
             gas_used = res.gas_used;
@@ -638,7 +642,9 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 ethres => {
                     // Unpack the result and environment if the transaction was successful.
                     res = ethres.map_err(EthCallError::InvalidTransaction)?;
-                    tracing::trace!("Executed tx in estimate_gas with gas limit {mid_gas_limit}, result {res:?}");
+                    tracing::trace!(
+                        "Executed tx in estimate_gas with gas limit {mid_gas_limit}, result {res:?}"
+                    );
                     // Update the estimated gas range based on the transaction result.
                     update_estimated_gas_range(
                         res.execution_result,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -590,7 +590,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 optimistic_gas_limit,
                 &mut highest_gas_limit,
                 &mut lowest_gas_limit,
-            )?;
+            );
         };
 
         if tx.tx_type() == ZkTxType::L1 {
@@ -645,7 +645,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                         mid_gas_limit,
                         &mut highest_gas_limit,
                         &mut lowest_gas_limit,
-                    )?;
+                    );
                 }
             }
 
@@ -744,7 +744,7 @@ pub fn update_estimated_gas_range(
     tx_gas_limit: u64,
     highest_gas_limit: &mut u64,
     lowest_gas_limit: &mut u64,
-) -> Result<(), EthCallError> {
+) {
     match result {
         ExecutionResult::Success { .. } => {
             // Cap the highest gas limit with the succeeding gas limit.
@@ -761,9 +761,7 @@ pub fn update_estimated_gas_range(
             // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/94697be8a3f0dfcd95dfb13ffbd39b5973f5c65d/contracts/metatx/ERC2771Forwarder.sol#L360-L367>
             *lowest_gas_limit = tx_gas_limit;
         }
-    };
-
-    Ok(())
+    }
 }
 
 /// Error types returned by `eth_call` implementation

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -308,7 +308,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthNamespace<RpcStorage, Me
         let on_chain_account_nonce = self
             .storage
             .state_at_block_id_or_latest(block_id)?
-            .account_nonce(address)
+            .nonce(address)
             .unwrap_or(0);
 
         if block_id == Some(BlockId::pending())

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -25,7 +25,7 @@ use jsonrpsee::core::RpcResult;
 use ruint::aliases::B160;
 use tokio::sync::watch;
 use zk_ee::common_structs::derive_flat_storage_key;
-use zk_os_api::helpers::{get_balance, get_code};
+use zk_os_api::helpers::get_code;
 use zksync_os_interface::traits::ReadStorage;
 use zksync_os_interface::types::BlockContext;
 use zksync_os_mempool::subpools::l2::L2Subpool;
@@ -269,13 +269,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthNamespace<RpcStorage, Me
         let Some(block_number) = self.storage.resolve_block_number(block_id)? else {
             return Err(EthError::BlockNotFound(block_id));
         };
-        Ok(self
-            .storage
-            .state_view_at(block_number)?
-            .get_account(address)
-            .as_ref()
-            .map(get_balance)
-            .unwrap_or(U256::ZERO))
+        Ok(self.storage.state_view_at(block_number)?.balance(address))
     }
 
     fn storage_at_impl(

--- a/lib/rpc/src/js_tracer/host.rs
+++ b/lib/rpc/src/js_tracer/host.rs
@@ -275,7 +275,7 @@ fn host_get_nonce<V: ViewState + 'static>(
     let nonce = env
         .state_view
         .borrow_mut()
-        .account_nonce(address)
+        .nonce(address)
         .ok_or(anyhow::anyhow!("Account {address:?} not found in a state"))?;
 
     Ok(format!("0x{nonce:x}"))

--- a/lib/rpc/src/js_tracer/host.rs
+++ b/lib/rpc/src/js_tracer/host.rs
@@ -393,12 +393,7 @@ fn resolve_balance<V: ViewState + 'static>(
             .map(|entry| entry.value.clone())
     };
 
-    let mut balance = env
-        .state_view
-        .borrow_mut()
-        .get_account(address)
-        .map(|props| props.balance)
-        .unwrap_or_default();
+    let mut balance = env.state_view.borrow_mut().balance(address);
 
     if let Some(delta) = delta {
         let (with_add, overflow) = balance.overflowing_add(delta.added);

--- a/lib/storage_api/src/state.rs
+++ b/lib/storage_api/src/state.rs
@@ -23,7 +23,7 @@ pub trait ViewState: ReadStorage + PreimageSource + Send + Clone {
     /// Get account's nonce by its address.
     ///
     /// Returns `None` if the account doesn't exist
-    fn account_nonce(&mut self, address: Address) -> Option<u64> {
+    fn nonce(&mut self, address: Address) -> Option<u64> {
         self.get_account(address).map(|a| a.nonce)
     }
 }

--- a/lib/storage_api/src/state.rs
+++ b/lib/storage_api/src/state.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::ruint::aliases::B160;
-use alloy::primitives::{Address, B256, BlockNumber};
+use alloy::primitives::{Address, B256, BlockNumber, U256};
 use std::fmt::Debug;
 use zk_ee::common_structs::derive_flat_storage_key;
 use zk_os_basic_system::system_implementation::flat_storage_model::{
@@ -25,6 +25,13 @@ pub trait ViewState: ReadStorage + PreimageSource + Send + Clone {
     /// Returns `None` if the account doesn't exist
     fn nonce(&mut self, address: Address) -> Option<u64> {
         self.get_account(address).map(|a| a.nonce)
+    }
+
+    /// Get account's balance by its address. Returns zero for non-existent accounts.
+    fn balance(&mut self, address: Address) -> U256 {
+        self.get_account(address)
+            .map(|a| a.balance)
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
## Summary

Refactors `estimate_gas_with_view` for readability and correctness.

**Stats:** the method was 207 lines, now split into `build_estimate_tx` (24 lines) + `estimate_gas_with_view` (64 lines).

- Extract `max_gas_from_balance` and `build_estimate_tx` helpers to separate tx setup from estimation logic
- Introduce `GasRange` struct to encapsulate binary search bounds with invariant: tx fails at `lowest`, succeeds at `highest`
- Introduce `Probe` enum (`Highest`/`Optimistic`/`Midpoint`) to carry gas limit + kind, enabling centralized logging and `apply_probe` dispatch
- Fix bug: OOG errors in the optimistic check were propagating as hard errors instead of narrowing the range (matching geth/reth behavior)
- Remove dead code: `CallerGasLimitMoreThanBlock` arm in binary search (impossible since all probes ≤ block gas limit)
- Simplify `biased_midpoint` to use `range.lowest * 3` instead of tracking `gas_used` separately
- Rename `try_at` closure to `run_at`; add `ViewState::balance` convenience method

🤖 Generated with [Claude Code](https://claude.com/claude-code)