### PR TITLE
test(consensus): ignore flaky integration tests

### DIFF
--- a/integration-tests/tests/consensus_node/mod.rs
+++ b/integration-tests/tests/consensus_node/mod.rs
@@ -382,6 +382,7 @@ async fn consensus_cluster_recovers_after_quorum_loss() -> anyhow::Result<()> {
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_cluster_fully_restarts_and_recovers() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))

--- a/integration-tests/tests/consensus_node/mod.rs
+++ b/integration-tests/tests/consensus_node/mod.rs
@@ -253,6 +253,7 @@ async fn consensus_cluster_rotates_leader_after_failure() -> anyhow::Result<()> 
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_cluster_stops_making_progress_without_quorum() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))
@@ -287,6 +288,7 @@ async fn consensus_cluster_stops_making_progress_without_quorum() -> anyhow::Res
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_original_leader_rejoins_and_cluster_remains_stable() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))

--- a/integration-tests/tests/consensus_node/restarted_node_catchup.rs
+++ b/integration-tests/tests/consensus_node/restarted_node_catchup.rs
@@ -378,6 +378,7 @@ async fn l2_block_snapshot(cluster: &MultiNodeTester, node_indices: &[usize]) ->
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_restarted_node_catches_up_after_long_transaction_storm() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))


### PR DESCRIPTION
## Summary

- Ignore four flaky consensus integration tests while @romanbrodetski works on them.
- Add the ignore reason directly on each test so the skip is visible in test listings.

## Testing

- cargo fmt --all -- --check