### PR TITLE
feat(rpc): per-method and global JSON-RPC rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.1.0",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -1320,7 +1320,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -1339,6 +1354,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -2755,7 +2779,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "dynify",
  "fast-float2",
  "float16",
@@ -3297,7 +3321,7 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
- "anstream",
+ "anstream 0.6.19",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -3329,6 +3353,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmark-writer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2163439d96aabd9cfd1d1b2719197faa6c594b90496bf8e91cfadf60a151115"
+dependencies = [
+ "cmark-writer-macros",
+ "ecow",
+ "env_logger",
+ "html-escape",
+ "log",
+]
+
+[[package]]
+name = "cmark-writer-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54786f507e396485ea597ffe8b1753100971c6a61052e05c4e64015f43fedee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4071,6 +4119,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -4108,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4380,6 +4441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4529,6 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -4537,9 +4605,10 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
+ "anstream 0.6.19",
  "anstyle",
  "env_filter",
+ "jiff",
  "log",
 ]
 
@@ -5492,6 +5561,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap 5.5.3",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5738,6 +5827,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -6237,7 +6335,7 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "env_logger",
  "indexmap 2.12.0",
  "itoa",
@@ -6375,6 +6473,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jni"
@@ -7270,6 +7392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7288,6 +7416,12 @@ source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd00
 name = "non_determinism_source"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
