### PR TITLE
chore: consensus - runtime local peer validation

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1954,7 +1954,7 @@ mod tests {
     use super::*;
     use alloy::signers::k256::ecdsa::SigningKey;
     use smart_config::{ConfigRepository, ConfigSchema, DescribeConfig, Environment};
-    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::net::Ipv4Addr;
 
     const TEST_SECRET_KEY: &str =
         "0x1111111111111111111111111111111111111111111111111111111111111111";
@@ -2013,18 +2013,6 @@ mod tests {
 
     fn local_signer(byte: u8) -> SignerConfig {
         SignerConfig::Local(SigningKey::from_slice(&[byte; 32]).unwrap())
-    }
-
-    fn secret_key(byte: u8) -> SecretKey {
-        SecretKey::from_slice(&[byte; 32]).unwrap()
-    }
-
-    fn peer_id_for_secret(secret_key: &SecretKey) -> PeerId {
-        NodeRecord::from_secret_key(
-            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3030).into(),
-            secret_key,
-        )
-        .id
     }
 
     fn base_config(node_role: NodeRole) -> Config {
@@ -2139,60 +2127,6 @@ mod tests {
         config.external_price_api_client_config = None;
 
         config.validate().await.unwrap();
-    }
-
-    #[test]
-    fn consensus_runtime_config_rejects_missing_local_peer_id() {
-        let local_secret_key = secret_key(0x44);
-        let other_secret_key = secret_key(0x55);
-        let local_peer_id = peer_id_for_secret(&local_secret_key);
-        let other_peer_id = peer_id_for_secret(&other_secret_key);
-        let network_config = NetworkConfig {
-            enabled: true,
-            secret_key: Some(local_secret_key),
-            ..Default::default()
-        };
-        let consensus_config = ConsensusConfig {
-            enabled: true,
-            peer_ids: vec![other_peer_id],
-            ..Default::default()
-        };
-
-        let err = consensus_config
-            .into_raft_consensus_config(&network_config, "raft".into())
-            .unwrap_err()
-            .to_string();
-
-        assert!(err.contains(
-            "`consensus.peer_ids` must include local peer id derived from `network.secret_key`"
-        ));
-        assert!(err.contains(&local_peer_id.to_string()));
-    }
-
-    #[test]
-    fn consensus_runtime_config_accepts_local_peer_id() {
-        let local_secret_key = secret_key(0x44);
-        let other_secret_key = secret_key(0x55);
-        let local_peer_id = peer_id_for_secret(&local_secret_key);
-        let other_peer_id = peer_id_for_secret(&other_secret_key);
-        let peer_ids = vec![other_peer_id, local_peer_id];
-        let network_config = NetworkConfig {
-            enabled: true,
-            secret_key: Some(local_secret_key),
-            ..Default::default()
-        };
-        let consensus_config = ConsensusConfig {
-            enabled: true,
-            peer_ids: peer_ids.clone(),
-            ..Default::default()
-        };
-
-        let raft_config = consensus_config
-            .into_raft_consensus_config(&network_config, "raft".into())
-            .unwrap();
-
-        assert_eq!(raft_config.node_id, local_peer_id);
-        assert_eq!(raft_config.peer_ids, peer_ids);
     }
 
     #[tokio::test]

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -664,22 +664,6 @@ pub struct ConsensusConfig {
         |root: &Config, value: &Vec<PeerId>| !root.consensus_config.enabled || !value.is_empty(),
         "must not be empty when `consensus.enabled=true`"
     ))]
-    #[config_validate(custom(
-        |root: &Config, value: &Vec<PeerId>| {
-            if !root.consensus_config.enabled {
-                return true;
-            }
-            let Some(secret_key) = root.network_config.secret_key.as_ref() else {
-                return true;
-            };
-            let local_peer_id = NodeRecord::from_secret_key(
-                SocketAddrV4::new(root.network_config.address, root.network_config.port).into(),
-                secret_key,
-            ).id;
-            value.contains(&local_peer_id)
-        },
-        "must include local peer id derived from `network.secret_key`"
-    ))]
     pub peer_ids: Vec<PeerId>,
     /// WARNING: Assumes all configured consensus nodes are already caught up to the same
     /// canonical L2 state. Bootstrap does not catch up stale nodes before admitting them
