### PR TITLE
feat(l1-watcher): traverse historical GW intervals

### DIFF
--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -10,7 +10,8 @@ use backon::{ConstantBuilder, Retryable};
 use std::fmt::Debug;
 use std::time::Duration;
 
-const L2_BRIDGEHUB_ADDRESS: Address = address!("0x0000000000000000000000000000000000010002");
+/// Standard L2 bridgehub address — present at the same well-known address on every Gateway.
+pub const L2_BRIDGEHUB_ADDRESS: Address = address!("0x0000000000000000000000000000000000010002");
 
 #[derive(Clone, Debug)]
 pub struct BatchVerificationSLConfig {
@@ -61,9 +62,11 @@ struct BatchFinality {
 impl L1State {
     /// Fetches L1 ecosystem contracts along with batch finality status as of latest block.
     ///
-    /// `gateway_provider` must be `Some` when the chain is settling on the Gateway and `None`
-    /// when settling on L1. An error is returned if the chain is found to be on the Gateway but
-    /// no provider was supplied.
+    /// `gateway_provider` must be `Some` when the chain is currently settling on the Gateway
+    /// (an error is returned if missing). It may also be passed when the chain is currently
+    /// settling on L1 but has historical Gateway intervals — in that case the Gateway diamond
+    /// proxy is resolved from it so historical batches committed on the Gateway can still be
+    /// looked up via [`SettlementLayerIntervals::resolve_proxy`].
     pub async fn fetch(
         l1_provider: DynProvider,
         gateway_provider: Option<DynProvider>,
@@ -87,7 +90,7 @@ impl L1State {
             (l1_chain_id, bridgehub_l1.clone())
         } else {
             // Settling on Gateway: require a dedicated Gateway RPC provider.
-            let gateway_provider = gateway_provider.with_context(|| {
+            let gateway_provider = gateway_provider.as_ref().with_context(|| {
                 format!(
                     "chain is settling on Gateway (settlement layer: {settlement_layer_address}) \
                      but no gateway RPC URL is configured"
@@ -98,7 +101,8 @@ impl L1State {
                 sl_chain_id != l1_chain_id,
                 "settling on Gateway but SL chain ID is identical to L1 chain ID"
             );
-            let bridgehub_sl = Bridgehub::new(L2_BRIDGEHUB_ADDRESS, gateway_provider, l2_chain_id);
+            let bridgehub_sl =
+                Bridgehub::new(L2_BRIDGEHUB_ADDRESS, gateway_provider.clone(), l2_chain_id);
             (sl_chain_id, bridgehub_sl)
         };
 
@@ -153,21 +157,17 @@ impl L1State {
         };
 
         let chain_asset_handler = bridgehub_l1.chain_asset_handler_address().await?;
-        let diamond_proxy_gw = if sl_chain_id == l1_chain_id {
-            None
-        } else {
-            Some((sl_chain_id, diamond_proxy_sl.clone()))
-        };
         let settlement_layer_intervals = SettlementLayerIntervals::discover(
             chain_asset_handler,
             diamond_proxy_l1.clone(),
-            diamond_proxy_gw,
+            gateway_provider,
             l2_chain_id,
         )
         .await?;
         tracing::info!(
-            "discovered {} settlement layer intervals",
-            settlement_layer_intervals.intervals().len()
+            "discovered {} settlement layer intervals: {:?}",
+            settlement_layer_intervals.intervals().len(),
+            settlement_layer_intervals.intervals(),
         );
 
         Ok(Self {

--- a/lib/contract_interface/src/settlement_layer_intervals.rs
+++ b/lib/contract_interface/src/settlement_layer_intervals.rs
@@ -1,6 +1,6 @@
-use crate::{IChainAssetHandler, ZkChain, is_method_missing};
+use crate::{Bridgehub, IChainAssetHandler, ZkChain, is_method_missing};
 use alloy::primitives::{Address, U256};
-use alloy::providers::DynProvider;
+use alloy::providers::{DynProvider, Provider};
 use anyhow::Context;
 use std::fmt;
 use std::sync::Arc;
@@ -71,16 +71,37 @@ impl SettlementLayerIntervals {
     pub async fn discover(
         chain_asset_handler: Address,
         diamond_proxy_l1: ZkChain<DynProvider>,
-        diamond_proxy_gw: Option<(u64, ZkChain<DynProvider>)>,
-        chain_id: u64,
+        gateway_provider: Option<DynProvider>,
+        l2_chain_id: u64,
     ) -> anyhow::Result<Self> {
         let intervals = find_settlement_layer_intervals(
             chain_asset_handler,
             diamond_proxy_l1.provider().clone(),
-            chain_id,
+            l2_chain_id,
         )
         .await
         .context("failed to discover settlement layer intervals")?;
+        // Resolve historical Gateway diamond proxy if the chain has any Gateway interval AND
+        // gateway_provider is configured.
+        let has_historical_gateway = intervals
+            .iter()
+            .any(|i| matches!(i.settlement_layer, IntervalSettlementLayer::Gateway(_)));
+        let diamond_proxy_gw =
+            if has_historical_gateway && let Some(gateway_provider) = &gateway_provider {
+                let gw_chain_id = gateway_provider.get_chain_id().await?;
+                let bridgehub_gw = Bridgehub::new(
+                    crate::l1_discovery::L2_BRIDGEHUB_ADDRESS,
+                    gateway_provider.clone(),
+                    l2_chain_id,
+                );
+                let historical_diamond_proxy_gw = bridgehub_gw
+                    .zk_chain()
+                    .await
+                    .context("failed to resolve historical Gateway diamond proxy")?;
+                Some((gw_chain_id, historical_diamond_proxy_gw))
+            } else {
+                None
+            };
         Ok(Self {
             intervals: Arc::new(intervals),
             diamond_proxy_l1,

--- a/lib/contract_interface/src/settlement_layer_intervals.rs
+++ b/lib/contract_interface/src/settlement_layer_intervals.rs
@@ -23,7 +23,8 @@ impl fmt::Display for IntervalSettlementLayer {
     }
 }
 
-/// Inclusive batch-number range during which the chain committed to a single settlement layer.
+/// Inclusive batch-number range during which the chain committed to a single settlement layer,
+/// paired with the diamond proxy for that settlement layer.
 ///
 /// `last_batch` is `None` for the currently-active (open-ended) interval.
 #[derive(Debug, Clone)]
@@ -31,6 +32,8 @@ pub struct SettlementLayerInterval {
     pub settlement_layer: IntervalSettlementLayer,
     pub first_batch: u64,
     pub last_batch: Option<u64>,
+    /// Diamond proxy on `settlement_layer`.
+    pub proxy: ZkChain<DynProvider>,
 }
 
 impl fmt::Display for SettlementLayerInterval {
@@ -50,31 +53,33 @@ impl fmt::Display for SettlementLayerInterval {
     }
 }
 
-/// Settlement layer intervals for a chain paired with the diamond proxies needed to route batch
-/// lookups to the correct RPC.
+struct RawSettlementLayerInterval {
+    settlement_layer: IntervalSettlementLayer,
+    first_batch: u64,
+    last_batch: Option<u64>,
+}
+
+/// Settlement layer intervals for a chain. Each entry carries the diamond proxy needed to route
+/// batch lookups to the correct RPC.
 ///
 /// The intervals cover all batches from `1` upwards in ascending order, with the last entry being
 /// open-ended (`last_batch = None`).
 #[derive(Debug, Clone)]
 pub struct SettlementLayerIntervals {
     intervals: Arc<Vec<SettlementLayerInterval>>,
-    diamond_proxy_l1: ZkChain<DynProvider>,
-    /// Diamond proxy of the chain's current settlement layer, paired with that SL's chain ID.
-    /// `None` means the chain currently settles on L1, in which case lookups for historical
-    /// Gateway intervals are unsupported (no Gateway provider is configured).
-    diamond_proxy_gw: Option<(u64, ZkChain<DynProvider>)>,
 }
 
 impl SettlementLayerIntervals {
-    /// Discovers the intervals on-chain from `IL1ChainAssetHandler.migrationInterval` and stores
-    /// the diamond proxies needed to resolve future lookups.
+    /// Discovers the intervals on-chain from `IL1ChainAssetHandler.migrationInterval` and attaches
+    /// the matching diamond proxy to each. Fails if a historical Gateway interval references a
+    /// chain that the configured `gateway_provider` cannot serve.
     pub async fn discover(
         chain_asset_handler: Address,
         diamond_proxy_l1: ZkChain<DynProvider>,
         gateway_provider: Option<DynProvider>,
         l2_chain_id: u64,
     ) -> anyhow::Result<Self> {
-        let intervals = find_settlement_layer_intervals(
+        let raw_intervals = find_settlement_layer_intervals(
             chain_asset_handler,
             diamond_proxy_l1.provider().clone(),
             l2_chain_id,
@@ -83,7 +88,7 @@ impl SettlementLayerIntervals {
         .context("failed to discover settlement layer intervals")?;
         // Resolve historical Gateway diamond proxy if the chain has any Gateway interval AND
         // gateway_provider is configured.
-        let has_historical_gateway = intervals
+        let has_historical_gateway = raw_intervals
             .iter()
             .any(|i| matches!(i.settlement_layer, IntervalSettlementLayer::Gateway(_)));
         let diamond_proxy_gw =
@@ -102,10 +107,41 @@ impl SettlementLayerIntervals {
             } else {
                 None
             };
+
+        let mut intervals = Vec::with_capacity(raw_intervals.len());
+        for raw in raw_intervals {
+            let proxy = match raw.settlement_layer {
+                IntervalSettlementLayer::L1 => diamond_proxy_l1.clone(),
+                IntervalSettlementLayer::Gateway(chain_id) => match &diamond_proxy_gw {
+                    Some((gw_chain_id, gw)) if *gw_chain_id == chain_id => gw.clone(),
+                    Some((gw_chain_id, _)) => anyhow::bail!(
+                        "interval {}..{} was committed on Gateway with chain ID {chain_id} but \
+                         the chain's current Gateway is {gw_chain_id}; no provider is available \
+                         for the historical Gateway",
+                        raw.first_batch,
+                        raw.last_batch
+                            .map(|b| b.to_string())
+                            .unwrap_or_else(|| "?".to_string()),
+                    ),
+                    None => anyhow::bail!(
+                        "interval {}..{} was committed on Gateway with chain ID {chain_id} but \
+                         the chain currently settles on L1; no Gateway provider is configured",
+                        raw.first_batch,
+                        raw.last_batch
+                            .map(|b| b.to_string())
+                            .unwrap_or_else(|| "?".to_string()),
+                    ),
+                },
+            };
+            intervals.push(SettlementLayerInterval {
+                settlement_layer: raw.settlement_layer,
+                first_batch: raw.first_batch,
+                last_batch: raw.last_batch,
+                proxy,
+            });
+        }
         Ok(Self {
             intervals: Arc::new(intervals),
-            diamond_proxy_l1,
-            diamond_proxy_gw,
         })
     }
 
@@ -131,30 +167,8 @@ impl SettlementLayerIntervals {
         )
     }
 
-    /// Returns the diamond proxy that should be used to fetch data about `batch_number`, based on
-    /// which settlement layer interval it falls into.
-    pub fn resolve_proxy(&self, batch_number: u64) -> anyhow::Result<&ZkChain<DynProvider>> {
-        let interval = self.find_interval(batch_number).with_context(|| {
-            format!("batch {batch_number} does not belong to any known settlement layer interval")
-        })?;
-        match interval.settlement_layer {
-            IntervalSettlementLayer::L1 => Ok(&self.diamond_proxy_l1),
-            IntervalSettlementLayer::Gateway(chain_id) => match &self.diamond_proxy_gw {
-                Some((gw_chain_id, gw)) if *gw_chain_id == chain_id => Ok(gw),
-                Some((gw_chain_id, _)) => anyhow::bail!(
-                    "batch {batch_number} was committed on Gateway with chain ID {chain_id} but \
-                     the chain's current Gateway is {gw_chain_id}; no provider is available for \
-                     the historical Gateway"
-                ),
-                None => anyhow::bail!(
-                    "batch {batch_number} was committed on Gateway with chain ID {chain_id} but \
-                     the chain currently settles on L1; no Gateway provider is configured"
-                ),
-            },
-        }
-    }
-
-    fn find_interval(&self, batch_number: u64) -> Option<&SettlementLayerInterval> {
+    /// Returns the settlement layer interval containing `batch_number`.
+    pub fn find_interval(&self, batch_number: u64) -> Option<&SettlementLayerInterval> {
         self.intervals.iter().find(|i| {
             batch_number >= i.first_batch && i.last_batch.is_none_or(|last| batch_number <= last)
         })
@@ -178,7 +192,7 @@ async fn find_settlement_layer_intervals(
     chain_asset_handler: Address,
     provider: DynProvider,
     chain_id: u64,
-) -> anyhow::Result<Vec<SettlementLayerInterval>> {
+) -> anyhow::Result<Vec<RawSettlementLayerInterval>> {
     let cah = IChainAssetHandler::new(chain_asset_handler, provider);
     let total_migrations: u64 = match cah.migrationNumber(U256::from(chain_id)).call().await {
         Ok(n) => n
@@ -191,7 +205,7 @@ async fn find_settlement_layer_intervals(
                 "ChainAssetHandler does not expose migrationNumber; assuming pre-V31 protocol \
                  with no Gateway migrations: {e}"
             );
-            return Ok(vec![SettlementLayerInterval {
+            return Ok(vec![RawSettlementLayerInterval {
                 settlement_layer: IntervalSettlementLayer::L1,
                 first_batch: 1,
                 last_batch: None,
@@ -238,7 +252,7 @@ async fn find_settlement_layer_intervals(
             to_batch + 1,
             cursor
         );
-        intervals.push(SettlementLayerInterval {
+        intervals.push(RawSettlementLayerInterval {
             settlement_layer: IntervalSettlementLayer::L1,
             first_batch: cursor,
             last_batch: Some(to_batch),
@@ -246,7 +260,7 @@ async fn find_settlement_layer_intervals(
         cursor = to_batch + 1;
 
         if raw.isActive {
-            intervals.push(SettlementLayerInterval {
+            intervals.push(RawSettlementLayerInterval {
                 settlement_layer: IntervalSettlementLayer::Gateway(sl_chain_id),
                 first_batch: cursor,
                 last_batch: None,
@@ -258,7 +272,7 @@ async fn find_settlement_layer_intervals(
             .migrateFromGWBatchNumber
             .try_into()
             .map_err(|e| anyhow::anyhow!("migrateFromGWBatchNumber overflow: {e}"))?;
-        intervals.push(SettlementLayerInterval {
+        intervals.push(RawSettlementLayerInterval {
             settlement_layer: IntervalSettlementLayer::Gateway(sl_chain_id),
             first_batch: cursor,
             last_batch: Some(from_batch),
@@ -266,7 +280,7 @@ async fn find_settlement_layer_intervals(
         cursor = from_batch + 1;
     }
     if !on_active_gw {
-        intervals.push(SettlementLayerInterval {
+        intervals.push(RawSettlementLayerInterval {
             settlement_layer: IntervalSettlementLayer::L1,
             first_batch: cursor,
             last_batch: None,

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -170,7 +170,11 @@ impl CommittedBatchProvider {
     ) -> anyhow::Result<()> {
         stream::iter(batch_numbers)
             .map(|batch_number| async move {
-                let proxy = self.intervals.resolve_proxy(batch_number)?;
+                let proxy = &self
+                    .intervals
+                    .find_interval(batch_number)
+                    .with_context(|| format!("batch {batch_number} does not belong to any known settlement layer interval"))?
+                    .proxy;
                 let discovered_batch =
                     fetch_batch(proxy, batch_number, max_l1_blocks_to_scan).await?;
                 tracing::info!(

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -2,61 +2,131 @@ use alloy::primitives::ruint::FromUintError;
 use alloy::providers::DynProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
+use anyhow::Context;
 use std::collections::HashMap;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMessageRoot::NewInteropRoot;
 use zksync_os_contract_interface::InteropRoot;
+use zksync_os_contract_interface::l1_discovery::L2_BRIDGEHUB_ADDRESS;
+use zksync_os_contract_interface::settlement_layer_intervals::{
+    IntervalSettlementLayer, SettlementLayerIntervals,
+};
 use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
 use zksync_os_types::IndexedInteropRoot;
 
-use crate::util::find_l1_block_by_interop_root_id;
-use crate::watcher::{L1Watcher, L1WatcherError};
+use crate::sl_aware_watcher::{SegmentSpec, SlAwareL1Watcher};
+use crate::util::{find_l1_block_by_interop_root_id, find_l1_execute_block_by_batch_number};
+use crate::watcher::L1WatcherError;
 use crate::{L1WatcherConfig, ProcessRawEvents};
 
-/// Watches interop root updates on the settlement layer and feeds them into the interop subpool.
+/// Watches interop root updates emitted by Gateway settlement layers and feeds them into the
+/// interop subpool.
 ///
-/// This component reads `NewInteropRoot` events from the bridgehub message root contract,
-/// de-duplicates multiple logs for the same `logId`, and inserts the latest `IndexedInteropRoot`
-/// into `InteropRootsSubpool`.
+/// This component reads `NewInteropRoot` events from the Gateway bridgehub's message-root
+/// contract, de-duplicates multiple logs for the same `logId`, and inserts the latest
+/// `IndexedInteropRoot` into `InteropRootsSubpool`.
+///
+/// To support a chain that has migrated GW → L1 (or GW → L1 → GW → …), the watcher walks every
+/// Gateway interval — historical and active — via [`SlAwareL1Watcher`]. Each historical Gateway
+/// segment is bounded by the L1/SL block where the last included interop root was emitted.
 pub struct InteropWatcher {
     starting_interop_root_id: u64,
     interop_roots_subpool: InteropRootsSubpool,
 }
 
 impl InteropWatcher {
+    /// Builds the watcher iff the chain has at least one Gateway interval. Returns `Ok(None)`
+    /// for chains that have only ever settled on L1 — those have no interop roots to watch.
     pub async fn create_watcher(
-        bridgehub: Bridgehub<DynProvider>,
+        intervals: SettlementLayerIntervals,
         config: L1WatcherConfig,
+        l2_chain_id: u64,
         starting_interop_root_id: u64,
         interop_roots_subpool: InteropRootsSubpool,
-        l1_chain_id: u64,
-    ) -> anyhow::Result<L1Watcher> {
-        let contract_address = bridgehub.message_root_address().await?;
+    ) -> anyhow::Result<Option<SlAwareL1Watcher>> {
+        let mut segments = Vec::new();
+        for interval in intervals.intervals() {
+            // L1 intervals never emit interop roots; skip them outright.
+            let IntervalSettlementLayer::Gateway(_) = interval.settlement_layer else {
+                continue;
+            };
+            // Empty intervals are possible when a migration closes without committing anything
+            // (`first_batch > last_batch`). Nothing to scan.
+            if interval
+                .last_batch
+                .is_some_and(|lb| interval.first_batch > lb)
+            {
+                continue;
+            }
 
-        tracing::info!(
-            contract_address = ?contract_address,
-            starting_interop_root_id,
-            "initializing interop watcher"
-        );
+            let gw_zk_chain = intervals.resolve_proxy(interval.first_batch)?.clone();
+            let bridgehub = Bridgehub::new(
+                L2_BRIDGEHUB_ADDRESS,
+                gw_zk_chain.provider().clone(),
+                l2_chain_id,
+            );
+            let message_root = bridgehub.message_root_address().await.with_context(|| {
+                format!("failed to fetch message_root address for interval {interval}")
+            })?;
 
-        let next_l1_block =
-            find_l1_block_by_interop_root_id(bridgehub.clone(), starting_interop_root_id).await?;
+            // The chain's `interop_root_id` cursor carries over across migrations, so the same
+            // value is the floor anchor on every segment — `find_l1_block_by_interop_root_id`
+            // resolves it to the correct block on whichever SL we point it at.
+            let start_block = find_l1_block_by_interop_root_id(
+                bridgehub.clone(),
+                starting_interop_root_id,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to find {} block for interop_root_id={starting_interop_root_id} \
+                     in interval {interval}",
+                    interval.settlement_layer
+                )
+            })?;
+            // End block is chosen pessimistically: it's the GW block where last batch was executed,
+            // hence we could import extra roots that were never picked up during the interval.
+            // This is not a problem though as mempool will not serve them in the next interval as
+            // interop is not possible on L1. The slight tradeoff here is that they will be stuck
+            // in memory until the next restart.
+            let end_block = match interval.last_batch {
+                Some(last_batch) => Some(
+                    find_l1_execute_block_by_batch_number(gw_zk_chain.clone(), last_batch)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to find Gateway execute block for batch #{last_batch} \
+                                 in interval {interval}"
+                            )
+                        })?,
+                ),
+                None => None,
+            };
 
-        let this = Self {
+            tracing::info!(
+                ?interval,
+                message_root = ?message_root,
+                start_block,
+                ?end_block,
+                "scheduling interop watcher segment"
+            );
+            segments.push(SegmentSpec {
+                provider: gw_zk_chain.provider().clone(),
+                address: message_root.into(),
+                start_block,
+                end_block,
+            });
+        }
+        if segments.is_empty() {
+            tracing::info!("chain has no Gateway intervals; skipping interop roots watcher");
+            return Ok(None);
+        }
+
+        let processor = Self {
             starting_interop_root_id,
             interop_roots_subpool,
         };
-
-        L1Watcher::new(
-            config,
-            bridgehub.provider().clone(),
-            contract_address.into(),
-            next_l1_block,
-            None,
-            l1_chain_id,
-            Box::new(this),
-        )
-        .await
+        SlAwareL1Watcher::new(config, segments, Box::new(processor)).map(Some)
     }
 }
 

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -59,7 +59,7 @@ impl InteropWatcher {
                 continue;
             }
 
-            let gw_zk_chain = intervals.resolve_proxy(interval.first_batch)?.clone();
+            let gw_zk_chain = &interval.proxy;
             let bridgehub = Bridgehub::new(
                 L2_BRIDGEHUB_ADDRESS,
                 gw_zk_chain.provider().clone(),

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -35,7 +35,7 @@ pub struct InteropWatcher {
 }
 
 impl InteropWatcher {
-    /// Builds the watcher iff the chain has at least one Gateway interval. Returns `Ok(None)`
+    /// Builds the watcher if the chain has at least one Gateway interval. Returns `Ok(None)`
     /// for chains that have only ever settled on L1 — those have no interop roots to watch.
     pub async fn create_watcher(
         intervals: SettlementLayerIntervals,

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -4,6 +4,7 @@ use crate::{L1WatcherConfig, SegmentSpec, SlAwareL1Watcher, util};
 use alloy::providers::DynProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
+use anyhow::Context;
 use std::collections::HashMap;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
 use zksync_os_contract_interface::IExecutor::{BlockExecution, ReportCommittedBatchRangeZKsyncOS};
@@ -33,14 +34,14 @@ pub struct L1PersistBatchWatcher<BatchStorage> {
 
 impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
     /// Builds an [`SlAwareL1Watcher`] that walks every settlement-layer interval still relevant
-    /// to persistence, in order. Returns cheaply: per-segment block resolution and event
-    /// scanning happen lazily inside the watcher's `run()` loop.
+    /// to persistence, in order. Per-segment block resolution happens here; event scanning
+    /// happens lazily inside the watcher's `run()` loop.
     ///
     /// The migration contract requires `totalBatchesCommitted == totalBatchesExecuted` before a
     /// chain can migrate off an SL (`Migrator.sol`), so each closed interval is self-contained:
     /// every commit on that SL has a matching execute on the same SL, and the in-memory
     /// `committed_batches` map is empty at interval boundaries.
-    pub fn create_watcher(
+    pub async fn create_watcher(
         config: L1WatcherConfig,
         intervals: SettlementLayerIntervals,
         batch_storage: BatchStorage,
@@ -57,8 +58,9 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
         // Build segment specs from the relevant intervals. The first non-skipped segment is
         // adjusted to start at `last_persisted_batch` (so we re-validate it on resume), unless
         // we're at genesis — in which case `0` triggers the batch-0 fast path inside
-        // `find_l1_commit_block_by_batch_number` on the watcher side.
+        // `find_l1_commit_block_by_batch_number`.
         let mut segments = Vec::new();
+        let mut is_first = true;
         for interval in intervals.intervals() {
             // Empty interval: a migration can close without any new batches on the SL.
             if interval
@@ -76,7 +78,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
             }
 
             let zk_chain = intervals.resolve_proxy(interval.first_batch)?.clone();
-            let first_batch = if segments.is_empty() {
+            let first_batch = if is_first {
                 anyhow::ensure!(
                     interval.first_batch <= last_persisted_batch + 1,
                     "first SL interval ({interval}) must start at or before first non-persisted batch ({})",
@@ -84,15 +86,39 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 );
                 last_persisted_batch
             } else {
-                // First batch in the interval might not have been committed yet. We will find the
-                // canonical start of the segment instead where previous batch got imported during
-                // migration.
+                // First batch in the interval might not have been committed yet. We resolve the
+                // canonical start of the segment from the previous batch's import block.
                 interval.first_batch - 1
             };
-            segments.push(SegmentSpec {
-                zk_chain,
+            is_first = false;
+
+            let start_block = util::find_l1_commit_block_by_batch_number(
+                zk_chain.clone(),
                 first_batch,
-                last_batch: interval.last_batch,
+                config.max_blocks_to_process,
+            )
+            .await
+            .with_context(|| {
+                format!("failed to find L1 commit for batch #{first_batch} in interval {interval}")
+            })?;
+            let end_block = match interval.last_batch {
+                Some(last_batch) => Some(
+                    util::find_l1_execute_block_by_batch_number(zk_chain.clone(), last_batch)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to find L1 execute for batch #{last_batch} in interval {interval}"
+                            )
+                        })?,
+                ),
+                None => None,
+            };
+
+            segments.push(SegmentSpec {
+                provider: zk_chain.provider().clone(),
+                address: (*zk_chain.address()).into(),
+                start_block,
+                end_block,
             });
         }
 

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -77,7 +77,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 continue;
             }
 
-            let zk_chain = intervals.resolve_proxy(interval.first_batch)?.clone();
+            let zk_chain = &interval.proxy;
             let first_batch = if is_first {
                 anyhow::ensure!(
                     interval.first_batch <= last_persisted_batch + 1,

--- a/lib/l1_watcher/src/sl_aware_watcher.rs
+++ b/lib/l1_watcher/src/sl_aware_watcher.rs
@@ -1,29 +1,37 @@
-use crate::util;
 use crate::watcher::L1Watcher;
 use crate::{L1WatcherConfig, ProcessRawEvents};
+use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::DynProvider;
-use anyhow::Context;
+use alloy::rpc::types::ValueOrArray;
 use std::collections::VecDeque;
-use zksync_os_contract_interface::ZkChain;
 
 /// Description of a single settlement-layer segment that [`SlAwareL1Watcher`] should scan, in
-/// isolation, before advancing to the next one. `last_batch = None` marks the open-ended (live)
-/// segment; it must appear exactly once, as the final entry.
+/// isolation, before advancing to the next one. `end_block = None` marks the open-ended (live)
+/// segment; it must appear at most once, as the final entry.
+///
+/// Block boundaries are pre-resolved by the caller.
 #[derive(Clone, Debug)]
 pub struct SegmentSpec {
-    /// ZKChain (diamond proxy + provider) that hosts commit/execute events for this segment.
-    pub zk_chain: ZkChain<DynProvider>,
-    /// First batch, inclusive, whose commit block the watcher should resolve to its scan start.
-    pub first_batch: u64,
-    /// Last batch, inclusive, whose execute block closes the segment. `None` means open-ended.
-    pub last_batch: Option<u64>,
+    /// Provider for the settlement layer this segment is scanned on.
+    pub provider: DynProvider,
+    /// Contract address(es) whose logs the segment scans (e.g. the chain's diamond proxy or a
+    /// bridgehub's message-root contract).
+    pub address: ValueOrArray<Address>,
+    /// First SL block to scan from, inclusive.
+    pub start_block: BlockNumber,
+    /// Last SL block to scan, inclusive. `None` means open-ended (tailed against the SL's
+    /// finalized boundary).
+    pub end_block: Option<BlockNumber>,
 }
 
 /// Settlement-layer-aware variant of [`L1Watcher`] that walks a chain of SL segments
 /// (L1 → Gateway → L1 → …) in order. Historical segments are scanned to completion once their
-/// commit and execute blocks resolve; the final open-ended segment is tailed live against the
-/// finalized boundary so events that haven't yet been irreversibly observed on-chain are not
-/// processed.
+/// `start_block`..=`end_block` window is exhausted; if the final segment is open-ended
+/// (`end_block = None`) it is tailed live against the finalized boundary so events that haven't
+/// yet been irreversibly observed on-chain are not processed. If every segment is closed, the
+/// watcher drains them in order and then exits cleanly — useful for scenarios where the active
+/// settlement layer no longer emits events of interest (e.g. an interop-root watcher on a chain
+/// that has migrated back to L1).
 pub struct SlAwareL1Watcher {
     config: L1WatcherConfig,
     segments: VecDeque<SegmentSpec>,
@@ -40,13 +48,11 @@ impl SlAwareL1Watcher {
             !segments.is_empty(),
             "SlAwareL1Watcher requires at least one segment"
         );
-        anyhow::ensure!(
-            segments.last().unwrap().last_batch.is_none(),
-            "SlAwareL1Watcher requires the final segment to be open-ended (`last_batch = None`)"
-        );
+        // Only the final segment may be open-ended. Internal open-ended segments are nonsense
+        // because they'd never yield to the next one.
         for seg in &segments[..segments.len() - 1] {
             anyhow::ensure!(
-                seg.last_batch.is_some(),
+                seg.end_block.is_some(),
                 "non-final SlAwareL1Watcher segments must be closed"
             );
         }
@@ -65,16 +71,11 @@ impl SlAwareL1Watcher {
             mut processor,
         } = self;
         while let Some(segment) = segments.pop_front() {
-            processor = match run_segment(config.clone(), segment, processor).await {
-                Ok(processor) => processor,
-                Err(e) => {
-                    tracing::error!("sl-aware l1 watcher fatal error: {e}");
-                    panic!("sl-aware watcher failed: {e}");
-                }
-            };
+            processor = run_segment(config.clone(), segment, processor).await;
         }
-        // Unreachable: the constructor enforces a non-empty segment list whose final entry is
-        // open-ended, so the loop above never exits normally.
+        // Returns once every segment has been fully scanned. For a watcher with an open-ended
+        // final segment this is unreachable; for one with only closed segments it terminates
+        // cleanly after the historical sweep.
     }
 }
 
@@ -82,56 +83,29 @@ async fn run_segment(
     config: L1WatcherConfig,
     segment: SegmentSpec,
     processor: Box<dyn ProcessRawEvents>,
-) -> anyhow::Result<Box<dyn ProcessRawEvents>> {
-    let zk_chain = segment.zk_chain.clone();
-
-    let start_block = util::find_l1_commit_block_by_batch_number(
-        zk_chain.clone(),
-        segment.first_batch,
-        config.max_blocks_to_process,
-    )
-    .await
-    .with_context(|| {
-        format!(
-            "failed to find L1 commit for batch #{} in segment {segment:?}",
-            segment.first_batch
-        )
-    })?;
-
-    let end_block = match segment.last_batch {
-        Some(last_batch) => Some(
-            util::find_l1_execute_block_by_batch_number(zk_chain.clone(), last_batch)
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to find L1 execute for batch #{} for segment {segment:?}",
-                        last_batch
-                    )
-                })?,
-        ),
-        None => None,
-    };
-
+) -> Box<dyn ProcessRawEvents> {
     tracing::info!(
-        "sl-aware watcher activated segment at {} for batches=({}-{}), L1 blocks=({}-{})",
-        zk_chain.address(),
-        segment.first_batch,
-        segment.last_batch.unwrap_or(u64::MAX),
-        start_block,
-        end_block.unwrap_or(u64::MAX),
+        "sl-aware watcher activated segment at {:?} for SL blocks=({}-{})",
+        segment.address,
+        segment.start_block,
+        segment
+            .end_block
+            .map(|b| b.to_string())
+            .unwrap_or("*".to_string()),
     );
 
-    // Closed segments are bounded by an executed batch on-chain, so the boundary mode does not
-    // matter — `end_block` dominates the cap. The open-ended segment uses the finalized boundary
-    // so persistence-style processors only react to irreversibly observed events.
+    // Closed segments are bounded by `end_block` (already pre-resolved by the caller against an
+    // executed-batch / migration boundary), so the boundary mode does not matter — `end_block`
+    // dominates the cap. The open-ended segment uses the finalized boundary so persistence-style
+    // processors only react to irreversibly observed events.
     let mut watcher = L1Watcher::new_finalized(
         config,
-        zk_chain.provider().clone(),
-        (*zk_chain.address()).into(),
-        start_block,
-        end_block,
+        segment.provider,
+        segment.address,
+        segment.start_block,
+        segment.end_block,
         processor,
     );
     watcher.run_inner().await;
-    Ok(watcher.processor)
+    watcher.processor
 }

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -705,20 +705,20 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             .run(),
         );
 
-        if settles_on_gateway {
-            runtime.spawn_critical_task(
-                "interop roots watcher",
-                InteropWatcher::create_watcher(
-                    node_startup_state.l1_state.bridgehub_sl.clone(),
-                    config.l1_watcher_config.clone().into(),
-                    next_cursors.interop_root_id,
-                    interop_roots_subpool.clone(),
-                    node_startup_state.l1_state.l1_chain_id,
-                )
-                .await
-                .expect("failed to start L1 interop roots watcher")
-                .run(),
-            );
+        if let Some(interop_watcher) = InteropWatcher::create_watcher(
+            node_startup_state
+                .l1_state
+                .settlement_layer_intervals
+                .clone(),
+            config.l1_watcher_config.clone().into(),
+            chain_id,
+            next_cursors.interop_root_id,
+            interop_roots_subpool.clone(),
+        )
+        .await
+        .expect("failed to start L1 interop roots watcher")
+        {
+            runtime.spawn_critical_task("interop roots watcher", interop_watcher.run());
         }
     }
 
@@ -905,6 +905,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 .clone(),
             persistent_batch_storage.clone(),
         )
+        .await
         .expect("failed to start L1 batch persist watcher")
         .run(),
     );


### PR DESCRIPTION
## Summary

Makes `InteropWatcher` start even if current SL is not gateway. It then traverses historical intervals and fetches interop roots from GW.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

