### PR TITLE
fix(network): pin reth with bounded RLPx buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8761,7 +8761,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-chain-state"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8812,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8855,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -8882,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8911,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8975,7 +8975,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9109,7 +9109,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9127,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9182,7 +9182,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9217,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "serde",
  "serde_json",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "bindgen",
  "cc",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "futures",
  "metrics",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9291,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9361,7 +9361,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9464,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9499,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9517,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9595,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9644,7 +9644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9722,7 +9722,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "clap",
  "eyre",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9891,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9918,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9955,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.1"
-source = "git+https://github.com/matter-labs/reth.git?branch=fix%2Fdiscv5-shutdown-v1.11.1#35a09721e0f1c2b8c95a18c03731abe4da4bafcb"
+source = "git+https://github.com/EmilLuta/reth.git?rev=2bb8f26ac1086a06ba6cf2fb413e9469756de766#2bb8f26ac1086a06ba6cf2fb413e9469756de766"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,24 +235,24 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-appender-tracing = "0.31.1"
 
 # Reth dependencies
-reth-db-models = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-evm-ethereum = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-chainspec = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-trie-common = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-primitives = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-primitives-traits = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-revm = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-storage-api = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-transaction-pool = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-execution-types = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-network = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-network-peers = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-net-nat = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-eth-wire = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-discv5 = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-provider = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-rpc-eth-types = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
-reth-tasks = { git = "https://github.com/matter-labs/reth.git", branch = "fix/discv5-shutdown-v1.11.1" }
+reth-db-models = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-evm-ethereum = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-chainspec = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-trie-common = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-primitives = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-primitives-traits = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-revm = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-storage-api = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-transaction-pool = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-execution-types = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-network = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-network-peers = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-net-nat = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-eth-wire = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-discv5 = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-provider = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-rpc-eth-types = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
+reth-tasks = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
 
 zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.0.4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,11 @@ num_cpus = "1.17.0"
 rocksdb = "0.24.0"
 thread_local = "1.1.9"
 pin-project = "1.1.10"
-openraft = { version = "0.9.24", features = ["serde", "generic-snapshot-data", "storage-v2"] }
+openraft = { version = "0.9.24", features = [
+    "serde",
+    "generic-snapshot-data",
+    "storage-v2",
+] }
 assert_matches = "1.5"
 serde_yaml = "0.9"
 secrecy = "0.10.3"
@@ -220,8 +224,15 @@ rangemap = "1.7.1"
 flate2 = "1.1.8"
 tar = "0.4.45"
 http-body-util = "0.1.3"
-hyper-rustls = { version = "0.27.7", default-features = false, features = ["native-tokio", "ring", "tls12"] }
-rustls = { version = "0.23.31", default-features = false, features = ["ring", "std"] }
+hyper-rustls = { version = "0.27.7", default-features = false, features = [
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+rustls = { version = "0.23.31", default-features = false, features = [
+    "ring",
+    "std",
+] }
 test-casing = "0.2.0-beta.1"
 quote = "1"
 syn = "2"
@@ -235,6 +246,7 @@ opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-appender-tracing = "0.31.1"
 
 # Reth dependencies
+# currently pinned to specific commit that bounds the per-connection RLPx multiplexer outbound buffer
 reth-db-models = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
 reth-evm-ethereum = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }
 reth-chainspec = { git = "https://github.com/EmilLuta/reth.git", rev = "2bb8f26ac1086a06ba6cf2fb413e9469756de766" }


### PR DESCRIPTION
Pins the reth dependency to a forked revision that bounds the per-connection RLPx multiplexer outbound buffer. To move back to the original codebase once fix is applied upstream.