@@ -8107,6 +8241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "poseidon2"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
@@ -8834,9 +8977,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8846,9 +8989,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9204,7 +9347,7 @@ version = "2.2.0"
 source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4b231f55daeb2e00#ff8afdc5dbc253019df5b68f4b231f55daeb2e00"
 dependencies = [
  "alloy-primitives",
- "dashmap",
+ "dashmap 6.1.0",
  "data-encoding",
  "enr",
  "hickory-resolver",
@@ -9468,7 +9611,7 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "crossbeam-queue",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
@@ -9736,7 +9879,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
@@ -10003,7 +10146,7 @@ version = "2.2.0"
 source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4b231f55daeb2e00#ff8afdc5dbc253019df5b68f4b231f55daeb2e00"
 dependencies = [
  "crossbeam-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "futures-util",
  "libc",
  "metrics",
@@ -11656,13 +11799,13 @@ dependencies = [
 [[package]]
 name = "smart-config"
 version = "0.4.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c50fee3c860c15fdfeb3b6171041ea83e40e731b25a18f97f2cd00ecbc961"
+source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
 dependencies = [
  "alloy 1.7.3",
  "anyhow",
  "compile-fmt",
  "primitive-types",
+ "regex",
  "secrecy",
  "serde",
  "serde_json",
@@ -11674,11 +11817,11 @@ dependencies = [
 [[package]]
 name = "smart-config-commands"
 version = "0.4.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22793fb71a9f2751308846d09f70dee804e70d4f686620e31ae8d47c82718b24"
+source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
+ "cmark-writer",
  "serde_json",
  "serde_yaml",
  "smart-config",
@@ -11687,8 +11830,7 @@ dependencies = [
 [[package]]
 name = "smart-config-derive"
 version = "0.4.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ca44e2f43adc461f96da7cf5ffdb1ab5c1439bb2d86aaf05fbc0b98b56c48d"
+source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11753,6 +11895,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -14967,7 +15118,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backon",
- "dashmap",
+ "dashmap 6.1.0",
  "futures",
  "metrics",
  "openraft",
@@ -15079,7 +15230,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
- "dashmap",
+ "dashmap 6.1.0",
  "futures",
  "openraft",
  "reth-network-peers",
@@ -15175,10 +15326,11 @@ dependencies = [
  "blake2",
  "boa_engine",
  "boa_gc",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more 2.1.1",
  "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
+ "governor",
  "hyper",
  "jsonrpsee",
  "reth-rpc-eth-types",
@@ -15413,7 +15565,7 @@ version = "0.20.3"
 dependencies = [
  "alloy 2.0.4",
  "anyhow",
- "dashmap",
+ "dashmap 6.1.0",
  "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "ruint",
  "tokio",
@@ -15464,7 +15616,7 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "bincode 2.0.1",
- "dashmap",
+ "dashmap 6.1.0",
  "roaring",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4169,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11798,8 +11798,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config"
-version = "0.4.0-pre.2"
-source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
+version = "0.4.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577867735f5417dfcce4c94dee45c8d5e94047a7e728816d2b20322e15c5de61"
 dependencies = [
  "alloy 1.7.3",
  "anyhow",
@@ -11816,8 +11817,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config-commands"
-version = "0.4.0-pre.2"
-source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
+version = "0.4.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd5efe69c80e9f079b41af31fbff3d4466c04e211c62f5d62bf0417e93a7698"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -11829,8 +11831,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config-derive"
-version = "0.4.0-pre.2"
-source = "git+https://github.com/matter-labs/smart-config#a0f6e2283a44293ca6a33ac042cc825f2a166d7b"
+version = "0.4.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6afb95867f82dda0bfb6a11000ec9fe297c76c37a2f74cd2c825a261f85a63"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,8 @@ futures = "0.3"
 vise = "0.3.0"
 vise-exporter = "0.3.0"
 bincode = { version = "2.0.1", features = ["serde"] }
-smart-config = { git = "https://github.com/matter-labs/smart-config" }
-smart-config-commands = { git = "https://github.com/matter-labs/smart-config" }
+smart-config = { version = "0.4.0-pre.3" }
+smart-config-commands = { version = "0.4.0-pre.3" }
 thiserror = "2.0.12"
 tikv-jemallocator = { version = "0.6.1", features = [
     "override_allocator_on_supported_platforms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"
 serde_json = "1"
 sentry = "0.43.0"
-regex = "1.11.3"
+regex = "1.12.3"
 roaring = "0.11.3"
 
 #zksync_os_interface = { path = "../zksync-os-interface/crates/interface" }
@@ -168,8 +168,8 @@ futures = "0.3"
 vise = "0.3.0"
 vise-exporter = "0.3.0"
 bincode = { version = "2.0.1", features = ["serde"] }
-smart-config = { version = "0.4.0-pre.2" }
-smart-config-commands = { version = "0.4.0-pre.2" }
+smart-config = { git = "https://github.com/matter-labs/smart-config" }
+smart-config-commands = { git = "https://github.com/matter-labs/smart-config" }
 thiserror = "2.0.12"
 tikv-jemallocator = { version = "0.6.1", features = [
     "override_allocator_on_supported_platforms",
@@ -197,6 +197,7 @@ criterion = "0.7.0"
 sha2 = "0.10.9"
 tower = "0.5.2"
 tower-http = "0.6.6"
+governor = "0.6"
 hyper = "1.6.0"
 semver = { version = "1", features = ["serde"] }
 num_cpus = "1.17.0"

--- a/lib/rpc/Cargo.toml
+++ b/lib/rpc/Cargo.toml
@@ -54,6 +54,7 @@ tracing.workspace = true
 vise.workspace = true
 tower.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
+governor.workspace = true
 hyper.workspace = true
 
 boa_engine.workspace = true

--- a/lib/rpc/src/config.rs
+++ b/lib/rpc/src/config.rs
@@ -1,6 +1,25 @@
 use alloy::primitives::Address;
 use std::collections::HashSet;
+use std::num::NonZeroU32;
 use std::time::Duration;
+
+/// A per-method rate limit entry.
+#[derive(Clone, Debug)]
+pub struct RpcRateLimit {
+    /// Exact RPC method name, e.g. `"eth_call"`.
+    pub method: String,
+    /// Maximum number of requests per second across all callers combined.
+    pub requests_per_second: NonZeroU32,
+}
+
+impl From<(String, NonZeroU32)> for RpcRateLimit {
+    fn from((method, requests_per_second): (String, NonZeroU32)) -> Self {
+        Self {
+            method,
+            requests_per_second,
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct RpcConfig {
@@ -47,6 +66,10 @@ pub struct RpcConfig {
     /// users submitting unexecutable transactions (fail with `OutOfNativeResourcesDuringValidation`)
     /// because pubdata price increase in-between estimation and sequencing.
     pub estimate_gas_pubdata_price_factor: f64,
+
+    /// Per-method rate limits.  Use `"*"` as the method name for a global limit applied before
+    /// per-method limits.  Empty means no rate limiting.
+    pub rate_limits: Vec<RpcRateLimit>,
 }
 
 impl RpcConfig {

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -2,7 +2,7 @@ mod call_fees;
 
 mod config;
 
-pub use config::RpcConfig;
+pub use config::{RpcConfig, RpcRateLimit};
 use std::sync::Arc;
 use tokio::sync::watch;
 
@@ -23,6 +23,7 @@ pub mod js_tracer;
 mod log_proof_utils;
 mod monitoring_middleware;
 mod net_impl;
+mod rate_limit_middleware;
 mod sandbox;
 mod tx_handler;
 mod txpool_impl;
@@ -38,6 +39,7 @@ use crate::eth_pubsub_impl::EthPubsubNamespace;
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
+use crate::rate_limit_middleware::{RateLimiting, build_limiters};
 use crate::txpool_impl::TxpoolNamespace;
 use crate::unstable_impl::UnstableNamespace;
 use crate::web3_impl::Web3Namespace;
@@ -146,8 +148,12 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     let middleware = tower::ServiceBuilder::new().layer(cors);
 
     let max_response_size_bytes = config.max_response_size_bytes();
+    // Build once so all connections share the same token-bucket state.
+    let limiters = build_limiters(&config.rate_limits);
     let rpc_middleware = RpcServiceBuilder::new()
-        .layer_fn(move |service| Monitoring::new(service, max_response_size_bytes));
+        // Monitoring is outermost so rate-limited responses still appear in error metrics.
+        .layer_fn(move |service| Monitoring::new(service, max_response_size_bytes))
+        .layer_fn(move |service| RateLimiting::new(service, limiters.clone()));
 
     let server_config = ServerConfigBuilder::default()
         .max_connections(config.max_connections)

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -16,13 +16,13 @@ pub enum CallKind {
 }
 
 #[derive(Clone)]
-pub struct Monitoring {
-    inner: RpcService,
+pub struct Monitoring<S = RpcService> {
+    inner: S,
     max_response_size_bytes: usize,
 }
 
-impl Monitoring {
-    pub fn new(inner: RpcService, max_response_size_bytes: u32) -> Self {
+impl<S> Monitoring<S> {
+    pub fn new(inner: S, max_response_size_bytes: u32) -> Self {
         Self {
             inner,
             max_response_size_bytes: max_response_size_bytes as usize,
@@ -155,10 +155,19 @@ impl Drop for CallGuard {
     }
 }
 
-impl RpcServiceT for Monitoring {
-    type MethodResponse = <RpcService as RpcServiceT>::MethodResponse;
-    type NotificationResponse = <RpcService as RpcServiceT>::NotificationResponse;
-    type BatchResponse = <RpcService as RpcServiceT>::BatchResponse;
+impl<S> RpcServiceT for Monitoring<S>
+where
+    S: RpcServiceT<
+            MethodResponse = MethodResponse,
+            NotificationResponse = MethodResponse,
+            BatchResponse = MethodResponse,
+        > + Clone
+        + Send
+        + 'static,
+{
+    type MethodResponse = MethodResponse;
+    type NotificationResponse = MethodResponse;
+    type BatchResponse = MethodResponse;
 
     fn call<'a>(
         &self,

--- a/lib/rpc/src/rate_limit_middleware.rs
+++ b/lib/rpc/src/rate_limit_middleware.rs
@@ -1,0 +1,124 @@
+use crate::config::RpcRateLimit;
+use governor::clock::{Clock, DefaultClock};
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+use jsonrpsee::MethodResponse;
+use jsonrpsee::core::middleware::{Batch, Notification};
+use jsonrpsee::core::to_json_raw_value;
+use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
+use jsonrpsee::types::Request;
+use jsonrpsee::types::error::ErrorObject;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// EIP-1474 "Limit exceeded" — the de facto Ethereum rate-limit error code used by Infura, Alchemy, etc.
+const RATE_LIMIT_ERROR_CODE: i32 = -32005;
+
+/// Pre-builds the shared limiter map from config.  Pass the returned `Arc` to every
+/// `RateLimiting::new` call so all connections share the same token-bucket state.
+pub(crate) fn build_limiters(
+    limits: &[RpcRateLimit],
+) -> Arc<HashMap<String, DefaultDirectRateLimiter>> {
+    Arc::new(
+        limits
+            .iter()
+            .map(|l| {
+                (
+                    l.method.clone(),
+                    RateLimiter::direct(Quota::per_second(l.requests_per_second)),
+                )
+            })
+            .collect(),
+    )
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RetryData {
+    retry_after_ms: u64,
+}
+
+fn rate_limited_err(retry_after_ms: u64) -> ErrorObject<'static> {
+    let data = to_json_raw_value(&RetryData { retry_after_ms }).expect("infallible serialization");
+    ErrorObject::owned(RATE_LIMIT_ERROR_CODE, "Too many requests", Some(data))
+}
+
+/// JSON-RPC middleware that enforces per-method request rate limits globally across all connections.
+///
+/// Build the limiter map once with [`build_limiters`] and share it across connections via `Arc`.
+/// Sit this layer inside `Monitoring` so rate-limited responses are counted in error metrics.
+/// `Monitoring` decomposes batch requests by calling `call()` per entry, so batch items are
+/// rate-limited automatically.  Any method absent from the map is unrestricted.
+#[derive(Clone)]
+pub(crate) struct RateLimiting<S = RpcService> {
+    inner: S,
+    limiters: Arc<HashMap<String, DefaultDirectRateLimiter>>,
+}
+
+impl<S> RateLimiting<S> {
+    pub(crate) fn new(inner: S, limiters: Arc<HashMap<String, DefaultDirectRateLimiter>>) -> Self {
+        Self { inner, limiters }
+    }
+}
+
+impl<S> RpcServiceT for RateLimiting<S>
+where
+    S: RpcServiceT<
+            MethodResponse = MethodResponse,
+            NotificationResponse = MethodResponse,
+            BatchResponse = MethodResponse,
+        > + Clone
+        + Send
+        + 'static,
+{
+    type MethodResponse = MethodResponse;
+    type NotificationResponse = MethodResponse;
+    type BatchResponse = MethodResponse;
+
+    fn call<'a>(
+        &self,
+        request: Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        // Check synchronously before the async block to avoid holding a borrow across an await.
+        // Global limit ("*") is checked first; if it fires the per-method limiter is not touched.
+        let now = DefaultClock::default().now();
+        let not_until_global = self.limiters.get("*").and_then(|l| l.check().err());
+        let not_until_method = if not_until_global.is_none() {
+            self.limiters
+                .get(request.method_name())
+                .and_then(|l| l.check().err())
+        } else {
+            None
+        };
+        let retry_after_ms = not_until_global.or(not_until_method).map(|not_until| {
+            not_until
+                .wait_time_from(now)
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX)
+        });
+        let inner = self.inner.clone();
+        async move {
+            if let Some(ms) = retry_after_ms {
+                return MethodResponse::error(
+                    request.id.clone().into_owned(),
+                    rate_limited_err(ms),
+                );
+            }
+            inner.call(request).await
+        }
+    }
+
+    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        async move { inner.batch(batch).await }
+    }
+
+    fn notification<'a>(
+        &self,
+        n: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        async move { inner.notification(n).await }
+    }
+}

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -11,10 +11,14 @@ use smart_config::metadata::{SizeUnit, TimeUnit};
 use smart_config::value::SecretString;
 use smart_config::{
     ByteSize, ConfigRepository, ConfigSchema, ConfigSources, DescribeConfig, DeserializeConfig,
-    ErrorWithOrigin, EtherAmount, ParseErrors, Serde, de::Delimited, metadata::EtherUnit,
+    ErrorWithOrigin, EtherAmount, ParseErrors, Serde,
+    de::{Delimited, Entries},
+    metadata::EtherUnit,
+    pat::lazy_regex,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::num::NonZeroU32;
 use std::{path::PathBuf, time::Duration};
 use zksync_os_batch_verification;
 use zksync_os_config_validation_macros::ConfigValidate;
@@ -984,6 +988,18 @@ pub struct RpcConfig {
     /// because pubdata price increases or native price decreases in-between estimation and sequencing.
     #[config(default_t = 2.0)]
     pub estimate_gas_pubdata_price_factor: f64,
+
+    /// Per-method rate limits: map from RPC method name to max requests per second (across all
+    /// callers).  Use `"*"` for a global limit applied before per-method limits.  Methods absent
+    /// from the map are unrestricted.
+    ///
+    /// Accepts a JSON object or a comma-separated `method = rps` string, e.g.
+    /// `* = 500, eth_call = 100, debug_traceTransaction = 5`.
+    #[config(default, with = Entries::WELL_KNOWN.delimited(
+        lazy_regex!(ref r"\s*,\s*"),
+        lazy_regex!(ref r"\s*=\s*"),
+    ))]
+    pub rate_limits: HashMap<String, NonZeroU32>,
 }
 
 /// L1 sender configuration. The signing key fields are only required on the Main Node;
@@ -1702,6 +1718,7 @@ impl From<RpcConfig> for zksync_os_rpc::RpcConfig {
             send_raw_transaction_sync_timeout: c.send_raw_transaction_sync_timeout,
             gas_price_scale_factor: c.gas_price_scale_factor,
             estimate_gas_pubdata_price_factor: c.estimate_gas_pubdata_price_factor,
+            rate_limits: c.rate_limits.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -995,8 +995,8 @@ pub struct RpcConfig {
     /// Accepts a JSON object or a comma-separated `method=rps` string, e.g.
     /// `*=500,eth_call=100,debug_traceTransaction=5`.
     #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="), validate(
-        rate_limits_sum_within_global,
-        "sum of per-method limits must not exceed the global `*` limit"
+        rate_limits_within_global,
+        "each per-method limit must not exceed the global `*` limit"
     ))]
     pub rate_limits: HashMap<String, NonZeroU32>,
 }
@@ -1109,16 +1109,14 @@ pub struct ForceTransactionResubmissionConfig {
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
 }
 
-fn rate_limits_sum_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
+fn rate_limits_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
     let Some(&global) = limits.get("*") else {
         return true;
     };
-    let per_method_sum: u64 = limits
+    limits
         .iter()
         .filter(|(k, _)| k.as_str() != "*")
-        .map(|(_, v)| u64::from(v.get()))
-        .sum();
-    per_method_sum <= u64::from(global.get())
+        .all(|(_, &v)| v <= global)
 }
 
 fn is_positive_f64(&val: &f64) -> bool {

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -14,7 +14,6 @@ use smart_config::{
     ErrorWithOrigin, EtherAmount, ParseErrors, Serde,
     de::{Delimited, Entries},
     metadata::EtherUnit,
-    pat::lazy_regex,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
@@ -993,12 +992,9 @@ pub struct RpcConfig {
     /// callers).  Use `"*"` for a global limit applied before per-method limits.  Methods absent
     /// from the map are unrestricted.
     ///
-    /// Accepts a JSON object or a comma-separated `method = rps` string, e.g.
-    /// `* = 500, eth_call = 100, debug_traceTransaction = 5`.
-    #[config(default, with = Entries::WELL_KNOWN.delimited(
-        lazy_regex!(ref r"\s*,\s*"),
-        lazy_regex!(ref r"\s*=\s*"),
-    ))]
+    /// Accepts a JSON object or a comma-separated `method=rps` string, e.g.
+    /// `*=500,eth_call=100,debug_traceTransaction=5`.
+    #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="))]
     pub rate_limits: HashMap<String, NonZeroU32>,
 }
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -926,7 +926,7 @@ pub struct PolicyServiceConfig {
     pub auth_token: Option<SecretString>,
 }
 
-#[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
+#[derive(Clone, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
 #[config(derive(Default))]
 pub struct RpcConfig {
     /// JSON-RPC address to listen on.
@@ -994,7 +994,10 @@ pub struct RpcConfig {
     ///
     /// Accepts a JSON object or a comma-separated `method=rps` string, e.g.
     /// `*=500,eth_call=100,debug_traceTransaction=5`.
-    #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="))]
+    #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="), validate(
+        rate_limits_sum_within_global,
+        "sum of per-method limits must not exceed the global `*` limit"
+    ))]
     pub rate_limits: HashMap<String, NonZeroU32>,
 }
 
@@ -1104,6 +1107,18 @@ pub struct ForceTransactionResubmissionConfig {
     /// Multiplier applied to `max_fee_per_blob_gas` when force transaction resubmission is enabled.
     #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
+}
+
+fn rate_limits_sum_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
+    let Some(&global) = limits.get("*") else {
+        return true;
+    };
+    let per_method_sum: u64 = limits
+        .iter()
+        .filter(|(k, _)| k.as_str() != "*")
+        .map(|(_, v)| u64::from(v.get()))
+        .sum();
+    per_method_sum <= u64::from(global.get())
 }
 
 fn is_positive_f64(&val: &f64) -> bool {

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -926,7 +926,7 @@ pub struct PolicyServiceConfig {
     pub auth_token: Option<SecretString>,
 }
 
-#[derive(Clone, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
+#[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
 #[config(derive(Default))]
 pub struct RpcConfig {
     /// JSON-RPC address to listen on.


### PR DESCRIPTION
## Summary

- Adds a `RateLimiting<S>` RPC middleware layer (token bucket via `governor`) that sits inside `Monitoring` so rate-limited requests are counted in error metrics
- Config: `rpc.rate_limits` is a map of method name → max req/s; use `"*"` for a global cap applied before per-method limits; empty map (the default) means no limiting
- Rejected requests return EIP-1474 error `-32005` with `{"retryAfterMs": N}` in the error data field
- `Monitoring` generalised from `Monitoring<RpcService>` to `Monitoring<S>` to allow middleware composition

**Config example (YAML):**
```yaml
rpc:
  rate_limits:
    "*": 1000       # global cap across all methods
    eth_call: 100   # stricter limit for eth_call
    eth_getLogs: 50
```

**Config example (env var):**
```
RPC_RATE_LIMITS='*=1000,eth_call=100,eth_getLogs=50'
```
