### PR TITLE
fix(l1-watcher): do not panic on non-existent migration 

### DIFF
--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -1,16 +1,13 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, ChainId, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::DynProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use zksync_os_contract_interface::ServerNotifier::MigrateFromGateway;
 use zksync_os_contract_interface::{Bridgehub, ServerNotifier::MigrateToGateway, ZkChain};
 use zksync_os_mempool::subpools::sl_chain_id::SlChainIdSubpool;
 use zksync_os_types::SystemTxEnvelope;
-
-/// Limit the number of L1 blocks to scan when looking for the migration number block.
-const INITIAL_LOOKBEHIND_BLOCKS: u64 = 100_000;
 
 /// Watches for both `MigrateToGateway` and `MigrateFromGateway` events on L1 in a single
 /// polling loop, and submits a `SetSLChainId` system transaction for each.
@@ -46,25 +43,13 @@ impl GatewayMigrationWatcher {
         let server_notifier_contract = zk_chain.get_server_notifier_address().await?;
         let chain_asset_handler_address = bridgehub.chain_asset_handler_address().await?;
 
-        let current_l1_block = zk_chain.provider().get_block_number().await?;
         let next_l1_block = util::find_block_by_migration_number(
             zk_chain.clone(),
             chain_asset_handler_address,
             l2_chain_id,
             next_migration_number,
         )
-        .await
-        .or_else(|err| {
-            if current_l1_block > INITIAL_LOOKBEHIND_BLOCKS {
-                anyhow::bail!(
-                    "Binary search failed with {err}. Cannot default starting block to zero \
-                     for a long chain. Current L1 block number: {current_l1_block}. \
-                     Limit: {INITIAL_LOOKBEHIND_BLOCKS}."
-                );
-            } else {
-                Ok(0)
-            }
-        })?;
+        .await?;
 
         tracing::info!(
             contract = %server_notifier_contract,

--- a/lib/l1_watcher/src/migration_finalized_watcher.rs
+++ b/lib/l1_watcher/src/migration_finalized_watcher.rs
@@ -1,15 +1,12 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::DynProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use tokio::sync::watch;
 use zksync_os_contract_interface::settlement_layer_intervals::SettlementLayerIntervals;
 use zksync_os_contract_interface::{Bridgehub, IChainAssetHandler::MigrationFinalized, ZkChain};
-
-/// Limit the number of SL blocks to scan when performing the initial binary search.
-const INITIAL_LOOKBEHIND_BLOCKS: u64 = 100_000;
 
 /// Watches for `MigrationFinalized(uint256 indexed chainId, uint256 migrationNumber, ...)` events
 /// emitted by the `IChainAssetHandler` contract on the current settlement layer.
@@ -64,7 +61,6 @@ impl MigrationFinalizedWatcher {
         }
 
         let chain_asset_handler = bridgehub_sl.chain_asset_handler_address().await?;
-        let current_sl_block = zk_chain.provider().get_block_number().await?;
         // todo: not necessary to run binary search here, just use latest
         let starting_block = util::find_block_by_migration_number(
             zk_chain.clone(),
@@ -72,18 +68,7 @@ impl MigrationFinalizedWatcher {
             l2_chain_id,
             active_migration_number,
         )
-        .await
-        .or_else(|err| {
-            if current_sl_block > INITIAL_LOOKBEHIND_BLOCKS {
-                anyhow::bail!(
-                    "Binary search failed with {err}. Cannot default starting block to zero \
-                     for a long chain. Current SL block number: {current_sl_block}. \
-                     Limit: {INITIAL_LOOKBEHIND_BLOCKS}."
-                );
-            } else {
-                Ok(0)
-            }
-        })?;
+        .await?;
 
         tracing::info!(
             contract = %chain_asset_handler,

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -24,8 +24,6 @@ use zksync_os_types::{
 use zksync_os_contract_interface::IChainTypeManager::IChainTypeManagerInstance;
 use zksync_os_contract_interface::ISettlementLayerV31Upgrade::ISettlementLayerV31UpgradeInstance;
 
-/// Limit the number of L1 blocks to scan when looking for the set timestamp transaction.
-const INITIAL_LOOKBEHIND_BLOCKS: u64 = 100_000;
 /// The constant value is higher than for other watchers, since we're looking for rare/specific events
 /// and we don't expect a lot of results.
 const UPGRADE_DATA_LOOKBEHIND_BLOCKS: u64 = 2_500_000;
@@ -88,21 +86,11 @@ impl L1UpgradeTxWatcher {
         let ctm_sl = zk_chain_sl.get_chain_type_manager().await?;
         tracing::info!(ctm_sl = ?ctm_sl, "resolved SL chain type manager");
 
-        let current_l1_block = zk_chain_l1.provider().get_block_number().await?;
-        let last_l1_block = find_l1_block_by_protocol_version(zk_chain_l1.clone(), current_protocol_version.clone())
-            .await
-            .or_else(|err| {
-                // This may error on Anvil with `--load-state` - as it doesn't support `eth_call` even for recent blocks.
-                // We default to `0` in this case - `eth_getLogs` are still supported.
-                // Assert that we don't fallback on longer chains (e.g. Sepolia)
-                if current_l1_block > INITIAL_LOOKBEHIND_BLOCKS {
-                    anyhow::bail!(
-                        "Binary search failed with {err}. Cannot default starting block to zero for a long chain. Current L1 block number: {current_l1_block}. Limit: {INITIAL_LOOKBEHIND_BLOCKS}."
-                    );
-                } else {
-                    Ok(0)
-                }
-            })?;
+        let last_l1_block = find_l1_block_by_protocol_version(
+            zk_chain_l1.clone(),
+            current_protocol_version.clone(),
+        )
+        .await?;
         // The configured bytecode supplier address is used as fallback for pre-v31 CTMs.
         // On v31+ CTMs, `resolve_active_bytecode_supplier` discovers the address dynamically.
         // Sanity check: make sure the fallback address has code deployed.

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -20,7 +20,7 @@ use zksync_os_types::ProtocolSemanticVersion;
 pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
 
 /// Finds the first block where `IChainAssetHandler::migrationNumber(chain_id) >= migration_number`
-/// using binary search.
+/// using binary search. Returns latest block if migration number is not reached yet.
 ///
 /// Used by both [`GatewayMigrationWatcher`][crate::GatewayMigrationWatcher] (on L1) and
 /// [`MigrationCompleteWatcher`][crate::MigrationCompleteWatcher] (on the current settlement layer)
@@ -36,6 +36,16 @@ pub async fn find_block_by_migration_number(
         zk_chain.provider().clone(),
     ));
     let target = U256::from(migration_number);
+    let latest = instance.provider().get_block_number().await?;
+    let latest_migration_number = instance
+        .migrationNumber(U256::from(chain_id))
+        .block(latest.into())
+        .call()
+        .await?;
+    // If this migration has not been reached yet, return the latest block.
+    if latest_migration_number < migration_number {
+        return Ok(latest);
+    }
 
     find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| {
         let instance = instance.clone();

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -69,13 +69,6 @@ pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool
     start_block_number: BlockNumber,
     predicate: impl Fn(Arc<ZkChain<DynProvider>>, u64) -> Fut,
 ) -> anyhow::Result<BlockNumber> {
-    if zk_chain.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
-        // Binary search may error on Anvil with `--load-state` - as it doesn't support `eth_call`
-        // even for recent blocks. We default to `start_block_number` in this case - `eth_getLogs`
-        // are still supported.
-        return Ok(start_block_number);
-    }
-
     let latest = zk_chain.provider().get_block_number().await?;
 
     let guarded_predicate =
@@ -213,27 +206,6 @@ pub async fn find_l1_commit_block_by_batch_number(
     batch_number: u64,
     max_l1_blocks_to_scan: u64,
 ) -> anyhow::Result<BlockNumber> {
-    if zk_chain.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
-        // Binary search may error on Anvil with `--load-state` - as it doesn't support `eth_call`
-        // for historical blocks. We run linear search as a fallback.
-        if batch_number == 0 {
-            // For genesis we must return L1 block where `zk_chain` got deployed. For Anvil it's okay
-            // to return 0 here as the chain should not be long anyway.
-            return Ok(0);
-        }
-        return find_last_matching_event::<ReportCommittedBatchRangeZKsyncOS>(
-            *zk_chain.address(),
-            zk_chain.provider(),
-            0,
-            max_l1_blocks_to_scan,
-            |e| e.batchNumber == batch_number,
-        )
-        .await?
-        .with_context(|| {
-            format!("linear search failed to find where batch {batch_number} was committed")
-        });
-    }
-
     let is_batch_committed = move |zk: Arc<ZkChain<DynProvider>>, block: BlockNumber| async move {
         let res = zk.get_total_batches_committed(block.into()).await?;
         Ok(res >= batch_number)
@@ -322,13 +294,6 @@ pub async fn find_l1_block_by_interop_root_id(
     next_interop_root_id: u64,
 ) -> anyhow::Result<BlockNumber> {
     if next_interop_root_id == 0 {
-        return Ok(0);
-    }
-
-    // Binary search via `eth_call` with historical block IDs is not supported on Anvil with
-    // `--load-state`. Fall back to block 0 so the watcher starts from genesis and catches up
-    // via `eth_getLogs`, which Anvil does support.
-    if bridgehub.provider().get_chain_id().await? == ANVIL_L1_CHAIN_ID {
         return Ok(0);
     }
 


### PR DESCRIPTION
## Summary

* Removes anvil-related hacks in all L1 watchers
* Makes `find_block_by_migration_number` not panic when next migration has not been activated yet on L1

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

