### PR TITLE
feat(rpc): add eth_fillTransaction

### DIFF
--- a/integration-tests/tests/rpc/fill_transaction.rs
+++ b/integration-tests/tests/rpc/fill_transaction.rs
@@ -1,0 +1,204 @@
+use alloy::consensus::{BlobTransactionSidecar, BlobTransactionSidecarVariant, Transaction};
+use alloy::eips::Encodable2718;
+use alloy::network::TransactionBuilder;
+use alloy::primitives::{Bytes, U128, U256, address};
+use alloy::providers::Provider;
+use alloy::rpc::types::{FillTransaction, TransactionRequest};
+use alloy::transports::TransportResult;
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
+use zksync_os_server::config::FeeConfig;
+use zksync_os_types::ZkEnvelope;
+
+const FIXED_BASE_FEE: u128 = 100_000_000;
+const FILL_GAS_PRICE_SCALE_FACTOR: f64 = 2.0;
+const EXPECTED_FILL_GAS_PRICE: u128 = 200_000_000;
+
+async fn launch_with_fixed_gas_price(env: TestEnvironment) -> anyhow::Result<Tester> {
+    let mut config = env.default_config().await?;
+    config.fee_config = FeeConfig {
+        native_price_usd: 3e-9,
+        base_fee_override: Some(U128::from(FIXED_BASE_FEE)),
+        native_per_gas: 100,
+        pubdata_price_override: Some(U128::from(1_000_000u64)),
+        native_price_override: Some(U128::from(1_000_000u64)),
+        pubdata_price_cap: None,
+    };
+    config.rpc_config.gas_price_scale_factor = FILL_GAS_PRICE_SCALE_FACTOR;
+    env.launch(config).await
+}
+
+async fn fill_transaction(
+    tester: &Tester,
+    request: TransactionRequest,
+) -> TransportResult<FillTransaction<ZkEnvelope>> {
+    tester
+        .l2_provider
+        .client()
+        .request("eth_fillTransaction", (request,))
+        .await
+}
+
+async fn expect_fill_transaction_to_fail(tester: &Tester, request: TransactionRequest, msg: &str) {
+    let err = fill_transaction(tester, request)
+        .await
+        .expect_err("`eth_fillTransaction` should fail");
+    assert!(
+        err.to_string().contains(msg),
+        "expected `eth_fillTransaction` to fail with '{msg}' but got: {err}"
+    );
+}
+
+#[test_multisetup([CURRENT_TO_L1])]
+async fn fill_transaction_fills_defaults(env: TestEnvironment) -> anyhow::Result<()> {
+    let tester = launch_with_fixed_gas_price(env).await?;
+    let from = tester.l2_wallet.default_signer().address();
+    let to = address!("0xa5d85D1D865F89a23A95d4F5F74850f289Dbc5f9");
+    let expected_nonce = tester
+        .l2_provider
+        .get_transaction_count(from)
+        .pending()
+        .await?;
+    let expected_chain_id = tester.l2_provider.get_chain_id().await?;
+    assert_eq!(
+        tester.l2_provider.get_gas_price().await?,
+        EXPECTED_FILL_GAS_PRICE
+    );
+
+    let filled = fill_transaction(
+        &tester,
+        TransactionRequest::default()
+            .from(from)
+            .to(to)
+            .value(U256::ONE),
+    )
+    .await?;
+
+    assert_eq!(filled.raw, Bytes::from(filled.tx.encoded_2718()));
+    assert!(!filled.raw.is_empty());
+    assert_eq!(filled.tx.chain_id(), Some(expected_chain_id));
+    assert_eq!(filled.tx.nonce(), expected_nonce);
+    assert_eq!(filled.tx.to(), Some(to));
+    assert_eq!(filled.tx.value(), U256::ONE);
+    assert!(filled.tx.gas_limit() > 0);
+    assert_eq!(filled.tx.max_priority_fee_per_gas(), Some(0));
+    assert_eq!(filled.tx.max_fee_per_gas(), EXPECTED_FILL_GAS_PRICE);
+
+    Ok(())
+}
+
+#[test_multisetup([CURRENT_TO_L1])]
+async fn fill_transaction_preserves_provided_fields(tester: Tester) -> anyhow::Result<()> {
+    let from = tester.l2_wallet.default_signer().address();
+    let to = address!("0xa5d85D1D865F89a23A95d4F5F74850f289Dbc5f9");
+    let expected_chain_id = tester.l2_provider.get_chain_id().await?;
+
+    let filled = fill_transaction(
+        &tester,
+        TransactionRequest::default()
+            .from(from)
+            .to(to)
+            .nonce(7)
+            .gas_limit(50_000)
+            .gas_price(1_000_000_000)
+            .with_chain_id(expected_chain_id + 1),
+    )
+    .await?;
+
+    assert_eq!(filled.tx.chain_id(), Some(expected_chain_id));
+    assert_eq!(filled.tx.nonce(), 7);
+    assert_eq!(filled.tx.gas_limit(), 50_000);
+    assert_eq!(filled.tx.gas_price(), Some(1_000_000_000));
+    assert_eq!(filled.tx.max_priority_fee_per_gas(), None);
+
+    Ok(())
+}
+
+#[test_multisetup([CURRENT_TO_L1])]
+async fn fill_transaction_estimates_gas_without_balance(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let tester = launch_with_fixed_gas_price(env).await?;
+    let unfunded = address!("0x38711eC715A5A32180427792Dc0e97f8E3303072");
+    let to = address!("0xF8fF3e62E94807a5C687f418Fe36942dD3a24525");
+    assert_eq!(tester.l2_provider.get_balance(unfunded).await?, U256::ZERO);
+
+    let filled =
+        fill_transaction(&tester, TransactionRequest::default().from(unfunded).to(to)).await?;
+
+    assert_eq!(filled.tx.nonce(), 0);
+    assert_eq!(filled.tx.value(), U256::ZERO);
+    assert!(filled.tx.gas_limit() > 0);
+    assert_eq!(filled.tx.max_fee_per_gas(), EXPECTED_FILL_GAS_PRICE);
+
+    Ok(())
+}
+
+#[test_multisetup([CURRENT_TO_L1])]
+async fn fill_transaction_fail(tester: Tester) -> anyhow::Result<()> {
+    let from = tester.l2_wallet.default_signer().address();
+
+    expect_fill_transaction_to_fail(
+        &tester,
+        TransactionRequest {
+            from: Some(from),
+            sidecar: Some(BlobTransactionSidecarVariant::Eip4844(
+                BlobTransactionSidecar {
+                    blobs: vec![],
+                    commitments: vec![],
+                    proofs: vec![],
+                },
+            )),
+            ..Default::default()
+        },
+        "EIP-4844 transactions are not supported",
+    )
+    .await;
+
+    expect_fill_transaction_to_fail(
+        &tester,
+        TransactionRequest {
+            from: Some(from),
+            authorization_list: Some(vec![]),
+            ..Default::default()
+        },
+        "EIP-7702 transactions are not supported",
+    )
+    .await;
+
+    expect_fill_transaction_to_fail(
+        &tester,
+        TransactionRequest {
+            from: Some(from),
+            gas_price: Some(100),
+            max_fee_per_gas: Some(100),
+            ..Default::default()
+        },
+        "both `gasPrice` and (`maxFeePerGas` or `maxPriorityFeePerGas`) specified",
+    )
+    .await;
+
+    expect_fill_transaction_to_fail(
+        &tester,
+        TransactionRequest {
+            from: Some(from),
+            max_fee_per_gas: Some(1_000_000_001),
+            max_priority_fee_per_gas: Some(1_000_000_002),
+            ..Default::default()
+        },
+        "`maxPriorityFeePerGas` higher than `maxFeePerGas`",
+    )
+    .await;
+
+    expect_fill_transaction_to_fail(
+        &tester,
+        TransactionRequest {
+            from: Some(from),
+            max_priority_fee_per_gas: Some(u128::MAX),
+            ..Default::default()
+        },
+        "`maxPriorityFeePerGas` is too high",
+    )
+    .await;
+
+    Ok(())
+}

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -2,6 +2,7 @@ mod api;
 mod call;
 mod debug;
 mod deployment_filter;
