### PR TITLE
feat(pipeline): block on full channel instead of panicking

### DIFF
--- a/lib/batch_verification/src/main_node/component.rs
+++ b/lib/batch_verification/src/main_node/component.rs
@@ -105,10 +105,12 @@ impl<E: Send + Sync + 'static> PipelineComponent for BatchVerificationPipelineSt
                     return Ok(());
                 };
                 state_reporter.enter_state(GenericComponentState::Active);
-                output.send_and_record(
-                    batch.with_signatures(BatchSignatureData::NotNeeded),
-                    &state_reporter,
-                )?;
+                output
+                    .send_and_record(
+                        batch.with_signatures(BatchSignatureData::NotNeeded),
+                        &state_reporter,
+                    )
+                    .await?;
             }
         }
 
@@ -200,12 +202,14 @@ impl BatchVerificationRunner {
                     "Skipping signing of already committed batch {}",
                     batch_envelope.batch_number()
                 );
-                signed_batch_sender.send_and_record(
-                    batch_envelope
-                        .with_stage(BatchExecutionStage::BatchSigned)
-                        .with_signatures(BatchSignatureData::AlreadyCommitted),
-                    &self.state_reporter,
-                )?;
+                signed_batch_sender
+                    .send_and_record(
+                        batch_envelope
+                            .with_stage(BatchExecutionStage::BatchSigned)
+                            .with_signatures(BatchSignatureData::AlreadyCommitted),
+                        &self.state_reporter,
+                    )
+                    .await?;
                 continue;
             }
 
@@ -255,12 +259,14 @@ impl BatchVerificationRunner {
             metrics.attempts_to_success.observe(retry_count + 1);
             metrics.total_latency.observe(start_time.elapsed());
 
-            signed_batch_sender.send_and_record(
-                batch_envelope
-                    .with_signatures(BatchSignatureData::Signed { signatures })
-                    .with_stage(BatchExecutionStage::BatchSigned),
-                &self.state_reporter,
-            )?;
+            signed_batch_sender
+                .send_and_record(
+                    batch_envelope
+                        .with_signatures(BatchSignatureData::Signed { signatures })
+                        .with_stage(BatchExecutionStage::BatchSigned),
+                    &self.state_reporter,
+                )
+                .await?;
         }
     }
 

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -347,7 +347,9 @@ where
         for command in completed_commands {
             for mut output_envelope in command.into() {
                 output_envelope.set_stage(Input::MINED_STAGE);
-                outbound.send_and_record(output_envelope, state_reporter)?;
+                outbound
+                    .send_and_record(output_envelope, state_reporter)
+                    .await?;
             }
         }
         Ok(())
@@ -587,10 +589,12 @@ where
                                 batch_number = batch.batch_number(),
                                 "Not actually sending to L1, just passing through"
                             );
-                            outbound.send_and_record(
-                                (*batch).with_stage(Input::PASSTHROUGH_STAGE),
-                                state_reporter,
-                            )?;
+                            outbound
+                                .send_and_record(
+                                    (*batch).with_stage(Input::PASSTHROUGH_STAGE),
+                                    state_reporter,
+                                )
+                                .await?;
                         }
                     }
                 }

--- a/lib/l1_sender/src/upgrade_gatekeeper.rs
+++ b/lib/l1_sender/src/upgrade_gatekeeper.rs
@@ -106,7 +106,7 @@ impl PipelineComponent for UpgradeGatekeeper {
                     .await?;
             }
 
-            output.send_and_record(command, &state_reporter)?;
+            output.send_and_record(command, &state_reporter).await?;
         }
     }
 }

--- a/lib/observability/src/component_state_reporter.rs
+++ b/lib/observability/src/component_state_reporter.rs
@@ -67,6 +67,10 @@ impl ComponentStateReporter {
         )
     }
 
