### PR TITLE
refactor: rename zksync-os deps (dev->curr, curr->prev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,15 +277,7 @@ dependencies = [
  "alloy-consensus 1.7.3",
  "alloy-core",
  "alloy-eips 1.7.3",
- "alloy-network 1.7.3",
- "alloy-rpc-types 1.7.3",
  "alloy-serde 1.7.3",
- "alloy-signer 1.7.3",
- "alloy-signer-aws 1.7.3",
- "alloy-signer-gcp 1.7.3",
- "alloy-signer-ledger 1.7.3",
- "alloy-signer-local 1.7.3",
- "alloy-signer-turnkey 1.7.3",
  "alloy-trie",
 ]
 
@@ -300,20 +292,20 @@ dependencies = [
  "alloy-core",
  "alloy-eips 2.0.4",
  "alloy-genesis",
- "alloy-json-rpc 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-json-rpc",
+ "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types 2.0.4",
+ "alloy-rpc-types",
  "alloy-serde 2.0.4",
- "alloy-signer 2.0.4",
- "alloy-signer-aws 2.0.4",
- "alloy-signer-gcp 2.0.4",
- "alloy-signer-ledger 2.0.4",
- "alloy-signer-local 2.0.4",
- "alloy-signer-turnkey 2.0.4",
+ "alloy-signer",
+ "alloy-signer-aws",
+ "alloy-signer-gcp",
+ "alloy-signer-ledger",
+ "alloy-signer-local",
+ "alloy-signer-turnkey",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ws",
@@ -390,20 +382,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-eips 1.7.3",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.7.3",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
@@ -426,12 +404,12 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network 2.0.4",
- "alloy-network-primitives 2.0.4",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -591,7 +569,7 @@ dependencies = [
  "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
@@ -656,21 +634,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "http 1.3.1",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e352478b756bad5d7203148e4b461861282ea2ded3da406ba24868b52cd098"
@@ -686,46 +649,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-consensus-any 1.7.3",
- "alloy-eips 1.7.3",
- "alloy-json-rpc 1.7.3",
- "alloy-network-primitives 1.7.3",
- "alloy-primitives",
- "alloy-rpc-types-any 1.7.3",
- "alloy-rpc-types-eth 1.7.3",
- "alloy-serde 1.7.3",
- "alloy-signer 1.7.3",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more 2.0.1",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-network"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-consensus-any 2.0.4",
+ "alloy-consensus-any",
  "alloy-eips 2.0.4",
- "alloy-json-rpc 2.0.4",
- "alloy-network-primitives 2.0.4",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 2.0.4",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -734,19 +671,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-eips 1.7.3",
- "alloy-primitives",
- "alloy-serde 1.7.3",
- "serde",
 ]
 
 [[package]]
@@ -770,10 +694,10 @@ checksum = "5a29998ddc1f3a7658b82de0784566c65e2f116917a349de7fdd0b765e539d0c"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.12",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
- "alloy-signer-local 2.0.4",
+ "alloy-signer",
+ "alloy-signer-local",
  "k256",
  "libc",
  "rand 0.8.5",
@@ -824,19 +748,19 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
- "alloy-json-rpc 2.0.4",
- "alloy-network 2.0.4",
- "alloy-network-primitives 2.0.4",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -850,7 +774,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -867,7 +791,7 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d86958b02bca85103d64fa60d7b364a8b017c6e40f2b02c3f50ca22964a738"
 dependencies = [
- "alloy-json-rpc 2.0.4",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "auto_impl",
@@ -911,14 +835,14 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
 dependencies = [
- "alloy-json-rpc 2.0.4",
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ws",
  "futures",
- "pin-project 1.1.10",
+ "pin-project",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -932,18 +856,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth 1.7.3",
- "alloy-serde 1.7.3",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
@@ -952,7 +864,7 @@ dependencies = [
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-serde 2.0.4",
@@ -978,20 +890,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df32156f085e74eac942b6103744be49b817c302341aaa8cb0c1c88dc29228d9"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
-dependencies = [
- "alloy-consensus-any 1.7.3",
- "alloy-rpc-types-eth 1.7.3",
- "alloy-serde 1.7.3",
 ]
 
 [[package]]
@@ -1000,10 +901,10 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
 dependencies = [
- "alloy-consensus-any 2.0.4",
- "alloy-network-primitives 2.0.4",
+ "alloy-consensus-any",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "serde",
  "serde_json",
@@ -1041,35 +942,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-consensus-any 1.7.3",
- "alloy-eips 1.7.3",
- "alloy-network-primitives 1.7.3",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.7.3",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-consensus-any 2.0.4",
+ "alloy-consensus-any",
  "alloy-eips 2.0.4",
- "alloy-network-primitives 2.0.4",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde 2.0.4",
@@ -1089,7 +969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "serde",
  "serde_json",
@@ -1103,7 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b631c361e7c7baaf4f1f5a9877730f3507fed2acb9d4b34841b8184b2ec28"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "serde",
 ]
@@ -1133,23 +1013,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-primitives",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-signer"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41eb29f7a8adcd8941fbb8e134022a133e6f8dfd345f2e3b7109599f8a7dca08"
@@ -1167,54 +1030,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38b411077d7b17e464de7dfa599f5b94161cdffc25c2f28a90a3a345b6d6490"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-network 1.7.3",
- "alloy-primitives",
- "alloy-signer 1.7.3",
- "async-trait",
- "aws-config",
- "aws-sdk-kms",
- "k256",
- "spki",
- "thiserror 2.0.17",
- "tracing",
-]
-
-[[package]]
-name = "alloy-signer-aws"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1258987fbc82716b5153ec7bb95a8a295e7640871b8f03d8ec7c4000dc80c215"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
- "k256",
- "spki",
- "thiserror 2.0.17",
- "tracing",
-]
-
-[[package]]
-name = "alloy-signer-gcp"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485d0c73c53a36580be4d882a5c6c9a069759088de88ff759e59342a793adb16"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-network 1.7.3",
- "alloy-primitives",
- "alloy-signer 1.7.3",
- "async-trait",
- "gcloud-sdk 0.27.4",
  "k256",
  "spki",
  "thiserror 2.0.17",
@@ -1228,33 +1054,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc2a49bca5b73c6964711b57452f6c36a6bcb7f845ab7e9ad05b5a828d0161"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "async-trait",
- "gcloud-sdk 0.29.0",
+ "gcloud-sdk",
  "k256",
  "spki",
- "thiserror 2.0.17",
- "tracing",
-]
-
-[[package]]
-name = "alloy-signer-ledger"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a41e469bce9a836a9fbba7c09f8eba25703062accf6a64bd90b5ed61c1b01"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-dyn-abi",
- "alloy-network 1.7.3",
- "alloy-primitives",
- "alloy-signer 1.7.3",
- "alloy-sol-types",
- "async-trait",
- "coins-ledger 0.12.0",
- "futures-util",
- "semver 1.0.26",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -1267,32 +1073,16 @@ checksum = "94e11ddaddfb98c1ddce737dc440225565b0ae0987ac9ad5e59a85db5904878c"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-dyn-abi",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
- "coins-ledger 0.13.0",
+ "coins-ledger",
  "futures-util",
  "semver 1.0.26",
  "thiserror 2.0.17",
  "tracing",
-]
-
-[[package]]
-name = "alloy-signer-local"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-network 1.7.3",
- "alloy-primitives",
- "alloy-signer 1.7.3",
- "async-trait",
- "k256",
- "rand 0.8.5",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1302,29 +1092,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef839e7ce9b59aa60fa9a175e97986c6145c888d643b0f1fb0a3e7b8e56a2e2"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "async-trait",
  "k256",
  "rand 0.8.5",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-signer-turnkey"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589b334f4cf9de0d80568e8eaf11479b492e74dc2c08991306361065bde2321a"
-dependencies = [
- "alloy-consensus 1.7.3",
- "alloy-network 1.7.3",
- "alloy-primitives",
- "alloy-signer 1.7.3",
- "async-trait",
- "thiserror 2.0.17",
- "tracing",
- "turnkey_client 0.5.0",
 ]
 
 [[package]]
@@ -1334,13 +1108,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82ff16b4166fb90bbe79bd1e49244824fb3cadc6b8cd11e9c8a002c1f8c07492"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.4",
+ "alloy-signer",
  "async-trait",
  "thiserror 2.0.17",
  "tracing",
- "turnkey_client 0.6.0",
+ "turnkey_client",
 ]
 
 [[package]]
