### PR TITLE
feat(status): add pipeline status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15618,6 +15618,7 @@ version = "0.20.9"
 dependencies = [
  "futures",
  "reth-tasks",
+ "serde",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -16138,6 +16139,7 @@ dependencies = [
  "async-trait",
  "futures",
  "reth-tasks",
+ "serde",
  "tokio",
  "tracing",
  "vise",
@@ -16594,6 +16596,8 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "zksync_os_backpressure",
+ "zksync_os_observability",
  "zksync_os_raft",
 ]
 

--- a/lib/backpressure/Cargo.toml
+++ b/lib/backpressure/Cargo.toml
@@ -19,4 +19,5 @@ tokio-stream            = { workspace = true }
 futures                 = { workspace = true }
 vise                    = { workspace = true }
 tracing                 = { workspace = true }
+serde                   = { workspace = true, features = ["derive"] }
 

--- a/lib/backpressure/src/lib.rs
+++ b/lib/backpressure/src/lib.rs
@@ -9,5 +9,7 @@ pub use config::{
     PipelineCondition,
 };
 pub use gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
-pub use monitor::{AdjacentSnapshot, BackpressureMonitor, PipelineSnapshot};
+pub use monitor::{
+    AdjacentSnapshot, BackpressureMonitor, PipelineSnapshot, compute_adjacent_snapshots,
+};
 pub use tracker::PipelineTracker;

--- a/lib/backpressure/src/monitor.rs
+++ b/lib/backpressure/src/monitor.rs
@@ -2,6 +2,7 @@ use crate::config::{BackpressureConfig, ComponentId, is_pipeline_stage};
 use crate::gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 use crate::metrics::MONITOR_METRICS;
 use reth_tasks::Runtime;
+use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use tokio::sync::watch;
@@ -14,16 +15,19 @@ use zksync_os_types::{
 pub type PipelineSnapshot = Vec<(ComponentId, ComponentState)>;
 
 /// Lag between two adjacent pipeline stages: how far the downstream component is behind its upstream neighbor.
+#[derive(Clone, Serialize)]
 pub struct AdjacentSnapshot {
     /// Number of blocks the downstream stage is behind the upstream stage.
     pub block_diff: u64,
     /// Diff between the last processed block timestamps of the two stages.
+    #[serde(skip)]
     pub time_diff: Option<Duration>,
     /// Number of batches the downstream stage is behind the upstream stage.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_diff: Option<u64>,
 }
 
-fn compute_adjacent_snapshots(
+pub fn compute_adjacent_snapshots(
     snapshot: &PipelineSnapshot,
 ) -> HashMap<ComponentId, AdjacentSnapshot> {
     snapshot

--- a/lib/observability/src/component_state_reporter.rs
+++ b/lib/observability/src/component_state_reporter.rs
@@ -1,20 +1,23 @@
 use crate::generic_component_state::GenericComponentState;
 use crate::metrics::GENERAL_METRICS;
 use crate::state_label::StateLabel;
+use serde::Serialize;
 use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 use tokio::time::Instant;
 
 /// Coordinates for a pipeline item
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct TrackingCoordinates {
     pub block_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_number: Option<u64>,
 }
 
 /// State snapshot reported by a pipeline component on every state transition.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ComponentState {
     /// Component state - Idle or Active.
     pub state: GenericComponentState,
@@ -23,12 +26,15 @@ pub struct ComponentState {
     pub specific_state: &'static str,
 
     /// When the current state was entered.
+    #[serde(skip)]
     pub state_entered_at: Instant,
 
     /// Last item picked from the input channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub picked: Option<TrackingCoordinates>,
 
     /// Last item fully handled/forwarded downstream.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub processed: Option<TrackingCoordinates>,
 }
 

--- a/lib/observability/src/generic_component_state.rs
+++ b/lib/observability/src/generic_component_state.rs
@@ -1,7 +1,9 @@
+use serde::Serialize;
 use vise::EncodeLabelValue;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, Serialize)]
 #[metrics(label = "state", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum GenericComponentState {
     /// No work available — waiting for upstream.
     Idle,

--- a/lib/pipeline/Cargo.toml
+++ b/lib/pipeline/Cargo.toml
@@ -17,5 +17,6 @@ futures.workspace = true
 tracing.workspace = true
 
 reth-tasks.workspace = true
+serde = { workspace = true, features = ["derive"] }
 vise.workspace = true
 zksync_os_observability.workspace = true

--- a/lib/pipeline/src/component_id.rs
+++ b/lib/pipeline/src/component_id.rs
@@ -1,9 +1,21 @@
+use serde::Serialize;
 use vise::{EncodeLabelSet, EncodeLabelValue};
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, EncodeLabelValue, EncodeLabelSet,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    EncodeLabelValue,
+    EncodeLabelSet,
+    Serialize,
 )]
 #[metrics(rename_all = "snake_case", label = "component")]
