### PR TITLE
chore: enable revm_consistency_checker_revert_on_divergence in local_dev config

### DIFF
--- a/local-chains/local_dev.yaml
+++ b/local-chains/local_dev.yaml
@@ -24,7 +24,7 @@ observability:
     use_color: true
 
 sequencer:
-  revm_consistency_checker_enabled: false
+  revm_consistency_checker_revert_on_divergence: true
 
 external_price_api_client:
   source: Forced


### PR DESCRIPTION
## Summary

Enable revm_consistency_checker_revert_on_divergence in local_dev config so that we catch revm divergences in integration tests

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

