### PR TITLE
feat: S3 replay archive implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.9.2",
- "sha1",
+ "sha1 0.10.6",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -230,7 +230,7 @@ dependencies = [
  "bech32",
  "chacha20poly1305",
  "cookie-factory",
- "hmac",
+ "hmac 0.12.1",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
@@ -239,7 +239,7 @@ dependencies = [
  "rand 0.8.5",
  "rust-embed",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "x25519-dalek",
  "zeroize",
@@ -259,7 +259,7 @@ dependencies = [
  "nom",
  "rand 0.8.5",
  "secrecy",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
 ]
 
@@ -598,7 +598,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.3",
+ "lru",
  "parking_lot",
  "pin-project",
  "reqwest 0.13.3",
@@ -1923,18 +1923,19 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.7"
+version = "1.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b37ddf8d2e9744a0b9c19ce0b78efe4795339a90b66b7bae77987092cd2e69"
+checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -1948,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.7"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a1290207254984cb7c05245111bc77958b92a3c9bb449598044b36341cce6"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1982,23 +1983,26 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.11"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1ed337dabcf765ad5f2fb426f13af22d576328aaf09eac8f70953530798ec0"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -2014,8 +2018,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.3",
+ "aws-smithy-json 0.61.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2029,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.107.0"
+version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9118b3454ba89b30df55931a1fa7605260fc648e070b5aab402c24b375b1f"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2039,8 +2043,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2049,29 +2054,30 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.3.1",
- "http-body 0.4.6",
- "lru 0.12.5",
+ "http-body 1.0.1",
+ "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.87.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871bec9a79a3e8d928c7788d654f135dde0e71d2dd98089388bab36b37ef607"
+checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.6",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -2080,38 +2086,39 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
+ "http 1.3.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.4"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.3.1",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.5"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -2120,29 +2127,30 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.8"
+version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d2df0314b8e307995a3b86d44565dfe9de41f876901a7d71886c756a25979f"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.12"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9656b85088f8d9dc7ad40f9a6c7228e1e8447cdf4b046c87e152e0805dea02fa"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -2155,7 +2163,6 @@ version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -2171,10 +2178,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.1.2"
+name = "aws-smithy-http"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734b4282fbb7372923ac339cc2222530f8180d9d4745e582de19a18cee409fd8"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2204,19 +2233,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-observability"
-version = "0.1.3"
+name = "aws-smithy-json"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -2224,15 +2264,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa63ad37685ceb7762fa4d73d06f1d5493feb88e3f27259b9ed277f4c01b185"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -2240,6 +2281,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -2248,11 +2290,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f5e0fc8a6b3f2303f331b94504bbf754d85488f402d6f1dd7a6080f99afe56"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -2264,10 +2307,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.3.3"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5b3a7486f6690ba25952cabf1e7d75e34d69eaff5081904a47bc79074d6457"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -2291,22 +2356,23 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.10"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.8"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version 0.4.1",
  "tracing",
@@ -3574,6 +3640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "coins-ledger"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3737,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -3831,15 +3909,12 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.3.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "libc",
- "rand 0.9.2",
- "regex",
+ "spin",
 ]
 
 [[package]]
@@ -3961,7 +4036,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zeroize",
 ]
@@ -3988,7 +4063,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zeroize",
 ]
@@ -4015,7 +4090,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zeroize",
 ]
@@ -4042,7 +4117,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zeroize",
 ]
@@ -4069,7 +4144,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "zeroize",
 ]