+mod fill_transaction;
 mod filter;
 mod policy_client;
 mod pubsub;

--- a/lib/rpc/src/eth_fill_transaction_handler.rs
+++ b/lib/rpc/src/eth_fill_transaction_handler.rs
@@ -1,0 +1,74 @@
+use crate::call_fees::CallFeesError;
+use crate::eth_call_handler::{EthCallError, EthCallHandler, build_pending_block_context};
+use crate::rpc_storage::ReadRpcStorage;
+use alloy::eips::{BlockId, Encodable2718};
+use alloy::primitives::U256;
+use alloy::rpc::types::{FillTransaction, TransactionRequest};
+use zksync_os_types::{L2Envelope, ZkEnvelope};
+
+impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
+    pub(crate) fn fill_transaction_impl(
+        &self,
+        mut request: TransactionRequest,
+        pending_nonce: u64,
+        fill_gas_price: U256,
+    ) -> Result<FillTransaction<ZkEnvelope>, EthCallError> {
+        request.normalize_input();
+
+        if request.has_eip4844_fields() {
+            return Err(EthCallError::Eip4844NotSupported);
+        }
+        if request.authorization_list.is_some() {
+            return Err(EthCallError::Eip7702NotSupported);
+        }
+        if request.gas_price.is_some()
+            && (request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some())
+        {
+            return Err(CallFeesError::ConflictingFeeFieldsInRequest.into());
+        }
+
+        if request.value.is_none() {
+            request.value = Some(U256::ZERO);
+        }
+        if request.nonce.is_none() {
+            request.nonce = Some(pending_nonce);
+        }
+        request.chain_id = Some(self.chain_id);
+
+        if request.gas.is_none() {
+            let estimated_gas =
+                self.estimate_gas_impl(request.clone(), Some(BlockId::pending()), None)?;
+            request.gas = Some(estimated_gas.saturating_to());
+        }
+
+        if request.gas_price.is_none() {
+            let tip = request.max_priority_fee_per_gas.unwrap_or(0);
+            if request.max_priority_fee_per_gas.is_none() {
+                request.max_priority_fee_per_gas = Some(tip);
+            }
+            if request.max_fee_per_gas.is_none() {
+                let max_fee_per_gas = fill_gas_price
+                    .checked_add(U256::from(tip))
+                    .ok_or(CallFeesError::TipVeryHigh)?
+                    .saturating_to();
+                request.max_fee_per_gas = Some(max_fee_per_gas);
+            }
+            if request.max_fee_per_gas.unwrap_or_default() < tip {
+                return Err(CallFeesError::TipAboveFeeCap.into());
+            }
+        }
+
+        let max_fee_per_gas = request.max_fee_per_gas;
+        let block_context = build_pending_block_context(&self.storage, self.chain_id);
+        let mut tx = self
+            .create_tx_from_request(request, &block_context, false)?
+            .into_envelope();
+        if let (Some(max_fee_per_gas), ZkEnvelope::L2(L2Envelope::Eip1559(inner))) =
+            (max_fee_per_gas, &mut tx)
+        {
+            inner.tx_mut().max_fee_per_gas = max_fee_per_gas;
+        }
+        let raw = tx.encoded_2718().into();
+        Ok(FillTransaction { raw, tx })
+    }
+}

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -17,7 +17,7 @@ use alloy::rpc::types::simulate::{SimulatePayload, SimulatedBlock};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::{
     AccountInfo, BlockOverrides, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory,
-    Index, Log, StateContext, SyncStatus, TransactionRequest,
+    FillTransaction, Index, Log, StateContext, SyncStatus, TransactionRequest,
 };
 use alloy::serde::JsonStorageKey;
 use async_trait::async_trait;
