### PR TITLE
chore: fix compilation by using BlockContext from storage api crate

### DIFF
--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -331,7 +331,7 @@ mod tests {
 
     fn test_replay_record(block_number: u64) -> ReplayRecord {
         ReplayRecord {
-            block_context: zksync_os_interface::types::BlockContext {
+            block_context: zksync_os_storage_api::BlockContext {
                 block_number,
                 ..Default::default()
             },

--- a/lib/replay_archive/src/recovery.rs
+++ b/lib/replay_archive/src/recovery.rs
@@ -608,7 +608,7 @@ mod tests {
         block_number: BlockNumber,
         previous_block_hash: BlockHash,
     ) -> ReplayRecord {
-        let mut block_context = zksync_os_interface::types::BlockContext {
+        let mut block_context = zksync_os_storage_api::BlockContext {
             block_number,
             ..Default::default()
         };

--- a/lib/replay_archive/src/write_replay.rs
+++ b/lib/replay_archive/src/write_replay.rs
@@ -4,8 +4,7 @@ use alloy::primitives::{BlockNumber, Sealed};
 use anyhow::Context;
 use std::fmt::Debug;
 use std::time::Instant;
-use zksync_os_interface::types::BlockContext;
-use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay};
+use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay, BlockContext};
 
 /// [`WriteReplay`] wrapper that writes to replay storage and enqueues records for archiving.
 #[derive(Debug, Clone)]

--- a/lib/replay_archive/src/write_replay.rs
+++ b/lib/replay_archive/src/write_replay.rs
@@ -4,7 +4,7 @@ use alloy::primitives::{BlockNumber, Sealed};
 use anyhow::Context;
 use std::fmt::Debug;
 use std::time::Instant;
-use zksync_os_storage_api::{ReadReplay, ReplayRecord, WriteReplay, BlockContext};
+use zksync_os_storage_api::{BlockContext, ReadReplay, ReplayRecord, WriteReplay};
 
 /// [`WriteReplay`] wrapper that writes to replay storage and enqueues records for archiving.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

CI in main broken by consecutive merges that were working separately, but not together. Fix compilation by using BlockContext from storage api crate.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

