### PR TITLE
fix(raft): rate-limit ensure_linearizable to silence log spam

### DIFF
--- a/lib/raft/src/leadership_monitor.rs
+++ b/lib/raft/src/leadership_monitor.rs
@@ -10,9 +10,12 @@ use tokio::time::{MissedTickBehavior, interval, timeout};
 use zksync_os_consensus_types::{RaftNode, RaftTypeConfig};
 
 /// How often we re-probe `ensure_linearizable` while holding the Leader state but waiting
-/// for confirmation. Decoupled from openraft's metrics channel — that fires many times per
-/// second during elections, and probing on every change produced one log line per metrics
-/// tick during a stuck-leader window.
+/// for confirmation. We still wake on every OpenRaft metrics change (to keep the status
+/// watch and the role-loss reaction responsive), but the probe call itself is rate-limited
+/// to one per `PROBE_INTERVAL` — without this, a metrics-churn storm against unreachable
+/// voters produces one openraft-side ERROR (`timeout while confirming leadership for read
+/// request`) per unreachable voter per metrics tick. The `claims_leader: false → true` edge
+/// bypasses the rate limit so a fresh election confirms without paying the full interval.
 const PROBE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Per-probe budget for the linearizability round-trip.
@@ -69,13 +72,16 @@ pub fn spawn_leadership_monitor(
         let mut leader_confirmed = false;
         let mut prev_role = ConsensusRole::Replica;
         let mut streak: Option<FailureStreak> = None;
+        let mut last_probe_at: Option<Instant> = None;
         let mut probe_timer = interval(PROBE_INTERVAL);
         probe_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
-            // React to either an openraft metrics change or the periodic probe tick. Using
-            // an interval here decouples probe rate from openraft's metrics churn, which
-            // can fire many times per second during elections.
+            // Wake on either an OpenRaft metrics change or the periodic probe tick. Both
+            // are needed: metrics changes drive the status watch and the role-loss
+            // reaction; the probe tick ensures we periodically re-attempt confirmation
+            // even if metrics go quiet. The `ensure_linearizable` call below is separately
+            // rate-limited by `last_probe_at` — see `PROBE_INTERVAL`.
             tokio::select! {
                 biased;
                 changed = metrics_rx.changed() => {
@@ -104,10 +110,15 @@ pub fn spawn_leadership_monitor(
             let claims_leader = matches!(metrics.state, ServerState::Leader);
             if !claims_leader {
                 // Once we stop claiming leader, any in-progress streak is moot; the role
-                // change itself is logged below.
+                // change itself is logged below. Clearing `last_probe_at` ensures the next
+                // false→true edge probes immediately rather than waiting out an interval.
                 streak = None;
                 leader_confirmed = false;
-            } else if !leader_confirmed {
+                last_probe_at = None;
+            } else if !leader_confirmed
+                && last_probe_at.is_none_or(|t| t.elapsed() >= PROBE_INTERVAL)
+            {
+                last_probe_at = Some(Instant::now());
                 match timeout(PROBE_TIMEOUT, raft.ensure_linearizable()).await {
                     Ok(Ok(_)) => {
                         if let Some(s) = streak.take() {


### PR DESCRIPTION
## Summary

When consensus is enabled and a node holds the Raft leader role but cannot reach its voters (e.g. peers are mid-handshake or partitioned), the logs spam thousands of lines per second:

```
ERROR openraft::core::raft_core: timeout while confirming leadership for read request target=0x… error=Unreachable node: … peer 0x… is not connected
```

The leadership monitor (`lib/raft/src/leadership_monitor.rs`) wakes the loop on every OpenRaft metrics-watch change, and the `ensure_linearizable()` probe was called inside that body. Each failed probe emits one openraft-side ERROR per unreachable voter (openraft `RaftCore::handle_check_is_leader_request`). Because our transport returns `NotConnected` synchronously, each call resolves in microseconds, so a metrics-churn storm fans out into roughly `unreachable_voters × metrics_rate` log lines per second. The existing `note_failure` / `STUCK_REMINDER_INTERVAL` dedup only suppresses *our* warn-level lines, not openraft's internal `tracing::error!`.

This change rate-limits the probe call:

- Add `last_probe_at: Option<Instant>`. Only call `ensure_linearizable()` if `last_probe_at` is `None` *or* its elapsed exceeds `PROBE_INTERVAL` (1s).
- Reset `last_probe_at = None` whenever `!claims_leader`, so the `false → true` edge of a fresh election still probes immediately (no added confirmation latency).
- Keep the `select!` waking on metrics changes — status-watch freshness and the role-loss panic path stay responsive.

Under the reported scenario, openraft ERROR rate drops from thousands/sec to `unreachable_voters × 1 Hz`. Our own steady-state warn lines remain dedup-throttled to one per `STUCK_REMINDER_INTERVAL` (30 s).

## Test plan

- [ ] Workspace fmt + clippy pass.
- [ ] `cargo nextest run -p zksync_os_integration_tests --profile no-pig` passes.
- [ ] Manual: bring up a multi-node consensus cluster with one follower offline; confirm openraft no longer emits ERROR per metrics tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)