### PR TITLE
fix(watcher): skip old transactions in upgrade watcher

### DIFF
--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -622,12 +622,6 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
         request: L1UpgradeRequest,
         _log: Log,
     ) -> Result<(), L1WatcherError> {
-        // We do not verify that these logs match with replay records, skip them.
-        if request.old_protocol_version
-            < ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
-        {
-            return Ok(());
-        }
         // Since we don't have the old events, current_version might be wrong
         // Update it here to pass related sanity checks
         if self.current_protocol_version

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -68,7 +68,7 @@ impl L1UpgradeTxWatcher {
         zk_chain_l1: ZkChain<DynProvider>,
         zk_chain_sl: ZkChain<DynProvider>,
         bytecode_supplier_address: Address,
-        current_protocol_version: ProtocolSemanticVersion,
+        mut current_protocol_version: ProtocolSemanticVersion,
         upgrade_subpool: UpgradeSubpool,
     ) -> anyhow::Result<L1Watcher> {
         tracing::info!(
@@ -88,11 +88,24 @@ impl L1UpgradeTxWatcher {
         let ctm_sl = zk_chain_sl.get_chain_type_manager().await?;
         tracing::info!(ctm_sl = ?ctm_sl, "resolved SL chain type manager");
 
-        let last_l1_block = find_l1_block_by_protocol_version(
-            zk_chain_l1.clone(),
-            current_protocol_version.clone(),
-        )
-        .await?;
+        let last_l1_block = if current_protocol_version
+            < ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+        {
+            tracing::info!(
+                from_protocol_version = %current_protocol_version,
+                to_protocol_version = %ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
+                "skipping historical upgrade logs"
+            );
+            current_protocol_version =
+                ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS;
+            // The target protocol version may not exist on old environments. Since the
+            // historical logs below the floor are intentionally skipped, start tailing
+            // from the current L1 tip instead of searching for the floor on-chain.
+            zk_chain_l1.provider().get_block_number().await?
+        } else {
+            find_l1_block_by_protocol_version(zk_chain_l1.clone(), current_protocol_version.clone())
+                .await?
+        };
         // The configured bytecode supplier address is used as fallback for pre-v31 CTMs.
         // On v31+ CTMs, `resolve_active_bytecode_supplier` discovers the address dynamically.
         // Sanity check: make sure the fallback address has code deployed.

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -68,7 +68,7 @@ impl L1UpgradeTxWatcher {
         zk_chain_l1: ZkChain<DynProvider>,
         zk_chain_sl: ZkChain<DynProvider>,
         bytecode_supplier_address: Address,
-        mut current_protocol_version: ProtocolSemanticVersion,
+        current_protocol_version: ProtocolSemanticVersion,
         upgrade_subpool: UpgradeSubpool,
     ) -> anyhow::Result<L1Watcher> {
         tracing::info!(
@@ -88,24 +88,11 @@ impl L1UpgradeTxWatcher {
         let ctm_sl = zk_chain_sl.get_chain_type_manager().await?;
         tracing::info!(ctm_sl = ?ctm_sl, "resolved SL chain type manager");
 
-        let last_l1_block = if current_protocol_version
-            < ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
-        {
-            tracing::info!(
-                from_protocol_version = %current_protocol_version,
-                to_protocol_version = %ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
-                "skipping historical upgrade logs"
-            );
-            current_protocol_version =
-                ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS;
-            // The target protocol version may not exist on old environments. Since the
-            // historical logs below the floor are intentionally skipped, start tailing
-            // from the current L1 tip instead of searching for the floor on-chain.
-            zk_chain_l1.provider().get_block_number().await?
-        } else {
-            find_l1_block_by_protocol_version(zk_chain_l1.clone(), current_protocol_version.clone())
-                .await?
-        };
+        let last_l1_block = find_l1_block_by_protocol_version(
+            zk_chain_l1.clone(),
+            current_protocol_version.clone(),
+        )
+        .await?;
         // The configured bytecode supplier address is used as fallback for pre-v31 CTMs.
         // On v31+ CTMs, `resolve_active_bytecode_supplier` discovers the address dynamically.
         // Sanity check: make sure the fallback address has code deployed.
@@ -635,6 +622,20 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
         request: L1UpgradeRequest,
         _log: Log,
     ) -> Result<(), L1WatcherError> {
+        // We do not verify that these logs match with replay records, skip them.
+        if request.old_protocol_version
+            < ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+        {
+            return Ok(());
+        }
+        // Since we don't have the old events, current_version might be wrong
+        // Update it here to pass related sanity checks
+        if self.current_protocol_version
+            < ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+        {
+            self.current_protocol_version = request.old_protocol_version.clone();
+        }
+
         if request.old_protocol_version < self.current_protocol_version {
             tracing::info!(
                 ?request.old_protocol_version,

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -93,8 +93,9 @@ impl UpgradeSubpool {
             upgrade.protocol_version()
                 > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
         });
-        current_protocol_version = protocol_version.clone();
-        if protocol_version > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
+        if protocol_version <= &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
+            current_protocol_version = protocol_version.clone();
+        } else {
             for tx in txs {
                 // Skip fetched patch upgrades
                 let pending_tx = loop {

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -91,9 +91,9 @@ impl UpgradeSubpool {
         // watcher. During replay, the ReplayRecord is the source of truth.
         self.inner.write().await.pending_upgrades.retain(|upgrade| {
             upgrade.protocol_version()
-                > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+                >= &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
         });
-        if protocol_version <= &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
+        if protocol_version < &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
             current_protocol_version = protocol_version.clone();
         } else {
             for tx in txs {

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -89,11 +89,10 @@ impl UpgradeSubpool {
 
         // Older upgrade logs cannot be found or processed reliably by the current
         // watcher. During replay, the ReplayRecord is the source of truth.
-        self.inner
-            .write()
-            .await
-            .pending_upgrades
-            .retain(|upgrade| upgrade.protocol_version() > protocol_version);
+        self.inner.write().await.pending_upgrades.retain(|upgrade| {
+            upgrade.protocol_version()
+                > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+        });
         current_protocol_version = protocol_version.clone();
         if protocol_version > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
             for tx in txs {

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -83,50 +83,54 @@ impl UpgradeSubpool {
         // We track current protocol version that we end up with after applying upgrade transaction.
         let mut current_protocol_version = self.inner.read().await.current_protocol_version.clone();
 
-        // If there are no upgrade transactions and current protocol version matches the one in the
-        // block, we do not have to do anything.
-        if txs.is_empty() && protocol_version == &current_protocol_version {
-            return;
-        }
+        if protocol_version <= &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
+            // Older upgrade logs cannot be found or processed reliably by the current
+            // watcher. During replay, the ReplayRecord is the source of truth.
+            self.inner
+                .write()
+                .await
+                .pending_upgrades
+                .retain(|upgrade| upgrade.protocol_version() > protocol_version);
+            current_protocol_version = protocol_version.clone();
+        } else {
+            for tx in txs {
+                // Skip fetched patch upgrades
+                let pending_tx = loop {
+                    let pending_upgrade_info = self.pop_wait().await;
+                    // Update current protocol version with discovered upgrade.
+                    current_protocol_version = pending_upgrade_info.protocol_version().clone();
+                    if let Some(pending_tx) = pending_upgrade_info.tx {
+                        break pending_tx;
+                    }
+                };
+                assert_eq!(tx, &pending_tx);
+            }
 
-        for tx in txs {
-            // Skip fetched patch upgrades
-            let pending_tx = loop {
-                let pending_upgrade_info = self.pop_wait().await;
-                // Update current protocol version with discovered upgrade.
-                current_protocol_version = pending_upgrade_info.protocol_version().clone();
-                if let Some(pending_tx) = pending_upgrade_info.tx {
-                    break pending_tx;
-                }
-            };
-            assert_eq!(tx, &pending_tx);
-        }
-
-        // We need to make sure that our current protocol version matches the one in the block.
-        // For patch upgrades there might be no upgrade transaction, but we still have to find and
-        // consume relevant upgrade info from L1 watcher.
-        loop {
-            if &current_protocol_version == protocol_version {
-                break;
-            } else if &current_protocol_version < protocol_version {
-                let upgrade = self.pop_wait().await;
-                if upgrade.tx.is_some() {
+            // We need to make sure that our current protocol version matches the one in the block.
+            // For patch upgrades there might be no upgrade transaction, but we still have to find and
+            // consume relevant upgrade info from L1 watcher.
+            loop {
+                if &current_protocol_version == protocol_version {
+                    break;
+                } else if &current_protocol_version < protocol_version {
+                    let upgrade = self.pop_wait().await;
+                    if upgrade.tx.is_some() {
+                        panic!(
+                            "expected patch protocol upgrade {}->{} but found minor protocol upgrade {} with unapplied upgrade transaction",
+                            current_protocol_version,
+                            protocol_version,
+                            upgrade.protocol_version()
+                        );
+                    }
+                    // Update current protocol version with discovered upgrade and do one more iteration.
+                    current_protocol_version = upgrade.protocol_version().clone();
+                } else {
                     panic!(
-                        "expected patch protocol upgrade {}->{} but found minor protocol upgrade {} with unapplied upgrade transaction",
-                        current_protocol_version,
-                        protocol_version,
-                        upgrade.protocol_version()
+                        "current protocol version ({current_protocol_version}) is larger than block's protocol version ({protocol_version})",
                     );
                 }
-                // Update current protocol version with discovered upgrade and do one more iteration.
-                current_protocol_version = upgrade.protocol_version().clone();
-            } else {
-                panic!(
-                    "current protocol version ({current_protocol_version}) is larger than block's protocol version ({protocol_version})",
-                );
             }
         }
-
         // Write protocol version we ended up with.
         self.inner.write().await.current_protocol_version = current_protocol_version;
     }
@@ -193,5 +197,161 @@ impl Stream for UpgradeTransactionsStream {
         } else {
             Poll::Ready(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, B256, Bytes, U256};
+    use std::marker::PhantomData;
+    use std::time::Duration;
+    use zksync_os_types::{L1Tx, UpgradeMetadata, UpgradeTxType};
+
+    fn version(minor: u64, patch: u64) -> ProtocolSemanticVersion {
+        ProtocolSemanticVersion::new(0, minor, patch)
+    }
+
+    fn upgrade_tx(hash_byte: u8) -> L1UpgradeEnvelope {
+        L1UpgradeEnvelope {
+            inner: L1Tx::<UpgradeTxType> {
+                hash: B256::repeat_byte(hash_byte),
+                initiator: Address::ZERO,
+                to: Address::ZERO,
+                gas_limit: 0,
+                gas_per_pubdata_byte_limit: 0,
+                max_fee_per_gas: 0,
+                max_priority_fee_per_gas: 0,
+                nonce: 0,
+                value: U256::ZERO,
+                to_mint: U256::ZERO,
+                refund_recipient: Address::ZERO,
+                input: Bytes::new(),
+                factory_deps: Vec::new(),
+                marker: PhantomData,
+            },
+        }
+    }
+
+    fn upgrade_info(
+        protocol_version: ProtocolSemanticVersion,
+        tx: Option<L1UpgradeEnvelope>,
+    ) -> UpgradeInfo {
+        UpgradeInfo {
+            tx,
+            metadata: UpgradeMetadata {
+                timestamp: 0,
+                protocol_version,
+                force_preimages: Vec::new(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn historical_upgrade_replay_does_not_wait_for_watcher() {
+        let subpool = UpgradeSubpool::new(ProtocolSemanticVersion::legacy_genesis_version());
+        let tx = upgrade_tx(1);
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            subpool.on_canonical_state_change(
+                &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
+                vec![&tx],
+            ),
+        )
+        .await
+        .expect("historical upgrade replay should not wait for watcher data");
+
+        assert_eq!(
+            subpool.inner.read().await.current_protocol_version,
+            ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_replay_drains_pending_old_upgrades() {
+        let subpool = UpgradeSubpool::new(ProtocolSemanticVersion::legacy_genesis_version());
+        let old_tx = upgrade_tx(1);
+        let new_tx = upgrade_tx(2);
+        let new_version = version(31, 0);
+        subpool
+            .insert(upgrade_info(
+                ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
+                Some(old_tx),
+            ))
+            .await;
+        subpool
+            .insert(upgrade_info(new_version.clone(), Some(new_tx.clone())))
+            .await;
+
+        subpool
+            .on_canonical_state_change(
+                &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
+                Vec::new(),
+            )
+            .await;
+
+        let mut stream = subpool.upgrade_info_stream().await;
+        let remaining = stream
+            .next()
+            .await
+            .expect("newer pending upgrade should not be drained");
+        assert_eq!(remaining.protocol_version(), &new_version);
+        assert_eq!(remaining.tx.as_ref(), Some(&new_tx));
+    }
+
+    #[tokio::test]
+    async fn supported_upgrade_waits_for_watcher_and_validates_tx() {
+        let subpool =
+            UpgradeSubpool::new(ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS);
+        let tx = upgrade_tx(1);
+        let target_version = version(31, 0);
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                subpool.on_canonical_state_change(&target_version, vec![&tx]),
+            )
+            .await
+            .is_err(),
+            "supported upgrade should wait for watcher data"
+        );
+
+        subpool
+            .insert(upgrade_info(target_version.clone(), Some(tx.clone())))
+            .await;
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            subpool.on_canonical_state_change(&target_version, vec![&tx]),
+        )
+        .await
+        .expect("matching watcher upgrade should validate");
+
+        assert_eq!(
+            subpool.inner.read().await.current_protocol_version,
+            target_version
+        );
+    }
+
+    #[tokio::test]
+    async fn supported_patch_upgrade_consumes_watcher_metadata() {
+        let subpool =
+            UpgradeSubpool::new(ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS);
+        let target_version = version(30, 3);
+        subpool
+            .insert(upgrade_info(target_version.clone(), None))
+            .await;
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            subpool.on_canonical_state_change(&target_version, Vec::new()),
+        )
+        .await
+        .expect("patch upgrade metadata should be consumed");
+
+        assert_eq!(
+            subpool.inner.read().await.current_protocol_version,
+            target_version
+        );
     }
 }

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -252,22 +252,20 @@ mod tests {
 
     #[tokio::test]
     async fn historical_upgrade_replay_does_not_wait_for_watcher() {
+        let unreliable_version = version(30, 1);
         let subpool = UpgradeSubpool::new(ProtocolSemanticVersion::legacy_genesis_version());
         let tx = upgrade_tx(1);
 
         tokio::time::timeout(
             Duration::from_millis(50),
-            subpool.on_canonical_state_change(
-                &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
-                vec![&tx],
-            ),
+            subpool.on_canonical_state_change(&unreliable_version, vec![&tx]),
         )
         .await
         .expect("historical upgrade replay should not wait for watcher data");
 
         assert_eq!(
             subpool.inner.read().await.current_protocol_version,
-            ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS
+            unreliable_version
         );
     }
 
@@ -277,21 +275,16 @@ mod tests {
         let old_tx = upgrade_tx(1);
         let new_tx = upgrade_tx(2);
         let new_version = version(31, 0);
+        let unreliable_version = version(30, 1);
         subpool
-            .insert(upgrade_info(
-                ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
-                Some(old_tx),
-            ))
+            .insert(upgrade_info(unreliable_version.clone(), Some(old_tx)))
             .await;
         subpool
             .insert(upgrade_info(new_version.clone(), Some(new_tx.clone())))
             .await;
 
         subpool
-            .on_canonical_state_change(
-                &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS,
-                Vec::new(),
-            )
+            .on_canonical_state_change(&unreliable_version, Vec::new())
             .await;
 
         let mut stream = subpool.upgrade_info_stream().await;

--- a/lib/mempool/src/subpools/upgrade.rs
+++ b/lib/mempool/src/subpools/upgrade.rs
@@ -83,16 +83,19 @@ impl UpgradeSubpool {
         // We track current protocol version that we end up with after applying upgrade transaction.
         let mut current_protocol_version = self.inner.read().await.current_protocol_version.clone();
 
-        if protocol_version <= &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
-            // Older upgrade logs cannot be found or processed reliably by the current
-            // watcher. During replay, the ReplayRecord is the source of truth.
-            self.inner
-                .write()
-                .await
-                .pending_upgrades
-                .retain(|upgrade| upgrade.protocol_version() > protocol_version);
-            current_protocol_version = protocol_version.clone();
-        } else {
+        if txs.is_empty() && protocol_version == &current_protocol_version {
+            return;
+        }
+
+        // Older upgrade logs cannot be found or processed reliably by the current
+        // watcher. During replay, the ReplayRecord is the source of truth.
+        self.inner
+            .write()
+            .await
+            .pending_upgrades
+            .retain(|upgrade| upgrade.protocol_version() > protocol_version);
+        current_protocol_version = protocol_version.clone();
+        if protocol_version > &ProtocolSemanticVersion::MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS {
             for tx in txs {
                 // Skip fetched patch upgrades
                 let pending_tx = loop {

--- a/lib/types/src/protocol/mod.rs
+++ b/lib/types/src/protocol/mod.rs
@@ -38,10 +38,12 @@ impl Deref for ProtocolSemanticVersion {
 
 impl ProtocolSemanticVersion {
     /// Smallest version such that upgrading to that version uses the current log format
+    /// In other words: if replay record has protocol version this or greater,
+    /// we can expect the watcher to pick up the logs.
     ///
     /// Example:
     /// For 30.1 -> 30.2, 30.1 -> 31.0 we expect to find a log
-    /// Fo r 30.0 -> 30.1 or 30.1 -> 30.1 we don't
+    /// For 30.0 -> 30.1 or 30.1 -> 30.1 we don't
     pub const MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS: Self = Self::new(0, 30, 2);
 
     pub const fn new(major: u64, minor: u64, patch: u64) -> Self {

--- a/lib/types/src/protocol/mod.rs
+++ b/lib/types/src/protocol/mod.rs
@@ -37,6 +37,10 @@ impl Deref for ProtocolSemanticVersion {
 }
 
 impl ProtocolSemanticVersion {
+    /// Upgrade logs before this protocol version used a different format that
+    /// the current L1 upgrade watcher cannot find or process reliably.
+    pub const MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS: Self = Self::new(0, 30, 2);
+
     pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
         Self(semver::Version {
             major,

--- a/lib/types/src/protocol/mod.rs
+++ b/lib/types/src/protocol/mod.rs
@@ -37,8 +37,11 @@ impl Deref for ProtocolSemanticVersion {
 }
 
 impl ProtocolSemanticVersion {
-    /// Upgrade logs before this protocol version used a different format that
-    /// the current L1 upgrade watcher cannot find or process reliably.
+    /// Smallest version such that upgrading to that version uses the current log format
+    ///
+    /// Example:
+    /// For 30.1 -> 30.2, 30.1 -> 31.0 we expect to find a log
+    /// Fo r 30.0 -> 30.1 or 30.1 -> 30.1 we don't
     pub const MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS: Self = Self::new(0, 30, 2);
 
     pub const fn new(major: u64, minor: u64, patch: u64) -> Self {


### PR DESCRIPTION
## Summary

We changed what logs we use to track L1 Upgrade transactions, which means we are missing some old ones. In particular `30.0 -> 30.1` upgrade transactoin for stage-rollup. This breaks EN sync in two ways:

1. ENs get stuck when replaying, because they are waiting for watcher to find the transaction.
2. The watcher itself has some sanity checks 

Note that if we stop relying on upgrade watcher for replay validation this would only fix point 1.

Fix:
Introduce `MIN_VERSION_WITH_RELIABLE_UPGRADE_LOGS = v30.2`
1. Skip the legacy(`version <= 30.2`) upgrade transaction validation for replays.
2. Fix the watcher not to panic due to missed legacy upgrade transactions.


<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

