### PR TITLE
refactor: rely on owned `BlockContext` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14710,8 +14710,8 @@ dependencies = [
  "tokio",
  "zksync_os_api",
  "zksync_os_contract_interface",
- "zksync_os_interface",
  "zksync_os_l1_watcher",
+ "zksync_os_storage_api",
  "zksync_os_types",
 ]
 
@@ -14955,6 +14955,7 @@ dependencies = [
  "tracing",
  "url",
  "zksync_os_interface",
+ "zksync_os_storage_api",
  "zksync_os_types",
 ]
 

--- a/lib/batch_types/src/batch_info.rs
+++ b/lib/batch_types/src/batch_info.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::ops;
 use std::ops::{Deref, DerefMut};
 use zksync_os_contract_interface::models::{CommitBatchInfo, StoredBatchInfo};
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::{BlockHashes, BlockOutput};
 use zksync_os_mini_merkle_tree::MiniMerkleTree;
 use zksync_os_types::{
     L2_TO_L1_TREE_SIZE, L2ToL1Log, ProtocolSemanticVersion, PubdataMode, ZkEnvelope, ZkTransaction,
@@ -33,7 +33,6 @@ impl ExtendedCommitBatchInfo {
     pub fn build(
         blocks: Vec<(
             &BlockOutput,
-            &BlockContext,
             &[ZkTransaction],
             &zksync_os_merkle_tree::TreeBatchOutput,
         )>,
@@ -43,6 +42,7 @@ impl ExtendedCommitBatchInfo {
         sl_chain_id: u64,
         multichain_root: B256,
         protocol_version: &ProtocolSemanticVersion,
+        last_256_block_hashes: &BlockHashes,
     ) -> (Self, Option<BlobTransactionSidecar>) {
         let mut priority_operations_hash = keccak256([]);
         let mut number_of_layer1_txs = 0;
@@ -50,14 +50,14 @@ impl ExtendedCommitBatchInfo {
         let mut total_pubdata = vec![];
         let mut encoded_l2_l1_logs = vec![];
 
-        let (first_block_output, _, _, _) = *blocks.first().unwrap();
-        let (last_block_output, last_block_context, _, last_block_tree) = *blocks.last().unwrap();
+        let (first_block_output, _, _) = *blocks.first().unwrap();
+        let (last_block_output, _, last_block_tree) = *blocks.last().unwrap();
 
         let mut upgrade_tx_hash = None;
 
         let mut dependency_roots_rolling_hash = B256::ZERO;
 
-        for (block_output, _, transactions, _) in blocks {
+        for (block_output, transactions, _) in blocks {
             total_pubdata.extend(block_output.pubdata.clone());
 
             for tx in transactions {
@@ -118,7 +118,7 @@ impl ExtendedCommitBatchInfo {
 
         let last_256_block_hashes_blake = {
             let mut blocks_hasher = Blake2s256::new();
-            for block_hash in &last_block_context.block_hashes.0[1..] {
+            for block_hash in &last_256_block_hashes.0[1..] {
                 blocks_hasher.update(block_hash.to_be_bytes::<32>());
             }
             blocks_hasher.update(last_block_output.header.hash());
@@ -127,11 +127,7 @@ impl ExtendedCommitBatchInfo {
         };
 
         /* ---------- operator DA input ---------- */
-        let da_fields = calculate_da_fields(
-            &total_pubdata,
-            pubdata_mode,
-            last_block_context.execution_version,
-        );
+        let da_fields = calculate_da_fields(&total_pubdata, pubdata_mode);
 
         /* ---------- new state commitment ---------- */
         // FIXME: extract to a type common batch types?
@@ -266,63 +262,57 @@ struct DAFields {
     pub blob_sidecar: Option<BlobTransactionSidecar>,
 }
 
-fn calculate_da_fields(
-    pubdata: &[u8],
-    pubdata_mode: PubdataMode,
-    batch_execution_version: u32,
-) -> DAFields {
-    let (da_commitment, operator_da_input, blob_sidecar) =
-        match (pubdata_mode, batch_execution_version) {
-            (PubdataMode::Calldata | PubdataMode::RelayedL2Calldata, _)
-            | (PubdataMode::Validium, 4) => {
-                let mut operator_da_input = Vec::with_capacity(32 * 3 + 1 + pubdata.len() + 1 + 32);
+fn calculate_da_fields(pubdata: &[u8], pubdata_mode: PubdataMode) -> DAFields {
+    let (da_commitment, operator_da_input, blob_sidecar) = match pubdata_mode {
+        PubdataMode::Calldata | PubdataMode::RelayedL2Calldata => {
+            let mut operator_da_input = Vec::with_capacity(32 * 3 + 1 + pubdata.len() + 1 + 32);
 
-                // reference for this header is taken from zk_ee: https://github.com/matter-labs/zk_ee/blob/ad-aggregation-program/aggregator/src/aggregation/da_commitment.rs#L27
-                // consider reusing that code instead:
-                //
-                // hasher.update([0u8; 32]); // we don't have to validate state diffs hash
-                // hasher.update(Keccak256::digest(&pubdata)); // full pubdata keccak
-                // hasher.update([1u8]); // with calldata we should provide 1 blob
-                // hasher.update([0u8; 32]); // its hash will be ignored on the settlement layer
-                // Ok(hasher.finalize().into())
+            // reference for this header is taken from zk_ee: https://github.com/matter-labs/zk_ee/blob/ad-aggregation-program/aggregator/src/aggregation/da_commitment.rs#L27
+            // consider reusing that code instead:
+            //
+            // hasher.update([0u8; 32]); // we don't have to validate state diffs hash
+            // hasher.update(Keccak256::digest(&pubdata)); // full pubdata keccak
+            // hasher.update([1u8]); // with calldata we should provide 1 blob
+            // hasher.update([0u8; 32]); // its hash will be ignored on the settlement layer
+            // Ok(hasher.finalize().into())
 
-                operator_da_input.extend(B256::ZERO.as_slice());
-                operator_da_input.extend(keccak256(pubdata));
-                operator_da_input.push(1);
-                operator_da_input.extend(B256::ZERO.as_slice());
+            operator_da_input.extend(B256::ZERO.as_slice());
+            operator_da_input.extend(keccak256(pubdata));
+            operator_da_input.push(1);
+            operator_da_input.extend(B256::ZERO.as_slice());
 
-                //     bytes32 daCommitment; - we compute hash of the first part of the operator_da_input (see above)
-                let da_commitment = keccak256(&operator_da_input);
+            //     bytes32 daCommitment; - we compute hash of the first part of the operator_da_input (see above)
+            let da_commitment = keccak256(&operator_da_input);
 
-                operator_da_input.extend([PUBDATA_SOURCE_CALLDATA]);
-                operator_da_input.extend(pubdata);
-                // blob_commitment should be set to zero in ZK OS
-                operator_da_input.extend(B256::ZERO.as_slice());
+            operator_da_input.extend([PUBDATA_SOURCE_CALLDATA]);
+            operator_da_input.extend(pubdata);
+            // blob_commitment should be set to zero in ZK OS
+            operator_da_input.extend(B256::ZERO.as_slice());
 
-                if pubdata_mode == PubdataMode::Validium {
-                    operator_da_input = U256::ZERO.to_be_bytes_vec();
-                }
-
-                (da_commitment, operator_da_input, None)
+            if pubdata_mode == PubdataMode::Validium {
+                operator_da_input = U256::ZERO.to_be_bytes_vec();
             }
-            (PubdataMode::Validium, _) => (B256::ZERO, vec![0u8; 32], None),
-            (PubdataMode::Blobs, _) => {
-                // returns error in case of internal error during sidecar calculation
-                let blob_sidecar: BlobTransactionSidecar =
-                    SidecarBuilder::<SimpleCoder>::from_slice(pubdata)
-                        .build()
-                        .unwrap();
-                let versioned_hashes: Vec<u8> = blob_sidecar
-                    .versioned_hashes()
-                    .flat_map(|hash| hash.0.to_vec())
-                    .collect();
-                let da_commitment = keccak256(&versioned_hashes);
 
-                // we place zeroes into da input to publish blobs with commit transaction
-                let operator_da_input = vec![0u8; versioned_hashes.len()];
-                (da_commitment, operator_da_input, Some(blob_sidecar))
-            }
-        };
+            (da_commitment, operator_da_input, None)
+        }
+        PubdataMode::Validium => (B256::ZERO, vec![0u8; 32], None),
+        PubdataMode::Blobs => {
+            // returns error in case of internal error during sidecar calculation
+            let blob_sidecar: BlobTransactionSidecar =
+                SidecarBuilder::<SimpleCoder>::from_slice(pubdata)
+                    .build()
+                    .unwrap();
+            let versioned_hashes: Vec<u8> = blob_sidecar
+                .versioned_hashes()
+                .flat_map(|hash| hash.0.to_vec())
+                .collect();
+            let da_commitment = keccak256(&versioned_hashes);
+
+            // we place zeroes into da input to publish blobs with commit transaction
+            let operator_da_input = vec![0u8; versioned_hashes.len()];
+            (da_commitment, operator_da_input, Some(blob_sidecar))
+        }
+    };
     DAFields {
         da_commitment,
         operator_da_input,

--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -123,17 +123,13 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
 
         let state_view = self.read_state.state_view_at(request.last_block_number)?;
         let multichain_root = read_multichain_root(state_view);
+        let (_, last_replay_record, _) = blocks.last().unwrap();
 
         let (batch_info, _) = ExtendedCommitBatchInfo::build(
             blocks
                 .iter()
                 .map(|(block_output, replay_record, tree)| {
-                    (
-                        *block_output,
-                        &replay_record.block_context,
-                        replay_record.transactions.as_slice(),
-                        tree,
-                    )
+                    (*block_output, replay_record.transactions.as_slice(), tree)
                 })
                 .collect(),
             self.chain_id,
@@ -142,6 +138,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
             self.l1_state.sl_chain_id,
             multichain_root,
             &blocks.first().unwrap().1.protocol_version,
+            &last_replay_record.block_context.block_hashes,
         );
 
         let expected_commit_data = normalized_commit_data(

--- a/lib/genesis/Cargo.toml
+++ b/lib/genesis/Cargo.toml
@@ -13,8 +13,7 @@ categories.workspace = true
 zksync_os_types.workspace = true
 zksync_os_l1_watcher.workspace = true
 zksync_os_contract_interface.workspace = true
-
-zksync_os_interface.workspace = true
+zksync_os_storage_api.workspace = true
 
 alloy = { workspace = true, default-features = false, features = ["consensus", "sol-types", "eips", "serde"] }
 serde.workspace = true

--- a/lib/genesis/src/lib.rs
+++ b/lib/genesis/src/lib.rs
@@ -19,7 +19,7 @@ use zk_os_basic_system::system_implementation::flat_storage_model::{
 };
 use zksync_os_contract_interface::IL1GenesisUpgrade::GenesisUpgrade;
 use zksync_os_contract_interface::ZkChain;
-use zksync_os_interface::types::BlockContext;
+use zksync_os_storage_api::BlockContext;
 use zksync_os_types::{ConfigFormat, ExecutionVersion, L1UpgradeEnvelope, ProtocolSemanticVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/multivm/Cargo.toml
+++ b/lib/multivm/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 
 [dependencies]
 zksync_os_interface.workspace = true
+zksync_os_storage_api.workspace = true
 zk_os_forward_system_0_1_2.workspace = true
 zk_os_forward_system_0_0_28.workspace = true
 zk_os_forward_system_0_2_8.workspace = true

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -12,8 +12,8 @@ use zksync_os_interface::tracing::{AnyTracer, AnyTxValidator};
 use zksync_os_interface::traits::{
     EncodedTx, PreimageSource, ReadStorage, RunBlock, SimulateTx, TxResultCallback, TxSource,
 };
-use zksync_os_interface::types::BlockContext;
 use zksync_os_interface::types::{BlockOutput, TxOutput};
+use zksync_os_storage_api::BlockContext;
 
 mod adapter;
 pub mod apps;
@@ -41,6 +41,7 @@ pub fn run_block<
         .execution_version
         .try_into()
         .expect("Unsupported ZKsync OS execution version");
+    let block_context = block_context.to_interface();
     match execution_version {
         ExecutionVersion::V1 | ExecutionVersion::V2 | ExecutionVersion::V3 => {
             let object = RunBlockForwardV3 {};
@@ -128,6 +129,7 @@ pub fn simulate_tx<
         .execution_version
         .try_into()
         .expect("Unsupported ZKsync OS execution version");
+    let block_context = block_context.to_interface();
     match execution_version {
         ExecutionVersion::V1 | ExecutionVersion::V2 | ExecutionVersion::V3 => {
             let object = RunBlockForwardV3 {};

--- a/lib/network/src/wire/replays/impls.rs
+++ b/lib/network/src/wire/replays/impls.rs
@@ -7,9 +7,9 @@ use crate::wire::replays::{WireReplayRecord, v0, v1, v2, v3};
 use crate::wire::{BlockHashes, ForcedPreimage};
 use alloy::consensus::crypto::RecoveryError;
 use alloy::primitives::{BlockNumber, Bytes};
-use zksync_os_interface::types::BlockContext as InterfaceBlockContext;
 use zksync_os_interface::types::BlockHashes as InterfaceBlockHashes;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
+use zksync_os_storage_api::BlockContext as StorageBlockContext;
 use zksync_os_storage_api::ReplayRecord as StorageReplayRecord;
 use zksync_os_types::InteropRootsLogIndex;
 use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
@@ -36,7 +36,7 @@ impl TryFrom<v0::ReplayRecord> for StorageReplayRecord {
     type Error = RecoveryError;
 
     fn try_from(value: v0::ReplayRecord) -> Result<Self, Self::Error> {
-        let block_context = InterfaceBlockContext {
+        let block_context = StorageBlockContext {
             block_number: value.block_number,
             ..Default::default()
         };
@@ -63,8 +63,8 @@ impl WireReplayRecord for v1::ReplayRecord {
     }
 }
 
-impl From<InterfaceBlockContext> for v1::BlockContext {
-    fn from(value: InterfaceBlockContext) -> Self {
+impl From<StorageBlockContext> for v1::BlockContext {
+    fn from(value: StorageBlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
             block_number: value.block_number,
@@ -110,7 +110,7 @@ impl From<StorageReplayRecord> for v1::ReplayRecord {
     }
 }
 
-impl From<v1::BlockContext> for InterfaceBlockContext {
+impl From<v1::BlockContext> for StorageBlockContext {
     fn from(value: v1::BlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
@@ -135,7 +135,7 @@ impl TryFrom<v1::ReplayRecord> for StorageReplayRecord {
 
     fn try_from(value: v1::ReplayRecord) -> Result<Self, Self::Error> {
         Ok(Self {
-            block_context: value.block_context.into(),
+            block_context: StorageBlockContext::from(value.block_context),
             transactions: value
                 .transactions
                 .into_iter()
@@ -172,8 +172,8 @@ impl WireReplayRecord for v2::ReplayRecord {
     }
 }
 
-impl From<InterfaceBlockContext> for v2::BlockContext {
-    fn from(value: InterfaceBlockContext) -> Self {
+impl From<StorageBlockContext> for v2::BlockContext {
+    fn from(value: StorageBlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
             block_number: value.block_number,
@@ -192,7 +192,7 @@ impl From<InterfaceBlockContext> for v2::BlockContext {
     }
 }
 
-impl From<v2::BlockContext> for InterfaceBlockContext {
+impl From<v2::BlockContext> for StorageBlockContext {
     fn from(value: v2::BlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
@@ -246,7 +246,7 @@ impl TryFrom<v2::ReplayRecord> for StorageReplayRecord {
 
     fn try_from(value: v2::ReplayRecord) -> Result<Self, Self::Error> {
         Ok(Self {
-            block_context: value.block_context.into(),
+            block_context: StorageBlockContext::from(value.block_context),
             transactions: value
                 .transactions
                 .into_iter()
@@ -283,8 +283,8 @@ impl WireReplayRecord for v3::ReplayRecord {
     }
 }
 
-impl From<InterfaceBlockContext> for v3::BlockContext {
-    fn from(value: InterfaceBlockContext) -> Self {
+impl From<StorageBlockContext> for v3::BlockContext {
+    fn from(value: StorageBlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
             block_number: value.block_number,
@@ -303,7 +303,7 @@ impl From<InterfaceBlockContext> for v3::BlockContext {
     }
 }
 
-impl From<v3::BlockContext> for InterfaceBlockContext {
+impl From<v3::BlockContext> for StorageBlockContext {
     fn from(value: v3::BlockContext) -> Self {
         Self {
             chain_id: value.chain_id,
@@ -356,7 +356,7 @@ impl TryFrom<v3::ReplayRecord> for StorageReplayRecord {
 
     fn try_from(value: v3::ReplayRecord) -> Result<Self, Self::Error> {
         Ok(Self {
-            block_context: value.block_context.into(),
+            block_context: StorageBlockContext::from(value.block_context),
             transactions: value
                 .transactions
                 .into_iter()

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -11,7 +11,6 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use test_casing::test_casing;
 use tokio::sync::{broadcast, mpsc};
-use zksync_os_interface::types::BlockContext;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_network::protocol::{
     ExternalNodeProtocolConfig, ExternalNodeVerifierConfig, HandlerSharedState,
@@ -22,6 +21,7 @@ use zksync_os_network::version::{
     ZksProtocolVersionSpec, ZksVersion,
 };
 use zksync_os_network::{PeerVerifyBatchResult, VerifyBatchOutcome, VerifyBatchResult};
+use zksync_os_storage_api::BlockContext;
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};
 use zksync_os_types::{BlockStartCursors, NodeRole, ProtocolSemanticVersion};
 

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -21,10 +21,10 @@ use zk_os_api::helpers::get_nonce;
 use zksync_os_interface::types::{BlockHashes, ExecutionOutput};
 use zksync_os_interface::{
     error::InvalidTransaction,
-    types::{BlockContext, ExecutionResult, TxOutput},
+    types::{ExecutionResult, TxOutput},
 };
 use zksync_os_storage_api::{
-    RepositoryError, StateError, ViewState, state_override_view::OverriddenStateView,
+    BlockContext, RepositoryError, StateError, ViewState, state_override_view::OverriddenStateView,
 };
 use zksync_os_tx_validators::policy_client::{AccessType, PolicyClient, PolicySession};
 use zksync_os_types::ZksyncOsEncode;

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -27,13 +27,12 @@ use tokio::sync::watch;
 use zk_ee::common_structs::derive_flat_storage_key;
 use zk_os_api::helpers::get_code;
 use zksync_os_interface::traits::ReadStorage;
-use zksync_os_interface::types::BlockContext;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_rpc_api::eth::EthApiServer;
 use zksync_os_rpc_api::types::{
     L2FeeHistory, RpcBlockConvert, ZkApiBlock, ZkApiTransaction, ZkHeader, ZkTransactionReceipt,
 };
-use zksync_os_storage_api::{RepositoryError, StateError, TxMeta, ViewState};
+use zksync_os_storage_api::{BlockContext, RepositoryError, StateError, TxMeta, ViewState};
 use zksync_os_tx_validators::policy_client::PolicyClient;
 use zksync_os_types::{L2Envelope, TransactionAcceptanceState, ZkEnvelope, ZkReceiptEnvelope};
 

--- a/lib/rpc/src/js_tracer/tracer.rs
+++ b/lib/rpc/src/js_tracer/tracer.rs
@@ -1008,7 +1008,7 @@ impl EvmTracer for JsTracer {
 
 pub fn trace_block<V: ViewState + 'static>(
     txs: Vec<ZkTransaction>,
-    block_context: zksync_os_interface::types::BlockContext,
+    block_context: zksync_os_storage_api::BlockContext,
     state_view: V,
     js_tracer_config: String,
 ) -> anyhow::Result<Vec<JsonValue>> {

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -53,7 +53,6 @@ use reth_rpc_eth_types::EthSubscriptionIdProvider;
 use reth_tasks::Runtime;
 use tower_http::cors::{Any, CorsLayer};
 use zksync_os_genesis::GenesisInputSource;
-use zksync_os_interface::types::BlockContext;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_rpc_api::debug::DebugApiServer;
 use zksync_os_rpc_api::eth::EthApiServer;
@@ -65,6 +64,7 @@ use zksync_os_rpc_api::txpool::TxpoolApiServer;
 use zksync_os_rpc_api::unstable::UnstableApiServer;
 use zksync_os_rpc_api::web3::Web3ApiServer;
 use zksync_os_rpc_api::zks::ZksApiServer;
+use zksync_os_storage_api::BlockContext;
 use zksync_os_tx_validators::policy_client::PolicyClient;
 use zksync_os_types::TransactionAcceptanceState;
 

--- a/lib/rpc/src/sandbox.rs
+++ b/lib/rpc/src/sandbox.rs
@@ -8,9 +8,9 @@ use zksync_os_interface::tracing::{
     EvmResources, EvmTracer, NopTracer, NopValidator,
 };
 use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
-use zksync_os_interface::types::{BlockContext, ExecutionResult, TxOutput};
+use zksync_os_interface::types::{ExecutionResult, TxOutput};
 use zksync_os_multivm::{run_block, simulate_tx};
-use zksync_os_storage_api::ViewState;
+use zksync_os_storage_api::{BlockContext, ViewState};
 use zksync_os_types::{ZkTransaction, ZksyncOsEncode};
 
 /// EVM max stack size.

--- a/lib/rpc/src/simulate.rs
+++ b/lib/rpc/src/simulate.rs
@@ -17,11 +17,10 @@ use zk_os_api::helpers::get_nonce;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{NopTracer, NopValidator};
 use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
-use zksync_os_interface::types::{
-    BlockContext, BlockOutput, ExecutionOutput, ExecutionResult, TxOutput,
-};
+use zksync_os_interface::types::{BlockOutput, ExecutionOutput, ExecutionResult, TxOutput};
 use zksync_os_multivm::run_block;
 use zksync_os_rpc_api::types::{ZkApiBlock, ZkHeader};
+use zksync_os_storage_api::BlockContext;
 use zksync_os_storage_api::ViewState;
 use zksync_os_storage_api::state_override_view::{
     OverriddenStateView, OwnedOverrides, build_state_override_maps,

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -10,11 +10,11 @@ use alloy::transports::{RpcError, TransportErrorKind};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use zksync_os_interface::error::InvalidTransaction;
-use zksync_os_interface::types::BlockContext;
 use zksync_os_mempool::PoolError;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_mempool::{InvalidPoolTransactionError, PoolErrorKind};
 use zksync_os_rpc_api::types::ZkTransactionReceipt;
+use zksync_os_storage_api::BlockContext;
 use zksync_os_tx_validators::policy_client::{AccessType, PolicyClient};
 use zksync_os_types::{
     L2Envelope, L2Transaction, NotAcceptingReason, TransactionAcceptanceState, ZkTransaction,

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -7,9 +7,10 @@ use anyhow::Context as _;
 use futures::StreamExt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::{sync::watch, time::Instant};
-use zksync_os_interface::types::{BlockContext, BlockHashes, BlockOutput};
+use zksync_os_interface::types::{BlockHashes, BlockOutput};
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_mempool::{MarkingTxStream, Pool};
+use zksync_os_storage_api::BlockContext;
 use zksync_os_storage_api::ReplayRecord;
 use zksync_os_types::{
     BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion, SystemTxEnvelope, SystemTxType,

--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -12,10 +12,12 @@ use vise::EncodeLabelValue;
 use zk_ee::memory::stack_trait::Stack;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{AnyTracer, AnyTxValidator};
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::BlockOutput;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_observability::ComponentStateReporter;
-use zksync_os_storage_api::{MeteredViewState, OverriddenStateView, ReplayRecord, ViewState};
+use zksync_os_storage_api::{
+    BlockContext, MeteredViewState, OverriddenStateView, ReplayRecord, ViewState,
+};
 use zksync_os_types::{SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
 // Note that this is a pure function without a container struct (e.g. `struct BlockExecutor`)
 // MAINTAIN this to ensure the function is completely stateless - explicit or implicit.

--- a/lib/sequencer/src/execution/utils.rs
+++ b/lib/sequencer/src/execution/utils.rs
@@ -3,7 +3,8 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::BlockOutput;
+use zksync_os_storage_api::BlockContext;
 use zksync_os_types::ZkTransaction;
 
 // Hash of the block output, which is used to identify divergences in block execution.

--- a/lib/sequencer/src/execution/vm_wrapper.rs
+++ b/lib/sequencer/src/execution/vm_wrapper.rs
@@ -8,8 +8,8 @@ use tokio::{
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{AnyTracer, AnyTxValidator};
 use zksync_os_interface::traits::{EncodedTx, NextTxResponse, TxResultCallback, TxSource};
-use zksync_os_interface::types::{BlockContext, BlockOutput, TxProcessingOutputOwned};
-use zksync_os_storage_api::ViewState;
+use zksync_os_interface::types::{BlockOutput, TxProcessingOutputOwned};
+use zksync_os_storage_api::{BlockContext, ViewState};
 
 /// A one‐by‐one driver around `run_block`, enabling `execute_next_tx` interface
 /// (as opposed to pull interface of `run_block` in zksync-os)

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -2,9 +2,10 @@ use alloy::primitives::{B256, TxHash};
 use std::fmt::Display;
 use std::time::Duration;
 use zksync_os_interface::error::InvalidTransaction;
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::BlockOutput;
 use zksync_os_mempool::MarkingTxStream;
 use zksync_os_pipeline::HasBlockRangeEnd;
+use zksync_os_storage_api::BlockContext;
 use zksync_os_storage_api::ReplayRecord;
 use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
 

--- a/lib/sequencer/src/model/debug_formatting.rs
+++ b/lib/sequencer/src/model/debug_formatting.rs
@@ -1,7 +1,8 @@
 use crate::model::blocks::PreparedBlockCommand;
 use alloy::primitives::B256;
 use std::fmt;
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::BlockOutput;
+use zksync_os_storage_api::BlockContext;
 
 struct BlockContextDbg<'a>(&'a BlockContext);
 impl<'a> fmt::Debug for BlockContextDbg<'a> {

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -5,11 +5,10 @@ use std::time::Duration;
 use vise::Unit;
 use vise::{Buckets, Histogram, Metrics};
 use zksync_os_genesis::Genesis;
-use zksync_os_interface::types::BlockContext;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::{NamedColumnFamily, WriteBatch};
-use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay};
+use zksync_os_storage_api::{BlockContext, ReadReplay, ReplayRecord, WriteReplay};
 use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
 
 /// A write-ahead log storing [`ReplayRecord`]s.

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -2,7 +2,7 @@ mod metered_state;
 pub use metered_state::{MeteredViewState, StateAccessLabel};
 
 mod model;
-pub use model::{FinalityStatus, ReplayRecord, StoredTxData, TreeBlock, TxMeta};
+pub use model::{BlockContext, FinalityStatus, ReplayRecord, StoredTxData, TreeBlock, TxMeta};
 
 mod replay;
 pub use replay::{ReadReplay, ReadReplayExt, WriteReplay};

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -1,8 +1,8 @@
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, U256};
 use alloy::rlp::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 use zksync_os_batch_types::BlockMerkleTreeData;
-use zksync_os_interface::types::{BlockContext, BlockOutput};
+use zksync_os_interface::types::{BlockHashes, BlockOutput};
 use zksync_os_pipeline::HasBlockRangeEnd;
 use zksync_os_types::{
     BlockStartCursors, ProtocolSemanticVersion, ZkEnvelope, ZkReceiptEnvelope, ZkTransaction,
@@ -138,5 +138,51 @@ impl HasBlockRangeEnd for ReplayRecord {
     }
     fn block_timestamp(&self) -> Option<u64> {
         Some(self.block_context.timestamp)
+    }
+}
+
+/// Be careful when changing this struct as making non-backwards-compatible changes will make old
+/// storage non-loadable.
+#[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize)]
+pub struct BlockContext {
+    // Chain id is temporarily also added here (so that it can be easily passed from the oracle)
+    // long term, we have to decide whether we want to keep it here, or add a separate oracle
+    // type that would return some 'chain' specific metadata (as this class is supposed to hold block metadata only).
+    pub chain_id: u64,
+    pub block_number: u64,
+    pub block_hashes: BlockHashes,
+    pub timestamp: u64,
+    pub eip1559_basefee: U256,
+    pub pubdata_price: U256,
+    pub native_price: U256,
+    pub coinbase: Address,
+    pub gas_limit: u64,
+    pub pubdata_limit: u64,
+    /// Source of randomness, currently holds the value of prevRandao.
+    pub mix_hash: U256,
+    /// Version of the ZKsync OS and its config to be used for this block.
+    pub execution_version: u32,
+    pub blob_fee: U256,
+}
+
+impl BlockContext {
+    // todo: this will not be needed in the future once zksync-os-interface accepts a trait instead
+    //       of concrete BlockContext struct
+    pub fn to_interface(self) -> zksync_os_interface::types::BlockContext {
+        zksync_os_interface::types::BlockContext {
+            chain_id: self.chain_id,
+            block_number: self.block_number,
+            block_hashes: self.block_hashes,
+            timestamp: self.timestamp,
+            eip1559_basefee: self.eip1559_basefee,
+            pubdata_price: self.pubdata_price,
+            native_price: self.native_price,
+            coinbase: self.coinbase,
+            gas_limit: self.gas_limit,
+            pubdata_limit: self.pubdata_limit,
+            mix_hash: self.mix_hash,
+            execution_version: self.execution_version,
+            blob_fee: self.blob_fee,
+        }
     }
 }

--- a/lib/storage_api/src/replay.rs
+++ b/lib/storage_api/src/replay.rs
@@ -1,4 +1,4 @@
-use crate::ReplayRecord;
+use crate::{BlockContext, ReplayRecord};
 use alloy::primitives::{BlockNumber, Sealed};
 use futures::Stream;
 use futures::stream::BoxStream;
@@ -9,7 +9,6 @@ use std::task::Poll;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{Instant, Sleep};
-use zksync_os_interface::types::BlockContext;
 
 /// Read-only view on block replay storage.
 ///

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -29,6 +29,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
     let block_number_from = blocks.first().unwrap().1.block_context.block_number;
     let block_number_to = blocks.last().unwrap().1.block_context.block_number;
     let protocol_version = blocks.first().unwrap().1.protocol_version.clone();
+    let (_, last_replay_record, _, _) = blocks.last().unwrap();
 
     let state_view = read_state.state_view_at(block_number_to)?;
     let multichain_root = read_multichain_root(state_view);
@@ -36,12 +37,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
         blocks
             .iter()
             .map(|(block_output, replay_record, tree, _)| {
-                (
-                    block_output,
-                    &replay_record.block_context,
-                    replay_record.transactions.as_slice(),
-                    tree,
-                )
+                (block_output, replay_record.transactions.as_slice(), tree)
             })
             .collect(),
         chain_id,
@@ -50,6 +46,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
         sl_chain_id,
         multichain_root,
         &protocol_version,
+        &last_replay_record.block_context.block_hashes,
     );
 
     let mut logs = Vec::new();

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -247,7 +247,8 @@ fn compute_prover_input(
                 .expect("Failed to convert DA commitment scheme");
             generate_proof_input_from_bytes(
                 bin_bytes,
-                BlockMetadataFromOracle::from_interface(replay_record.block_context),
+                // todo: not ideal but will be gone in v0.4.0 with new PIG anyway
+                BlockMetadataFromOracle::from_interface(replay_record.block_context.to_interface()),
                 ProofData {
                     state_root_view: initial_storage_commitment,
                     last_block_timestamp: replay_record.previous_block_timestamp,
@@ -285,7 +286,8 @@ fn compute_prover_input(
                 .expect("Failed to convert DA commitment scheme");
             generate_proof_input_from_bytes(
                 bin_bytes,
-                BlockMetadataFromOracle::from_interface(replay_record.block_context),
+                // todo: not ideal but will be gone in v0.4.0 with new PIG anyway
+                BlockMetadataFromOracle::from_interface(replay_record.block_context.to_interface()),
                 ProofData {
                     state_root_view: initial_storage_commitment,
                     last_block_timestamp: replay_record.previous_block_timestamp,


### PR DESCRIPTION
## Summary

Get rids of all usages of `zksync_os_interface::types::BlockContext` (except the new `zksync_os_storage_api::BlockContext::to_interface` which will be removed in the future as well). Instead we rely on our own owned struct that we can change independently from zksync-os.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