@@ -35,7 +35,7 @@ use zksync_os_rpc_api::types::{
 };
 use zksync_os_storage_api::{RepositoryError, StateError, TxMeta, ViewState};
 use zksync_os_tx_validators::policy_client::PolicyClient;
-use zksync_os_types::{L2Envelope, TransactionAcceptanceState, ZkReceiptEnvelope};
+use zksync_os_types::{L2Envelope, TransactionAcceptanceState, ZkEnvelope, ZkReceiptEnvelope};
 
 pub struct EthNamespace<RpcStorage, Mempool> {
     config: RpcConfig,
@@ -705,6 +705,29 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthApiServer
     ) -> RpcResult<Bytes> {
         self.eth_call_handler
             .call_impl(request, block_number, state_overrides, block_overrides)
+            .to_rpc_result()
+    }
+
+    fn fill_transaction(
+        &self,
+        request: TransactionRequest,
+    ) -> RpcResult<FillTransaction<ZkEnvelope>> {
+        let pending_nonce = if request.nonce.is_none() {
+            self.transaction_count_impl(request.from.unwrap_or_default(), Some(BlockId::pending()))
+                .to_rpc_result()?
+                .saturating_to()
+        } else {
+            0
+        };
+
+        let fill_gas_price = if request.gas_price.is_none() && request.max_fee_per_gas.is_none() {
+            self.gas_price_impl().to_rpc_result()?
+        } else {
+            U256::ZERO
+        };
+
+        self.eth_call_handler
+            .fill_transaction_impl(request, pending_nonce, fill_gas_price)
             .to_rpc_result()
     }
 

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -8,6 +8,7 @@ use tokio::sync::watch;
 
 mod eth_call_handler;
 pub use eth_call_handler::EthCallHandler;
