### PR TITLE
feat(l1-sender): estimate gas via eth_simulateV1

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -15,13 +15,13 @@ use alloy::eips::{BlockId, BlockNumberOrTag, Encodable2718};
 use alloy::network::{
     Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilder4844, TransactionResponse,
 };
+use alloy::primitives::U256;
 use alloy::primitives::utils::{format_ether, format_units};
 use alloy::primitives::{Address, B256};
 use alloy::providers::ext::DebugApi;
 use alloy::providers::fillers::TxFiller;
 use alloy::providers::utils::Eip1559Estimation;
 use alloy::providers::{Provider, WalletProvider};
-use alloy::primitives::U256;
 use alloy::rpc::types::simulate::{SimBlock, SimulatePayload};
 use alloy::rpc::types::state::{AccountOverride, StateOverridesBuilder};
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
@@ -700,7 +700,6 @@ where
         operator_address: Address,
         fee_params: FeeParams,
     ) -> anyhow::Result<Vec<u64>> {
-
         // Anvil parses each simulate call into a typed transaction before executing it, and
         // EIP-4844 parsing requires `nonce` and `gas_limit` to be present. We fetch the
         // operator's pending nonce once and assign sequential values to each call.

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -21,6 +21,9 @@ use alloy::providers::ext::DebugApi;
 use alloy::providers::fillers::TxFiller;
 use alloy::providers::utils::Eip1559Estimation;
 use alloy::providers::{Provider, WalletProvider};
+use alloy::primitives::U256;
+use alloy::rpc::types::simulate::{SimBlock, SimulatePayload};
+use alloy::rpc::types::state::{AccountOverride, StateOverridesBuilder};
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::transports::TransportError;
@@ -181,7 +184,7 @@ where
                 last.block_timestamp(),
                 Some(last.last_batch_number()),
             );