+    pub fn component_name(&self) -> &'static str {
+        self.component
+    }
+
     /// Transition to a new state.
     pub fn enter_state(&self, new_state: impl StateLabel) {
         let now = Instant::now();

--- a/lib/pipeline/src/lib.rs
+++ b/lib/pipeline/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod builder;
 pub mod component_id;
 pub mod has_block_range_end;
+pub mod metrics;
 pub mod peekable_receiver;
 pub mod send_and_record;
 pub mod traits;

--- a/lib/pipeline/src/metrics.rs
+++ b/lib/pipeline/src/metrics.rs
@@ -1,0 +1,13 @@
+use vise::{Counter, LabeledFamily, Metrics};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "pipeline")]
+pub struct PipelineMetrics {
+    /// Number of times a component's output channel was full and the send had to wait.
+    /// Labeled by the producer component name.
+    #[metrics(labels = ["component"])]
+    pub channel_stall_count: LabeledFamily<&'static str, Counter<u64>>,
+}
+
+#[vise::register]
+pub static PIPELINE_METRICS: vise::Global<PipelineMetrics> = vise::Global::new();

--- a/lib/pipeline/src/send_and_record.rs
+++ b/lib/pipeline/src/send_and_record.rs
@@ -1,21 +1,30 @@
 use std::fmt;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
 
 use crate::has_block_range_end::HasBlockRangeEnd;
-use tokio::sync::mpsc;
+use crate::metrics::PIPELINE_METRICS;
+
+/// If a blocked send does not complete within this duration the downstream
+/// consumer is considered stuck and the component shuts down with an error.
+const STALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Error returned by [`SendAndRecordExt::send_and_record`].
 pub enum PipelineSendError<T> {
     /// The channel's receiver was dropped.
     Closed(T),
-    /// The channel is full — consumer is catastrophically behind.
-    Full(T),
+    /// The channel was full and the downstream consumer did not drain it
+    /// within [`STALL_TIMEOUT`]. The consumer is considered stuck.
+    Stuck,
 }
 
 impl<T> fmt::Debug for PipelineSendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Closed(_) => write!(f, "PipelineSendError::Closed(..)"),
-            Self::Full(_) => write!(f, "PipelineSendError::Full(..)"),
+            Self::Stuck => write!(f, "PipelineSendError::Stuck"),
         }
     }
 }
@@ -23,10 +32,13 @@ impl<T> fmt::Debug for PipelineSendError<T> {
 impl<T> fmt::Display for PipelineSendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Closed(_) => write!(f, "pipeline channel closed: receiver was dropped"),
-            Self::Full(_) => write!(
+            Self::Closed(_) => write!(
                 f,
-                "pipeline channel full: consumer is catastrophically behind"
+                "pipeline channel closed: downstream receiver was dropped"
+            ),
+            Self::Stuck => write!(
+                f,
+                "pipeline channel stuck: downstream consumer did not drain within {STALL_TIMEOUT:?}"
             ),
         }
     }
@@ -37,19 +49,24 @@ impl<T> std::error::Error for PipelineSendError<T> {}
 /// Extension trait on `mpsc::Sender<T>` that combines sending an item
 /// with recording it as processed on a `ComponentStateReporter`.
 ///
