### PR TITLE
refactor(command_source): new approach with windows and pacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14518,6 +14518,7 @@ dependencies = [
 name = "zksync_os_backpressure"
 version = "0.20.3"
 dependencies = [
+ "anyhow",
  "futures",
  "reth-tasks",
  "tokio",
@@ -14596,6 +14597,27 @@ name = "zksync_os_batcher_metrics"
 version = "0.20.3"
 dependencies = [
  "vise",
+]
+
+[[package]]
+name = "zksync_os_command_source"
+version = "0.20.3"
+dependencies = [
+ "alloy 2.0.4",
+ "anyhow",
+ "async-trait",
+ "futures",
+ "semver 1.0.26",
+ "tokio",
+ "tracing",
+ "zksync_os_backpressure",
+ "zksync_os_interface",
+ "zksync_os_observability",
+ "zksync_os_pipeline",
+ "zksync_os_raft",
+ "zksync_os_sequencer",
+ "zksync_os_storage_api",
+ "zksync_os_types",
 ]
 
 [[package]]
@@ -15373,6 +15395,7 @@ dependencies = [
  "zksync_os_batch_types",
  "zksync_os_batch_verification",
  "zksync_os_batcher_metrics",
+ "zksync_os_command_source",
  "zksync_os_config_validation_macros",
  "zksync_os_contract_interface",
  "zksync_os_external_price_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "lib/contract_interface",
     "lib/consensus_types",
+    "lib/command_source",
     "lib/crypto",
     "lib/genesis",
     "lib/l1_sender",
@@ -275,6 +276,7 @@ revm = { version = "=38.0.0", features = ["optional_balance_check"] }
 # "Local" dependencies
 zksync_os_contract_interface = { version = "=0.20.3", path = "lib/contract_interface" }
 zksync_os_consensus_types = { version = "=0.20.3", path = "lib/consensus_types" }
+zksync_os_command_source = { version = "=0.20.3", path = "lib/command_source" }
 zksync_os_crypto = { version = "=0.20.3", path = "lib/crypto" }
 zksync_os_l1_sender = { version = "=0.20.3", path = "lib/l1_sender" }
 zksync_os_l1_watcher = { version = "=0.20.3", path = "lib/l1_watcher" }

--- a/lib/backpressure/Cargo.toml
+++ b/lib/backpressure/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 zksync_os_observability = { path = "../observability" }
 zksync_os_pipeline      = { path = "../pipeline" }
 zksync_os_types         = { path = "../types" }
+anyhow                  = { workspace = true }
 reth-tasks              = { workspace = true }
 tokio                   = { workspace = true, features = ["time", "sync", "macros", "rt"] }
 tokio-stream            = { workspace = true }

--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -1,0 +1,57 @@
+use tokio::sync::watch;
+
+/// Admission gate for internal pipeline sources.
+///
+/// This is deliberately separate from RPC transaction acceptance. `true` means
+/// the block pipeline can accept more work; `false` means command sources should
+/// stop forwarding new work until downstream lag clears.
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionGate {
+    tx: watch::Sender<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionReceiver {
+    rx: watch::Receiver<bool>,
+}
+
+impl PipelineAdmissionGate {
+    pub fn open() -> (Self, PipelineAdmissionReceiver) {
+        let (tx, rx) = watch::channel(true);
+        (Self { tx }, PipelineAdmissionReceiver { rx })
+    }
+
+    pub fn subscribe(&self) -> PipelineAdmissionReceiver {
+        PipelineAdmissionReceiver {
+            rx: self.tx.subscribe(),
+        }
+    }
+
+    pub fn set_open(&self) {
+        self.set(true);
+    }
+
+    pub fn set_closed(&self) {
+        self.set(false);
+    }
+
+    pub fn set(&self, open: bool) {
+        let _ = self.tx.send_if_modified(|current| {
+            if *current == open {
+                return false;
+            }
+            *current = open;
+            true
+        });
+    }
+}
+
+impl PipelineAdmissionReceiver {
+    pub fn is_open(&self) -> bool {
+        *self.rx.borrow()
+    }
+
+    pub async fn wait_until_open(&mut self) {
+        let _ = self.rx.wait_for(|open| *open).await;
+    }
+}

--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use tokio::sync::watch;
 
 /// Admission gate for internal pipeline sources.
@@ -51,7 +52,50 @@ impl PipelineAdmissionReceiver {
         *self.rx.borrow()
     }
 
-    pub async fn wait_until_open(&mut self) {
-        let _ = self.rx.wait_for(|open| *open).await;
+    pub async fn wait_until_open(&mut self) -> anyhow::Result<()> {
+        self.rx
+            .wait_for(|open| *open)
+            .await
+            .map(|_| ())
+            .context("pipeline admission gate sender dropped before reopening")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn receiver_waits_until_gate_opens() {
+        let (gate, mut rx) = PipelineAdmissionGate::open();
+        gate.set_closed();
+
+        assert!(!rx.is_open());
+        assert!(
+            timeout(Duration::from_millis(20), rx.wait_until_open())
+                .await
+                .is_err()
+        );
+
+        gate.set_open();
+        timeout(Duration::from_millis(100), rx.wait_until_open())
+            .await
+            .expect("gate opening should release waiter")
+            .expect("open gate should not error");
+        assert!(rx.is_open());
+    }
+
+    #[tokio::test]
+    async fn receiver_errors_when_gate_sender_drops_while_closed() {
+        let (gate, mut rx) = PipelineAdmissionGate::open();
+        gate.set_closed();
+        drop(gate);
+
+        let result = timeout(Duration::from_millis(100), rx.wait_until_open())
+            .await
+            .expect("dropped sender should release waiter");
+        assert!(result.is_err());
     }
 }

--- a/lib/backpressure/src/lib.rs
+++ b/lib/backpressure/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod gate;
 pub mod metrics;
 pub mod monitor;
 pub mod tracker;
@@ -7,5 +8,6 @@ pub use config::{
     BackpressureConfig, ComponentId, DEFAULT_BATCH_DIFF_LIMIT, DEFAULT_BLOCK_DIFF_LIMIT,
     PipelineCondition,
 };
+pub use gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 pub use monitor::{AdjacentSnapshot, BackpressureMonitor, PipelineSnapshot};
 pub use tracker::PipelineTracker;

--- a/lib/backpressure/src/monitor.rs
+++ b/lib/backpressure/src/monitor.rs
@@ -1,4 +1,5 @@
 use crate::config::{BackpressureConfig, ComponentId, is_pipeline_stage};
+use crate::gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 use crate::metrics::MONITOR_METRICS;
 use reth_tasks::Runtime;
 use std::collections::{HashMap, HashSet};
@@ -58,17 +59,24 @@ fn compute_adjacent_snapshots(
 pub struct BackpressureMonitor {
     config: BackpressureConfig,
     acceptance_tx: watch::Sender<TransactionAcceptanceState>,
+    pipeline_gate: PipelineAdmissionGate,
     stop_receiver: watch::Receiver<bool>,
 }
 
 impl BackpressureMonitor {
     pub fn new(config: BackpressureConfig, stop_receiver: watch::Receiver<bool>) -> Self {
         let (acceptance_tx, _) = watch::channel(TransactionAcceptanceState::Accepting);
+        let (pipeline_gate, _) = PipelineAdmissionGate::open();
         Self {
             config,
             acceptance_tx,
+            pipeline_gate,
             stop_receiver,
         }
+    }
+
+    pub fn subscribe_gate(&self) -> PipelineAdmissionReceiver {
+        self.pipeline_gate.subscribe()
     }
 
     pub fn spawn(
@@ -186,6 +194,8 @@ impl BackpressureMonitor {
     }
 
     fn update_acceptance_state(&self, new_state: TransactionAcceptanceState) {
+        self.pipeline_gate
+            .set(matches!(new_state, TransactionAcceptanceState::Accepting));
         self.acceptance_tx.send_if_modified(|current| {
             if *current == new_state {
                 return false;

--- a/lib/command_source/Cargo.toml
+++ b/lib/command_source/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "zksync_os_command_source"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+zksync_os_backpressure.workspace = true
+zksync_os_observability.workspace = true
+zksync_os_pipeline.workspace = true
+zksync_os_raft.workspace = true
+zksync_os_sequencer.workspace = true
+zksync_os_storage_api.workspace = true
+zksync_os_types.workspace = true
+
+anyhow.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+alloy = { workspace = true, default-features = false }
+semver.workspace = true
+zksync_os_interface.workspace = true

--- a/lib/command_source/README.md
+++ b/lib/command_source/README.md
@@ -1,0 +1,138 @@
+# zksync_os_command_source
+
+Pipeline command sources for sequencer block work.
+
+This crate owns the decision of **when a block command may enter execution**.
+It converts local replay state, consensus events, external-node replay input,
+and leadership status into `BlockCommand`s consumed by `BlockExecutor`.
+
+---
+
+## Responsibilities
+
+The crate provides two pipeline sources:
+
+- `ConsensusNodeCommandSource` for main nodes.
+  - Replays local WAL records on startup.
+  - Optionally emits rebuild commands for rollback/rebuild flows.
+  - Forwards canonized replay records returned by consensus.
+  - Emits fresh `Produce` commands only while the node is leader.
+- `ExternalNodeCommandSource` for external nodes.
+  - Forwards replay records received from the main node into local execution.
+
+It intentionally does **not** execute blocks, apply state, canonize consensus
+results, manage mempool contents, or decide RPC transaction acceptance.
+
+---
+
+## Pacing model
+
+Command-source pacing is explicit and does not rely on Tokio channel capacity
+for correctness.
+
+`CommandWindow` bounds how many commands may be outstanding until
+`BlockExecutor` sends `CommandAck::Executed`:
+
+| Command | Window behavior |
+|---|---|
+| `Produce` | At most one pending produce command. |
+| `Replay` | May fill the configured command window. |
+| `Rebuild` | May fill the configured command window. |
+
+The default command window size is `DEFAULT_COMMAND_WINDOW_CAPACITY` (currently
+`2`). This is a shared window, not a per-type quota. With the default:
+
+- `Replay + Replay` is allowed.
+- `Replay + Rebuild` is allowed.
+- `Produce + Replay` is allowed.
+- `Produce + Produce` is not allowed.
+
+`ReplayCommandForwarder` also checks the pipeline admission gate before replay
+work is forwarded. When downstream backpressure closes the gate, both main-node
+and external-node replay forwarding pause until the gate opens again.
+
+The pipeline's mpsc buffers remain useful as transport buffers, but they are not
+the source of the sequencing guarantee.
+
+---
+
+## Acknowledgements
+
+The command source records every emitted command in FIFO order inside
+`CommandWindow`. `BlockExecutor` sends `CommandAck::Executed(command_type)` after
+the command has executed and the resulting `BlockPayload` has been handed to the
+next pipeline stage.
+
+An acknowledgement frees one command-window slot. Its command type must match
+the oldest pending command; a mismatch is treated as an error because it means
+the source and executor no longer agree on command ordering.
+
+This ACK is an execution-boundary signal only. It does **not** mean the block was
+applied to storage, canonized by consensus, batched, or finalized on L1. Those
+are tracked by later pipeline stages.
+
+### Why `CommandAck` and not a `Semaphore`
+
+A `tokio::sync::Semaphore` would handle the concurrency-bounding concern with
+less code, but it carries no information — releasing a permit tells the source
+only that a slot is free, nothing about what happened during execution.
+
+`CommandAck` is a typed feedback channel. The current `Executed` variant is
+minimal, but the enum is the natural place to add execution metadata when
+throttling based on observed runtime behaviour becomes necessary:
+
+```rust
+// hypothetical future extension
+CommandAck::ExecutedWithStats {
+    cmd_type: BlockCommandType,
+    tx_count: u64,
+    execution_ms: u64,
+    memory_bytes: u64,
+}
+```
+
+The source already receives acks inside its `select!` loop, so a token-bucket
+or leaky-bucket rate limiter driven by real execution data can be added there
+without changing the channel topology or the executor's interface. A semaphore
+would require a separate stats channel alongside it, splitting what `CommandAck`
+keeps in one place.
+
+---
+
+## Main-node flow
+
+```text
+local WAL / consensus / leadership
+        │
+        ▼
+ConsensusNodeCommandSource
+        │ BlockCommand::{Replay, Rebuild, Produce}
+        ▼
+BlockExecutor
+        │ CommandAck::Executed(command_type)
+        └───────────────────────────────► CommandWindow
+```
+
+The main-node source gives priority to role changes and executor ACKs, then
+canonized replay records, and emits fresh `Produce` commands as lowest-priority
+leader work.
+
+---
+
+## External-node flow
+
+```text
+main-node replay stream
+        │
+        ▼
+ExternalNodeCommandSource
+        │ BlockCommand::Replay
+        ▼
+BlockExecutor
+        │ CommandAck::Executed(Replay)
+        └───────────────────────────────► CommandWindow
+```
+
+The external-node source uses the same command window and admission-gate model
+as the main-node replay path, so replay throughput can be bounded independently
+from raw network buffering.

--- a/lib/command_source/src/command_window.rs
+++ b/lib/command_source/src/command_window.rs
@@ -1,0 +1,82 @@
+use std::collections::VecDeque;
+use zksync_os_sequencer::model::blocks::{BlockCommandType, CommandAck};
+
+pub const DEFAULT_COMMAND_WINDOW_CAPACITY: usize = 2;
+
+#[derive(Debug)]
+pub(crate) struct CommandWindow {
+    capacity: usize,
+    pending: VecDeque<BlockCommandType>,
+}
+
+impl CommandWindow {
+    pub fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "command window capacity must be non-zero");
+        Self {
+            capacity,
+            pending: VecDeque::new(),
+        }
+    }
+
+    pub fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    pub fn can_send(&self, command_type: BlockCommandType) -> bool {
+        self.pending.len() < self.capacity
+            && (!matches!(command_type, BlockCommandType::Produce)
+                || !self
+                    .pending
+                    .iter()
+                    .any(|pending| matches!(pending, BlockCommandType::Produce)))
+    }
+
+    pub fn push(&mut self, command_type: BlockCommandType) {
+        assert!(
+            self.can_send(command_type),
+            "command window is full for {command_type:?}"
+        );
+        self.pending.push_back(command_type);
+    }
+
+    pub fn acknowledge(&mut self, ack: CommandAck) -> anyhow::Result<()> {
+        let expected = self
+            .pending
+            .pop_front()
+            .ok_or_else(|| anyhow::anyhow!("received {ack:?} with no pending command"))?;
+        anyhow::ensure!(
+            ack.command_type() == expected,
+            "received {ack:?} while waiting for {expected:?} command acknowledgement"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zksync_os_sequencer::model::blocks::BlockCommandType;
+
+    #[test]
+    fn permits_multiple_replay_or_rebuild_commands() {
+        let mut window = CommandWindow::new(2);
+
+        assert!(window.can_send(BlockCommandType::Replay));
+        window.push(BlockCommandType::Replay);
+        assert!(window.can_send(BlockCommandType::Rebuild));
+        window.push(BlockCommandType::Rebuild);
+
+        assert!(!window.can_send(BlockCommandType::Replay));
+    }
+
+    #[test]
+    fn permits_only_one_pending_produce_command() {
+        let mut window = CommandWindow::new(2);
+
+        assert!(window.can_send(BlockCommandType::Produce));
+        window.push(BlockCommandType::Produce);
+
+        assert!(!window.can_send(BlockCommandType::Produce));
+        assert!(window.can_send(BlockCommandType::Replay));
+    }
+}

--- a/lib/command_source/src/consensus.rs
+++ b/lib/command_source/src/consensus.rs
@@ -1,12 +1,14 @@
+use crate::{CommandWindow, DEFAULT_COMMAND_WINDOW_CAPACITY, ReplayCommandForwarder};
 use async_trait::async_trait;
 use std::collections::HashSet;
 use tokio::sync::{mpsc, watch};
-use zksync_os_backpressure::PipelineAdmissionReceiver;
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_raft::{ConsensusRole, LeadershipSignal};
 use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
-use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
+use zksync_os_sequencer::model::blocks::{
+    BlockCommand, BlockCommandType, CommandAck, ProduceCommand, RebuildCommand,
+};
 use zksync_os_storage_api::{ReadReplay, ReplayRecord};
 use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
@@ -23,11 +25,11 @@ pub struct ConsensusNodeCommandSource<Replay> {
     pub rebuild_options: Option<RebuildOptions>,
     /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
     pub replays_to_execute: mpsc::UnboundedReceiver<ReplayRecord>,
-    /// Acknowledges that the previously emitted Produce command crossed the
-    /// downstream lifecycle boundary and the source may emit another one.
-    pub produce_acks: mpsc::Receiver<()>,
-    /// Internal pipeline admission gate driven by backpressure monitoring.
-    pub pipeline_gate: PipelineAdmissionReceiver,
+    /// Acknowledges that the previously emitted command crossed its downstream
+    /// lifecycle boundary and the source may emit another one.
+    pub command_acks: mpsc::Receiver<CommandAck>,
+    /// Shared Replay forwarding and admission helper.
+    pub replay_forwarder: ReplayCommandForwarder,
     /// Optional operational cap on newly produced blocks. Replays bypass this.
     pub max_blocks_to_produce: Option<u64>,
     /// Signals RPC admission when the configured production limit is reached.
@@ -43,14 +45,6 @@ pub struct RebuildOptions {
     pub reset_timestamps: bool,
 }
 
-/// External node command source.
-#[derive(Debug)]
-pub struct ExternalNodeCommandSource {
-    pub up_to_block: Option<u64>,
-    pub replays_for_sequencer: mpsc::Receiver<ReplayRecord>,
-    pub pipeline_gate: PipelineAdmissionReceiver,
-}
-
 #[async_trait]
 impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay> {
     type Input = ();
@@ -58,8 +52,6 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 
     const COMPONENT_ID: zksync_os_pipeline::ComponentId =
         zksync_os_pipeline::ComponentId::ConsensusNodeCommandSource;
-    // Keep the transport buffer small so BlockExecutor remains the near-term pacer.
-    const OUTPUT_CHANNEL_CAPACITY: usize = 1;
 
     async fn run(
         mut self,
@@ -113,8 +105,6 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 }
 
 impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
-    const MAX_REPLAYS_TO_DRAIN_PER_LOOP: usize = 32;
-
     /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
     /// Produces `Produce` commands only when the node is the leader.
     async fn run_loop(
@@ -124,29 +114,13 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
     ) -> anyhow::Result<()> {
         let mut leadership = self.leadership.clone();
         let mut role = leadership.current_role();
-        let mut produce_in_flight = false;
+        let mut command_window = CommandWindow::new(DEFAULT_COMMAND_WINDOW_CAPACITY);
         let mut produced_blocks_count = 0u64;
         let mut production_limit_reported = false;
         tracing::info!(?role, "Consensus role initialized");
 
         loop {
-            let gate_open = self.pipeline_gate.is_open();
-            for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
-                if !gate_open {
-                    break;
-                }
-                match self.replays_to_execute.try_recv() {
-                    Ok(record) => {
-                        Self::forward_replay(record, &output, &state_reporter).await?;
-                    }
-                    Err(mpsc::error::TryRecvError::Empty) => break,
-                    Err(mpsc::error::TryRecvError::Disconnected) => {
-                        tracing::info!("inbound channel closed");
-                        return Ok(());
-                    }
-                }
-            }
-
+            let gate_open = self.replay_forwarder.is_open();
             let production_limit_reached = self
                 .max_blocks_to_produce
                 .is_some_and(|limit| produced_blocks_count >= limit);
@@ -165,10 +139,13 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             }
 
             let can_produce = role == ConsensusRole::Leader
-                && !produce_in_flight
+                && command_window.can_send(BlockCommandType::Produce)
                 && gate_open
                 && !production_limit_reached;
+            let can_replay = gate_open && command_window.can_send(BlockCommandType::Replay);
 
+            // Priority is intentional: handle role changes and downstream acks first,
+            // then canonized replays, and emit fresh Produce only as the lowest-priority work.
             tokio::select! {
                 biased;
 
@@ -182,27 +159,30 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         role = new_role;
                     }
                 }
-                maybe_ack = self.produce_acks.recv(), if produce_in_flight => {
-                    if maybe_ack.is_none() {
-                        tracing::info!("Produce ack channel closed, stopping source");
+                maybe_ack = self.command_acks.recv(), if command_window.has_pending() => {
+                    let Some(ack) = maybe_ack else {
+                        tracing::info!("Command ack channel closed, stopping source");
                         break;
-                    }
-                    produce_in_flight = false;
+                    };
+                    command_window.acknowledge(ack)?;
                 }
-                maybe_record = self.replays_to_execute.recv(), if gate_open => {
+                maybe_record = self.replays_to_execute.recv(), if can_replay => {
                     let Some(record) = maybe_record else {
                         tracing::info!("inbound channel closed");
                         return Ok(());
                     };
-                    Self::forward_replay(record, &output, &state_reporter).await?;
+                    self.forward_replay(record, &output, &state_reporter).await?;
+                    command_window.push(BlockCommandType::Replay);
                 }
-                _ = self.pipeline_gate.wait_until_open(), if !gate_open => {}
+                res = self.replay_forwarder.wait_until_open(), if !gate_open => {
+                    res?;
+                }
                 send_res = output.send(BlockCommand::Produce(ProduceCommand)), if can_produce => {
                     if send_res.is_err() {
                         tracing::info!("Command output channel closed, stopping source");
                         break;
                     }
-                    produce_in_flight = true;
+                    command_window.push(BlockCommandType::Produce);
                     produced_blocks_count += 1;
                     // Advance watermark to the last sealed block so diff stays near 0.
                     let latest = self.block_replay_storage.latest_record();
@@ -227,36 +207,32 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             latest >= end,
             "Requested range end {end} exceeds latest record {latest}"
         );
+        let mut command_window = CommandWindow::new(DEFAULT_COMMAND_WINDOW_CAPACITY);
         for block_num in start..=end {
-            self.pipeline_gate.wait_until_open().await;
+            self.wait_for_command_capacity(&mut command_window, BlockCommandType::Replay)
+                .await?;
+            self.replay_forwarder.wait_until_open().await?;
             let record = self
                 .block_replay_storage
                 .get_replay_record(block_num)
                 .ok_or_else(|| anyhow::anyhow!("missing replay record for block {block_num}"))?;
-            output
-                .send(BlockCommand::Replay(Box::new(record)))
-                .await
-                .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+            let _ = self.replay_forwarder.forward(record, output).await?;
+            command_window.push(BlockCommandType::Replay);
         }
+        self.drain_command_window(&mut command_window).await?;
         Ok(())
     }
 
     async fn forward_replay(
+        &self,
         record: ReplayRecord,
         output: &mpsc::Sender<BlockCommand>,
         state_reporter: &ComponentStateReporter,
     ) -> anyhow::Result<()> {
         let block_number = record.block_context.block_number;
-        let timestamp = record.block_context.timestamp;
         tracing::info!(block_number, "Received canonized block from consensus",);
-        if output
-            .send(BlockCommand::Replay(Box::new(record)))
-            .await
-            .is_err()
-        {
-            anyhow::bail!("command output channel closed");
-        }
-        state_reporter.record_processed(block_number, Some(timestamp), None);
+        let forwarded = self.replay_forwarder.forward(record, output).await?;
+        state_reporter.record_processed(forwarded.block_number, Some(forwarded.timestamp), None);
         Ok(())
     }
 
@@ -269,7 +245,10 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         tracing::warn!(
             "Starting block rebuilds! {rebuild_options:?}, last_block_in_wal: {last_block_in_wal}"
         );
+        let mut command_window = CommandWindow::new(DEFAULT_COMMAND_WINDOW_CAPACITY);
         for block_number in rebuild_options.from_block..=last_block_in_wal {
+            self.wait_for_command_capacity(&mut command_window, BlockCommandType::Rebuild)
+                .await?;
             let replay_record = self
                 .block_replay_storage
                 .get_replay_record(block_number)
@@ -287,73 +266,47 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 make_empty,
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
-            self.pipeline_gate.wait_until_open().await;
+            self.replay_forwarder.wait_until_open().await?;
             if output.send(command).await.is_err() {
                 tracing::info!("Command output channel closed, stopping source");
                 break;
             }
+            command_window.push(BlockCommandType::Rebuild);
+        }
+        self.drain_command_window(&mut command_window).await?;
+        Ok(())
+    }
+
+    async fn wait_for_command_capacity(
+        &mut self,
+        command_window: &mut CommandWindow,
+        command_type: BlockCommandType,
+    ) -> anyhow::Result<()> {
+        while !command_window.can_send(command_type) {
+            self.wait_for_command_ack(command_window).await?;
         }
         Ok(())
     }
-}
 
-#[async_trait]
-impl PipelineComponent for ExternalNodeCommandSource {
-    type Input = ();
-    type Output = BlockCommand;
-
-    const COMPONENT_ID: zksync_os_pipeline::ComponentId =
-        zksync_os_pipeline::ComponentId::ExternalNodeCommandSource;
-    const OUTPUT_CHANNEL_CAPACITY: usize = 5;
-
-    async fn run(
-        mut self,
-        _input: PeekableReceiver<()>,
-        output: mpsc::Sender<BlockCommand>,
-        state_reporter: ComponentStateReporter,
+    async fn drain_command_window(
+        &mut self,
+        command_window: &mut CommandWindow,
     ) -> anyhow::Result<()> {
-        loop {
-            self.pipeline_gate.wait_until_open().await;
-            let Some(record) = self.replays_for_sequencer.recv().await else {
-                break;
-            };
-            let block_number = record.block_context.block_number;
-            let timestamp = record.block_context.timestamp;
-            let txs = record.transactions.len();
-            let force_preimages = record.force_preimages.len();
-            let force_preimage_bytes = record
-                .force_preimages
-                .iter()
-                .map(|(_, value)| value.len())
-                .sum::<usize>();
-            let protocol_version = record.protocol_version.to_string();
-            let starting_l1_priority_id = record.starting_cursors.l1_priority_id;
-            let command = BlockCommand::Replay(Box::new(record));
-            tracing::info!(
-                "Received replay block command from main node: block_number: {block_number}, \
-                 txs: {txs}, force_preimages: {force_preimages}, \
-                 force_preimage_bytes: {force_preimage_bytes}, protocol_version: {protocol_version}, \
-                 starting_l1_priority_id: {starting_l1_priority_id}"
-            );
-            tracing::debug!(?command, "Received replay block command from main node");
-
-            if let Some(up_to_block) = self.up_to_block
-                && block_number > up_to_block
-            {
-                tracing::info!(
-                    up_to_block,
-                    "Reached up_to_block, halting external command source"
-                );
-                futures::future::pending::<()>().await;
-            }
-
-            if output.send(command).await.is_err() {
-                tracing::info!("Command output channel closed, stopping source");
-                break;
-            }
-            state_reporter.record_processed(block_number, Some(timestamp), None);
+        while command_window.has_pending() {
+            self.wait_for_command_ack(command_window).await?;
         }
-
         Ok(())
+    }
+
+    async fn wait_for_command_ack(
+        &mut self,
+        command_window: &mut CommandWindow,
+    ) -> anyhow::Result<()> {
+        let ack = self
+            .command_acks
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("command ack channel closed"))?;
+        command_window.acknowledge(ack)
     }
 }

--- a/lib/command_source/src/external.rs
+++ b/lib/command_source/src/external.rs
@@ -1,0 +1,103 @@
+use crate::{CommandWindow, DEFAULT_COMMAND_WINDOW_CAPACITY, ReplayCommandForwarder};
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use zksync_os_observability::ComponentStateReporter;
+use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_sequencer::model::blocks::{BlockCommand, BlockCommandType, CommandAck};
+use zksync_os_storage_api::ReplayRecord;
+
+/// External node command source.
+#[derive(Debug)]
+pub struct ExternalNodeCommandSource {
+    pub up_to_block: Option<u64>,
+    pub replays_for_sequencer: mpsc::Receiver<ReplayRecord>,
+    pub command_acks: mpsc::Receiver<CommandAck>,
+    pub replay_forwarder: ReplayCommandForwarder,
+}
+
+#[async_trait]
+impl PipelineComponent for ExternalNodeCommandSource {
+    type Input = ();
+    type Output = BlockCommand;
+
+    const COMPONENT_ID: zksync_os_pipeline::ComponentId =
+        zksync_os_pipeline::ComponentId::ExternalNodeCommandSource;
+
+    async fn run(
+        mut self,
+        _input: PeekableReceiver<()>,
+        output: mpsc::Sender<BlockCommand>,
+        state_reporter: ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let mut command_window = CommandWindow::new(DEFAULT_COMMAND_WINDOW_CAPACITY);
+        loop {
+            let gate_open = self.replay_forwarder.is_open();
+            let can_replay = gate_open && command_window.can_send(BlockCommandType::Replay);
+
+            tokio::select! {
+                biased;
+
+                maybe_ack = self.command_acks.recv(), if command_window.has_pending() => {
+                    let Some(ack) = maybe_ack else {
+                        tracing::info!("Command ack channel closed, stopping external source");
+                        break;
+                    };
+                    command_window.acknowledge(ack)?;
+                }
+                res = self.replay_forwarder.wait_until_open(), if !gate_open => {
+                    res?;
+                }
+                maybe_record = self.replays_for_sequencer.recv(), if can_replay => {
+                    let Some(record) = maybe_record else {
+                        while command_window.has_pending() {
+                            let ack = self
+                                .command_acks
+                                .recv()
+                                .await
+                                .ok_or_else(|| anyhow::anyhow!("command ack channel closed"))?;
+                            command_window.acknowledge(ack)?;
+                        }
+                        break;
+                    };
+                    let block_number = record.block_context.block_number;
+                    let txs = record.transactions.len();
+                    let force_preimages = record.force_preimages.len();
+                    let force_preimage_bytes = record
+                        .force_preimages
+                        .iter()
+                        .map(|(_, value)| value.len())
+                        .sum::<usize>();
+                    let protocol_version = record.protocol_version.to_string();
+                    let starting_l1_priority_id = record.starting_cursors.l1_priority_id;
+                    tracing::info!(
+                        "Received replay block command from main node: block_number: {block_number}, \
+                         txs: {txs}, force_preimages: {force_preimages}, \
+                         force_preimage_bytes: {force_preimage_bytes}, protocol_version: {protocol_version}, \
+                         starting_l1_priority_id: {starting_l1_priority_id}"
+                    );
+                    tracing::debug!(?record, "Received replay block command from main node");
+
+                    if let Some(up_to_block) = self.up_to_block
+                        && block_number > up_to_block
+                    {
+                        tracing::info!(
+                            up_to_block,
+                            "Reached up_to_block, halting external command source"
+                        );
+                        futures::future::pending::<()>().await;
+                    }
+
+                    let forwarded = self.replay_forwarder.forward(record, &output).await?;
+                    state_reporter.record_processed(
+                        forwarded.block_number,
+                        Some(forwarded.timestamp),
+                        None,
+                    );
+                    command_window.push(BlockCommandType::Replay);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/lib/command_source/src/lib.rs
+++ b/lib/command_source/src/lib.rs
@@ -1,0 +1,10 @@
+pub(crate) mod command_window;
+pub mod consensus;
+pub mod external;
+pub mod replay_forwarder;
+
+pub(crate) use command_window::CommandWindow;
+pub use command_window::DEFAULT_COMMAND_WINDOW_CAPACITY;
+pub use consensus::{ConsensusNodeCommandSource, RebuildOptions};
+pub use external::ExternalNodeCommandSource;
+pub use replay_forwarder::ReplayCommandForwarder;

--- a/lib/command_source/src/replay_forwarder.rs
+++ b/lib/command_source/src/replay_forwarder.rs
@@ -1,0 +1,108 @@
+use tokio::sync::mpsc;
+use zksync_os_backpressure::PipelineAdmissionReceiver;
+use zksync_os_sequencer::model::blocks::BlockCommand;
+use zksync_os_storage_api::ReplayRecord;
+
+/// Shared forwarding path for replay commands from local WAL, consensus, and EN sync.
+#[derive(Debug)]
+pub struct ReplayCommandForwarder {
+    pipeline_gate: PipelineAdmissionReceiver,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ForwardedReplay {
+    pub block_number: u64,
+    pub timestamp: u64,
+}
+
+impl ReplayCommandForwarder {
+    pub fn new(pipeline_gate: PipelineAdmissionReceiver) -> Self {
+        Self { pipeline_gate }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.pipeline_gate.is_open()
+    }
+
+    pub async fn wait_until_open(&mut self) -> anyhow::Result<()> {
+        self.pipeline_gate.wait_until_open().await
+    }
+
+    pub(crate) async fn forward(
+        &self,
+        record: ReplayRecord,
+        output: &mpsc::Sender<BlockCommand>,
+    ) -> anyhow::Result<ForwardedReplay> {
+        let block_number = record.block_context.block_number;
+        let timestamp = record.block_context.timestamp;
+        output
+            .send(BlockCommand::Replay(Box::new(record)))
+            .await
+            .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+
+        Ok(ForwardedReplay {
+            block_number,
+            timestamp,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{B256, BlockNumber};
+    use zksync_os_backpressure::PipelineAdmissionGate;
+    use zksync_os_interface::types::BlockHashes;
+    use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
+
+    fn replay_record(block_number: BlockNumber) -> ReplayRecord {
+        ReplayRecord::new(
+            zksync_os_storage_api::BlockContext {
+                chain_id: 270,
+                block_number,
+                block_hashes: BlockHashes::default(),
+                timestamp: block_number + 1,
+                eip1559_basefee: Default::default(),
+                pubdata_price: Default::default(),
+                native_price: Default::default(),
+                coinbase: Default::default(),
+                gas_limit: 1_000_000,
+                pubdata_limit: 1_000_000,
+                mix_hash: Default::default(),
+                execution_version: 1,
+                blob_fee: Default::default(),
+            },
+            vec![],
+            block_number,
+            semver::Version::new(0, 0, 0),
+            ProtocolSemanticVersion::new(0, 31, 0),
+            B256::with_last_byte(block_number as u8),
+            vec![],
+            BlockStartCursors::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn replay_command_forwarder_sends_replay_command() {
+        let (_gate, pipeline_gate) = PipelineAdmissionGate::open();
+        let forwarder = ReplayCommandForwarder::new(pipeline_gate);
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+
+        let forwarded = forwarder
+            .forward(replay_record(7), &output_tx)
+            .await
+            .expect("replay should be forwarded");
+
+        assert_eq!(forwarded.block_number, 7);
+        assert_eq!(forwarded.timestamp, 8);
+
+        let command = output_rx
+            .recv()
+            .await
+            .expect("forwarded command should be available");
+        let BlockCommand::Replay(record) = command else {
+            panic!("expected replay command");
+        };
+        assert_eq!(record.block_context.block_number, 7);
+    }
+}

--- a/lib/sequencer/src/config.rs
+++ b/lib/sequencer/src/config.rs
@@ -36,10 +36,6 @@ pub struct SequencerConfig {
     /// Max pubdata bytes per block
     pub block_pubdata_limit_bytes: u64,
 
-    /// Maximum number of blocks to produce
-    /// None for indefinite block production (normal operations)
-    pub max_blocks_to_produce: Option<u64>,
-
     /// Max number of interop roots to be included in a single transaction
     pub interop_roots_per_tx: usize,
 

--- a/lib/sequencer/src/execution/block_canonizer.rs
+++ b/lib/sequencer/src/execution/block_canonizer.rs
@@ -26,6 +26,9 @@ where
     /// Channel to send new canonized blocks to for the node to replay.
     /// They are sent to `NodeCommandSource` and then through the whole pipeline.
     pub canonized_blocks_for_execution: mpsc::UnboundedSender<ReplayRecord>,
+    /// Releases `ConsensusNodeCommandSource` to emit the next Produce command
+    /// after this component accepts/proposes the previous produced block.
+    pub produce_acks: mpsc::Sender<()>,
 }
 
 #[async_trait]
@@ -199,6 +202,11 @@ where
                                 .enter_state(BlockCanonizerState::ProposingToConsensus);
                             let proposed = replay_record.clone();
                             self.consensus.propose(proposed).await?;
+                            if matches!(cmd_type, BlockCommandType::Produce)
+                                && self.produce_acks.send(()).await.is_err()
+                            {
+                                tracing::info!("produce ack channel closed");
+                            }
                             produced_queue.push_back(BlockPayload {
                                 output: block_output,
                                 record: replay_record,

--- a/lib/sequencer/src/execution/block_canonizer.rs
+++ b/lib/sequencer/src/execution/block_canonizer.rs
@@ -26,9 +26,6 @@ where
     /// Channel to send new canonized blocks to for the node to replay.
     /// They are sent to `NodeCommandSource` and then through the whole pipeline.
     pub canonized_blocks_for_execution: mpsc::UnboundedSender<ReplayRecord>,
-    /// Releases `ConsensusNodeCommandSource` to emit the next Produce command
-    /// after this component accepts/proposes the previous produced block.
-    pub produce_acks: mpsc::Sender<()>,
 }
 
 #[async_trait]
@@ -173,22 +170,22 @@ where
                     );
                     match cmd_type {
                         BlockCommandType::Replay => {
-                        tracing::info!(
-                            "Received a Replay block {} (block output hash: {}) from BlockExecutor. \
-                            Sending downstream.",
-                            replay_record.block_context.block_number,
-                            replay_record.block_output_hash,
-                        );
-                        output
-                            .send_and_record(
-                                BlockPayload {
-                                    output: block_output,
-                                    record: replay_record,
-                                    command_type: cmd_type,
-                                    failed_transactions,
-                                },
-                                &state_reporter,
-                            )?;
+                            tracing::info!(
+                                "Received a Replay block {} (block output hash: {}) from BlockExecutor. \
+                                Sending downstream.",
+                                replay_record.block_context.block_number,
+                                replay_record.block_output_hash,
+                            );
+                            output
+                                .send_and_record(
+                                    BlockPayload {
+                                        output: block_output,
+                                        record: replay_record,
+                                        command_type: cmd_type,
+                                        failed_transactions,
+                                    },
+                                    &state_reporter,
+                                )?;
                         }
                         BlockCommandType::Produce | BlockCommandType::Rebuild => {
                             tracing::info!(
@@ -202,11 +199,6 @@ where
                                 .enter_state(BlockCanonizerState::ProposingToConsensus);
                             let proposed = replay_record.clone();
                             self.consensus.propose(proposed).await?;
-                            if matches!(cmd_type, BlockCommandType::Produce)
-                                && self.produce_acks.send(()).await.is_err()
-                            {
-                                tracing::info!("produce ack channel closed");
-                            }
                             produced_queue.push_back(BlockPayload {
                                 output: block_output,
                                 record: replay_record,

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -3,7 +3,7 @@ use crate::execution::block_context_provider::BlockContextProvider;
 use crate::execution::execute_block_in_vm::execute_block_in_vm;
 use crate::execution::metrics::{EXECUTION_METRICS, SequencerState};
 use crate::execution::utils::save_dump;
-use crate::model::blocks::{BlockCommand, BlockCommandType, BlockPayload};
+use crate::model::blocks::{BlockCommand, BlockCommandType, BlockPayload, CommandAck};
 use anyhow::Context;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -28,6 +28,8 @@ where
     pub block_context_provider: BlockContextProvider<Subpool>,
     pub state: State,
     pub config: SequencerConfig,
+    /// Acknowledges commands after execution and successful downstream handoff.
+    pub command_acks: mpsc::Sender<CommandAck>,
     /// TEMPORARY: `BlockExecutor` waits for `BlockApplier` to apply block `N`
     /// before starting block `N + 1`. This works around an `OverlayBuffer` bug
     /// that reproduces during rebuilds when the runtime truncates base state.
@@ -191,6 +193,14 @@ where
                 },
                 &state_reporter,
             )?;
+            if self
+                .command_acks
+                .send(CommandAck::Executed(cmd_type))
+                .await
+                .is_err()
+            {
+                tracing::info!("command ack channel closed");
+            }
         }
     }
 }

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -16,7 +16,6 @@ use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
 use zksync_os_storage_api::{OverlayBuffer, ReadStateHistory, WriteState};
 use zksync_os_tx_validators::deployment_filter;
 use zksync_os_tx_validators::policy_client::AccessType;
-use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
 /// Executes blocks, while only updating local in-memory state (mempool, block context).
 /// Does not persist anything to disk.
@@ -29,9 +28,6 @@ where
     pub block_context_provider: BlockContextProvider<Subpool>,
     pub state: State,
     pub config: SequencerConfig,
-    /// Controls transaction acceptance state.
-    /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
-    pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     /// TEMPORARY: `BlockExecutor` waits for `BlockApplier` to apply block `N`
     /// before starting block `N + 1`. This works around an `OverlayBuffer` bug
     /// that reproduces during rebuilds when the runtime truncates base state.
@@ -61,9 +57,6 @@ where
         output: mpsc::Sender<Self::Output>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        // Track how many Produce commands we've processed (for `sequencer_max_blocks_to_produce` config)
-        let mut produced_blocks_count = 0u64;
-
         // Only used for metrics/logs
         let mut last_processed_block_at: Option<Instant> = None;
         // `BlockExecutor` doesn't persist/update state after block execution.
@@ -85,19 +78,6 @@ where
             )
             .await?;
 
-            // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
-            if matches!(cmd, BlockCommand::Produce(_))
-                && let Some(limit) = self.config.max_blocks_to_produce
-            {
-                check_block_production_limit(
-                    limit,
-                    produced_blocks_count,
-                    &self.tx_acceptance_state_sender,
-                    &state_reporter,
-                )
-                .await;
-                produced_blocks_count += 1;
-            }
             state_reporter.enter_state(SequencerState::WaitingForTransaction);
 
             let prepared_command = self.block_context_provider.prepare_command(cmd).await?;
@@ -247,32 +227,6 @@ async fn wait_for_block_applier(
         "BlockExecutor resumed after BlockApplier caught up"
     );
     Ok(())
-}
-
-/// Checks if block production limit has been reached.
-/// If limit is reached, signals to stop accepting transactions and awaits indefinitely (never returns).
-/// Should only be called for Produce commands.
-async fn check_block_production_limit(
-    limit: u64,
-    already_produced_blocks_count: u64,
-    tx_acceptance_state_sender: &watch::Sender<TransactionAcceptanceState>,
-    state_reporter: &ComponentStateReporter,
-) {
-    if already_produced_blocks_count >= limit {
-        tracing::warn!(
-            already_produced_blocks_count,
-            limit,
-            "Reached max_blocks_to_produce limit, stopping transaction acceptance"
-        );
-
-        // Signal to RPC that we're no longer accepting transactions
-        let _ = tx_acceptance_state_sender.send(TransactionAcceptanceState::NotAccepting(vec![
-            NotAcceptingReason::BlockProductionDisabled,
-        ]));
-
-        state_reporter.enter_state(SequencerState::ConfiguredBlockLimitReached);
-        std::future::pending::<()>().await;
-    }
 }
 
 fn make_deployment_filter(

--- a/lib/sequencer/src/execution/metrics.rs
+++ b/lib/sequencer/src/execution/metrics.rs
@@ -8,8 +8,6 @@ use zksync_os_storage_api::StateAccessLabel;
 pub enum SequencerState {
     /// Waiting for the next block command from the command source.
     WaitingForCommand,
-    /// `max_blocks_to_produce` limit reached — component is permanently halted.
-    ConfiguredBlockLimitReached,
     /// Command dequeued, waiting for BlockApplier to finish applying the
     /// previous block.
     WaitingForApplier,
@@ -32,9 +30,7 @@ pub enum SequencerState {
 impl StateLabel for SequencerState {
     fn generic(&self) -> GenericComponentState {
         match self {
-            Self::WaitingForCommand | Self::ConfiguredBlockLimitReached => {
-                GenericComponentState::Idle
-            }
+            Self::WaitingForCommand => GenericComponentState::Idle,
             Self::WaitingForApplier | Self::WaitingForTransaction | Self::WaitingForTx => {
                 GenericComponentState::Idle
             }
@@ -48,7 +44,6 @@ impl StateLabel for SequencerState {
     fn specific(&self) -> &'static str {
         match self {
             Self::WaitingForCommand => "waiting_for_command",
-            Self::ConfiguredBlockLimitReached => "configured_block_limit_reached",
             Self::WaitingForApplier => "waiting_for_applier",
             Self::WaitingForTransaction => "waiting_for_transaction",
             Self::InitializingVm => "initializing_vm",

--- a/lib/sequencer/src/model/blocks.rs
+++ b/lib/sequencer/src/model/blocks.rs
@@ -26,11 +26,25 @@ pub enum BlockCommand {
 }
 
 /// Type of the block command.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockCommandType {
     Replay,
     Produce,
     Rebuild,
+}
+
+/// Downstream lifecycle acknowledgements for commands emitted by command sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAck {
+    Executed(BlockCommandType),
+}
+
+impl CommandAck {
+    pub fn command_type(self) -> BlockCommandType {
+        match self {
+            CommandAck::Executed(command_type) => command_type,
+        }
+    }
 }
 
 /// Message flowing from `BlockExecutor` → `BlockCanonizer` → `BlockApplier`.

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -47,6 +47,7 @@ zksync_os_batcher_metrics.workspace = true
 zksync_os_internal_config.workspace = true
 zksync_os_network.workspace = true
 zksync_os_metadata.workspace = true
+zksync_os_command_source.workspace = true
 zksync_os_base_token_adjuster.workspace = true
 zksync_os_external_price_api.workspace = true
 zksync_os_operator_signer.workspace = true

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 use std::collections::HashSet;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
+use zksync_os_backpressure::PipelineAdmissionReceiver;
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_raft::{ConsensusRole, LeadershipSignal};
 use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
 use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
-use zksync_os_storage_api::{ReadReplay, ReadReplayExt, ReplayRecord};
+use zksync_os_storage_api::{ReadReplay, ReplayRecord};
+use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
 
 /// Command source for consensus-enabled main node.
 /// Replays local WAL starting from `starting_block` and then produces new blocks when leader.
@@ -21,11 +23,20 @@ pub struct ConsensusNodeCommandSource<Replay> {
     pub rebuild_options: Option<RebuildOptions>,
     /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
     pub replays_to_execute: mpsc::UnboundedReceiver<ReplayRecord>,
+    /// Acknowledges that the previously emitted Produce command crossed the
+    /// downstream lifecycle boundary and the source may emit another one.
+    pub produce_acks: mpsc::Receiver<()>,
+    /// Internal pipeline admission gate driven by backpressure monitoring.
+    pub pipeline_gate: PipelineAdmissionReceiver,
+    /// Optional operational cap on newly produced blocks. Replays bypass this.
+    pub max_blocks_to_produce: Option<u64>,
+    /// Signals RPC admission when the configured production limit is reached.
+    pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     /// Current leadership status from consensus.
     pub leadership: LeadershipSignal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RebuildOptions {
     pub from_block: u64,
     pub blocks_to_empty: HashSet<u64>,
@@ -37,6 +48,7 @@ pub struct RebuildOptions {
 pub struct ExternalNodeCommandSource {
     pub up_to_block: Option<u64>,
     pub replays_for_sequencer: mpsc::Receiver<ReplayRecord>,
+    pub pipeline_gate: PipelineAdmissionReceiver,
 }
 
 #[async_trait]
@@ -46,10 +58,7 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 
     const COMPONENT_ID: zksync_os_pipeline::ComponentId =
         zksync_os_pipeline::ComponentId::ConsensusNodeCommandSource;
-    // Capacity 1 is intentional: the leader arm in run_loop emits Produce tokens inside
-    // tokio::select! on output.send(), firing whenever the channel has space. A larger buffer
-    // would let the leader queue multiple tokens ahead of execution. Capacity of 1 ensures
-    // at most one un-executed Produce command in flight, making the downstream consumer the pacer.
+    // Keep the transport buffer small so BlockExecutor remains the near-term pacer.
     const OUTPUT_CHANNEL_CAPACITY: usize = 1;
 
     async fn run(
@@ -84,17 +93,11 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
             replay_until
         );
 
-        self.block_replay_storage
-            .forward_range_with(
-                self.starting_block,
-                replay_until,
-                output.clone(),
-                |record| BlockCommand::Replay(Box::new(record)),
-            )
+        self.forward_wal_replays(self.starting_block, replay_until, &output)
             .await?;
 
-        if let Some(rebuild_options) = &self.rebuild_options {
-            self.send_block_rebuilds(rebuild_options, last_block_in_wal, &output)
+        if let Some(rebuild_options) = self.rebuild_options.clone() {
+            self.send_block_rebuilds(&rebuild_options, last_block_in_wal, &output)
                 .await?;
         }
 
@@ -110,6 +113,8 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 }
 
 impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
+    const MAX_REPLAYS_TO_DRAIN_PER_LOOP: usize = 32;
+
     /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
     /// Produces `Produce` commands only when the node is the leader.
     async fn run_loop(
@@ -119,10 +124,54 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
     ) -> anyhow::Result<()> {
         let mut leadership = self.leadership.clone();
         let mut role = leadership.current_role();
+        let mut produce_in_flight = false;
+        let mut produced_blocks_count = 0u64;
+        let mut production_limit_reported = false;
         tracing::info!(?role, "Consensus role initialized");
 
         loop {
+            let gate_open = self.pipeline_gate.is_open();
+            for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
+                if !gate_open {
+                    break;
+                }
+                match self.replays_to_execute.try_recv() {
+                    Ok(record) => {
+                        Self::forward_replay(record, &output, &state_reporter).await?;
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        tracing::info!("inbound channel closed");
+                        return Ok(());
+                    }
+                }
+            }
+
+            let production_limit_reached = self
+                .max_blocks_to_produce
+                .is_some_and(|limit| produced_blocks_count >= limit);
+            if production_limit_reached && !production_limit_reported {
+                tracing::warn!(
+                    produced_blocks_count,
+                    limit = self.max_blocks_to_produce,
+                    "Reached max_blocks_to_produce limit, stopping transaction acceptance"
+                );
+                let _ =
+                    self.tx_acceptance_state_sender
+                        .send(TransactionAcceptanceState::NotAccepting(vec![
+                            NotAcceptingReason::BlockProductionDisabled,
+                        ]));
+                production_limit_reported = true;
+            }
+
+            let can_produce = role == ConsensusRole::Leader
+                && !produce_in_flight
+                && gate_open
+                && !production_limit_reached;
+
             tokio::select! {
+                biased;
+
                 res = leadership.wait_for_change() => {
                     if res.is_err() {
                         anyhow::bail!("leader watch channel closed");
@@ -133,33 +182,28 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         role = new_role;
                     }
                 }
-                maybe_record = self.replays_to_execute.recv() => {
+                maybe_ack = self.produce_acks.recv(), if produce_in_flight => {
+                    if maybe_ack.is_none() {
+                        tracing::info!("Produce ack channel closed, stopping source");
+                        break;
+                    }
+                    produce_in_flight = false;
+                }
+                maybe_record = self.replays_to_execute.recv(), if gate_open => {
                     let Some(record) = maybe_record else {
                         tracing::info!("inbound channel closed");
                         return Ok(());
                     };
-                    let block_number = record.block_context.block_number;
-                    let timestamp = record.block_context.timestamp;
-                    tracing::info!(
-                        block_number,
-                        role = ?role,
-                        "Received canonized block from consensus",
-                    );
-                    if output
-                        .send(BlockCommand::Replay(Box::new(record)))
-                        .await
-                        .is_err()
-                    {
-                        tracing::info!("Command output channel closed, stopping source");
-                        break;
-                    }
-                    state_reporter.record_processed(block_number, Some(timestamp), None);
+                    Self::forward_replay(record, &output, &state_reporter).await?;
                 }
-                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if role == ConsensusRole::Leader => {
+                _ = self.pipeline_gate.wait_until_open(), if !gate_open => {}
+                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if can_produce => {
                     if send_res.is_err() {
                         tracing::info!("Command output channel closed, stopping source");
                         break;
                     }
+                    produce_in_flight = true;
+                    produced_blocks_count += 1;
                     // Advance watermark to the last sealed block so diff stays near 0.
                     let latest = self.block_replay_storage.latest_record();
                     if let Some(ctx) = self.block_replay_storage.get_context(latest) {
@@ -172,8 +216,52 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         Ok(())
     }
 
+    async fn forward_wal_replays(
+        &mut self,
+        start: u64,
+        end: u64,
+        output: &mpsc::Sender<BlockCommand>,
+    ) -> anyhow::Result<()> {
+        let latest = self.block_replay_storage.latest_record();
+        anyhow::ensure!(
+            latest >= end,
+            "Requested range end {end} exceeds latest record {latest}"
+        );
+        for block_num in start..=end {
+            self.pipeline_gate.wait_until_open().await;
+            let record = self
+                .block_replay_storage
+                .get_replay_record(block_num)
+                .ok_or_else(|| anyhow::anyhow!("missing replay record for block {block_num}"))?;
+            output
+                .send(BlockCommand::Replay(Box::new(record)))
+                .await
+                .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+        }
+        Ok(())
+    }
+
+    async fn forward_replay(
+        record: ReplayRecord,
+        output: &mpsc::Sender<BlockCommand>,
+        state_reporter: &ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let block_number = record.block_context.block_number;
+        let timestamp = record.block_context.timestamp;
+        tracing::info!(block_number, "Received canonized block from consensus",);
+        if output
+            .send(BlockCommand::Replay(Box::new(record)))
+            .await
+            .is_err()
+        {
+            anyhow::bail!("command output channel closed");
+        }
+        state_reporter.record_processed(block_number, Some(timestamp), None);
+        Ok(())
+    }
+
     async fn send_block_rebuilds(
-        &self,
+        &mut self,
         rebuild_options: &RebuildOptions,
         last_block_in_wal: u64,
         output: &mpsc::Sender<BlockCommand>,
@@ -199,6 +287,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 make_empty,
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
+            self.pipeline_gate.wait_until_open().await;
             if output.send(command).await.is_err() {
                 tracing::info!("Command output channel closed, stopping source");
                 break;
@@ -223,7 +312,11 @@ impl PipelineComponent for ExternalNodeCommandSource {
         output: mpsc::Sender<BlockCommand>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        while let Some(record) = self.replays_for_sequencer.recv().await {
+        loop {
+            self.pipeline_gate.wait_until_open().await;
+            let Some(record) = self.replays_for_sequencer.recv().await else {
+                break;
+            };
             let block_number = record.block_context.block_number;
             let timestamp = record.block_context.timestamp;
             let txs = record.transactions.len();

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1,7 +1,7 @@
 pub use self::cli::ConfigArgs;
 pub(crate) use self::metrics::report_static_config_metrics;
 use self::util::{SecretKeyDeserializer, SignerConfigDeserializer};
-use crate::{command_source::RebuildOptions, default_protocol_version::DEFAULT_ROCKS_DB_PATH};
+use crate::default_protocol_version::DEFAULT_ROCKS_DB_PATH;
 use alloy::primitives::{Address, Bytes, U128};
 use num::{BigInt, BigUint, rational::Ratio};
 use reth_net_nat::net_if::resolve_net_if_ip;
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::{path::PathBuf, time::Duration};
 use zksync_os_batch_verification;
+use zksync_os_command_source::RebuildOptions;
 use zksync_os_config_validation_macros::ConfigValidate;
 use zksync_os_l1_sender::commands::commit::CommitCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1770,7 +1770,6 @@ impl From<&Config> for zksync_os_sequencer::config::SequencerConfig {
             block_dump_path: c.sequencer_config.block_dump_path.clone(),
             block_gas_limit: c.sequencer_config.block_gas_limit,
             block_pubdata_limit_bytes: c.sequencer_config.block_pubdata_limit_bytes,
-            max_blocks_to_produce: c.sequencer_config.max_blocks_to_produce,
             interop_roots_per_tx: c.sequencer_config.interop_roots_per_tx,
             tx_validator: {
                 let df = &c.sequencer_config.tx_validator.deployment_filter;

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1054,7 +1054,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             repositories.clone(),
             finality_storage.clone(),
             stop_receiver.clone(),
-            tx_acceptance_state_sender,
             chain_id,
             verify_batch_rx,
             outgoing_verify_results.clone(),
@@ -1168,8 +1167,10 @@ async fn run_main_node_pipeline(
     );
 
     let monitor = BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver);
+    let pipeline_gate = monitor.subscribe_gate();
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
+    let (produce_ack_sender, produce_acks) = tokio::sync::mpsc::channel(1);
     let (applied_block_number_sender, applied_block_number_receiver) =
         watch::channel(starting_block - 1);
 
@@ -1183,18 +1184,22 @@ async fn run_main_node_pipeline(
                 .clone()
                 .map(Into::into),
             replays_to_execute,
+            produce_acks,
+            pipeline_gate,
+            max_blocks_to_produce: config.sequencer_config.max_blocks_to_produce,
+            tx_acceptance_state_sender,
             leadership,
         })
         .pipe(BlockExecutor {
             block_context_provider,
             state: state.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockCanonizer {
             consensus: canonization_engine,
             canonized_blocks_for_execution: replays_to_execute_sender,
+            produce_acks: produce_ack_sender,
         })
         .pipe(BlockApplier {
             state: state.clone(),
@@ -1416,7 +1421,6 @@ async fn run_en_pipeline(
     repositories: impl WriteRepository + Clone,
     finality: impl ReadFinality + Clone,
     stop_receiver: watch::Receiver<bool>,
-    tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
     chain_id: u64,
     verify_batch_rx: tokio::sync::mpsc::Receiver<PeerVerifyBatch>,
     outgoing_verify_results: tokio::sync::broadcast::Sender<PeerVerifyBatchResult>,
@@ -1432,17 +1436,18 @@ async fn run_en_pipeline(
 
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());
+    let pipeline_gate = monitor.subscribe_gate();
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
             replays_for_sequencer,
             up_to_block: config.sequencer_config.en_sync_up_to_block,
+            pipeline_gate,
         })
         .pipe(BlockExecutor {
             block_context_provider,
             state: state.clone(),
             config: config.into(),
-            tx_acceptance_state_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockApplier {

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -4,7 +4,6 @@
 mod acceptance;
 mod batch_sink;
 pub mod batcher;
-mod command_source;
 pub mod config;
 pub mod default_protocol_version;
 mod en_remote_config;
@@ -21,7 +20,6 @@ pub mod util;
 
 use crate::batch_sink::{BatchSink, NoOpSink, clear_failing_block_config_task};
 use crate::batcher::{Batcher, BatcherStartupConfig, util::load_genesis_stored_batch_info};
-use crate::command_source::{ConsensusNodeCommandSource, ExternalNodeCommandSource};
 use crate::config::{
     Config, ProverApiConfig, base_token_price_updater_config, gas_adjuster_config,
     report_static_config_metrics,
@@ -61,6 +59,10 @@ use zksync_os_base_token_adjuster::BaseTokenPriceUpdater;
 use zksync_os_batch_verification::{
     BatchVerificationConfig as BatchVerificationPolicyConfig, BatchVerificationPipelineStep,
     BatchVerificationResponder, effective_verification_policy,
+};
+use zksync_os_command_source::{
+    ConsensusNodeCommandSource, DEFAULT_COMMAND_WINDOW_CAPACITY, ExternalNodeCommandSource,
+    ReplayCommandForwarder,
 };
 use zksync_os_contract_interface::l1_discovery::{BatchVerificationSL, L1State};
 use zksync_os_contract_interface::models::BatchDaInputMode;
@@ -1170,7 +1172,8 @@ async fn run_main_node_pipeline(
     let pipeline_gate = monitor.subscribe_gate();
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
-    let (produce_ack_sender, produce_acks) = tokio::sync::mpsc::channel(1);
+    let (command_ack_sender, command_acks) =
+        tokio::sync::mpsc::channel(DEFAULT_COMMAND_WINDOW_CAPACITY);
     let (applied_block_number_sender, applied_block_number_receiver) =
         watch::channel(starting_block - 1);
 
@@ -1184,8 +1187,8 @@ async fn run_main_node_pipeline(
                 .clone()
                 .map(Into::into),
             replays_to_execute,
-            produce_acks,
-            pipeline_gate,
+            command_acks,
+            replay_forwarder: ReplayCommandForwarder::new(pipeline_gate),
             max_blocks_to_produce: config.sequencer_config.max_blocks_to_produce,
             tx_acceptance_state_sender,
             leadership,
@@ -1194,12 +1197,12 @@ async fn run_main_node_pipeline(
             block_context_provider,
             state: state.clone(),
             config: config.into(),
+            command_acks: command_ack_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockCanonizer {
             consensus: canonization_engine,
             canonized_blocks_for_execution: replays_to_execute_sender,
-            produce_acks: produce_ack_sender,
         })
         .pipe(BlockApplier {
             state: state.clone(),
@@ -1437,17 +1440,21 @@ async fn run_en_pipeline(
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());
     let pipeline_gate = monitor.subscribe_gate();
+    let (command_ack_sender, command_acks) =
+        tokio::sync::mpsc::channel(DEFAULT_COMMAND_WINDOW_CAPACITY);
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
             replays_for_sequencer,
             up_to_block: config.sequencer_config.en_sync_up_to_block,
-            pipeline_gate,
+            command_acks,
+            replay_forwarder: ReplayCommandForwarder::new(pipeline_gate),
         })
         .pipe(BlockExecutor {
             block_context_provider,
             state: state.clone(),
             config: config.into(),
+            command_acks: command_ack_sender,
             applied_block_number_receiver,
         })
         .pipe(BlockApplier {


### PR DESCRIPTION
## Summary

Extracts `ConsensusNodeCommandSource` and `ExternalNodeCommandSource` into a dedicated `zksync_os_command_source` crate and replaces channel-capacity-based pacing with an explicit `CommandWindow` + `CommandAck` protocol.

**Pacing model.** The source tracks every emitted command in a small FIFO window. `BlockExecutor` acknowledges each command after handing the resulting `BlockPayload` to the next pipeline stage. The window bounds how many commands may be outstanding at once, with an additional rule that at most one `Produce` command may be pending at a time. `CommandAck` is a typed enum rather than a bare semaphore so that future throttling strategies (TPS limits, memory pressure) can attach execution metadata to the existing feedback channel without changing the topology between source and executor.

**Backpressure integration.** `PipelineAdmissionGate` is now wired into both command sources. When downstream backpressure closes the gate, replay forwarding pauses at the source rather than blocking inside the pipeline.

**Block production limit.** `max_blocks_to_produce` enforcement moves from `BlockExecutor` (which previously called `std::future::pending()` to freeze mid-pipeline) to `ConsensusNodeCommandSource`, where it simply stops emitting `Produce` commands once the limit is reached.