### PR TITLE
ci: drop +crt-static to fix jemalloc duplicate symbol on Linux

### DIFF
--- a/.github/workflows/release-bins.yml
+++ b/.github/workflows/release-bins.yml
@@ -78,8 +78,7 @@ jobs:
 
       - name: Build
         env:
-          # Build static binaries
-          RUSTFLAGS: '-C target-feature=+crt-static --cfg tokio_unstable'
+          RUSTFLAGS: '--cfg tokio_unstable'
         run: |
           cargo build --profile "${RELEASE_PROFILE}" \
             --target "${{ matrix.target }}" --bin "${ZKSYNC_OS_SERVER_BIN}"


### PR DESCRIPTION
## Summary

Building with `+crt-static` links glibc statically, which causes a duplicate symbol error (`malloc`, `free`, `realloc`) when jemalloc is configured with `override_allocator_on_supported_platforms`. Removing this flag makes glibc a dynamic runtime dependency - the same approach used by reth - and lets jemalloc override C-level allocators as intended.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