-/// Recording happens only if the send succeeds — if the receiver has been
-/// dropped, or the channel is full (consumer catastrophically behind), the
-/// error is returned and nothing is recorded.
+/// Uses `try_send` as a zero-cost fast path. If the channel is full, logs
+/// and increments the stall counter, then blocks via `send().await`
+/// until space is available. If the consumer does not drain the channel within
+/// [`STALL_TIMEOUT`], logs an `error` (forwarded to Sentry) and returns
+/// [`PipelineSendError::Stuck`] so the component shuts down cleanly.
+/// Recording happens only after a successful send.
+#[async_trait]
 pub trait SendAndRecordExt<T: HasBlockRangeEnd> {
-    fn send_and_record(
+    async fn send_and_record(
         &self,
         value: T,
         reporter: &zksync_os_observability::ComponentStateReporter,
     ) -> Result<(), PipelineSendError<T>>;
 }
 
+#[async_trait]
 impl<T: HasBlockRangeEnd> SendAndRecordExt<T> for mpsc::Sender<T> {
-    fn send_and_record(
+    async fn send_and_record(
         &self,
         value: T,
         reporter: &zksync_os_observability::ComponentStateReporter,
@@ -57,11 +74,32 @@ impl<T: HasBlockRangeEnd> SendAndRecordExt<T> for mpsc::Sender<T> {
         let block_number = value.block_number();
         let block_timestamp = value.block_timestamp();
         let batch_number = value.batch_number();
+
         match self.try_send(value) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Closed(v)) => return Err(PipelineSendError::Closed(v)),
-            Err(mpsc::error::TrySendError::Full(v)) => return Err(PipelineSendError::Full(v)),
+            Err(mpsc::error::TrySendError::Full(value)) => {
+                let component = reporter.component_name();
+                tracing::info!(
+                    component,
+                    "pipeline channel stall: output channel is full - downstream consumer is behind"
+                );
+                PIPELINE_METRICS.channel_stall_count[&component].inc();
+                match tokio::time::timeout(STALL_TIMEOUT, self.send(value)).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(mpsc::error::SendError(v))) => return Err(PipelineSendError::Closed(v)),
+                    Err(_elapsed) => {
+                        tracing::error!(
+                            component,
+                            "pipeline channel stuck: downstream consumer did not pick up within \
+                             {STALL_TIMEOUT:?}, shutting down"
+                        );
+                        return Err(PipelineSendError::Stuck);
+                    }
+                }
+            }
         }
+
         reporter.record_processed(block_number, block_timestamp, batch_number);
         Ok(())
     }

--- a/lib/priority_tree/src/lib.rs
+++ b/lib/priority_tree/src/lib.rs
@@ -175,10 +175,12 @@ impl<ReplayStorage: ReadReplay + Clone, Finality: ReadFinality + Clone>
                             "Passing through batch that was already executed"
                         );
                         if let Some(sender) = &execute_batches_sender {
-                            sender.send_and_record(
-                                L1SenderCommand::Passthrough(Box::new(envelope)),
-                                &state_reporter,
-                            )?;
+                            sender
+                                .send_and_record(
+                                    L1SenderCommand::Passthrough(Box::new(envelope)),
+                                    &state_reporter,
+                                )
+                                .await?;
                         }
 
                         continue;
@@ -349,7 +351,7 @@ impl<ReplayStorage: ReadReplay + Clone, Finality: ReadFinality + Clone>
                     priority_ops,
                     interop_roots,
                 ));
-                s.send_and_record(cmd, &state_reporter)?;
+                s.send_and_record(cmd, &state_reporter).await?;
             } else {
                 state_reporter.record_processed(
                     last_block,

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -263,13 +263,15 @@ where
                 }
             }
 
-            output.send_and_record(
-                AppliedBlock {
-                    output: block_output.clone(),
-                    record: replay_record.clone(),
-                },
-                &state_reporter,
-            )?;
+            output
+                .send_and_record(
+                    AppliedBlock {
+                        output: block_output.clone(),
+                        record: replay_record.clone(),
+                    },
+                    &state_reporter,
+                )
+                .await?;
         }
     }
 }

--- a/lib/sequencer/src/execution/block_applier.rs
+++ b/lib/sequencer/src/execution/block_applier.rs
@@ -90,13 +90,15 @@ where
 
             self.applied_block_number_sender.send_replace(block_number);
 
-            output.send_and_record(
-                AppliedBlock {
-                    output: block_output,
-                    record: executed_replay,
-                },
-                &state_reporter,
-            )?;
+            output
+                .send_and_record(
+                    AppliedBlock {
+                        output: block_output,
+                        record: executed_replay,
+                    },
+                    &state_reporter,
+                )
+                .await?;
         }
     }
 }

