### PR TITLE
fix(rpc): return -32602 instead of -32603 for block-not-found errors

### DIFF
--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -8,6 +8,7 @@ use crate::debug_impl::DebugError;
 use crate::eth_call_handler::EthCallError;
 use crate::eth_filter::EthFilterError;
 use crate::eth_impl::EthError;
+use crate::rpc_storage::RpcStorageError;
 use crate::tx_handler::{EthSendRawTransactionError, EthSendRawTransactionSyncError};
 use crate::unstable_impl::UnstableError;
 use crate::zks_impl::ZksError;
@@ -49,6 +50,9 @@ impl<Ok> ToRpcResult<Ok, EthError> for Result<Ok, EthError> {
             EthError::BlockNotFound(_)
             | EthError::NonceMaxValue
             | EthError::InvalidRewardPercentiles => invalid_params_rpc_err(err.to_string()),
+            EthError::RpcStorage(RpcStorageError::BlockNotFound(_)) => {
+                invalid_params_rpc_err(err.to_string())
+            }
             EthError::RpcStorage(_) | EthError::Repository(_) | EthError::State(_) => {
                 internal_rpc_err(err.to_string())
             }
@@ -141,6 +145,9 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
                 None,
             ),
             EthCallError::CallFees(_) => invalid_params_rpc_err(err.to_string()),
+            EthCallError::Storage(RpcStorageError::BlockNotFound(_)) => {
+                invalid_params_rpc_err(err.to_string())
+            }
             err => internal_rpc_err(err.to_string()),
         })
     }


### PR DESCRIPTION
## Summary

- `RpcStorageError::BlockNotFound` wrapped inside `EthCallError::Storage` (used by `eth_call`, `eth_estimateGas`, `eth_simulateV1`) was falling through to the `err => internal_rpc_err(...)` wildcard, emitting `-32603` (Internal Error)
- Same issue for `EthError::RpcStorage(RpcStorageError::BlockNotFound(_))` (used by `eth_getTransactionCount`)
- Added explicit match arms for both before their respective wildcards/catch-alls, mapping to `-32602` (Invalid Params) — consistent with how `EthError::BlockNotFound` is already handled

This caused external partners to misclassify these responses as provider-side internal errors instead of resource-not-found conditions, affecting their error routing logic.

## Test plan

- [ ] Build passes (`cargo build -p zksync_os_rpc`)
- [ ] Call `eth_call` / `eth_getTransactionCount` with a non-existent block number — should now return `-32602` instead of `-32603`

🤖 Generated with [Claude Code](https://claude.com/claude-code)