@@ -4173,6 +4248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -4415,7 +4499,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -4540,7 +4624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -4552,7 +4636,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -4682,7 +4768,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -5923,7 +6009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -5970,7 +6055,7 @@ dependencies = [
  "http 1.3.1",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -6076,7 +6161,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -6086,6 +6171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6832,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -7152,7 +7246,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -7278,7 +7372,7 @@ dependencies = [
  "k256",
  "multihash",
  "quick-protobuf",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
  "tracing",
  "zeroize",
@@ -7410,15 +7504,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -7526,12 +7611,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8324,7 +8409,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8417,7 +8502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -8761,9 +8846,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -9121,9 +9206,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -9780,12 +9865,12 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
  "secp256k1 0.30.0",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -10260,7 +10345,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -10917,7 +11002,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10951,7 +11036,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -11242,7 +11327,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -11477,9 +11562,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
@@ -11578,7 +11663,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -12119,6 +12204,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12127,6 +12223,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -12367,7 +12474,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -13067,9 +13174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -13493,7 +13600,7 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.17",
  "utf-8",
 ]
@@ -15307,7 +15414,7 @@ version = "0.20.3"
 dependencies = [
  "alloy 2.0.4",
  "blake2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -15405,7 +15512,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "smart-config",
  "tar",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.16.3",
  "parking_lot",
  "pin-project",
  "reqwest 0.13.3",
@@ -1989,6 +1989,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -2027,6 +2028,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-s3"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9118b3454ba89b30df55931a1fa7605260fc648e070b5aab402c24b375b1f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "lru 0.12.5",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "aws-sdk-sts"
 version = "1.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2083,11 +2119,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.63.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d2df0314b8e307995a3b86d44565dfe9de41f876901a7d71886c756a25979f"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9656b85088f8d9dc7ad40f9a6c7228e1e8447cdf4b046c87e152e0805dea02fa"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -2099,6 +2167,30 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734b4282fbb7372923ac339cc2222530f8180d9d4745e582de19a18cee409fd8"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.3.1",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
  "tracing",
 ]
 
@@ -2138,6 +2230,7 @@ checksum = "4fa63ad37685ceb7762fa4d73d06f1d5493feb88e3f27259b9ed277f4c01b185"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2179,6 +2272,7 @@ dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
+ "futures-core",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -2191,6 +2285,8 @@ dependencies = [
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3732,6 +3828,19 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "libc",
+ "rand 0.9.2",
+ "regex",
+]
 
 [[package]]
 name = "crc32fast"
@@ -5814,6 +5923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -6159,6 +6269,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -7299,6 +7410,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -7403,6 +7523,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -15642,6 +15772,9 @@ dependencies = [
  "alloy 2.0.4",
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-runtime",
+ "aws-sdk-s3",
  "clap",
  "futures",
  "reth-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,11 +72,11 @@ alloy = { version = "2.0.1", default-features = false, features = [
 alloy-rlp = { version = "0.3.13" }
 anyhow = "1"
 async-trait = "0.1"
-aws-config = { version = "1.8.6", default-features = false, features = [
+aws-config = { version = "1.8.17", default-features = false, features = [
     "behavior-version-latest",
 ] }
-aws-runtime = { version = "1.5.10" }
-aws-sdk-s3 = { version = "1.106.0", default-features = false, features = [
+aws-runtime = { version = "1.7.4" }
+aws-sdk-s3 = { version = "1.133.0", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",
     "default-https-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,15 @@ alloy = { version = "2.0.1", default-features = false, features = [
 alloy-rlp = { version = "0.3.13" }
 anyhow = "1"
 async-trait = "0.1"
+aws-config = { version = "1.8.6", default-features = false, features = [
+    "behavior-version-latest",
+] }
+aws-runtime = { version = "1.5.10" }
+aws-sdk-s3 = { version = "1.106.0", default-features = false, features = [
+    "behavior-version-latest",
+    "rt-tokio",
+    "default-https-client",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"
 serde_json = "1"

--- a/integration-tests/tests/node/replay_archive.rs
+++ b/integration-tests/tests/node/replay_archive.rs
@@ -63,10 +63,7 @@ async fn encrypted_replay_archive_recovers_node_storage_end_to_end(
 
     let archive_root = match &tester.config().replay_archive_config {
         ReplayArchiveConfig::FileSystem { root_path, .. } => root_path.clone(),
-        ReplayArchiveConfig::Noop => unreachable!("test enables replay archive"),
-        ReplayArchiveConfig::S3WithCredentialFile { .. } => {
-            unreachable!("test enables filesystem replay archive")
-        }
+        _ => unreachable!("test enables replay archive"),
     };
     let rocks_db_path = tester.config().general_config.rocks_db_path.clone();
     let stopped = tester.stop().await?;

--- a/integration-tests/tests/node/replay_archive.rs
+++ b/integration-tests/tests/node/replay_archive.rs
@@ -64,6 +64,9 @@ async fn encrypted_replay_archive_recovers_node_storage_end_to_end(
     let archive_root = match &tester.config().replay_archive_config {
         ReplayArchiveConfig::FileSystem { root_path, .. } => root_path.clone(),
         ReplayArchiveConfig::Noop => unreachable!("test enables replay archive"),
+        ReplayArchiveConfig::S3WithCredentialFile { .. } => {
+            unreachable!("test enables filesystem replay archive")
+        }
     };
     let rocks_db_path = tester.config().general_config.rocks_db_path.clone();
     let stopped = tester.stop().await?;

--- a/lib/replay_archive/Cargo.toml
+++ b/lib/replay_archive/Cargo.toml
@@ -21,6 +21,9 @@ age.workspace = true
 alloy = { workspace = true, default-features = false }
 anyhow.workspace = true
 async-trait.workspace = true
+aws-config.workspace = true
+aws-runtime.workspace = true
+aws-sdk-s3.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 futures.workspace = true
 reth-tasks.workspace = true

--- a/lib/replay_archive/README.md
+++ b/lib/replay_archive/README.md
@@ -60,7 +60,6 @@ Current archive implementations:
 - `FileSystemReplayArchiveStorage`: append-only object storage on local disk.
 - `FileSystemReplayArchiver`: filesystem archiver that stores plaintext JSON replay records.
 - `S3ReplayArchiveStorage`: append-only object storage in S3 or an S3-compatible service.
-- `S3ReplayArchiver`: S3 archiver that stores plaintext JSON replay records.
 - `AgeEncryptedReplayArchiver`: wrapper that JSON-encodes replay records and encrypts them with
   age X25519 before storing them in any `ReplayArchiveStorage`.
 

--- a/lib/replay_archive/README.md
+++ b/lib/replay_archive/README.md
@@ -27,6 +27,12 @@ For the filesystem backend, the full path is:
 <archive_root>/<timestamp_millis>-<node_id>/<block_number>/<block_hash>
 ```
 
+For the S3 backend, the object key is:
+
+```text
+<timestamp_millis>-<node_id>/<block_number>/<block_hash>
+```
+
 The object value is the replay record payload only. There is no wrapper, batch number, block range,
 or extra archive metadata in the object body.
 
@@ -53,14 +59,17 @@ Current archive implementations:
 
 - `FileSystemReplayArchiveStorage`: append-only object storage on local disk.
 - `FileSystemReplayArchiver`: filesystem archiver that stores plaintext JSON replay records.
+- `S3ReplayArchiveStorage`: append-only object storage in S3 or an S3-compatible service.
+- `S3ReplayArchiver`: S3 archiver that stores plaintext JSON replay records.
 - `AgeEncryptedReplayArchiver`: wrapper that JSON-encodes replay records and encrypts them with
   age X25519 before storing them in any `ReplayArchiveStorage`.
 
 Current reader implementation:
 
 - `FileSystemReplayArchiveReader`: lists archive objects from the filesystem layout.
+- `S3ReplayArchiveReader`: lists archive objects from S3.
 
-Other storage backends, such as S3, should implement:
+Other storage backends should implement:
 
 - `ReplayArchiveStorage` for node-side append/check operations.
 - `ReplayArchiveStorageReader` for recovery-side object listing.
@@ -120,6 +129,17 @@ Download archive objects:
 cargo run -p zksync_os_replay_archive --bin replay_archive_recovery -- \
   download \
   --archive-root ./db/replay_archive \
+  --output-root ./replay_archive_downloaded
+```
+
+Download archive objects from S3:
+
+```bash
+cargo run -p zksync_os_replay_archive --bin replay_archive_recovery -- \
+  download \
+  --s3-bucket-base-url my-replay-archive \
+  --s3-credential-file-path ./s3-credentials \
+  --s3-region us-east-2 \
   --output-root ./replay_archive_downloaded
 ```
 
@@ -183,3 +203,22 @@ replay_archive:
     type: AgeX25519
     recipient: age1...
 ```
+
+S3 archive with age encryption:
+
+```yaml
+replay_archive:
+  type: S3WithCredentialFile
+  bucket_base_url: my-replay-archive
+  s3_credential_file_path: ./s3-credentials
+  endpoint: null
+  region: us-east-2
+  encryption:
+    type: AgeX25519
+    recipient: age1...
+```
+
+The S3 backend follows the old object-store initialization path: credentials are loaded from the
+configured credentials file, `endpoint` overrides S3 API endpoint for S3-compatible
+providers, and `region` is used as the first region provider before falling back to the SDK
+defaults and then `auto`.

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -96,11 +96,10 @@ async fn main() -> anyhow::Result<()> {
                 let auth_mode = if let Some(path) = s3_credential_file_path {
                     S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(path)
                 } else {
-                    if !s3_anonymous {
-                        anyhow::bail!(
-                            "--s3-credential-file-path is required unless --s3-anonymous is set"
-                        );
-                    }
+                    anyhow::ensure!(
+                        s3_anonymous,
+                        "--s3-credential-file-path is required unless --s3-anonymous is set"
+                    );
                     S3ReplayArchiveAuthMode::Anonymous
                 };
                 let reader = S3ReplayArchiveReader::new(S3ReplayArchiveConfig {

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use zksync_os_replay_archive::{
-    FileSystemReplayArchiveReader, download_all_replay_archive_objects, parse_age_x25519_identity,
+    FileSystemReplayArchiveReader, S3ReplayArchiveAuthMode, S3ReplayArchiveConfig,
+    S3ReplayArchiveReader, download_all_replay_archive_objects, parse_age_x25519_identity,
     read_age_x25519_identity, recover_replay_records_to_rocksdb_with_optional_decryption,
 };
 
@@ -17,8 +18,31 @@ enum Command {
     /// Download all archived replay record objects to local disk.
     Download {
         /// Root folder of the replay archive storage.
-        #[arg(long)]
-        archive_root: PathBuf,
+        #[arg(
+            long,
+            conflicts_with = "s3_bucket_base_url",
+            required_unless_present = "s3_bucket_base_url"
+        )]
+        archive_root: Option<PathBuf>,
+        /// S3 bucket of the replay archive storage.
+        #[arg(long, conflicts_with = "archive_root")]
+        s3_bucket_base_url: Option<String>,
+        /// Path to the S3 credentials file.
+        #[arg(long, requires = "s3_bucket_base_url")]
+        s3_credential_file_path: Option<PathBuf>,
+        /// Use anonymous S3 access. This is only useful for public buckets.
+        #[arg(
+            long,
+            requires = "s3_bucket_base_url",
+            conflicts_with = "s3_credential_file_path"
+        )]
+        s3_anonymous: bool,
+        /// Optional S3-compatible endpoint URL, e.g. for MinIO.
+        #[arg(long, requires = "s3_bucket_base_url")]
+        s3_endpoint: Option<String>,
+        /// Optional S3 bucket region.
+        #[arg(long, requires = "s3_bucket_base_url")]
+        s3_region: Option<String>,
         /// Local folder where downloaded objects should be written.
         #[arg(long)]
         output_root: PathBuf,
@@ -58,10 +82,37 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Download {
             archive_root,
+            s3_bucket_base_url,
+            s3_credential_file_path,
+            s3_anonymous,
+            s3_endpoint,
+            s3_region,
             output_root,
         } => {
-            let reader = FileSystemReplayArchiveReader::new(archive_root);
-            let downloaded = download_all_replay_archive_objects(&reader, &output_root).await?;
+            let downloaded = if let Some(archive_root) = archive_root {
+                let reader = FileSystemReplayArchiveReader::new(archive_root);
+                download_all_replay_archive_objects(&reader, &output_root).await?
+            } else {
+                let auth_mode = if let Some(path) = s3_credential_file_path {
+                    S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(path)
+                } else {
+                    if !s3_anonymous {
+                        anyhow::bail!(
+                            "--s3-credential-file-path is required unless --s3-anonymous is set"
+                        );
+                    }
+                    S3ReplayArchiveAuthMode::Anonymous
+                };
+                let reader = S3ReplayArchiveReader::new(S3ReplayArchiveConfig {
+                    bucket_base_url: s3_bucket_base_url
+                        .expect("s3_bucket_base_url is required by clap"),
+                    auth_mode,
+                    endpoint: s3_endpoint,
+                    region: s3_region,
+                })
+                .await;
+                download_all_replay_archive_objects(&reader, &output_root).await?
+            };
             println!("Downloaded {downloaded} replay archive objects");
         }
         Command::RecoverRocksdb {

--- a/lib/replay_archive/src/component.rs
+++ b/lib/replay_archive/src/component.rs
@@ -1,12 +1,15 @@
 use crate::metrics::REPLAY_ARCHIVE_METRICS;
 use crate::{REPLAY_ARCHIVE_QUEUE_SIZE, ReplayArchiver};
-use alloy::primitives::BlockHash;
+use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
+use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::mpsc;
 use zksync_os_storage_api::ReplayRecord;
 
 pub type ReplayArchiveRecord = (BlockHash, ReplayRecord);
 pub type ReplayArchiveSender = mpsc::Sender<ReplayArchiveRecord>;
+
+const MAX_PARALLEL_OBJECT_PUTS: usize = 10;
 
 /// Background component that archives replay records from a bounded queue.
 ///
@@ -27,20 +30,81 @@ where
         (sender, Self { archive, records })
     }
 
-    pub async fn run(mut self) -> anyhow::Result<()> {
-        while let Some((block_hash, replay_record)) = self.records.recv().await {
-            let block_number = replay_record.block_context.block_number;
-            tracing::info!("Archiving replay record for block #{block_number}, {block_hash}");
-            self.archive
-                .append_replay_record(block_hash, replay_record)
-                .await
-                .with_context(|| {
-                    format!("failed to archive replay record for block {block_number}")
-                })?;
-            REPLAY_ARCHIVE_METRICS
-                .last_archived_block_number
-                .set(block_number);
+    pub async fn run(self) -> anyhow::Result<()> {
+        let Self {
+            archive,
+            mut records,
+        } = self;
+        let mut in_flight = FuturesUnordered::new();
+        let mut records_closed = false;
+        let mut highest_archived_block_number = None;
+
+        loop {
+            while in_flight.len() < MAX_PARALLEL_OBJECT_PUTS && !records_closed {
+                match records.try_recv() {
+                    Ok(record) => {
+                        in_flight.push(archive_replay_record(&archive, record));
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => records_closed = true,
+                }
+            }
+
+            if in_flight.is_empty() {
+                if records_closed {
+                    break;
+                }
+
+                match records.recv().await {
+                    Some(record) => {
+                        in_flight.push(archive_replay_record(&archive, record));
+                    }
+                    None => records_closed = true,
+                }
+                continue;
+            }
+
+            let archived_block_number = tokio::select! {
+                record = records.recv(), if !records_closed && in_flight.len() < MAX_PARALLEL_OBJECT_PUTS => {
+                    match record {
+                        Some(record) => {
+                            in_flight.push(archive_replay_record(&archive, record));
+                            continue;
+                        }
+                        None => {
+                            records_closed = true;
+                            continue;
+                        }
+                    }
+                }
+                result = in_flight.next() => {
+                    result.expect("in-flight archive writes are not empty")?
+                }
+            };
+
+            if highest_archived_block_number.is_none_or(|highest| archived_block_number > highest) {
+                REPLAY_ARCHIVE_METRICS
+                    .last_archived_block_number
+                    .set(archived_block_number);
+                highest_archived_block_number = Some(archived_block_number);
+            }
         }
         Ok(())
     }
+}
+
+async fn archive_replay_record<Archive>(
+    archive: &Archive,
+    (block_hash, replay_record): ReplayArchiveRecord,
+) -> anyhow::Result<BlockNumber>
+where
+    Archive: ReplayArchiver,
+{
+    let block_number = replay_record.block_context.block_number;
+    tracing::info!("Archiving replay record for block #{block_number}, {block_hash}");
+    archive
+        .append_replay_record(block_hash, replay_record)
+        .await
+        .with_context(|| format!("failed to archive replay record for block {block_number}"))?;
+    Ok(block_number)
 }

--- a/lib/replay_archive/src/component.rs
+++ b/lib/replay_archive/src/component.rs
@@ -2,8 +2,10 @@ use crate::metrics::REPLAY_ARCHIVE_METRICS;
 use crate::{REPLAY_ARCHIVE_QUEUE_SIZE, ReplayArchiver};
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{StreamExt as _, TryStreamExt as _};
+use std::sync::Mutex;
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_storage_api::ReplayRecord;
 
 pub type ReplayArchiveRecord = (BlockHash, ReplayRecord);
@@ -31,65 +33,41 @@ where
     }
 
     pub async fn run(self) -> anyhow::Result<()> {
-        let Self {
-            archive,
-            mut records,
-        } = self;
-        let mut in_flight = FuturesUnordered::new();
-        let mut records_closed = false;
-        let mut highest_archived_block_number = None;
+        let Self { archive, records } = self;
+        let highest_archived_block_number = Mutex::new(None);
 
-        loop {
-            while in_flight.len() < MAX_PARALLEL_OBJECT_PUTS && !records_closed {
-                match records.try_recv() {
-                    Ok(record) => {
-                        in_flight.push(archive_replay_record(&archive, record));
-                    }
-                    Err(mpsc::error::TryRecvError::Empty) => break,
-                    Err(mpsc::error::TryRecvError::Disconnected) => records_closed = true,
-                }
-            }
+        ReceiverStream::new(records)
+            .map(Ok::<_, anyhow::Error>)
+            .try_for_each_concurrent(MAX_PARALLEL_OBJECT_PUTS, |record| {
+                let archive = &archive;
+                let highest_archived_block_number = &highest_archived_block_number;
 
-            if in_flight.is_empty() {
-                if records_closed {
-                    break;
+                async move {
+                    let archived_block_number = archive_replay_record(archive, record).await?;
+                    update_highest_archived_block_number(
+                        highest_archived_block_number,
+                        archived_block_number,
+                    );
+                    Ok(())
                 }
+            })
+            .await
+    }
+}
 
-                match records.recv().await {
-                    Some(record) => {
-                        in_flight.push(archive_replay_record(&archive, record));
-                    }
-                    None => records_closed = true,
-                }
-                continue;
-            }
+fn update_highest_archived_block_number(
+    highest_archived_block_number: &Mutex<Option<BlockNumber>>,
+    archived_block_number: BlockNumber,
+) {
+    let mut highest_archived_block_number = highest_archived_block_number
+        .lock()
+        .expect("highest archived block number mutex is poisoned");
 
-            let archived_block_number = tokio::select! {
-                record = records.recv(), if !records_closed && in_flight.len() < MAX_PARALLEL_OBJECT_PUTS => {
-                    match record {
-                        Some(record) => {
-                            in_flight.push(archive_replay_record(&archive, record));
-                            continue;
-                        }
-                        None => {
-                            records_closed = true;
-                            continue;
-                        }
-                    }
-                }
-                result = in_flight.next() => {
-                    result.expect("in-flight archive writes are not empty")?
-                }
-            };
-
-            if highest_archived_block_number.is_none_or(|highest| archived_block_number > highest) {
-                REPLAY_ARCHIVE_METRICS
-                    .last_archived_block_number
-                    .set(archived_block_number);
-                highest_archived_block_number = Some(archived_block_number);
-            }
-        }
-        Ok(())
+    if highest_archived_block_number.is_none_or(|highest| archived_block_number > highest) {
+        REPLAY_ARCHIVE_METRICS
+            .last_archived_block_number
+            .set(archived_block_number);
+        *highest_archived_block_number = Some(archived_block_number);
     }
 }
 

--- a/lib/replay_archive/src/init.rs
+++ b/lib/replay_archive/src/init.rs
@@ -6,9 +6,9 @@ use anyhow::Context as _;
 use reth_tasks::Runtime;
 
 use crate::{
-    AgeEncryptedReplayArchiver, FileSystemReplayArchiveStorage, FileSystemReplayArchiver,
-    ReplayArchiveComponent, ReplayArchiveSender, ReplayArchiveSession, ReplayArchiveStorage,
-    ReplayArchiver,
+    AgeEncryptedReplayArchiver, FileSystemReplayArchiveStorage, ReplayArchiveComponent,
+    ReplayArchiveSender, ReplayArchiveSession, ReplayArchiveStorage, ReplayArchiver,
+    ReplayRecordArchiver, S3ReplayArchiveConfig, S3ReplayArchiveStorage,
 };
 
 #[derive(Debug, Clone)]
@@ -16,6 +16,10 @@ pub enum ReplayArchiveConfig {
     Noop,
     FileSystem {
         root_path: PathBuf,
+        encryption: ReplayArchiveEncryptionConfig,
+    },
+    S3 {
+        config: S3ReplayArchiveConfig,
         encryption: ReplayArchiveEncryptionConfig,
     },
 }
@@ -46,15 +50,7 @@ pub async fn init_replay_archive(
                 .await
                 .with_context(|| format!("failed to create replay archive session {session}"))
                 .expect("failed to initialize replay archive");
-            let archive: Arc<dyn ReplayArchiver> = match &encryption {
-                ReplayArchiveEncryptionConfig::Noop => {
-                    Arc::new(FileSystemReplayArchiver::new(storage))
-                }
-                ReplayArchiveEncryptionConfig::AgeX25519 { recipient } => Arc::new(
-                    AgeEncryptedReplayArchiver::from_recipient_str(storage, recipient)
-                        .expect("failed to initialize age X25519 replay archive encryption"),
-                ),
-            };
+            let archive = archive_for_storage(storage, &encryption);
             let (sender, component) = ReplayArchiveComponent::new(archive.clone());
             runtime.spawn_critical_task("replay archive", async move {
                 component
@@ -70,6 +66,49 @@ pub async fn init_replay_archive(
             );
             Some((sender, archive))
         }
+        ReplayArchiveConfig::S3 { config, encryption } => {
+            let node_id = std::env::var("POD_NAME").unwrap_or_else(|_| "node".to_owned());
+            let session = ReplayArchiveSession::new(current_timestamp_millis(), node_id)
+                .expect("failed to create replay archive session");
+
+            let storage = S3ReplayArchiveStorage::init(config.clone(), session.clone())
+                .await
+                .with_context(|| format!("failed to create replay archive S3 session {session}"))
+                .expect("failed to initialize S3 replay archive");
+            let archive = archive_for_storage(storage, &encryption);
+            let (sender, component) = ReplayArchiveComponent::new(archive.clone());
+            runtime.spawn_critical_task("replay archive", async move {
+                component
+                    .run()
+                    .await
+                    .expect("replay archive component failed");
+            });
+            tracing::info!(
+                bucket_base_url = %config.bucket_base_url,
+                endpoint = ?config.endpoint,
+                region = ?config.region,
+                %session,
+                encryption = ?encryption,
+                "S3 replay archive enabled"
+            );
+            Some((sender, archive))
+        }
+    }
+}
+
+fn archive_for_storage<Storage>(
+    storage: Storage,
+    encryption: &ReplayArchiveEncryptionConfig,
+) -> Arc<dyn ReplayArchiver>
+where
+    Storage: ReplayArchiveStorage,
+{
+    match encryption {
+        ReplayArchiveEncryptionConfig::Noop => Arc::new(ReplayRecordArchiver::new(storage)),
+        ReplayArchiveEncryptionConfig::AgeX25519 { recipient } => Arc::new(
+            AgeEncryptedReplayArchiver::from_recipient_str(storage, recipient)
+                .expect("failed to initialize age X25519 replay archive encryption"),
+        ),
     }
 }
 

--- a/lib/replay_archive/src/init.rs
+++ b/lib/replay_archive/src/init.rs
@@ -36,64 +36,43 @@ pub async fn init_replay_archive(
     config: ReplayArchiveConfig,
     runtime: &Runtime,
 ) -> Option<InitializedReplayArchive> {
-    match config {
-        ReplayArchiveConfig::Noop => None,
+    if let ReplayArchiveConfig::Noop = &config {
+        return None;
+    }
+
+    let node_id = std::env::var("POD_NAME").unwrap_or_else(|_| "node".to_owned());
+    let session = ReplayArchiveSession::new(current_timestamp_millis(), node_id)
+        .expect("failed to create replay archive session");
+
+    let archive = match &config {
+        ReplayArchiveConfig::Noop => unreachable!("already checked for Noop option"),
         ReplayArchiveConfig::FileSystem {
             root_path,
             encryption,
         } => {
-            let node_id = std::env::var("POD_NAME").unwrap_or_else(|_| "node".to_owned());
-            let session = ReplayArchiveSession::new(current_timestamp_millis(), node_id)
-                .expect("failed to create replay archive session");
-
             let storage = FileSystemReplayArchiveStorage::init(root_path.clone(), session.clone())
                 .await
                 .with_context(|| format!("failed to create replay archive session {session}"))
                 .expect("failed to initialize replay archive");
-            let archive = archive_for_storage(storage, &encryption);
-            let (sender, component) = ReplayArchiveComponent::new(archive.clone());
-            runtime.spawn_critical_task("replay archive", async move {
-                component
-                    .run()
-                    .await
-                    .expect("replay archive component failed");
-            });
-            tracing::info!(
-                archive_root = %root_path.display(),
-                %session,
-                encryption = ?encryption,
-                "Replay archive enabled"
-            );
-            Some((sender, archive))
+            archive_for_storage(storage, encryption)
         }
         ReplayArchiveConfig::S3 { config, encryption } => {
-            let node_id = std::env::var("POD_NAME").unwrap_or_else(|_| "node".to_owned());
-            let session = ReplayArchiveSession::new(current_timestamp_millis(), node_id)
-                .expect("failed to create replay archive session");
-
             let storage = S3ReplayArchiveStorage::init(config.clone(), session.clone())
                 .await
                 .with_context(|| format!("failed to create replay archive S3 session {session}"))
                 .expect("failed to initialize S3 replay archive");
-            let archive = archive_for_storage(storage, &encryption);
-            let (sender, component) = ReplayArchiveComponent::new(archive.clone());
-            runtime.spawn_critical_task("replay archive", async move {
-                component
-                    .run()
-                    .await
-                    .expect("replay archive component failed");
-            });
-            tracing::info!(
-                bucket_base_url = %config.bucket_base_url,
-                endpoint = ?config.endpoint,
-                region = ?config.region,
-                %session,
-                encryption = ?encryption,
-                "S3 replay archive enabled"
-            );
-            Some((sender, archive))
+            archive_for_storage(storage, encryption)
         }
-    }
+    };
+    let (sender, component) = ReplayArchiveComponent::new(archive.clone());
+    runtime.spawn_critical_task("replay archive", async move {
+        component
+            .run()
+            .await
+            .expect("replay archive component failed");
+    });
+    tracing::info!("Replay archive enabled, session: {session}");
+    Some((sender, archive))
 }
 
 fn archive_for_storage<Storage>(

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -35,7 +35,6 @@ pub use recovery::{
 pub use replay_record::ReplayRecordArchiver;
 pub use s3::{
     S3ReplayArchiveAuthMode, S3ReplayArchiveConfig, S3ReplayArchiveReader, S3ReplayArchiveStorage,
-    S3ReplayArchiver,
 };
 pub use write_replay::ReplayArchivingWriteReplay;
 

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -14,6 +14,7 @@ mod metrics;
 mod reader;
 mod recovery;
 mod replay_record;
+mod s3;
 mod write_replay;
 
 pub use age_encrypted::AgeEncryptedReplayArchiver;
@@ -32,6 +33,10 @@ pub use recovery::{
     recover_replay_records_to_rocksdb, recover_replay_records_to_rocksdb_with_optional_decryption,
 };
 pub use replay_record::ReplayRecordArchiver;
+pub use s3::{
+    S3ReplayArchiveAuthMode, S3ReplayArchiveConfig, S3ReplayArchiveReader, S3ReplayArchiveStorage,
+    S3ReplayArchiver,
+};
 pub use write_replay::ReplayArchivingWriteReplay;
 
 pub const REPLAY_ARCHIVE_QUEUE_SIZE: usize = 128;

--- a/lib/replay_archive/src/s3.rs
+++ b/lib/replay_archive/src/s3.rs
@@ -9,7 +9,7 @@ use aws_config::{BehaviorVersion, ConfigLoader, Region, meta::region::RegionProv
 use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
 use aws_sdk_s3::{Client, primitives::ByteStream};
 use futures::StreamExt as _;
-use std::{path::PathBuf, str::FromStr as _};
+use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -312,12 +312,9 @@ fn parse_s3_archive_key(object_key: &str) -> anyhow::Result<Option<ReplayArchive
     let block_number = parts[1].parse::<BlockNumber>().with_context(|| {
         format!("failed to parse replay archive S3 block number in {object_key}")
     })?;
-    let block_hash = {
-        let block_hash = parts[2].strip_prefix("0x").unwrap_or(parts[2]);
-        BlockHash::from_str(block_hash).with_context(|| {
-            format!("failed to parse replay archive S3 block hash in {object_key}")
-        })?
-    };
+    let block_hash = parts[2]
+        .parse::<BlockHash>()
+        .with_context(|| format!("failed to parse replay archive S3 block hash in {object_key}"))?;
 
     Ok(Some(ReplayArchiveKey::new(
         session,

--- a/lib/replay_archive/src/s3.rs
+++ b/lib/replay_archive/src/s3.rs
@@ -1,0 +1,431 @@
+use crate::{
+    ReplayArchiveKey, ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveSession,
+    ReplayArchiveStorage, ReplayArchiveStorageReader, ReplayArchiver, ReplayRecordArchiver,
+};
+use alloy::primitives::{BlockHash, BlockNumber};
+use anyhow::Context as _;
+use async_trait::async_trait;
+use aws_config::{BehaviorVersion, ConfigLoader, Region, meta::region::RegionProviderChain};
+use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
+use aws_sdk_s3::{Client, primitives::ByteStream};
+use futures::StreamExt as _;
+use std::{path::PathBuf, str::FromStr as _};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+const LIST_OBJECTS_CHANNEL_SIZE: usize = 128;
+const SESSION_MARKER_FILE_NAME: &str = ".session";
+
+/// Authentication mode for S3 replay archive access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum S3ReplayArchiveAuthMode {
+    /// Authentication via a credentials file at the specified path.
+    AuthenticatedWithCredentialFile(PathBuf),
+    /// Anonymous access. This is only useful for read-only recovery from public buckets.
+    Anonymous,
+}
+
+/// S3 replay archive configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3ReplayArchiveConfig {
+    /// Name or URL of the bucket.
+    pub bucket_base_url: String,
+    pub auth_mode: S3ReplayArchiveAuthMode,
+    /// Allows overriding AWS S3 API endpoint, e.g. to use another S3-compatible store provider.
+    pub endpoint: Option<String>,
+    /// Allows specifying bucket region. If omitted, the SDK provider chain is used, falling back to `auto`.
+    pub region: Option<String>,
+}
+
+impl S3ReplayArchiveConfig {
+    pub fn with_credential_file(
+        bucket_base_url: impl Into<String>,
+        s3_credential_file_path: PathBuf,
+    ) -> Self {
+        Self {
+            bucket_base_url: bucket_base_url.into(),
+            auth_mode: S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(
+                s3_credential_file_path,
+            ),
+            endpoint: None,
+            region: None,
+        }
+    }
+
+    pub fn anonymous(bucket_base_url: impl Into<String>) -> Self {
+        Self {
+            bucket_base_url: bucket_base_url.into(),
+            auth_mode: S3ReplayArchiveAuthMode::Anonymous,
+            endpoint: None,
+            region: None,
+        }
+    }
+}
+
+/// S3 implementation of [`ReplayArchiveStorage`].
+#[derive(Debug, Clone)]
+pub struct S3ReplayArchiveStorage {
+    config: S3ReplayArchiveConfig,
+    session: ReplayArchiveSession,
+    client: Client,
+}
+
+impl S3ReplayArchiveStorage {
+    pub fn config(&self) -> &S3ReplayArchiveConfig {
+        &self.config
+    }
+
+    pub fn session(&self) -> &ReplayArchiveSession {
+        &self.session
+    }
+
+    fn object_key(&self, block_number: BlockNumber, block_hash: BlockHash) -> String {
+        ReplayArchiveKey::new(self.session.clone(), block_number, block_hash).object_path()
+    }
+
+    fn session_marker_key(&self) -> String {
+        format!("{}/{}", self.session, SESSION_MARKER_FILE_NAME)
+    }
+
+    async fn put_new_object(&self, key: &str, object: Vec<u8>) -> anyhow::Result<()> {
+        self.client
+            .put_object()
+            .bucket(&self.config.bucket_base_url)
+            .key(key)
+            .if_none_match("*")
+            .body(ByteStream::from(object))
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create append-only replay archive S3 object s3://{}/{}",
+                    self.config.bucket_base_url, key
+                )
+            })?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ReplayArchiveStorage for S3ReplayArchiveStorage {
+    type Config = S3ReplayArchiveConfig;
+
+    async fn init(config: Self::Config, session: ReplayArchiveSession) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !config.bucket_base_url.is_empty(),
+            "replay archive S3 bucket_base_url cannot be empty"
+        );
+        let client = create_s3_client(&config).await;
+        let storage = Self {
+            config,
+            session,
+            client,
+        };
+        storage
+            .put_new_object(&storage.session_marker_key(), Vec::new())
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create append-only replay archive S3 session {}",
+                    storage.session
+                )
+            })?;
+        Ok(storage)
+    }
+
+    async fn append_object(
+        &self,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+        object: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        self.put_new_object(&self.object_key(block_number, block_hash), object)
+            .await
+    }
+
+    async fn contains_object(
+        &self,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+    ) -> anyhow::Result<bool> {
+        let key = self.object_key(block_number, block_hash);
+        let response = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.config.bucket_base_url)
+            .prefix(&key)
+            .max_keys(1)
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to check replay archive S3 object s3://{}/{}",
+                    self.config.bucket_base_url, key
+                )
+            })?;
+        Ok(response
+            .contents()
+            .iter()
+            .any(|object| object.key() == Some(key.as_str())))
+    }
+}
+
+/// S3 replay archiver that stores plaintext JSON replay records.
+#[derive(Debug, Clone)]
+pub struct S3ReplayArchiver {
+    inner: ReplayRecordArchiver<S3ReplayArchiveStorage>,
+}
+
+impl S3ReplayArchiver {
+    pub fn new(storage: S3ReplayArchiveStorage) -> Self {
+        Self {
+            inner: ReplayRecordArchiver::new(storage),
+        }
+    }
+
+    pub async fn init(
+        config: S3ReplayArchiveConfig,
+        session: ReplayArchiveSession,
+    ) -> anyhow::Result<Self> {
+        let storage = S3ReplayArchiveStorage::init(config, session).await?;
+        Ok(Self::new(storage))
+    }
+}
+
+#[async_trait]
+impl ReplayArchiver for S3ReplayArchiver {
+    async fn append_replay_record(
+        &self,
+        block_hash: BlockHash,
+        replay_record: zksync_os_storage_api::ReplayRecord,
+    ) -> anyhow::Result<()> {
+        self.inner
+            .append_replay_record(block_hash, replay_record)
+            .await
+    }
+
+    async fn contains_replay_record(
+        &self,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+    ) -> anyhow::Result<bool> {
+        self.inner
+            .contains_replay_record(block_number, block_hash)
+            .await
+    }
+}
+
+/// S3 implementation of [`ReplayArchiveStorageReader`].
+#[derive(Debug, Clone)]
+pub struct S3ReplayArchiveReader {
+    config: S3ReplayArchiveConfig,
+    client: Client,
+}
+
+impl S3ReplayArchiveReader {
+    pub async fn new(config: S3ReplayArchiveConfig) -> Self {
+        let client = create_s3_client(&config).await;
+        Self { config, client }
+    }
+
+    pub fn config(&self) -> &S3ReplayArchiveConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl ReplayArchiveStorageReader for S3ReplayArchiveReader {
+    async fn list_objects(&self) -> ReplayArchiveObjectStream {
+        let config = self.config.clone();
+        let client = self.client.clone();
+        let (sender, receiver) = mpsc::channel(LIST_OBJECTS_CHANNEL_SIZE);
+        tokio::spawn(async move {
+            if let Err(err) = list_objects(config, client, sender.clone()).await {
+                let _ = sender.send(Err(err)).await;
+            }
+        });
+        ReceiverStream::new(receiver).boxed()
+    }
+}
+
+async fn create_s3_client(config: &S3ReplayArchiveConfig) -> Client {
+    let region_provider = RegionProviderChain::first_try(config.region.clone().map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("auto"));
+    let mut sdk_config = get_client_config(config.auth_mode.clone()).region(region_provider);
+    if let Some(endpoint) = config.endpoint.clone() {
+        tracing::info!(%endpoint, "using S3 endpoint defined in replay archive config");
+        sdk_config = sdk_config.endpoint_url(endpoint);
+    }
+    let sdk_config = sdk_config.load().await;
+    Client::new(&sdk_config)
+}
+
+fn get_client_config(auth_mode: S3ReplayArchiveAuthMode) -> ConfigLoader {
+    match auth_mode {
+        S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(path) => {
+            let profile_files = EnvConfigFiles::builder()
+                .with_file(EnvConfigFileKind::Credentials, path)
+                .build();
+            aws_config::defaults(BehaviorVersion::latest()).profile_files(profile_files)
+        }
+        S3ReplayArchiveAuthMode::Anonymous => {
+            aws_config::defaults(BehaviorVersion::latest()).no_credentials()
+        }
+    }
+}
+
+async fn list_objects(
+    config: S3ReplayArchiveConfig,
+    client: Client,
+    sender: mpsc::Sender<anyhow::Result<ReplayArchiveObject>>,
+) -> anyhow::Result<()> {
+    let mut continuation_token = None;
+
+    loop {
+        let mut request = client.list_objects_v2().bucket(&config.bucket_base_url);
+        if let Some(token) = &continuation_token {
+            request = request.continuation_token(token);
+        }
+
+        let response = request.send().await.with_context(|| {
+            format!(
+                "failed to list replay archive S3 objects in s3://{}",
+                config.bucket_base_url
+            )
+        })?;
+
+        for object in response.contents() {
+            let Some(object_key) = object.key() else {
+                continue;
+            };
+            let Some(key) = parse_s3_archive_key(object_key)? else {
+                continue;
+            };
+            let bytes = client
+                .get_object()
+                .bucket(&config.bucket_base_url)
+                .key(object_key)
+                .send()
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to read replay archive S3 object s3://{}/{}",
+                        config.bucket_base_url, object_key
+                    )
+                })?
+                .body
+                .collect()
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to collect replay archive S3 object s3://{}/{}",
+                        config.bucket_base_url, object_key
+                    )
+                })?
+                .into_bytes()
+                .to_vec();
+
+            if sender
+                .send(Ok(ReplayArchiveObject { key, bytes }))
+                .await
+                .is_err()
+            {
+                return Ok(());
+            }
+        }
+
+        let Some(next_token) = response.next_continuation_token() else {
+            break;
+        };
+        continuation_token = Some(next_token.to_owned());
+    }
+
+    Ok(())
+}
+
+fn parse_s3_archive_key(object_key: &str) -> anyhow::Result<Option<ReplayArchiveKey>> {
+    let parts = object_key.split('/').collect::<Vec<_>>();
+    if parts.len() != 3 || parts[2] == SESSION_MARKER_FILE_NAME {
+        return Ok(None);
+    }
+
+    let session = parts[0]
+        .parse::<ReplayArchiveSession>()
+        .with_context(|| format!("failed to parse replay archive S3 session in {object_key}"))?;
+    let block_number = parts[1].parse::<BlockNumber>().with_context(|| {
+        format!("failed to parse replay archive S3 block number in {object_key}")
+    })?;
+    let block_hash = {
+        let block_hash = parts[2].strip_prefix("0x").unwrap_or(parts[2]);
+        BlockHash::from_str(block_hash).with_context(|| {
+            format!("failed to parse replay archive S3 block hash in {object_key}")
+        })?
+    };
+
+    Ok(Some(ReplayArchiveKey::new(
+        session,
+        block_number,
+        block_hash,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format_block_hash;
+    use alloy::primitives::B256;
+
+    #[test]
+    fn s3_object_key_uses_archive_layout() {
+        let session = ReplayArchiveSession::new(42, "node-a").unwrap();
+        let key = ReplayArchiveKey::new(session, 7, B256::ZERO);
+
+        assert_eq!(
+            key.object_path(),
+            "42-node-a/7/0x0000000000000000000000000000000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn s3_parser_skips_session_marker_and_non_archive_keys() {
+        assert!(parse_s3_archive_key("other/key").unwrap().is_none());
+        assert!(
+            parse_s3_archive_key("42-node-a/.session")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn s3_parser_accepts_archive_key() {
+        let block_hash = B256::with_last_byte(1);
+        let object_key = format!("42-node-a/7/{}", format_block_hash(block_hash));
+
+        let parsed = parse_s3_archive_key(&object_key).unwrap().unwrap();
+
+        assert_eq!(
+            parsed,
+            ReplayArchiveKey::new(
+                ReplayArchiveSession::new(42, "node-a").unwrap(),
+                7,
+                block_hash
+            )
+        );
+    }
+
+    #[test]
+    fn s3_config_builds_credential_file_auth_mode() {
+        let config =
+            S3ReplayArchiveConfig::with_credential_file("bucket", "/path/to/credentials".into());
+
+        assert_eq!(config.bucket_base_url, "bucket");
+        assert_eq!(
+            config.auth_mode,
+            S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(PathBuf::from(
+                "/path/to/credentials"
+            ))
+        );
+    }
+}

--- a/lib/replay_archive/src/s3.rs
+++ b/lib/replay_archive/src/s3.rs
@@ -1,6 +1,6 @@
 use crate::{
     ReplayArchiveKey, ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveSession,
-    ReplayArchiveStorage, ReplayArchiveStorageReader, ReplayArchiver, ReplayRecordArchiver,
+    ReplayArchiveStorage, ReplayArchiveStorageReader,
 };
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
@@ -168,51 +168,6 @@ impl ReplayArchiveStorage for S3ReplayArchiveStorage {
             .contents()
             .iter()
             .any(|object| object.key() == Some(key.as_str())))
-    }
-}
-
-/// S3 replay archiver that stores plaintext JSON replay records.
-#[derive(Debug, Clone)]
-pub struct S3ReplayArchiver {
-    inner: ReplayRecordArchiver<S3ReplayArchiveStorage>,
-}
-
-impl S3ReplayArchiver {
-    pub fn new(storage: S3ReplayArchiveStorage) -> Self {
-        Self {
-            inner: ReplayRecordArchiver::new(storage),
-        }
-    }
-
-    pub async fn init(
-        config: S3ReplayArchiveConfig,
-        session: ReplayArchiveSession,
-    ) -> anyhow::Result<Self> {
-        let storage = S3ReplayArchiveStorage::init(config, session).await?;
-        Ok(Self::new(storage))
-    }
-}
-
-#[async_trait]
-impl ReplayArchiver for S3ReplayArchiver {
-    async fn append_replay_record(
-        &self,
-        block_hash: BlockHash,
-        replay_record: zksync_os_storage_api::ReplayRecord,
-    ) -> anyhow::Result<()> {
-        self.inner
-            .append_replay_record(block_hash, replay_record)
-            .await
-    }
-
-    async fn contains_replay_record(
-        &self,
-        block_number: BlockNumber,
-        block_hash: BlockHash,
-    ) -> anyhow::Result<bool> {
-        self.inner
-            .contains_replay_record(block_number, block_hash)
-            .await
     }
 }
 

--- a/lib/replay_archive/src/s3.rs
+++ b/lib/replay_archive/src/s3.rs
@@ -150,24 +150,25 @@ impl ReplayArchiveStorage for S3ReplayArchiveStorage {
         block_hash: BlockHash,
     ) -> anyhow::Result<bool> {
         let key = self.object_key(block_number, block_hash);
-        let response = self
+        match self
             .client
-            .list_objects_v2()
+            .head_object()
             .bucket(&self.config.bucket_base_url)
-            .prefix(&key)
-            .max_keys(1)
+            .key(&key)
             .send()
             .await
-            .with_context(|| {
+        {
+            Ok(_) => Ok(true),
+            Err(err) if matches!(err.as_service_error(), Some(err) if err.is_not_found()) => {
+                Ok(false)
+            }
+            Err(err) => Err(err).with_context(|| {
                 format!(
                     "failed to check replay archive S3 object s3://{}/{}",
                     self.config.bucket_base_url, key
                 )
-            })?;
-        Ok(response
-            .contents()
-            .iter()
-            .any(|object| object.key() == Some(key.as_str())))
+            }),
+        }
     }
 }
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1410,6 +1410,18 @@ pub enum ReplayArchiveConfig {
         #[config(nest, default)]
         encryption: ReplayArchiveEncryptionConfig,
     },
+    S3WithCredentialFile {
+        /// Name or URL of the bucket.
+        bucket_base_url: String,
+        /// Path to the credentials file.
+        s3_credential_file_path: PathBuf,
+        /// Allows overriding AWS S3 API endpoint, e.g. to use another S3-compatible store provider.
+        endpoint: Option<String>,
+        /// Allows specifying bucket region (inferred from the env by default).
+        region: Option<String>,
+        #[config(nest, default)]
+        encryption: ReplayArchiveEncryptionConfig,
+    },
 }
 
 /// Replay archive encryption applied before data is written to cold storage.
@@ -1433,6 +1445,24 @@ impl From<ReplayArchiveConfig> for zksync_os_replay_archive::ReplayArchiveConfig
                 encryption,
             } => zksync_os_replay_archive::ReplayArchiveConfig::FileSystem {
                 root_path,
+                encryption: encryption.into(),
+            },
+            ReplayArchiveConfig::S3WithCredentialFile {
+                bucket_base_url,
+                s3_credential_file_path,
+                endpoint,
+                region,
+                encryption,
+            } => zksync_os_replay_archive::ReplayArchiveConfig::S3 {
+                config: zksync_os_replay_archive::S3ReplayArchiveConfig {
+                    bucket_base_url,
+                    auth_mode:
+                        zksync_os_replay_archive::S3ReplayArchiveAuthMode::AuthenticatedWithCredentialFile(
+                            s3_credential_file_path,
+                        ),
+                    endpoint,
+                    region,
+                },
                 encryption: encryption.into(),
             },
         }
@@ -2207,6 +2237,45 @@ mod tests {
                 assert!(matches!(encryption, ReplayArchiveEncryptionConfig::Noop));
             }
             ReplayArchiveConfig::Noop => panic!("expected file system replay archive config"),
+            ReplayArchiveConfig::S3WithCredentialFile { .. } => {
+                panic!("expected file system replay archive config")
+            }
+        }
+    }
+
+    #[test]
+    fn replay_archive_config_parses_s3_backend() {
+        let config = parse_replay_archive_config([
+            ("REPLAY_ARCHIVE_TYPE", "S3WithCredentialFile"),
+            ("REPLAY_ARCHIVE_BUCKET_BASE_URL", "replay-archive"),
+            (
+                "REPLAY_ARCHIVE_S3_CREDENTIAL_FILE_PATH",
+                "/path/to/credentials.json",
+            ),
+            ("REPLAY_ARCHIVE_ENDPOINT", "http://localhost:9000"),
+            ("REPLAY_ARCHIVE_REGION", "us-east-2"),
+        ]);
+
+        match config {
+            ReplayArchiveConfig::S3WithCredentialFile {
+                bucket_base_url,
+                s3_credential_file_path,
+                endpoint,
+                region,
+                encryption,
+            } => {
+                assert_eq!(bucket_base_url, "replay-archive");
+                assert_eq!(
+                    s3_credential_file_path,
+                    PathBuf::from("/path/to/credentials.json")
+                );
+                assert_eq!(endpoint.as_deref(), Some("http://localhost:9000"));
+                assert_eq!(region.as_deref(), Some("us-east-2"));
+                assert!(matches!(encryption, ReplayArchiveEncryptionConfig::Noop));
+            }
+            ReplayArchiveConfig::Noop | ReplayArchiveConfig::FileSystem { .. } => {
+                panic!("expected S3 replay archive config")
+            }
         }
     }
 
@@ -2229,6 +2298,9 @@ mod tests {
                 }
             },
             ReplayArchiveConfig::Noop => panic!("expected file system replay archive config"),
+            ReplayArchiveConfig::S3WithCredentialFile { .. } => {
+                panic!("expected file system replay archive config")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- adds support for s3 storage for archiving
- parallel object processing in `ReplayArchiveComponent`

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