--- a/lib/sequencer/src/execution/block_canonizer.rs
+++ b/lib/sequencer/src/execution/block_canonizer.rs
@@ -137,7 +137,8 @@ where
                                     failed_transactions,
                                 },
                                 &state_reporter,
-                            )?;
+                            )
+                            .await?;
                     } else {
                         tracing::info!(
                             "Received new block {} (block output hash: {}) from Consensus. \
@@ -185,7 +186,8 @@ where
                                     failed_transactions,
                                 },
                                 &state_reporter,
-                            )?;
+                            )
+                            .await?;
                         }
                         BlockCommandType::Produce | BlockCommandType::Rebuild => {
                             tracing::info!(

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -202,15 +202,17 @@ where
                 .last_execution_version
                 .set(replay_record.block_context.execution_version as u64);
 
-            output.send_and_record(
-                BlockPayload {
-                    output: block_output.clone(),
-                    record: replay_record.clone(),
-                    command_type: cmd_type,
-                    failed_transactions: purged_txs,
-                },
-                &state_reporter,
-            )?;
+            output
+                .send_and_record(
+                    BlockPayload {
+                        output: block_output.clone(),
+                        record: replay_record.clone(),
+                        command_type: cmd_type,
+                        failed_transactions: purged_txs,
+                    },
+                    &state_reporter,
+                )
+                .await?;
         }
     }
 }

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -200,7 +200,9 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to send sidecar: {e}"))?;
             }
-            output.send_and_record(batch_envelope, &state_reporter)?;
+            output
+                .send_and_record(batch_envelope, &state_reporter)
+                .await?;
         }
     }
 }

--- a/node/bin/src/migration_gate.rs
+++ b/node/bin/src/migration_gate.rs
@@ -91,7 +91,7 @@ impl PipelineComponent for MigrationGate {
                 );
             }
 
-            output.send_and_record(item, &state_reporter)?;
+            output.send_and_record(item, &state_reporter).await?;
         }
     }
 }

--- a/node/bin/src/prover_api/fri_proving_pipeline_step.rs
+++ b/node/bin/src/prover_api/fri_proving_pipeline_step.rs
@@ -84,7 +84,8 @@ impl PipelineComponent for FriProvingPipelineStep {
                         // Already proven - send with fake proof to pass through the pipeline
                         let batch_with_fake_proof = batch.with_data(FriProof::AlreadySubmittedToL1);
                         output
-                            .send_and_record(batch_with_fake_proof, &state_reporter)?;
+                            .send_and_record(batch_with_fake_proof, &state_reporter)
+                            .await?;
                     }
                 }
                 Ok::<(), anyhow::Error>(())
@@ -99,7 +100,9 @@ impl PipelineComponent for FriProvingPipelineStep {
                         "Received batch after FRI proving: {:?}",
                         proof.batch_number()
                     );
-                    output.send_and_record(proof, &state_reporter)?;
+                    output
+                        .send_and_record(proof, &state_reporter)
+                        .await?;
                 }
                 Ok::<(), anyhow::Error>(())
             } => {

--- a/node/bin/src/prover_api/gapless_committer.rs
+++ b/node/bin/src/prover_api/gapless_committer.rs
@@ -84,7 +84,7 @@ impl PipelineComponent for GaplessCommitter {
                                 .map(L1SenderCommand::SendToL1)
                                 .context("Committer batch signature failure")?
                             };
-                            output.send_and_record(result, &state_reporter)?;
+                            output.send_and_record(result, &state_reporter).await?;
                         }
                     }
                 }