@@ -706,6 +690,10 @@ impl ConsensusConfig {
         storage_path: PathBuf,
     ) -> anyhow::Result<RaftConsensusConfig> {
         let node_id = network_config.derived_peer_id()?;
+        anyhow::ensure!(
+            self.peer_ids.contains(&node_id),
+            "`consensus.peer_ids` must include local peer id derived from `network.secret_key`: {node_id}"
+        );
         Ok(RaftConsensusConfig {
             node_id,
             peer_ids: self.peer_ids,
@@ -1965,7 +1953,7 @@ mod tests {
     use super::*;
     use alloy::signers::k256::ecdsa::SigningKey;
     use smart_config::{ConfigRepository, ConfigSchema, DescribeConfig, Environment};
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, SocketAddrV4};
 
     const TEST_SECRET_KEY: &str =
         "0x1111111111111111111111111111111111111111111111111111111111111111";
@@ -2024,6 +2012,18 @@ mod tests {
 
     fn local_signer(byte: u8) -> SignerConfig {
         SignerConfig::Local(SigningKey::from_slice(&[byte; 32]).unwrap())
+    }
+
+    fn secret_key(byte: u8) -> SecretKey {
+        SecretKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn peer_id_for_secret(secret_key: &SecretKey) -> PeerId {
+        NodeRecord::from_secret_key(
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 3030).into(),
+            secret_key,
+        )
+        .id
     }
 
     fn base_config(node_role: NodeRole) -> Config {
@@ -2138,6 +2138,60 @@ mod tests {
         config.external_price_api_client_config = None;
 
         config.validate().await.unwrap();
+    }
+
+    #[test]
+    fn consensus_runtime_config_rejects_missing_local_peer_id() {
+        let local_secret_key = secret_key(0x44);
+        let other_secret_key = secret_key(0x55);
+        let local_peer_id = peer_id_for_secret(&local_secret_key);
+        let other_peer_id = peer_id_for_secret(&other_secret_key);
+        let network_config = NetworkConfig {
+            enabled: true,
+            secret_key: Some(local_secret_key),
+            ..Default::default()
+        };
+        let consensus_config = ConsensusConfig {
+            enabled: true,
+            peer_ids: vec![other_peer_id],
+            ..Default::default()
+        };
+
+        let err = consensus_config
+            .into_raft_consensus_config(&network_config, "raft".into())
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains(
+            "`consensus.peer_ids` must include local peer id derived from `network.secret_key`"
+        ));
+        assert!(err.contains(&local_peer_id.to_string()));
+    }
+
+    #[test]
+    fn consensus_runtime_config_accepts_local_peer_id() {
+        let local_secret_key = secret_key(0x44);
+        let other_secret_key = secret_key(0x55);
+        let local_peer_id = peer_id_for_secret(&local_secret_key);
+        let other_peer_id = peer_id_for_secret(&other_secret_key);
+        let peer_ids = vec![other_peer_id, local_peer_id];
+        let network_config = NetworkConfig {
+            enabled: true,
+            secret_key: Some(local_secret_key),
+            ..Default::default()
+        };
+        let consensus_config = ConsensusConfig {
+            enabled: true,
+            peer_ids: peer_ids.clone(),
+            ..Default::default()
+        };
+
+        let raft_config = consensus_config
+            .into_raft_consensus_config(&network_config, "raft".into())
+            .unwrap();
+
+        assert_eq!(raft_config.node_id, local_peer_id);
+        assert_eq!(raft_config.peer_ids, peer_ids);
     }
 
     #[tokio::test]

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -636,6 +636,7 @@ impl NetworkConfig {
 #[config(derive(Default))]
 pub struct ConsensusConfig {
     /// Whether OpenRaft-based consensus should be enabled.
+    /// WARNING: This is an experimental feature and will change in the future.
     #[config(default_t = false)]
     #[config_validate(custom(
         |root: &Config, value: &bool| !*value || root.general_config.node_role.is_main(),


### PR DESCRIPTION
Config Validation doesn't work with the current approach.
Reason: in config validation dummy secrets are used. 