### PR TITLE
fix(migration): idle when finalized migration channel is closed

### DIFF
--- a/node/bin/src/migration_gate.rs
+++ b/node/bin/src/migration_gate.rs
@@ -74,9 +74,17 @@ impl PipelineComponent for MigrationGate {
                 // the executed-batch precondition.
                 let _ = self.migration_triggered.send(Some(trigger_batch_number));
 
-                self.last_finalized_migration
+                if self
+                    .last_finalized_migration
                     .wait_for(|n| *n >= migration_number)
-                    .await?;
+                    .await
+                    .is_err()
+                {
+                    // This gets triggered if `MigrationFinalizedWatcher` is not running (i.e. we
+                    // are pending on a server restart to discover new SL interval).
+                    tracing::info!("last finalized migration channel closed; idling until restart");
+                    futures::future::pending::<()>().await;
+                }
                 tracing::info!(
                     migration_number,
                     "migration finalized; resuming commit pipeline"


### PR DESCRIPTION
## Summary

This prematurely crashes server sometimes during live chain migration

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

