### PR TITLE
refactor(command_source): move flow control to pipeline source

### DIFF
--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -1,0 +1,57 @@
+use tokio::sync::watch;
+
+/// Admission gate for internal pipeline sources.
+///
+/// This is deliberately separate from RPC transaction acceptance. `true` means
+/// the block pipeline can accept more work; `false` means command sources should
+/// stop forwarding new work until downstream lag clears.
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionGate {
+    tx: watch::Sender<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionReceiver {
+    rx: watch::Receiver<bool>,
+}
+
+impl PipelineAdmissionGate {
+    pub fn open() -> (Self, PipelineAdmissionReceiver) {
+        let (tx, rx) = watch::channel(true);
+        (Self { tx }, PipelineAdmissionReceiver { rx })
+    }
+
+    pub fn subscribe(&self) -> PipelineAdmissionReceiver {
+        PipelineAdmissionReceiver {
+            rx: self.tx.subscribe(),
+        }
+    }
+
+    pub fn set_open(&self) {
+        self.set(true);
+    }
+
+    pub fn set_closed(&self) {
+        self.set(false);
+    }
+
+    pub fn set(&self, open: bool) {
+        let _ = self.tx.send_if_modified(|current| {
+            if *current == open {
+                return false;
+            }
+            *current = open;
+            true
+        });
+    }
+}
+
+impl PipelineAdmissionReceiver {
+    pub fn is_open(&self) -> bool {
+        *self.rx.borrow()
+    }
+
+    pub async fn wait_until_open(&mut self) {
+        let _ = self.rx.wait_for(|open| *open).await;
+    }
+}

--- a/lib/backpressure/src/lib.rs
+++ b/lib/backpressure/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod gate;
 pub mod metrics;
 pub mod monitor;
 pub mod tracker;
@@ -7,5 +8,6 @@ pub use config::{
     BackpressureConfig, ComponentId, DEFAULT_BATCH_DIFF_LIMIT, DEFAULT_BLOCK_DIFF_LIMIT,
     PipelineCondition,
 };
+pub use gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 pub use monitor::{AdjacentSnapshot, BackpressureMonitor, PipelineSnapshot};
 pub use tracker::PipelineTracker;

--- a/lib/backpressure/src/monitor.rs
+++ b/lib/backpressure/src/monitor.rs
@@ -1,4 +1,5 @@
 use crate::config::{BackpressureConfig, ComponentId, is_pipeline_stage};
+use crate::gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 use crate::metrics::MONITOR_METRICS;
 use reth_tasks::Runtime;
 use std::collections::{HashMap, HashSet};
@@ -58,17 +59,24 @@ fn compute_adjacent_snapshots(
 pub struct BackpressureMonitor {
     config: BackpressureConfig,
     acceptance_tx: watch::Sender<TransactionAcceptanceState>,
+    pipeline_gate: PipelineAdmissionGate,
     stop_receiver: watch::Receiver<bool>,
 }
 
 impl BackpressureMonitor {
     pub fn new(config: BackpressureConfig, stop_receiver: watch::Receiver<bool>) -> Self {
         let (acceptance_tx, _) = watch::channel(TransactionAcceptanceState::Accepting);
+        let (pipeline_gate, _) = PipelineAdmissionGate::open();
         Self {
             config,
             acceptance_tx,
+            pipeline_gate,
             stop_receiver,
         }
+    }
+
+    pub fn subscribe_gate(&self) -> PipelineAdmissionReceiver {
+        self.pipeline_gate.subscribe()
     }
 
     pub fn spawn(
@@ -186,6 +194,8 @@ impl BackpressureMonitor {
     }
 
     fn update_acceptance_state(&self, new_state: TransactionAcceptanceState) {
+        self.pipeline_gate
+            .set(matches!(new_state, TransactionAcceptanceState::Accepting));
         self.acceptance_tx.send_if_modified(|current| {
             if *current == new_state {
                 return false;

--- a/lib/sequencer/src/config.rs
+++ b/lib/sequencer/src/config.rs
@@ -36,10 +36,6 @@ pub struct SequencerConfig {
     /// Max pubdata bytes per block
     pub block_pubdata_limit_bytes: u64,
 
-    /// Maximum number of blocks to produce
-    /// None for indefinite block production (normal operations)
-    pub max_blocks_to_produce: Option<u64>,
-
     /// Max number of interop roots to be included in a single transaction
     pub interop_roots_per_tx: usize,
 

--- a/lib/sequencer/src/execution/block_canonizer.rs
+++ b/lib/sequencer/src/execution/block_canonizer.rs
@@ -26,6 +26,9 @@ where
     /// Channel to send new canonized blocks to for the node to replay.
     /// They are sent to `NodeCommandSource` and then through the whole pipeline.
     pub canonized_blocks_for_execution: mpsc::UnboundedSender<ReplayRecord>,
+    /// Releases `ConsensusNodeCommandSource` to emit the next Produce command
+    /// after this component accepts/proposes the previous produced block.
+    pub produce_acks: mpsc::Sender<()>,
 }
 
 #[async_trait]
@@ -199,6 +202,11 @@ where
                                 .enter_state(BlockCanonizerState::ProposingToConsensus);
                             let proposed = replay_record.clone();
                             self.consensus.propose(proposed).await?;
+                            if matches!(cmd_type, BlockCommandType::Produce)
+                                && self.produce_acks.send(()).await.is_err()
+                            {
+                                tracing::info!("produce ack channel closed");
+                            }
                             produced_queue.push_back(BlockPayload {
                                 output: block_output,
                                 record: replay_record,

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -16,7 +16,6 @@ use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
 use zksync_os_storage_api::{OverlayBuffer, ReadStateHistory, WriteState};
 use zksync_os_tx_validators::deployment_filter;
 use zksync_os_tx_validators::policy_client::AccessType;
-use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
 /// Executes blocks, while only updating local in-memory state (mempool, block context).
 /// Does not persist anything to disk.
@@ -29,9 +28,6 @@ where
     pub block_context_provider: BlockContextProvider<Subpool>,
     pub state: State,
     pub config: SequencerConfig,
-    /// Controls transaction acceptance state.
-    /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
-    pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     /// TEMPORARY: `BlockExecutor` waits for `BlockApplier` to apply block `N`
     /// before starting block `N + 1`. This works around an `OverlayBuffer` bug
     /// that reproduces during rebuilds when the runtime truncates base state.
@@ -61,9 +57,6 @@ where
         output: mpsc::Sender<Self::Output>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        // Track how many Produce commands we've processed (for `sequencer_max_blocks_to_produce` config)
-        let mut produced_blocks_count = 0u64;
-
         // Only used for metrics/logs
         let mut last_processed_block_at: Option<Instant> = None;
         // `BlockExecutor` doesn't persist/update state after block execution.
@@ -85,19 +78,6 @@ where
             )
             .await?;
 
-            // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
-            if matches!(cmd, BlockCommand::Produce(_))
-                && let Some(limit) = self.config.max_blocks_to_produce
-            {
-                check_block_production_limit(
-                    limit,
-                    produced_blocks_count,
-                    &self.tx_acceptance_state_sender,
-                    &state_reporter,
-                )
-                .await;
-                produced_blocks_count += 1;
-            }
             state_reporter.enter_state(SequencerState::WaitingForTransaction);
 
             let prepared_command = self.block_context_provider.prepare_command(cmd).await?;
@@ -247,32 +227,6 @@ async fn wait_for_block_applier(
         "BlockExecutor resumed after BlockApplier caught up"
     );
     Ok(())
-}
-
-/// Checks if block production limit has been reached.
-/// If limit is reached, signals to stop accepting transactions and awaits indefinitely (never returns).
-/// Should only be called for Produce commands.
-async fn check_block_production_limit(
-    limit: u64,
-    already_produced_blocks_count: u64,
-    tx_acceptance_state_sender: &watch::Sender<TransactionAcceptanceState>,
-    state_reporter: &ComponentStateReporter,
-) {
-    if already_produced_blocks_count >= limit {
-        tracing::warn!(
-            already_produced_blocks_count,
-            limit,
-            "Reached max_blocks_to_produce limit, stopping transaction acceptance"
-        );
-
-        // Signal to RPC that we're no longer accepting transactions
-        let _ = tx_acceptance_state_sender.send(TransactionAcceptanceState::NotAccepting(vec![
-            NotAcceptingReason::BlockProductionDisabled,
-        ]));
-
-        state_reporter.enter_state(SequencerState::ConfiguredBlockLimitReached);
-        std::future::pending::<()>().await;
-    }
 }
 
 fn make_deployment_filter(

--- a/lib/sequencer/src/execution/metrics.rs
+++ b/lib/sequencer/src/execution/metrics.rs
@@ -8,8 +8,6 @@ use zksync_os_storage_api::StateAccessLabel;
 pub enum SequencerState {
     /// Waiting for the next block command from the command source.
     WaitingForCommand,
-    /// `max_blocks_to_produce` limit reached — component is permanently halted.
-    ConfiguredBlockLimitReached,
     /// Command dequeued, waiting for BlockApplier to finish applying the
     /// previous block.
     WaitingForApplier,
@@ -32,9 +30,7 @@ pub enum SequencerState {
 impl StateLabel for SequencerState {
     fn generic(&self) -> GenericComponentState {
         match self {
-            Self::WaitingForCommand | Self::ConfiguredBlockLimitReached => {
-                GenericComponentState::Idle
-            }
+            Self::WaitingForCommand => GenericComponentState::Idle,
             Self::WaitingForApplier | Self::WaitingForTransaction | Self::WaitingForTx => {
                 GenericComponentState::Idle
             }
@@ -48,7 +44,6 @@ impl StateLabel for SequencerState {
     fn specific(&self) -> &'static str {
         match self {
             Self::WaitingForCommand => "waiting_for_command",
-            Self::ConfiguredBlockLimitReached => "configured_block_limit_reached",
             Self::WaitingForApplier => "waiting_for_applier",
             Self::WaitingForTransaction => "waiting_for_transaction",
             Self::InitializingVm => "initializing_vm",

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 use std::collections::HashSet;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
+use zksync_os_backpressure::PipelineAdmissionReceiver;
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_raft::{ConsensusRole, LeadershipSignal};
 use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
 use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
-use zksync_os_storage_api::{ReadReplay, ReadReplayExt, ReplayRecord};
+use zksync_os_storage_api::{ReadReplay, ReplayRecord};
+use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
 /// Command source for consensus-enabled main node.
 /// Replays local WAL starting from `starting_block` and then produces new blocks when leader.
@@ -21,11 +23,20 @@ pub struct ConsensusNodeCommandSource<Replay> {
     pub rebuild_options: Option<RebuildOptions>,
     /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
     pub replays_to_execute: mpsc::UnboundedReceiver<ReplayRecord>,
+    /// Acknowledges that the previously emitted Produce command crossed the
+    /// downstream lifecycle boundary and the source may emit another one.
+    pub produce_acks: mpsc::Receiver<()>,
+    /// Internal pipeline admission gate driven by backpressure monitoring.
+    pub pipeline_gate: PipelineAdmissionReceiver,
+    /// Optional operational cap on newly produced blocks. Replays bypass this.
+    pub max_blocks_to_produce: Option<u64>,
+    /// Signals RPC admission when the configured production limit is reached.
+    pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     /// Current leadership status from consensus.
     pub leadership: LeadershipSignal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RebuildOptions {
     pub from_block: u64,
     pub blocks_to_empty: HashSet<u64>,
@@ -37,6 +48,7 @@ pub struct RebuildOptions {
 pub struct ExternalNodeCommandSource {
     pub up_to_block: Option<u64>,
     pub replays_for_sequencer: mpsc::Receiver<ReplayRecord>,
+    pub pipeline_gate: PipelineAdmissionReceiver,
 }
 
 #[async_trait]
@@ -46,10 +58,7 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 
     const COMPONENT_ID: zksync_os_pipeline::ComponentId =
         zksync_os_pipeline::ComponentId::ConsensusNodeCommandSource;
-    // Capacity 1 is intentional: the leader arm in run_loop emits Produce tokens inside
-    // tokio::select! on output.send(), firing whenever the channel has space. A larger buffer
-    // would let the leader queue multiple tokens ahead of execution. Capacity of 1 ensures
-    // at most one un-executed Produce command in flight, making the downstream consumer the pacer.
+    // Keep the transport buffer small so BlockExecutor remains the near-term pacer.
     const OUTPUT_CHANNEL_CAPACITY: usize = 1;
 
     async fn run(
@@ -84,17 +93,11 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
             replay_until
         );
 
-        self.block_replay_storage
-            .forward_range_with(
-                self.starting_block,
-                replay_until,
-                output.clone(),
-                |record| BlockCommand::Replay(Box::new(record)),
-            )
+        self.forward_wal_replays(self.starting_block, replay_until, &output)
             .await?;
 
-        if let Some(rebuild_options) = &self.rebuild_options {
-            self.send_block_rebuilds(rebuild_options, last_block_in_wal, &output)
+        if let Some(rebuild_options) = self.rebuild_options.clone() {
+            self.send_block_rebuilds(&rebuild_options, last_block_in_wal, &output)
                 .await?;
         }
 
@@ -110,6 +113,8 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 }
 
 impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
+    const MAX_REPLAYS_TO_DRAIN_PER_LOOP: usize = 32;
+
     /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
     /// Produces `Produce` commands only when the node is the leader.
     async fn run_loop(
@@ -119,10 +124,54 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
     ) -> anyhow::Result<()> {
         let mut leadership = self.leadership.clone();
         let mut role = leadership.current_role();
+        let mut produce_in_flight = false;
+        let mut produced_blocks_count = 0u64;
+        let mut production_limit_reported = false;
         tracing::info!(?role, "Consensus role initialized");
 
         loop {
+            let gate_open = self.pipeline_gate.is_open();
+            for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
+                if !gate_open {
+                    break;
+                }
+                match self.replays_to_execute.try_recv() {
+                    Ok(record) => {
+                        Self::forward_replay(record, &output, &state_reporter).await?;
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        tracing::info!("inbound channel closed");
+                        return Ok(());
+                    }
+                }
+            }
+
+            let production_limit_reached = self
+                .max_blocks_to_produce
+                .is_some_and(|limit| produced_blocks_count >= limit);
+            if production_limit_reached && !production_limit_reported {
+                tracing::warn!(
+                    produced_blocks_count,
+                    limit = self.max_blocks_to_produce,
+                    "Reached max_blocks_to_produce limit, stopping transaction acceptance"
+                );
+                let _ =
+                    self.tx_acceptance_state_sender
+                        .send(TransactionAcceptanceState::NotAccepting(vec![
+                            NotAcceptingReason::BlockProductionDisabled,
+                        ]));
+                production_limit_reported = true;
+            }
+
+            let can_produce = role == ConsensusRole::Leader
+                && !produce_in_flight
+                && gate_open
+                && !production_limit_reached;
+
             tokio::select! {
+                biased;
+
                 res = leadership.wait_for_change() => {
                     if res.is_err() {
                         anyhow::bail!("leader watch channel closed");
@@ -133,33 +182,28 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         role = new_role;
                     }
                 }
-                maybe_record = self.replays_to_execute.recv() => {
+                maybe_ack = self.produce_acks.recv(), if produce_in_flight => {
+                    if maybe_ack.is_none() {
+                        tracing::info!("Produce ack channel closed, stopping source");
+                        break;
+                    }
+                    produce_in_flight = false;
+                }
+                maybe_record = self.replays_to_execute.recv(), if gate_open => {
                     let Some(record) = maybe_record else {
                         tracing::info!("inbound channel closed");
                         return Ok(());
                     };
-                    let block_number = record.block_context.block_number;
-                    let timestamp = record.block_context.timestamp;
-                    tracing::info!(
-                        block_number,
-                        role = ?role,
-                        "Received canonized block from consensus",
-                    );
-                    if output
-                        .send(BlockCommand::Replay(Box::new(record)))
-                        .await
-                        .is_err()
-                    {
-                        tracing::info!("Command output channel closed, stopping source");
-                        break;
-                    }
-                    state_reporter.record_processed(block_number, Some(timestamp), None);
+                    Self::forward_replay(record, &output, &state_reporter).await?;
                 }
-                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if role == ConsensusRole::Leader => {
+                _ = self.pipeline_gate.wait_until_open(), if !gate_open => {}
+                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if can_produce => {
                     if send_res.is_err() {
                         tracing::info!("Command output channel closed, stopping source");
                         break;
                     }
+                    produce_in_flight = true;
+                    produced_blocks_count += 1;
                     // Advance watermark to the last sealed block so diff stays near 0.
                     let latest = self.block_replay_storage.latest_record();
                     if let Some(ctx) = self.block_replay_storage.get_context(latest) {
@@ -172,8 +216,52 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         Ok(())
     }
 
+    async fn forward_wal_replays(
+        &mut self,
+        start: u64,
+        end: u64,
+        output: &mpsc::Sender<BlockCommand>,
+    ) -> anyhow::Result<()> {
+        let latest = self.block_replay_storage.latest_record();
+        anyhow::ensure!(
+            latest >= end,
+            "Requested range end {end} exceeds latest record {latest}"
+        );
+        for block_num in start..=end {
+            self.pipeline_gate.wait_until_open().await;
+            let record = self
+                .block_replay_storage
+                .get_replay_record(block_num)
+                .ok_or_else(|| anyhow::anyhow!("missing replay record for block {block_num}"))?;
+            output
+                .send(BlockCommand::Replay(Box::new(record)))
+                .await
+                .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+        }
+        Ok(())
+    }
+
+    async fn forward_replay(
+        record: ReplayRecord,
+        output: &mpsc::Sender<BlockCommand>,
+        state_reporter: &ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let block_number = record.block_context.block_number;
+        let timestamp = record.block_context.timestamp;
+        tracing::info!(block_number, "Received canonized block from consensus",);
+        if output
+            .send(BlockCommand::Replay(Box::new(record)))
+            .await
+            .is_err()
+        {
+            anyhow::bail!("command output channel closed");
+        }
+        state_reporter.record_processed(block_number, Some(timestamp), None);
+        Ok(())
+    }
+
     async fn send_block_rebuilds(
-        &self,
+        &mut self,
         rebuild_options: &RebuildOptions,
         last_block_in_wal: u64,
         output: &mpsc::Sender<BlockCommand>,
@@ -199,6 +287,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 make_empty,
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
+            self.pipeline_gate.wait_until_open().await;
             if output.send(command).await.is_err() {
                 tracing::info!("Command output channel closed, stopping source");
                 break;
@@ -223,7 +312,11 @@ impl PipelineComponent for ExternalNodeCommandSource {
         output: mpsc::Sender<BlockCommand>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        while let Some(record) = self.replays_for_sequencer.recv().await {
+        loop {
+            self.pipeline_gate.wait_until_open().await;
+            let Some(record) = self.replays_for_sequencer.recv().await else {
+                break;
+            };
             let block_number = record.block_context.block_number;
             let timestamp = record.block_context.timestamp;
             let txs = record.transactions.len();

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1770,7 +1770,6 @@ impl From<&Config> for zksync_os_sequencer::config::SequencerConfig {
             block_dump_path: c.sequencer_config.block_dump_path.clone(),
             block_gas_limit: c.sequencer_config.block_gas_limit,
             block_pubdata_limit_bytes: c.sequencer_config.block_pubdata_limit_bytes,
-            max_blocks_to_produce: c.sequencer_config.max_blocks_to_produce,
             interop_roots_per_tx: c.sequencer_config.interop_roots_per_tx,
             tx_validator: {
                 let df = &c.sequencer_config.tx_validator.deployment_filter;

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1054,7 +1054,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             repositories.clone(),
             finality_storage.clone(),
             stop_receiver.clone(),
-            tx_acceptance_state_sender,
             chain_id,
             verify_batch_rx,
             outgoing_verify_results.clone(),
@@ -1168,8 +1167,10 @@ async fn run_main_node_pipeline(
     );
 
     let monitor = BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver);
+    let pipeline_gate = monitor.subscribe_gate();
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
+    let (produce_ack_sender, produce_acks) = tokio::sync::mpsc::channel(1);
     let (applied_block_number_sender, applied_block_number_receiver) =
         watch::channel(starting_block - 1);
 
@@ -1183,18 +1184,22 @@ async fn run_main_node_pipeline(
                 .clone()
                 .map(Into::into),
             replays_to_execute,
+            produce_acks,
+            pipeline_gate,
+            max_blocks_to_produce: config.sequencer_config.max_blocks_to_produce,
+            tx_acceptance_state_sender,
             leadership,
         })
         .pipe(BlockExecutor {
             block_context_provider,
             state: state.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockCanonizer {
             consensus: canonization_engine,
             canonized_blocks_for_execution: replays_to_execute_sender,
+            produce_acks: produce_ack_sender,
         })
         .pipe(BlockApplier {
             state: state.clone(),
@@ -1416,7 +1421,6 @@ async fn run_en_pipeline(
     repositories: impl WriteRepository + Clone,
     finality: impl ReadFinality + Clone,
     stop_receiver: watch::Receiver<bool>,
-    tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     chain_id: u64,
     verify_batch_rx: tokio::sync::mpsc::Receiver<PeerVerifyBatch>,
     outgoing_verify_results: tokio::sync::broadcast::Sender<PeerVerifyBatchResult>,
@@ -1432,17 +1436,18 @@ async fn run_en_pipeline(
 
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());
+    let pipeline_gate = monitor.subscribe_gate();
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
             replays_for_sequencer,
             up_to_block: config.sequencer_config.en_sync_up_to_block,
+            pipeline_gate,
         })
         .pipe(BlockExecutor {
             block_context_provider,
             state: state.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockApplier {


### PR DESCRIPTION
## Summary

Introduce `PipelineAdmissionGate` (a `watch::Sender<bool>` wrapper in `lib/backpressure`) driven by `BackpressureMonitor` and wire it through both `ConsensusNodeCommandSource` and `ExternalNodeCommandSource`.

Replace the old `BlockExecutor`-level `max_blocks_to_produce` park-forever approach with an ack-based single-in-flight Produce mechanism: `BlockCanonizer` sends a `produce_ack` after proposing each produced block, and the source only emits the next Produce once the ack arrives. The production limit and RPC acceptance signaling are now also handled at the source.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