+mod eth_fill_transaction_handler;
 mod eth_filter;
 mod eth_impl;
 mod eth_pubsub_impl;

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -140,6 +140,7 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
                 err.to_string(),
                 None,
             ),
+            EthCallError::CallFees(_) => invalid_params_rpc_err(err.to_string()),
             err => internal_rpc_err(err.to_string()),
         })
     }

--- a/lib/rpc_api/src/eth.rs
+++ b/lib/rpc_api/src/eth.rs
@@ -10,11 +10,12 @@ use alloy::rpc::types::simulate::{SimulatePayload, SimulatedBlock};
 use alloy::rpc::types::state::StateOverride;
 use alloy::rpc::types::{
     AccessListResult, AccountInfo, BlockOverrides, Bundle, EIP1186AccountProofResponse,
-    EthCallResponse, Index, StateContext, SyncStatus, TransactionRequest,
+    EthCallResponse, FillTransaction, Index, StateContext, SyncStatus, TransactionRequest,
 };
 use alloy::serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use zksync_os_types::ZkEnvelope;
 
 /// Eth rpc interface: <https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api>
 #[cfg_attr(not(feature = "server"), rpc(client, namespace = "eth"))]
@@ -197,6 +198,13 @@ pub trait EthApi {
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
     ) -> RpcResult<Bytes>;
+
+    /// Fills defaults on a given unsigned transaction.
+    #[method(name = "fillTransaction")]
+    fn fill_transaction(
+        &self,
+        request: TransactionRequest,
+    ) -> RpcResult<FillTransaction<ZkEnvelope>>;
 
     /// Simulate arbitrary number of transactions at an arbitrary blockchain index, with the
     /// optionality of state overrides


### PR DESCRIPTION
## Summary

Adds support for `eth_fillTransaction` to the ZKsync OS server RPC API.

`eth_fillTransaction` takes an unsigned transaction request, fills missing execution defaults, and returns both the EIP-2718 encoded raw transaction bytes and the filled transaction object. This is useful for wallet, relayer, and client flows that want the node to apply the same nonce, gas, fee, and chain defaults used by adjacent RPCs before the transaction is signed and submitted elsewhere.

The implementation follows the existing RPC stack instead of adding a parallel transaction-building path:

- Adds the `eth_fillTransaction` method to the `EthApi` RPC trait.
- Reuses `transaction_count_impl(..., pending)` for the default nonce so fill behavior matches `eth_getTransactionCount` with pending state.
- Reuses the existing ZKsync OS `gas_price_impl()` value for fee defaults so the method stays aligned with runtime `eth_gasPrice` semantics.
- Reuses the existing call handler transaction preparation path after filling request defaults.
- Estimates missing gas against the pending block, matching how clients expect fill/defaulting APIs to account for current pending state.

This improves parity with established Ethereum JSON-RPC implementations.

## Behavior Notes

The method mirrors reth more closely than geth where the implementations differ:

- `chainId` is set to the local chain ID during fill, matching reth's behavior of applying the local chain ID as a default. Geth rejects a mismatched caller-provided `chainId`; this PR does not add that stricter geth-only validation.
- The request input is normalized through Alloy's transaction request handling. This keeps compatibility with the legacy `data` field while preferring `input` when present, without adding geth's explicit mismatched `data`/`input` rejection.
- Missing `value` defaults to zero.
- Missing `nonce` defaults from pending transaction count.
- Missing `gas` is filled from pending gas estimation.
- Missing dynamic fee fields are filled using the ZKsync OS scaled `eth_gasPrice` path rather than reth's L1 base-fee lookup, because ZKsync OS fee semantics should remain consistent with this node's runtime RPC behavior.

Unsupported transaction families continue to use the existing server behavior:

- EIP-4844/blob transaction fields are rejected because they are not supported by this API path.
- EIP-7702 authorization lists are rejected because they are not supported by this API path.

## Works Cited

- reth `eth_fillTransaction` implementation: fills value, nonce, chain ID, gas, fee defaults, and returns `FillTransaction { raw, tx }`.
  https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-eth-api/src/helpers/transaction.rs

- geth `TransactionAPI.FillTransaction`: exposes the equivalent RPC and delegates defaulting to `TransactionArgs.setDefaults`.
  https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go

- geth `TransactionArgs.setDefaults`: documents defaulting behavior for nonce, gas, value, chain ID, fee fields, and legacy `data` / `input` handling.
  https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/transaction_args.go

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p zksync_os_rpc_api -p zksync_os_rpc`