--- a/node/bin/src/prover_api/gapless_l1_proof_sender.rs
+++ b/node/bin/src/prover_api/gapless_l1_proof_sender.rs
@@ -48,7 +48,9 @@ impl PipelineComponent for GaplessL1ProofSender {
 
                     while let Some(next_command) = buffer.remove(&next_expected_batch_number) {
                         next_expected_batch_number += next_command.batch_count() as u64;
-                        output.send_and_record(next_command, &state_reporter)?;
+                        output
+                            .send_and_record(next_command, &state_reporter)
+                            .await?;
                     }
                 }
                 None => {

--- a/node/bin/src/prover_api/snark_proving_pipeline_step.rs
+++ b/node/bin/src/prover_api/snark_proving_pipeline_step.rs
@@ -75,7 +75,9 @@ impl PipelineComponent for SnarkProvingPipelineStep {
                         self.snark_job_manager.add_job(batch).await;
                     } else {
                         let passthrough = L1SenderCommand::Passthrough(Box::new(batch));
-                        output.send_and_record(passthrough, &state_reporter)?;
+                        output
+                            .send_and_record(passthrough, &state_reporter)
+                            .await?;
                     }
                 }
                 Ok::<(), anyhow::Error>(())
@@ -86,10 +88,12 @@ impl PipelineComponent for SnarkProvingPipelineStep {
             },
             result = async {
                 while let Some(proof_command) = self.proof_commands_receiver.recv().await {
-                    output.send_and_record(
-                        L1SenderCommand::SendToL1(proof_command),
-                        &state_reporter,
-                    )?;
+                    output
+                        .send_and_record(
+                            L1SenderCommand::SendToL1(proof_command),
+                            &state_reporter,
+                        )
+                        .await?;
                 }
                 Ok::<(), anyhow::Error>(())
             } => {

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -67,15 +67,17 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                     return Ok(());
                 };
                 state_reporter.enter_state(GenericComponentState::Active);
-                output.send_and_record(
-                    ProverBlock {
-                        output: block_output,
-                        record: replay_record,
-                        prover_input: ProverInput::Fake,
-                        tree,
-                    },
-                    &state_reporter,
-                )?;
+                output
+                    .send_and_record(
+                        ProverBlock {
+                            output: block_output,
+                            record: replay_record,
+                            prover_input: ProverInput::Fake,
+                            tree,
+                        },
+                        &state_reporter,
+                    )
+                    .await?;
             }
         }
         // Process the first item alone — it involves heavy trusted-setup precomputation
@@ -91,7 +93,7 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
             block_number = result.output.header.number,
             "sending block with prover input to batcher",
         );
-        output.send_and_record(result, &state_reporter)?;
+        output.send_and_record(result, &state_reporter).await?;
 
         // Process remaining items with up to `maximum_in_flight_blocks` in parallel.
         // Results are delivered in arrival order via FuturesOrdered.
@@ -124,7 +126,9 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                         block_number = item.output.header.number,
                         "sending block with prover input to batcher",
                     );
-                    output.send_and_record(item, &state_reporter)?;
+                    output
+                        .send_and_record(item, &state_reporter)
+                        .await?;
                 }
             }
         }

--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -147,14 +147,16 @@ impl PipelineComponent for TreeManager {
                         block: block_number,
                     },
                 };
-                output.send_and_record(
-                    TreeBlock {
-                        output: block_output,
-                        record: replay_record,
-                        tree: tree_block_data,
-                    },
-                    &state_reporter,
-                )?;
+                output
+                    .send_and_record(
+                        TreeBlock {
+                            output: block_output,
+                            record: replay_record,
+                            tree: tree_block_data,
+                        },
+                        &state_reporter,
+                    )
+                    .await?;
             }
         }
     }


### PR DESCRIPTION
## Summary

Replace the fail-fast `try_send` in `send_and_record` with a blocking `send().await` so that a slow downstream component applies backpressure instead of crashing the server.

When the channel is full, log and increment a per-component `pipeline_channel_stall_count` counter, then await until space is available. Stall logs are intentionally kept at `info` level so that a temporarily slow downstream does not flood Sentry. If the consumer does not drain within 60 seconds it is considered stuck: a `tracing::error!` is emitted (forwarded to Sentry) and the component shuts down cleanly via `PipelineSendError::Stuck` rather than hanging forever.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. \`feat!: ...\`, \`fix!: ...\`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->