### PR TITLE
fix(integration-tests): import NetworkTransactionBuilder

### DIFF
--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -1,5 +1,5 @@
 use alloy::eips::Encodable2718;
-use alloy::network::TransactionBuilder;
+use alloy::network::{NetworkTransactionBuilder, TransactionBuilder};
 use alloy::primitives::{Address, TxKind, U256, utils::parse_ether};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;


### PR DESCRIPTION
## Summary

The `build` method on `TransactionRequest` is provided by the `NetworkTransactionBuilder` trait, which was not in scope, causing E0599 (and cascading E0282) in the two sync-rejection test cases.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