@@ -1422,7 +1196,7 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac7a80c0bac3e44559d53d002e34c461dc2f23262b42cafec019bc70551abbe"
 dependencies = [
- "alloy-json-rpc 2.0.4",
+ "alloy-json-rpc",
  "auto_impl",
  "base64",
  "derive_more 2.0.1",
@@ -1445,7 +1219,7 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
- "alloy-json-rpc 2.0.4",
+ "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
  "reqwest 0.13.3",
@@ -3559,29 +3333,6 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9bc0994d0aa0f4ade5f3a9baf4a8d936f250278c85a1124b401860454246ab"
-dependencies = [
- "async-trait",
- "byteorder",
- "cfg-if",
- "const-hex",
- "getrandom 0.2.16",
- "hidapi-rusb",
- "js-sys",
- "log",
- "nix",
- "once_cell",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "coins-ledger"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707b8909cef367cd04a11b0d71d65ab34a625d295a07869dd2fff2ca95bf688"
@@ -5458,7 +5209,7 @@ dependencies = [
  "futures-buffered",
  "futures-core",
  "futures-lite",
- "pin-project 1.1.10",
+ "pin-project",
  "slab",
  "smallvec",
 ]
@@ -5558,34 +5309,6 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "gcloud-sdk"
-version = "0.27.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8458d2ad7741b6a16981b84e66b7e4d8026423096da721894769c6980d06ecc"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "hyper",
- "jsonwebtoken 9.3.1",
- "once_cell",
- "prost 0.13.5",
- "prost-types 0.13.5",
- "reqwest 0.12.28",
- "secret-vault-value 0.3.9",
- "serde",
- "serde_json",
- "tokio",
- "tonic 0.13.1",
- "tower",
- "tower-layer",
- "tower-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "gcloud-sdk"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5b58d8683fa308be9bc58caece4972315a0b2547f9da16962511f0915d5b53"
@@ -5595,16 +5318,16 @@ dependencies = [
  "chrono",
  "futures",
  "hyper",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "once_cell",
  "prost 0.14.1",
  "prost-types 0.14.1",
  "reqwest 0.13.3",
- "secret-vault-value 1.0.1",
+ "secret-vault-value",
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.14.2",
+ "tonic",
  "tonic-prost",
  "tower",
  "tower-layer",
@@ -5721,7 +5444,7 @@ dependencies = [
  "gloo-utils",
  "http 1.3.1",
  "js-sys",
- "pin-project 1.1.10",
+ "pin-project",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6177,7 +5900,6 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -6776,7 +6498,7 @@ dependencies = [
  "gloo-net",
  "http 1.3.1",
  "jsonrpsee-core",
- "pin-project 1.1.10",
+ "pin-project",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
@@ -6804,7 +6526,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project",
  "rand 0.9.2",
  "rustc-hash",
  "serde",
@@ -6867,7 +6589,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "pin-project 1.1.10",
+ "pin-project",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -6916,21 +6638,6 @@ dependencies = [
  "jsonrpsee-types",
  "tower",
  "url",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -7993,7 +7700,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.1",
- "tonic 0.14.2",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -8278,31 +7985,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
-dependencies = [
- "pin-project-internal 0.4.30",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
- "pin-project-internal 1.1.10",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -8622,16 +8309,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
@@ -8648,19 +8325,6 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8686,15 +8350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost 0.13.5",
 ]
 
 [[package]]
@@ -9253,13 +8908,11 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -9337,12 +8990,12 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-signer 2.0.4",
- "alloy-signer-local 2.0.4",
+ "alloy-signer",
+ "alloy-signer-local",
  "derive_more 2.0.1",
  "metrics",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-errors",
@@ -9582,7 +9235,7 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "hmac",
- "pin-project 1.1.10",
+ "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
  "secp256k1 0.30.0",
@@ -9641,7 +9294,7 @@ dependencies = [
  "bytes",
  "derive_more 2.0.1",
  "futures",
- "pin-project 1.1.10",
+ "pin-project",
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
@@ -9716,7 +9369,7 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
@@ -9886,7 +9539,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project",
  "rand 0.8.5",
  "rand 0.9.2",
  "rayon",
@@ -9933,7 +9586,7 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-admin",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "auto_impl",
  "derive_more 2.0.1",
  "enr",
@@ -10035,7 +9688,7 @@ name = "reth-payload-builder-primitives"
 version = "2.2.0"
 source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4b231f55daeb2e00#ff8afdc5dbc253019df5b68f4b231f55daeb2e00"
 dependencies = [
- "pin-project 1.1.10",
+ "pin-project",
  "reth-payload-primitives",
  "tokio",
  "tokio-stream",
@@ -10077,7 +9730,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-trie",
  "arbitrary",
  "byteorder",
@@ -10181,10 +9834,10 @@ source = "git+https://github.com/itegulov/reth.git?rev=ff8afdc5dbc253019df5b68f4
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-evm",
- "alloy-json-rpc 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-json-rpc",
+ "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
@@ -10202,10 +9855,10 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
  "alloy-evm",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "derive_more 2.0.1",
@@ -10265,10 +9918,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
 dependencies = [
  "alloy-consensus 2.0.4",
- "alloy-network 2.0.4",
+ "alloy-network",
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
- "alloy-signer 2.0.4",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "reth-primitives-traits",
  "thiserror 2.0.17",
 ]
@@ -10354,7 +10007,7 @@ dependencies = [
  "libc",
  "metrics",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.17",
@@ -10407,7 +10060,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "paste",
- "pin-project 1.1.10",
+ "pin-project",
  "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
@@ -10469,7 +10122,7 @@ dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-serde 2.0.4",
  "alloy-trie",
  "arbitrary",
@@ -10672,7 +10325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.4",
+ "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -11390,19 +11043,6 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "secret-vault-value"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
-dependencies = [
- "prost 0.13.5",
- "prost-types 0.13.5",
- "serde",
- "serde_json",
  "zeroize",
 ]
 
@@ -12851,37 +12491,6 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project 1.1.10",
- "prost 0.13.5",
- "rustls-native-certs",
- "socket2 0.5.10",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
@@ -12898,7 +12507,7 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.10",
+ "pin-project",
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
@@ -12919,7 +12528,7 @@ checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
  "prost 0.14.1",
- "tonic 0.14.2",
+ "tonic",
 ]
 
 [[package]]
@@ -12975,18 +12584,6 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.30",
- "tower-service",
-]
 
 [[package]]
 name = "trace_and_split"
@@ -13081,7 +12678,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.1.10",
+ "pin-project",
  "tracing",
 ]
 
@@ -13262,22 +12859,6 @@ dependencies = [
 
 [[package]]
 name = "turnkey_api_key_stamper"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b72664037582371dfa96bfaa2e272446ea2551e269455e9fe3166445c76736"
-dependencies = [
- "base64",
- "hex",
- "k256",
- "p256",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "turnkey_api_key_stamper"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f72e05a07cb04163efff0c766521ebacbb268a851db83d419b7c56df90d046"
@@ -13290,24 +12871,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "turnkey_client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf8cea094b6536ecc5cfad42cd45d2f9abf523cc7dacf7de23f132412d0ec3"
-dependencies = [
- "mime",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.17",
- "tokio",
- "turnkey_api_key_stamper 0.5.0",
 ]
 
 [[package]]
@@ -13325,7 +12888,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.17",
  "tokio",
- "turnkey_api_key_stamper 0.6.2",
+ "turnkey_api_key_stamper",
 ]
 
 [[package]]
@@ -14934,20 +14497,20 @@ dependencies = [
 [[package]]
 name = "zksync_os_api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15#06a5f8a20b54632036079d2438dadaece27c6dae"
+source = "git+https://github.com/matter-labs/zksync-os?tag=v0.3.0#12833202c2c680646069edde3d4bd04cce60d481"
 dependencies = [
- "alloy 1.7.3",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "callable_oracles 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "alloy 2.0.4",
+ "alloy-sol-types",
+ "basic_bootloader 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "crypto 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "oracle_provider 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "ruint",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_interface",
- "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zksync_os_runner 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
 ]
 
 [[package]]
@@ -15138,7 +14701,7 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "blake2",
  "serde",
  "serde_json",
@@ -15159,7 +14722,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "blake2",
  "flate2",
  "fs2",
@@ -15270,7 +14833,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "blake2",
  "futures",
  "rangemap",
@@ -15295,7 +14858,7 @@ dependencies = [
  "auto_impl",
  "futures",
  "metrics",
- "pin-project 1.1.10",
+ "pin-project",
  "reth-chainspec",
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
@@ -15557,8 +15120,8 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
  "revm",
  "ruint",
@@ -15571,7 +15134,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync-os-revm",
  "zksync_os_api",
  "zksync_os_genesis",
@@ -15607,12 +15170,12 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "blake2",
  "boa_engine",
  "boa_gc",
  "dashmap",
- "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "evm_interpreter 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
  "hyper",
  "jsonrpsee",
@@ -15630,7 +15193,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_api",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
@@ -15728,8 +15291,8 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "async-trait",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
  "num",
  "ruint",
@@ -15740,7 +15303,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_gas_adjuster",
  "zksync_os_genesis",
  "zksync_os_interface",
@@ -15763,7 +15326,6 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
  "bincode 2.0.1",
  "blake2",
  "clap",
@@ -15850,12 +15412,12 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "dashmap",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "ruint",
  "tokio",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -15868,12 +15430,12 @@ version = "0.20.3"
 dependencies = [
  "alloy 2.0.4",
  "anyhow",
- "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "forward_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "ruint",
  "tempfile",
  "tracing",
  "vise",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_rocksdb",
@@ -15924,9 +15486,9 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "auto_impl",
- "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "basic_system 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "futures",
- "pin-project 1.1.10",
+ "pin-project",
  "roaring",
  "semver 1.0.26",
  "serde",
@@ -15934,7 +15496,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.2.9-interface-v0.0.15)",
+ "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.0)",
  "zksync_os_api",
  "zksync_os_batch_types",
  "zksync_os_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,28 +118,29 @@ zk_os_forward_system_0_2_8 = { package = "forward_system", git = "https://github
 # After its support is dropped, forward system is moved in the historical section above under a new name.
 # (`zk_os_forward_system_<version>`), while `zk_ee` and `zk_os_basic_system` dependencies are dropped completely.
 
-#zk_ee_prev = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.4" }
-#zk_os_basic_prev = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.4" }
-#zk_os_forward_prev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.4", features = [
-#    "production",
-#    "no_print",
-#], default-features = false }
-#execution_utils_prev = { package = "execution_utils", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.1" }
-#full_statement_verifier_prev = { package = "full_statement_verifier", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.1" }
+zk_ee_prev = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
+zk_os_basic_prev = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
+zk_os_forward_system_prev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15", features = [
+    "production",
+    "no_print",
+], default-features = false }
+zk_os_basic_system_prev = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
+#execution_utils_prev = { package = "execution_utils", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "" }
+#full_statement_verifier_prev = { package = "full_statement_verifier", git = "https://github.com/matter-labs/zksync-airbender.git", tag = "" }
 
 # Current (as in most recently released) version of zksync-os used to prove and submit new batches. Also includes
 # airbender dependencies that are necessary to verify said proofs on the server end.
 #
 # When a new version is released this version gets downgraded to the "previous version" section above.
 
-zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15", features = [
+zk_os_forward_system = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0", features = [
     "production",
     "no_print",
 ], default-features = false }
-zk_ee = { git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
-zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
-zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
-zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", tag = "v0.2.9-interface-v0.0.15" }
+zk_ee = { git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
+zk_os_basic_system = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
+zk_os_api = { package = "zksync_os_api", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
+zk_os_evm_interpreter = { package = "evm_interpreter", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
 execution_utils = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 full_statement_verifier = { git = "https://github.com/matter-labs/zksync-airbender.git", tag = "v0.5.2" }
 
@@ -147,12 +148,12 @@ full_statement_verifier = { git = "https://github.com/matter-labs/zksync-airbend
 #
 # Can be updated at any time and changing it does not count as a breaking change.
 
-zk_os_forward_system_dev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0", features = [
-    "production",
-    "no_print",
-], default-features = false }
-zk_ee_dev = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
-zk_os_basic_system_dev = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
+#zk_os_forward_system_dev = { package = "forward_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0", features = [
+#    "production",
+#    "no_print",
+#], default-features = false }
+#zk_ee_dev = { package = "zk_ee", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
+#zk_os_basic_system_dev = { package = "basic_system", git = "https://github.com/matter-labs/zksync-os", tag = "v0.3.0" }
 
 # Other dependencies.
 

--- a/lib/merkle_tree/Cargo.toml
+++ b/lib/merkle_tree/Cargo.toml
@@ -22,12 +22,12 @@ rayon.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 vise.workspace = true
+zk_os_forward_system_prev.workspace = true
+zk_os_basic_system_prev.workspace = true
+zk_ee_prev.workspace = true
 zk_os_forward_system.workspace = true
 zk_os_basic_system.workspace = true
 zk_ee.workspace = true
-zk_os_forward_system_dev.workspace = true
-zk_os_basic_system_dev.workspace = true
-zk_ee_dev.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true, default-features = false, features = ["rand"] }

--- a/lib/merkle_tree/src/with_version.rs
+++ b/lib/merkle_tree/src/with_version.rs
@@ -4,12 +4,13 @@ use crate::{
 };
 use alloy::primitives::{B256, FixedBytes};
 use zk_ee::utils::Bytes32;
-use zk_ee_dev::utils::Bytes32 as Bytes32Dev;
+use zk_ee_prev::utils::Bytes32 as Bytes32Prev;
 use zk_os_basic_system::system_implementation::flat_storage_model::FlatStorageLeaf;
-use zk_os_basic_system_dev::system_implementation::flat_storage_model::FlatStorageLeaf as FlatStorageLeafDev;
+use zk_os_basic_system_prev::system_implementation::flat_storage_model::FlatStorageLeaf as FlatStorageLeafPrev;
 use zk_os_forward_system::run::{LeafProof, ReadStorage, ReadStorageTree};
-use zk_os_forward_system_dev::run::{
-    LeafProof as LeafProofDev, ReadStorage as ReadStorageDev, ReadStorageTree as ReadStorageTreeDev,
+use zk_os_forward_system_prev::run::{
+    LeafProof as LeafProofPrev, ReadStorage as ReadStoragePrev,
+    ReadStorageTree as ReadStorageTreePrev,
 };
 use zksync_os_merkle_tree_api::Leaf;
 
@@ -180,19 +181,19 @@ impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTree for Merkle
     }
 }
 
-impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageDev for MerkleTreeVersion<DB, P> {
-    fn read(&mut self, key: Bytes32Dev) -> Option<Bytes32Dev> {
-        <Self as ReadStorageTreeDev>::tree_index(self, key).and_then(|index| {
+impl<DB: Database + 'static, P: TreeParams + 'static> ReadStoragePrev for MerkleTreeVersion<DB, P> {
+    fn read(&mut self, key: Bytes32Prev) -> Option<Bytes32Prev> {
+        <Self as ReadStorageTreePrev>::tree_index(self, key).and_then(|index| {
             self.traverse_to_leaf(index)
-                .map(|Leaf { value, .. }| fixed_bytes_to_bytes32_dev(value))
+                .map(|Leaf { value, .. }| fixed_bytes_to_bytes32_prev(value))
         })
     }
 }
 
-impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTreeDev
+impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTreePrev
     for MerkleTreeVersion<DB, P>
 {
-    fn tree_index(&mut self, key: Bytes32Dev) -> Option<u64> {
+    fn tree_index(&mut self, key: Bytes32Prev) -> Option<u64> {
         self.tree
             .db()
             .indices(self.block, &[FixedBytes::from_slice(key.as_u8_ref())])
@@ -203,8 +204,8 @@ impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTreeDev
             })
     }
 
-    fn merkle_proof(&mut self, tree_index: u64) -> LeafProofDev {
-        let mut sibling_hashes = Box::new([Bytes32Dev::zero(); 64]);
+    fn merkle_proof(&mut self, tree_index: u64) -> LeafProofPrev {
+        let mut sibling_hashes = Box::new([Bytes32Prev::zero(); 64]);
 
         let mut current_node = self
             .tree
@@ -272,9 +273,9 @@ impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTreeDev
             sibling_hashes[i] = self.tree.hasher.empty_subtree_hash(i as u8).0.into();
         }
 
-        LeafProofDev::new(
+        LeafProofPrev::new(
             tree_index,
-            FlatStorageLeafDev {
+            FlatStorageLeafPrev {
                 key: leaf.key.0.into(),
                 value: leaf.value.0.into(),
                 next: leaf.next_index,
@@ -283,7 +284,7 @@ impl<DB: Database + 'static, P: TreeParams + 'static> ReadStorageTreeDev
         )
     }
 
-    fn prev_tree_index(&mut self, key: Bytes32Dev) -> u64 {
+    fn prev_tree_index(&mut self, key: Bytes32Prev) -> u64 {
         // TODO: callers only invoke this for keys that are absent (membership proofs for missing
         // keys). If the key already exists in the tree, a different code path is needed.
         let res = &self
@@ -306,7 +307,7 @@ pub fn fixed_bytes_to_bytes32(x: B256) -> Bytes32 {
     x.into()
 }
 
-pub fn fixed_bytes_to_bytes32_dev(x: B256) -> Bytes32Dev {
+pub fn fixed_bytes_to_bytes32_prev(x: B256) -> Bytes32Prev {
     let x: [u8; 32] = x.into();
     x.into()
 }

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 
 [dependencies]
 zksync_os_interface.workspace = true
-zk_os_forward_system.workspace = true
 zk_os_forward_system_0_1_2.workspace = true
 zk_os_forward_system_0_0_28.workspace = true
 zk_os_forward_system_0_2_8.workspace = true
-zk_os_forward_system_dev.workspace = true
+zk_os_forward_system_prev.workspace = true
+zk_os_forward_system.workspace = true
 anyhow.workspace = true
 zksync_os_types.workspace = true
 alloy = { workspace = true, default-features = false, features = [

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -2,11 +2,11 @@
 //! When adding new ZKsync OS execution version, make sure it is handled in `run_block` and `simulate_tx` methods.
 //! Also, update the `LATEST_EXECUTION_VERSION` constant accordingly.
 
-use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV5Running;
+use zk_os_forward_system::run::RunBlockForward as RunBlockForwardV6;
 use zk_os_forward_system_0_0_28::run::RunBlockForward as RunBlockForwardV3;
 use zk_os_forward_system_0_1_2::run::RunBlockForward as RunBlockForwardV4;
 use zk_os_forward_system_0_2_8::run::RunBlockForward as RunBlockForwardV5Simulation;
-use zk_os_forward_system_dev::run::RunBlockForward as RunBlockForwardV6;
+use zk_os_forward_system_prev::run::RunBlockForward as RunBlockForwardV5Running;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{AnyTracer, AnyTxValidator};
 use zksync_os_interface::traits::{

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -60,13 +60,12 @@ zksync_os_tx_validators.workspace = true
 zksync_os_config_validation_macros.workspace = true
 zksync_os_backpressure.workspace = true
 
+zk_ee_prev.workspace = true
+zk_os_forward_system_prev.workspace = true
+
 zk_ee.workspace = true
 zk_os_forward_system.workspace = true
 
-zk_ee_dev.workspace = true
-zk_os_forward_system_dev.workspace = true
-
-zk_os_basic_system.workspace = true
 zksync_os_interface.workspace = true
 execution_utils.workspace = true
 full_statement_verifier.workspace = true

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -149,7 +149,7 @@ fn compute_batch_prover_input(
     pubdata_mode: PubdataMode,
 ) -> anyhow::Result<ProverInput> {
     use zk_os_forward_system::run::generate_batch_proof_input;
-    use zk_os_forward_system_dev::run::generate_batch_proof_input as generate_batch_proof_input_dev;
+    use zk_os_forward_system_prev::run::generate_batch_proof_input as generate_batch_proof_input_prev;
 
     if blocks
         .iter()
@@ -168,7 +168,7 @@ fn compute_batch_prover_input(
         }
         ProvingVersion::V6 => {
             // TODO: in the long-term we should generate proof input per batch
-            ProverInput::Real(generate_batch_proof_input(
+            ProverInput::Real(generate_batch_proof_input_prev(
                 blocks
                     .iter()
                     .map(|(_, _, _, prover_input)| prover_input.unwrap_real())
@@ -184,7 +184,7 @@ fn compute_batch_prover_input(
         }
         ProvingVersion::V7 => {
             // TODO: in the long-term we should generate proof input per batch
-            ProverInput::Real(generate_batch_proof_input_dev(
+            ProverInput::Real(generate_batch_proof_input(
                 blocks
                     .iter()
                     .map(|(_, _, _, prover_input)| prover_input.unwrap_real())

--- a/node/bin/src/prover_api/fri_proof_verifier.rs
+++ b/node/bin/src/prover_api/fri_proof_verifier.rs
@@ -1,7 +1,26 @@
 use crate::prover_api::fri_job_manager::SubmitError;
-use alloy::primitives::B256;
-use zk_os_basic_system::system_implementation::system::BatchPublicInput;
+use alloy::primitives::{B256, keccak256};
 use zksync_os_contract_interface::models::StoredBatchInfo;
+
+#[derive(Debug)]
+struct BatchPublicInput {
+    /// State commitment before the batch.
+    /// It should commit for everything needed for trustless execution(state, block number, hashes, etc).
+    pub state_before: B256,
+    /// State commitment after the batch.
+    pub state_after: B256,
+    /// Batch output to be opened on the settlement layer, needed to process DA, l1 <> l2 messaging, validate inputs.
+    pub batch_output: B256,
+}
+
+impl BatchPublicInput {
+    ///
+    /// Calculate keccak256 hash of public input
+    ///
+    pub fn hash(&self) -> B256 {
+        keccak256([self.state_before.0, self.state_after.0, self.batch_output.0].concat())
+    }
+}
 
 pub fn verify_fri_proof(
     previous_state_commitment: B256,
@@ -9,9 +28,9 @@ pub fn verify_fri_proof(
     proof: execution_utils::ProgramProof,
 ) -> Result<(), SubmitError> {
     let expected_pi = BatchPublicInput {
-        state_before: previous_state_commitment.0.into(),
-        state_after: stored_batch_info.state_commitment.0.into(),
-        batch_output: stored_batch_info.commitment.0.into(),
+        state_before: previous_state_commitment,
+        state_after: stored_batch_info.state_commitment,
+        batch_output: stored_batch_info.commitment,
     };
 
     let expected_hash_u32s: [u32; 8] = batch_output_hash_as_register_values(&expected_pi);
@@ -43,6 +62,7 @@ pub fn verify_fri_proof(
 fn batch_output_hash_as_register_values(public_input: &BatchPublicInput) -> [u32; 8] {
     public_input
         .hash()
+        .0
         .chunks_exact(4)
         .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("Slice with incorrect length")))
         .collect::<Vec<u32>>()

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -222,10 +222,10 @@ fn compute_prover_input(
             panic!("computing prover input for batch with prover version v1-v5 is not supported");
         }
         ProvingVersion::V6 => {
-            use zk_ee::{
+            use zk_ee_prev::{
                 common_structs::ProofData, system::metadata::zk_metadata::BlockMetadataFromOracle,
             };
-            use zk_os_forward_system::run::{
+            use zk_os_forward_system_prev::run::{
                 StorageCommitment, convert::FromInterface, generate_proof_input_from_bytes,
             };
 
@@ -260,10 +260,10 @@ fn compute_prover_input(
             .expect("proof gen failed")
         }
         ProvingVersion::V7 => {
-            use zk_ee_dev::{
+            use zk_ee::{
                 common_structs::ProofData, system::metadata::zk_metadata::BlockMetadataFromOracle,
             };
-            use zk_os_forward_system_dev::run::{
+            use zk_os_forward_system::run::{
                 StorageCommitment, convert::FromInterface, generate_proof_input_from_bytes,
             };
 


### PR DESCRIPTION
## Summary

- Renames zksync-os crates, current version (no suffix, e.g. `zk_ee`; `v0.2.9-interface-v0.0.15`) becomes `_prev`, `_dev` (`v0.3.0`) becomes current.

- [fri_proof_verifier.rs](https://github.com/matter-labs/zksync-os-server/compare/rename-zksync-os-deps?expand=1#diff-af7169642dd305ca9bf04a6a4fd4b9c51b131ea6c8343b20a675522030379170): `BatchPublicInput` struct was moved to `basic_bootloader` on zk-os side, we don't want to depend on full crate only because of `BatchPublicInput`, so it's duplicated (20 loc)


<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