-            let mut commands = cmd_buffer
+            let commands = cmd_buffer
                 .drain(..)
                 .map(|cmd| -> anyhow::Result<Input> {
                     match cmd {
@@ -198,22 +201,41 @@ where
             let range = Input::display_range(&commands); // Only for logging
             tracing::info!(command_name, range, "sending L1 transactions");
             L1_SENDER_METRICS.parallel_transactions[&command_name].set(commands.len() as u64);
+
+            // Simulate the whole batch of commands together so that gas estimation accounts
+            // for state changes between successive transactions sharing the same sender and
+            // target contract. Each per-tx gas limit is set to 2x the simulated value.
+            let operator_address = self.operator_address().await?;
+            let sim_fee_params = self
+                .resolve_fee_params(fee_config, force_transaction_resubmission)
+                .await?;
+            let gas_limits = self
+                .estimate_gas_limits(&commands, operator_address, sim_fee_params)
+                .await?;
+            tracing::info!(
+                command_name,
+                range,
+                ?gas_limits,
+                "estimated gas limits via eth_simulateV1",
+            );
+
             // It's important to preserve the order of commands -
             // so that we send them downstream also in order.
             // This holds true because l1 transactions are included in the order of sender nonce.
             // Keep this in mind if changing sending logic (that is, if adding `buffer` we'd need to set nonce manually)
             let pending_txs: Vec<PendingTx<Input>> =
-            futures::stream::iter(commands.drain(..))
-                .then(|mut cmd| async {
+            futures::stream::iter(commands.into_iter().zip(gas_limits))
+                .then(|(mut cmd, gas_limit)| {
+                    let range = range.clone();
+                    async move {
                     let fee_params = self
                         .resolve_fee_params(
                         fee_config,
                         force_transaction_resubmission,
                     )
                     .await?;
-                    let operator_address = self.operator_address().await?;
                     let mut tx_request = self
-                        .tx_request_with_gas_fields(operator_address, fee_params)
+                        .tx_request_with_gas_fields(operator_address, fee_params, gas_limit)
                         .with_to(self.to_address)
                         .with_input(cmd.solidity_call(self.gateway, &operator_address));
 
@@ -287,6 +309,7 @@ where
                         .iter_mut()
                         .for_each(|envelope| envelope.set_stage(Input::SENT_STAGE));
                     anyhow::Ok((receipt_fut, cmd, submitted_at))
+                    }
                 })
                 // We could buffer the stream here to enable sending multiple batches of transactions in parallel,
                 // but this is not necessary for now - we wait for them to be included in parallel
@@ -653,12 +676,118 @@ where
         &self,
         operator_address: Address,
         fee_params: FeeParams,
+        gas_limit: u64,
     ) -> TransactionRequest {
         TransactionRequest::default()
             .with_from(operator_address)
             .with_max_fee_per_gas(fee_params.max_fee_per_gas)
             .with_max_priority_fee_per_gas(fee_params.max_priority_fee_per_gas)
-            .with_gas_limit(15000000)
+            .with_gas_limit(gas_limit)
+    }
+
+    /// Estimates gas limits for a batch of L1 commands using `eth_simulateV1`.
+    ///
+    /// All calls are placed in a single simulated block so that state changes from earlier
+    /// commands (e.g., updates to the bridge contract by an earlier commit) are visible to
+    /// later commands. Estimating each command independently against the current chain
+    /// state would mis-estimate gas — or revert outright — for any command after the first.
+    ///
+    /// Returns `2 * gas_used` per call to leave headroom for state drift between
+    /// simulation and actual inclusion.
+    async fn estimate_gas_limits(
+        &self,
+        commands: &[Input],
+        operator_address: Address,
+        fee_params: FeeParams,
+    ) -> anyhow::Result<Vec<u64>> {
+
+        // Anvil parses each simulate call into a typed transaction before executing it, and
+        // EIP-4844 parsing requires `nonce` and `gas_limit` to be present. We fetch the
+        // operator's pending nonce once and assign sequential values to each call.
+        let starting_nonce = self
+            .provider
+            .get_transaction_count(operator_address)
+            .pending()
+            .await
+            .context("get pending nonce for L1 sender gas estimation")?;
+        // Cap gas at a generous upper bound; the simulation reports the actual `gas_used`.
+        const SIM_GAS_LIMIT: u64 = 30_000_000;
+
+        let mut sim_block = SimBlock::default();
+        for (i, cmd) in commands.iter().enumerate() {
+            // Fee fields are required by some L1 providers (e.g., anvil) when parsing the
+            // transaction request, even though `eth_simulateV1` does not run validation by
+            // default. We mirror the fee params we plan to use for the real submission.
+            let mut req = TransactionRequest::default()
+                .with_from(operator_address)
+                .with_to(self.to_address)
+                .with_input(cmd.solidity_call(self.gateway, &operator_address))
+                .with_max_fee_per_gas(fee_params.max_fee_per_gas)
+                .with_max_priority_fee_per_gas(fee_params.max_priority_fee_per_gas)
+                .with_nonce(starting_nonce + i as u64)
+                .with_gas_limit(SIM_GAS_LIMIT);
+            // Include blob versioned hashes so the BLOBHASH opcode (used by the commit
+            // contract to verify blob commitments) sees the same values it will see on L1.
+            // The KZG sidecar (blobs/commitments/proofs) is not needed: anvil ignores it
+            // during simulation, and real L1 nodes only need the hashes for execution.
+            if let Some(sidecar) = cmd.blob_sidecar() {
+                req.blob_versioned_hashes = Some(sidecar.versioned_hashes().collect());
+                req.max_fee_per_blob_gas = Some(fee_params.max_fee_per_blob_gas);
+                // Anvil's `transaction_request_to_typed` requires an explicit `type=3` to
+                // route a blob-tagged request through the EIP-4844 arm — otherwise it
+                // falls through to the catch-all and returns -32602 missing required fields.
+                req.transaction_type = Some(3);
+            }
+            sim_block = sim_block.call(req);
+        }
+
+        // Some L1 providers (e.g., anvil) check the sender's balance even when
+        // `validation` is false, which would fail with realistic max-fee-per-gas values.
+        // Override the operator's balance to a large value so the simulation runs.
+        sim_block.state_overrides = Some(
+            StateOverridesBuilder::default()
+                .append(
+                    operator_address,
+                    AccountOverride {
+                        balance: Some(U256::MAX),
+                        ..Default::default()
+                    },
+                )
+                .build(),
+        );
+
+        let payload = SimulatePayload {
+            block_state_calls: vec![sim_block],
+            ..Default::default()
+        };
+
+        let results = self
+            .provider
+            .simulate(&payload)
+            .pending()
+            .await
+            .context("eth_simulateV1 for L1 sender gas estimation")?;
+        let block = results
+            .into_iter()
+            .next()
+            .context("eth_simulateV1 returned no blocks")?;
+        anyhow::ensure!(
+            block.calls.len() == commands.len(),
+            "eth_simulateV1 returned {} call results for {} commands",
+            block.calls.len(),
+            commands.len(),
+        );
+
+        let mut gas_limits = Vec::with_capacity(block.calls.len());
+        for (i, call) in block.calls.iter().enumerate() {
+            anyhow::ensure!(
+                call.status,
+                "eth_simulateV1 call {i} reverted: {:?}",
+                call.return_data,
+            );
+            gas_limits.push(call.gas_used.saturating_mul(2));
+        }
+        Ok(gas_limits)
     }
 
     async fn report_custom_priority_fee_metrics(&self) -> anyhow::Result<()> {

--- a/lib/rpc/src/simulate.rs
+++ b/lib/rpc/src/simulate.rs
@@ -46,10 +46,19 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
     ///   its block context; use `blockOverrides.random` (prevrandao) instead.
     /// - `blockOverrides.parentBeaconBlockRoot`: silently ignored. There is no corresponding
     ///   field in `BlockContext`.
-    /// - `validation=false` nonce relaxation: partially unsupported. The basefee is zeroed as
-    ///   the spec requires, but nonce checks are not disabled. Transactions without an explicit
-    ///   nonce are auto-filled from state (the common case works), but an explicitly supplied
-    ///   stale nonce will be rejected by the VM.
+    /// - `validation=false` nonce relaxation: partially unsupported. The basefee is zeroed
+    ///   as the spec requires, but nonce checks are not disabled. Transactions without an
+    ///   explicit nonce are auto-filled from state (the common case works), but an
+    ///   explicitly supplied stale nonce will be rejected by the VM.
+    ///
+    /// Note that even with `validation=false`, the returned `gas_used` accounts for the
+    /// bootloader's post-execution pubdata pre-charge using the *response* basefee, not the
+    /// zeroed execution basefee. The V31 bootloader returns `gas_price = 0` whenever
+    /// basefee is zero, which sets `native_per_gas = 0` and takes the "unlimited native"
+    /// branch — the bootloader's own `gas_used` then loses the native cost of pubdata. A
+    /// real submission against a non-zero basefee can fail the pre-charge check at
+    /// `gas_limit = 2 * reported_gas_used`, so we patch in the floor that would let the tx
+    /// clear the check at submission time (see `min_gas_for_pubdata_check`).
     pub fn simulate_v1_impl(
         &self,
         opts: SimulatePayload,
@@ -127,13 +136,16 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             };
             let overridden_view =
                 OverriddenStateView::new(simulation_view, state_overrides.clone());
-            let txs = self.create_simulation_txs(
+            let txs_with_fees = self.create_simulation_txs(
                 sim_block.calls,
                 execution_context,
                 overridden_view.clone(),
             )?;
             let tx_source = TxListSource {
-                transactions: txs.iter().cloned().map(|tx| tx.encode()).collect(),
+                transactions: txs_with_fees
+                    .iter()
+                    .map(|(tx, _)| tx.clone().encode())
+                    .collect(),
             };
             let block_output = run_block(
                 execution_context,
@@ -148,7 +160,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 
             let (simulated_block, block_overlay) = build_simulated_block_response(
                 response_context,
-                txs,
+                txs_with_fees,
                 block_output,
                 return_full_transactions,
             )?;
@@ -221,7 +233,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         calls: Vec<TransactionRequest>,
         block_context: BlockContext,
         mut state_view: V,
-    ) -> Result<Vec<ZkTransaction>, EthCallError> {
+    ) -> Result<Vec<(ZkTransaction, RequestFees)>, EthCallError> {
         let default_gas_limit = simulation_default_gas_limit(
             &calls,
             block_context.gas_limit,
@@ -266,7 +278,18 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                             ))?;
                 }
 
-                self.create_tx_from_request(request, &block_context, false)
+                // Capture the request's fee fields *before* `create_tx_from_request` runs
+                // them through `ensure_fees`, which clamps them using the (potentially
+                // zeroed) execution-context basefee. We need the original values to size
+                // the pubdata-pre-charge headroom against the real submission basefee.
+                let request_fees = RequestFees {
+                    max_fee_per_gas: request.max_fee_per_gas,
+                    max_priority_fee_per_gas: request.max_priority_fee_per_gas,
+                    gas_price: request.gas_price,
+                };
+
+                let tx = self.create_tx_from_request(request, &block_context, false)?;
+                Ok((tx, request_fees))
             })
             .collect()
     }
@@ -281,7 +304,7 @@ struct SimulationStartContext {
 
 fn build_simulated_block_response(
     block_context: BlockContext,
-    txs: Vec<ZkTransaction>,
+    txs_with_fees: Vec<(ZkTransaction, RequestFees)>,
     block_output: BlockOutput,
     return_full_transactions: bool,
 ) -> Result<(SimulatedBlock<ZkApiBlock>, OwnedOverrides), EthCallError> {
@@ -300,7 +323,9 @@ fn build_simulated_block_response(
     let mut simulated_txs = Vec::with_capacity(tx_results.len());
     let mut executed_tx_index = 0;
 
-    for (call_index, (tx, result)) in txs.into_iter().zip(tx_results).enumerate() {
+    for (call_index, ((tx, request_fees), result)) in
+        txs_with_fees.into_iter().zip(tx_results).enumerate()
+    {
         let simulated_tx = match result {
             Ok(tx_output) => {
                 let receipt = build_simulated_receipt(&tx, &tx_output, cumulative_gas_used);
@@ -308,6 +333,7 @@ fn build_simulated_block_response(
                 cumulative_gas_used += tx_output.gas_used;
                 let simulated_tx = SimulatedTx {
                     tx,
+                    request_fees,
                     tx_index_in_block: executed_tx_index,
                     number_of_logs_before_this_tx,
                     result: SimulatedTxResult::Executed {
@@ -322,6 +348,7 @@ fn build_simulated_block_response(
             }
             Err(err) => SimulatedTx {
                 tx,
+                request_fees,
                 tx_index_in_block: call_index as u64,
                 number_of_logs_before_this_tx,
                 result: SimulatedTxResult::Invalid(err),
@@ -551,8 +578,21 @@ fn simulation_default_gas_limit(
     Ok(((block_gas_limit - total_specified_gas) / calls_without_gas).min(per_call_gas_cap))
 }
 
+/// The fee-related fields from the original `TransactionRequest`, captured before
+/// `ensure_fees` (called by `create_tx_from_request`) clamps them using the
+/// execution-context basefee. We use these to size the pubdata-pre-charge headroom in
+/// `min_gas_for_pubdata_check` against the response basefee (what production will see).
+#[derive(Clone, Copy, Default)]
+struct RequestFees {
+    max_fee_per_gas: Option<u128>,
+    max_priority_fee_per_gas: Option<u128>,
+    /// Legacy `gasPrice` field. Set when the caller used a legacy-style request.
+    gas_price: Option<u128>,
+}
+
 struct SimulatedTx {
     tx: ZkTransaction,
+    request_fees: RequestFees,
     tx_index_in_block: u64,
     number_of_logs_before_this_tx: u64,
     result: SimulatedTxResult,
@@ -593,10 +633,15 @@ impl SimulatedTx {
                     }
                 };
 
+                let gas_used =
+                    min_gas_for_pubdata_check(output, &self.request_fees, &block_context);
+
                 SimCallResult {
                     return_data,
                     logs,
-                    gas_used: output.gas_used,
+                    gas_used,
+                    // `max_used_gas` reports the bootloader's raw observation; only the
+                    // top-level `gas_used` is patched to cover the pubdata pre-charge.
                     max_used_gas: Some(output.gas_used),
                     status: error.is_none(),
                     error,
@@ -675,6 +720,74 @@ impl SimulatedTx {
             SimulatedTxResult::Invalid(_) => 0,
         }
     }
+}
+
+/// Returns the floor on the L2 `gas_limit` required for the bootloader's post-execution
+/// pubdata pre-charge check to succeed at submission time, given the response context's
+/// real basefee and the original request's fee fields.
+///
+/// The bootloader requires
+///
+/// ```text
+///     gas_limit * native_per_gas >= native_used
+/// ```
+///
+/// where `native_per_gas = ceil(gas_price / native_price)`. Under `validation=false`,
+/// `eth_simulateV1` zeros the execution-context basefee, so the V31 bootloader's
+/// `get_gas_price` short-circuits to zero and takes the "unlimited native" branch — the
+/// reported `gas_used` then loses any signal from pubdata-bound native cost. We patch
+/// `gas_used` to be at least `ceil(native_used / production_native_per_gas)`, where
+/// `production_native_per_gas` is derived from the *response* basefee combined with the
+/// fee fields originally in the request (before `ensure_fees` clamped them against the
+/// zeroed basefee).
+///
+/// When the request provided no fee fields at all, the caller is presumed to want
+/// free-gas semantics in production too, and the reported `gas_used` is returned
+/// unchanged.
+fn min_gas_for_pubdata_check(
+    output: &TxOutput,
+    request_fees: &RequestFees,
+    block_context: &BlockContext,
+) -> u64 {
+    let basefee_u128 = block_context.eip1559_basefee.saturating_to::<u128>();
+
+    // Reconstruct what gas_price would be at submission time, using the same min/max
+    // contortions as the bootloader and `ensure_fees`. For legacy txs (`gas_price` set),
+    // the value is used as both max_fee and effective price.
+    let gas_price = match (
+        request_fees.gas_price,
+        request_fees.max_fee_per_gas,
+        request_fees.max_priority_fee_per_gas,
+    ) {
+        (Some(gp), _, _) => gp,
+        (None, None, None) => {
+            // No fees specified — caller wants free-gas semantics, which in production
+            // also yields `native_per_gas = 0` (unlimited native, no pubdata constraint).
+            return output.gas_used;
+        }
+        (None, max_fee, priority) => {
+            let max_fee = max_fee.unwrap_or(0);
+            let priority = priority.unwrap_or(0);
+            // bootloader: gas_price = min(max_fee, basefee + priority)
+            let tip = basefee_u128.saturating_add(priority);
+            max_fee.min(tip)
+        }
+    };
+
+    if gas_price == 0 || block_context.native_price.is_zero() {
+        return output.gas_used;
+    }
+
+    // Match bootloader's `U256::from(gas_price).div_ceil(native_price)`.
+    let npg = U256::from(gas_price).div_ceil(block_context.native_price);
+    if npg.is_zero() {
+        return output.gas_used;
+    }
+
+    // `gas_limit * npg >= native_used` ⇒ `gas_limit >= ceil(native_used / npg)`.
+    let min_gas = U256::from(output.native_used).div_ceil(npg);
+    let min_gas = u64::try_from(min_gas).unwrap_or(u64::MAX);
+    output.gas_used.max(min_gas)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replaces the hardcoded 15M L1-sender gas limit with `eth_simulateV1`-based estimation (`2 × simulated gas_used`). All commands in a batch are simulated together in one `SimBlock` so later txs see state writes from earlier ones.
- Fixes the gateway-settlement failure mode where the V31 bootloader's `get_gas_price` short-circuits to 0 whenever basefee=0 (which `validation=false` enforces per spec). That short-circuit forces `native_per_gas = 0` → "unlimited native" branch → reported `gas_used` loses the native cost of pubdata → `2 × gas_used` fails the post-execution pubdata pre-charge check at submission.

  `simulate_v1_impl` now patches the returned `gas_used` to `max(reported, ceil(native_used / production_native_per_gas))`, where `production_native_per_gas` is derived from the *response* basefee and the original request's fee fields (captured before `ensure_fees` clamps them against the zeroed execution basefee). Requests with no fee fields are presumed to want free-gas semantics in production and the correction is skipped.

## Test plan
- [x] `cargo nextest run -p zksync_os_rpc` — 17/17 pass
- [x] `cargo nextest run --workspace --exclude zksync_os_integration_tests` — 282/282 pass
- [x] `cargo nextest run -p zksync_os_integration_tests --profile no-pig` — 106/107 pass; the one failure (`node::external_node::batch_verification_works::next_to_gateway`) is a load-induced flake that passes cleanly in isolation (106s vs. 270s under concurrent load) and is unrelated to the simulate change
- [x] Gateway-settlement tests previously failing on this branch — all pass: `test_interop_bundle_send`, `upgrade_patch_no_deployments_settles_to_gateway`, `upgrade_to_v32_with_deployments_settles_to_gateway`, `upgrade_patch_no_deployments_gateway`, `test_interop_l2_to_l1_message_verification`
- [x] `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)