+#[serde(rename_all = "snake_case")]
 pub enum ComponentId {
     ConsensusNodeCommandSource,
     ExternalNodeCommandSource,

--- a/lib/status/Cargo.toml
+++ b/lib/status/Cargo.toml
@@ -18,3 +18,5 @@ tracing.workspace = true
 
 reth-tasks.workspace = true
 zksync_os_raft.workspace = true
+zksync_os_backpressure.workspace = true
+zksync_os_observability.workspace = true

--- a/lib/status/src/lib.rs
+++ b/lib/status/src/lib.rs
@@ -1,35 +1,44 @@
+//! Status HTTP endpoints.
+//!
+//! - `GET /status` — general node status, including consensus (Raft) state.
+//! - `GET /status/health` — liveness endpoint. Always 200 while the process is up.
+//! - `GET /status/pipeline` — per-component backpressure and lag snapshot for
+//!   diagnostics and dashboards.
+
 mod health;
+mod pipeline;
 mod status;
 
 use crate::health::health;
+use crate::pipeline::pipeline;
 use crate::status::status;
 use axum::{Router, routing::get};
 use reth_tasks::shutdown::GracefulShutdown;
 use tokio::{net::TcpListener, sync::watch};
+use zksync_os_backpressure::PipelineSnapshot;
 use zksync_os_raft::RaftConsensusStatus;
 
 pub use status::{ConsensusStatus, StatusResponse};
 
 #[derive(Clone)]
-struct AppState {
-    consensus_raft_status_rx: Option<watch::Receiver<Option<RaftConsensusStatus>>>,
+pub struct StatusServerState {
+    pub pipeline_snapshot: watch::Receiver<PipelineSnapshot>,
+    pub consensus_raft_status_rx: Option<watch::Receiver<Option<RaftConsensusStatus>>>,
 }
 
-// todo: handle graceful shutdown in a meaningful manner:
-//       we should start a timer for status server's lifetime, report healthy=false and only shutdown
-//       after timer is expired
+pub(crate) type AppState = StatusServerState;
+
 /// Runs the status HTTP server on a pre-bound listener.
 pub async fn run_status_server(
     listener: TcpListener,
     shutdown: GracefulShutdown,
-    consensus_raft_status_rx: Option<watch::Receiver<Option<RaftConsensusStatus>>>,
+    state: StatusServerState,
 ) -> anyhow::Result<()> {
     let app = Router::new()
-        .route("/status/health", get(health))
         .route("/status", get(status))
-        .with_state(AppState {
-            consensus_raft_status_rx,
-        });
+        .route("/status/health", get(health))
+        .route("/status/pipeline", get(pipeline))
+        .with_state(state);
 
     let addr = listener.local_addr()?;
     tracing::info!(%addr, "status server running");

--- a/lib/status/src/pipeline.rs
+++ b/lib/status/src/pipeline.rs
@@ -1,0 +1,29 @@
+use crate::AppState;
+use axum::{Json, extract::State};
+use serde::Serialize;
+use zksync_os_backpressure::{AdjacentSnapshot, ComponentId, compute_adjacent_snapshots};
+use zksync_os_observability::ComponentState;
+
+#[derive(Serialize)]
+pub(crate) struct ComponentView {
+    name: ComponentId,
+    #[serde(flatten)]
+    state: ComponentState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lag: Option<AdjacentSnapshot>,
+}
+
+pub(crate) async fn pipeline(State(state): State<AppState>) -> Json<Vec<ComponentView>> {
+    let snapshot = state.pipeline_snapshot.borrow().clone();
+    let mut adjacent = compute_adjacent_snapshots(&snapshot);
+    Json(
+        snapshot
+            .into_iter()
+            .map(|(id, state)| ComponentView {
+                name: id,
+                state,
+                lag: adjacent.remove(&id),
+            })
+            .collect(),
+    )
+}

--- a/node/bin/src/batch_sink.rs
+++ b/node/bin/src/batch_sink.rs
@@ -52,7 +52,7 @@ impl PipelineComponent for BatchSink {
             );
             state_reporter.record_processed(
                 envelope.batch.last_block_number,
-                None,
+                Some(envelope.batch.batch_info.last_block_timestamp),
                 Some(envelope.batch_number()),
             );
             if let Some(n) = internal_config.failing_block

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -60,7 +60,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-use zksync_os_backpressure::{BackpressureMonitor, PipelineTracker};
+use zksync_os_backpressure::{BackpressureMonitor, PipelineSnapshot, PipelineTracker};
 use zksync_os_base_token_adjuster::{BaseTokenPriceHandle, BaseTokenPriceUpdater};
 use zksync_os_batch_verification::{
     BatchVerificationConfig as BatchVerificationPolicyConfig, BatchVerificationPipelineStep,
@@ -109,7 +109,7 @@ use zksync_os_revm_consistency_checker::node::RevmConsistencyChecker;
 use zksync_os_rpc::{EthCallHandler, RpcStorage};
 use zksync_os_sequencer::execution::block_context_provider::BlockContextProvider;
 use zksync_os_sequencer::execution::{BlockApplier, BlockCanonizer, BlockExecutor, FeeProvider};
-use zksync_os_status_server::run_status_server;
+use zksync_os_status_server::{StatusServerState, run_status_server};
 use zksync_os_storage::db::{BlockReplayStorage, ExecutedBatchStorage};
 use zksync_os_storage::in_memory::Finality;
 use zksync_os_storage::lazy::RepositoryManager;
@@ -893,6 +893,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     let PipelineHandles {
         backpressure_acceptance_rx,
+        pipeline_snapshot_rx,
         prover_api_port,
     } = if node_role.is_main() {
         run_main_node_pipeline(
@@ -925,28 +926,25 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         )
         .await
     } else {
-        PipelineHandles {
-            backpressure_acceptance_rx: run_en_pipeline(
-                &config,
-                replays_for_sequencer,
-                committed_batch_provider.clone(),
-                node_startup_state,
-                archiving_block_replay_storage,
-                runtime,
-                block_context_provider,
-                state.clone(),
-                tree_db,
-                repositories.clone(),
-                finality_storage.clone(),
-                stop_receiver.clone(),
-                tx_acceptance_state_sender,
-                chain_id,
-                verify_batch_rx,
-                outgoing_verify_results.clone(),
-            )
-            .await,
-            prover_api_port: None, // EN has no prover server
-        }
+        run_en_pipeline(
+            &config,
+            replays_for_sequencer,
+            committed_batch_provider.clone(),
+            node_startup_state,
+            archiving_block_replay_storage,
+            runtime,
+            block_context_provider,
+            state.clone(),
+            tree_db,
+            repositories.clone(),
+            finality_storage.clone(),
+            stop_receiver.clone(),
+            tx_acceptance_state_sender,
+            chain_id,
+            verify_batch_rx,
+            outgoing_verify_results.clone(),
+        )
+        .await
     };
 
     // Aggregate all "not accepting" signals into a single combined receiver for the RPC server.
@@ -967,10 +965,14 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             .local_addr()
             .expect("status server local_addr")
             .port();
+        let status_state = StatusServerState {
+            pipeline_snapshot: pipeline_snapshot_rx,
+            consensus_raft_status_rx: raft_status_rx,
+        };
         runtime.spawn_critical_with_graceful_shutdown_signal(
             "status server",
             |shutdown| async move {
-                run_status_server(status_listener, shutdown, raft_status_rx)
+                run_status_server(status_listener, shutdown, status_state)
                     .await
                     .expect("failed to run status server");
             },
@@ -1131,6 +1133,8 @@ async fn fetch_l1_state_with_startup_revert(
 struct PipelineHandles {
     /// Registered into the `TxAcceptanceGate`.
     backpressure_acceptance_rx: watch::Receiver<TransactionAcceptanceState>,
+    /// Per-component pipeline state, exposed via the status server's `/status/pipeline`.
+    pipeline_snapshot_rx: watch::Receiver<PipelineSnapshot>,
     /// Prover API port, reported by the status server. `None` on external nodes.
     prover_api_port: Option<u16>,
 }
@@ -1237,7 +1241,8 @@ async fn run_main_node_pipeline(
         );
         let snapshot_rx = PipelineTracker::spawn(runtime, components);
         return PipelineHandles {
-            backpressure_acceptance_rx: monitor.spawn(runtime, snapshot_rx),
+            backpressure_acceptance_rx: monitor.spawn(runtime, snapshot_rx.clone()),
+            pipeline_snapshot_rx: snapshot_rx,
             prover_api_port: None,
         };
     }
@@ -1414,7 +1419,8 @@ async fn run_main_node_pipeline(
     pipeline.spawn();
     let snapshot_rx = PipelineTracker::spawn(runtime, components);
     PipelineHandles {
-        backpressure_acceptance_rx: monitor.spawn(runtime, snapshot_rx),
+        backpressure_acceptance_rx: monitor.spawn(runtime, snapshot_rx.clone()),
+        pipeline_snapshot_rx: snapshot_rx,
         prover_api_port,
     }
 }
@@ -1439,7 +1445,7 @@ async fn run_en_pipeline(
     chain_id: u64,
     verify_batch_rx: tokio::sync::mpsc::Receiver<PeerVerifyBatch>,
     outgoing_verify_results: tokio::sync::broadcast::Sender<PeerVerifyBatchResult>,
-) -> watch::Receiver<TransactionAcceptanceState> {
+) -> PipelineHandles {
     let internal_config_manager = init_and_report_internal_config_manager(
         config
             .general_config
@@ -1538,7 +1544,11 @@ async fn run_en_pipeline(
         "clear failing block config",
         clear_failing_block_config_task(finality, internal_config_manager),
     );
-    monitor.spawn(runtime, snapshot_rx)
+    PipelineHandles {
+        backpressure_acceptance_rx: monitor.spawn(runtime, snapshot_rx.clone()),
+        pipeline_snapshot_rx: snapshot_rx,
+        prover_api_port: None, // EN has no prover server
+    }
 }
 
 fn init_and_report_internal_config_manager(


### PR DESCRIPTION
## Summary

Adds a pipeline diagnostics endpoint to the status server, on both the main node and external nodes.

**`GET /status/pipeline`**
Per-component pipeline state snapshot. Returns an ordered array of components, each with its current state (`idle`/`active` plus the component-specific state), last picked/processed block and batch coordinates, and lag to its upstream neighbor (`block_diff`, `batch_diff`).

Intended for diagnostics and dashboards to observe pipeline health and backpressure in detail.

Example element:

```json
{
  "name": "l1_sender_execute",
  "state": "active",
  "specific_state": "waiting_l1_inclusion",
  "picked": { "block_number": 2, "timestamp": 1783436859, "batch_number": 2 },
  "processed": { "block_number": 1, "timestamp": 1783436859, "batch_number": 1 },
  "lag": { "block_diff": 1, "batch_diff": 1 }
}
```

## Implementation notes

- Core types (`ComponentId`, `GenericComponentState`, `ComponentState`, `TrackingCoordinates`, `AdjacentSnapshot`) derive `Serialize` so they own their JSON representation; the endpoint only assembles them.
- Both pipelines now expose their `PipelineTracker` snapshot watch through `PipelineHandles`, so the endpoint works on external nodes too.
- `BatchSink` now reports the last block timestamp so the final stage carries time coordinates like every other stage.
- The existing `/status` and `/status/health` endpoints are unchanged.

Smoke-tested against a local chain (`run_local.sh`): the endpoint returns all 19 pipeline components with live state and lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
