### PR TITLE
refactor: get rid of `FillProvider` requirement

### DIFF
--- a/lib/base_token_adjuster/src/lib.rs
+++ b/lib/base_token_adjuster/src/lib.rs
@@ -3,7 +3,6 @@ use alloy::network::{Ethereum, EthereumWallet, TransactionBuilder};
 use alloy::primitives::Address;
 use alloy::primitives::utils::format_ether;
 use alloy::providers::ext::DebugApi;
-use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{DynProvider, Provider, WalletProvider};
 use alloy::rpc::types::TransactionReceipt;
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
@@ -76,15 +75,14 @@ impl BaseTokenPriceUpdaterConfig {
 
 #[derive(Debug)]
 pub struct BaseTokenPriceUpdater<
-    F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet>,
-    P: Provider<Ethereum> + Clone,
+    P: Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone,
 > {
     base_token: APIToken,
     sl_token: APIToken,
     price_api_client: Box<dyn PriceApiClient>,
     config: BaseTokenPriceUpdaterConfig,
     last_l1_ratio: Ratio<BigUint>,
-    chain_admin_contract: IChainAdminOwnableInstance<FillProvider<F, P>, Ethereum>,
+    chain_admin_contract: IChainAdminOwnableInstance<P, Ethereum>,
     token_multiplier_setter_address: Option<Address>,
     zk_chain_address: Address,
     token_price_sender: watch::Sender<Option<TokenPricesForFees>>,
@@ -111,13 +109,13 @@ async fn register_operator<P: Provider + WalletProvider<Wallet = EthereumWallet>
     Ok(address)
 }
 
-impl<F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet>, P: Provider<Ethereum> + Clone>
-    BaseTokenPriceUpdater<F, P>
+impl<P: Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone>
+    BaseTokenPriceUpdater<P>
 {
     pub async fn new(
         zk_chain_l1: ZkChain<DynProvider>,
         zk_chain_gateway: Option<ZkChain<DynProvider>>,
-        mut l1_provider: FillProvider<F, P>,
+        mut l1_provider: P,
         base_token_adjuster_config: BaseTokenPriceUpdaterConfig,
         external_price_api_client_config: ExternalPriceApiClientConfig,
         token_price_sender: watch::Sender<Option<TokenPricesForFees>>,
@@ -231,7 +229,7 @@ impl<F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet>, P: Provide
         token_address: Address,
         token_address_override: Option<Address>,
         decimals_override: Option<u8>,
-        l1_provider: &FillProvider<F, P>,
+        l1_provider: &P,
     ) -> anyhow::Result<APIToken> {
         let token_address = token_address_override.unwrap_or(token_address);
         match token_address {

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -8,17 +8,16 @@ use crate::commands::{L1SenderCommand, SendToL1};
 use crate::config::L1SenderFeeConfig;
 use crate::metrics::{L1_SENDER_METRICS, PriorityFeeEstimatePercentile, PriorityFeeEstimateWindow};
 use crate::pipeline_component::L1Sender;
-use alloy::consensus::BlobTransactionValidationError;
 use alloy::consensus::Transaction as ConsensusTransaction;
+use alloy::eips::eip4844::env_settings::EnvKzgSettings;
 use alloy::eips::eip7594::BlobTransactionSidecarVariant;
-use alloy::eips::{BlockId, BlockNumberOrTag, Encodable2718};
+use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::network::{
     Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilder4844, TransactionResponse,
 };
 use alloy::primitives::utils::{format_ether, format_units};
 use alloy::primitives::{Address, B256};
 use alloy::providers::ext::DebugApi;
-use alloy::providers::fillers::TxFiller;
 use alloy::providers::utils::Eip1559Estimation;
 use alloy::providers::{Provider, WalletProvider};
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
@@ -94,10 +93,9 @@ struct FeeParams {
 ///
 /// Note: we pass `to_address` - L1 contract address to send transactions to.
 /// It differs between commit/prove/execute (e.g., timelock vs diamond proxy)
-impl<LF, LP, Input> L1Sender<LF, LP, Input>
+impl<P, Input> L1Sender<P, Input>
 where
-    LF: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
-    LP: Provider<Ethereum> + Clone + 'static,
+    P: Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone + 'static,
     Input: SendToL1 + Send + 'static,
 {
     pub async fn operator_address(&self) -> anyhow::Result<Address> {
@@ -234,34 +232,20 @@ where
                             );
                         }
                         tx_request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
-                        tx_request
-                            .set_blob_sidecar(BlobTransactionSidecarVariant::Eip4844(blob_sidecar));
+
+                        let pending_block = self.provider.get_block(BlockId::pending()).await?.expect("no pending block");
+                        // todo: make conversion unconditional (and remove respective config) once anvil
+                        //       supports EIP-7594 blobs (see https://github.com/foundry-rs/foundry/issues/12222)
+                        if self.config.fusaka_upgrade_timestamp <= pending_block.header.timestamp {
+                            tx_request.set_blob_sidecar(BlobTransactionSidecarVariant::Eip7594(
+                                blob_sidecar.try_into_7594(EnvKzgSettings::Default.get())?,
+                            ));
+                        } else {
+                            tx_request.set_blob_sidecar(BlobTransactionSidecarVariant::Eip4844(blob_sidecar));
+                        }
                     };
 
-                    // Fill the transaction (e.g., nonce, gas, etc.) using the provider and convert it to an
-                    // envelope.
-                    let envelope = self.provider.fill(tx_request).await?.try_into_envelope()?.try_into_pooled()?;
-
-                    let pending_block = self.provider.get_block(BlockId::pending()).await?.expect("no pending block");
-                    // todo: make conversion unconditional (and remove respective config) once anvil
-                    //       supports EIP-7594 blobs (see https://github.com/foundry-rs/foundry/issues/12222)
-                    let tx = if self.config.fusaka_upgrade_timestamp <= pending_block.header.timestamp {
-                        // Convert the envelope into an EIP-7594 transaction by converting the sidecar
-                        envelope.try_map_eip4844(|tx| {
-                            tx.try_map_sidecar(|sidecar| {
-                                Ok::<_, BlobTransactionValidationError>(
-                                    BlobTransactionSidecarVariant::Eip7594(sidecar.try_into_eip7594()?)
-                                )
-                            })
-                        })?
-                    } else {
-                        // Keep the regular EIP-4844 sidecar
-                        envelope
-                    };
-
-                    let pending_tx = self.provider
-                        .send_raw_transaction(&tx.encoded_2718())
-                        .await?;
+                    let pending_tx = self.provider.send_transaction(tx_request).await?;
                     let submitted_at = Instant::now();
                     let tx_hash = *pending_tx.tx_hash();
                     let receipt_fut = self.wait_for_confirmed_receipt(tx_hash);
@@ -354,7 +338,7 @@ where
     }
 
     fn wait_for_confirmed_receipt(&self, tx_hash: B256) -> TransactionReceiptFuture {
-        let provider = self.provider.root().clone();
+        let provider = self.provider.clone();
         let required_confirmations = if self.gateway {
             REQUIRED_CONFIRMATIONS_GATEWAY
         } else {

--- a/lib/l1_sender/src/pipeline_component.rs
+++ b/lib/l1_sender/src/pipeline_component.rs
@@ -2,7 +2,6 @@ use crate::commands::{L1SenderCommand, SendToL1};
 use crate::config::L1SenderConfig;
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy::primitives::Address;
-use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{Provider, WalletProvider};
 use async_trait::async_trait;
 use tokio::sync::{mpsc, watch};
@@ -12,8 +11,8 @@ use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 
 /// Generic L1 Sender pipeline component
 /// Can be used for commit, prove, or execute operations
-pub struct L1Sender<F: TxFiller<Ethereum>, P: Provider<Ethereum>, C> {
-    pub provider: FillProvider<F, P>,
+pub struct L1Sender<P: Provider<Ethereum>, C> {
+    pub provider: P,
     pub config: L1SenderConfig<C>,
     pub to_address: Address,
     pub gateway: bool,
@@ -24,10 +23,9 @@ pub struct L1Sender<F: TxFiller<Ethereum>, P: Provider<Ethereum>, C> {
 }
 
 #[async_trait]
-impl<F, P, C> PipelineComponent for L1Sender<F, P, C>
+impl<P, C> PipelineComponent for L1Sender<P, C>
 where
-    F: TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
-    P: Provider<Ethereum> + Clone + 'static,
+    P: Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone + 'static,
     C: SendToL1 + Send + Sync + 'static,
 {
     type Input = L1SenderCommand<C>;

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -46,7 +46,6 @@ use crate::tree_manager::TreeManager;
 use alloy::consensus::BlobTransactionSidecar;
 use alloy::network::{Ethereum, EthereumWallet};
 use alloy::primitives::BlockNumber;
-use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{Provider, WalletProvider};
 use anyhow::Context;
 use jsonrpsee::http_client::HttpClient;
@@ -1135,10 +1134,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 #[allow(clippy::too_many_arguments)]
 async fn run_main_node_pipeline(
     config: &Config,
-    sl_provider: FillProvider<
-        impl TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
-        impl Provider<Ethereum> + Clone + 'static,
-    >,
+    sl_provider: impl Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone + 'static,
     node_state_on_startup: NodeStateOnStartup,
     block_replay_storage: impl WriteReplay + Clone,
     runtime: &Runtime,
@@ -1365,7 +1361,7 @@ async fn run_main_node_pipeline(
         .pipe_opt(replay_archiver.map(|replay_archiver| {
             ReplayArchiveGateComponent::new(replay_archiver, block_replay_storage.clone())
         }))
-        .pipe(L1Sender::<_, _, CommitCommand> {
+        .pipe(L1Sender::<_, CommitCommand> {
             provider: sl_provider.clone(),
             config: commit_sender_config,
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
@@ -1377,7 +1373,7 @@ async fn run_main_node_pipeline(
         .pipe(GaplessL1ProofSender::new(
             node_state_on_startup.l1_state.last_executed_batch + 1,
         ))
-        .pipe(L1Sender::<_, _, ProofCommand> {
+        .pipe(L1Sender::<_, ProofCommand> {
             provider: sl_provider.clone(),
             config: prove_sender_config,
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -4,7 +4,6 @@ mod retry;
 
 use crate::config::ProviderConfig;
 use alloy::network::{Ethereum, EthereumWallet};
-use alloy::providers::fillers::{FillProvider, TxFiller};
 use alloy::providers::{Provider, ProviderBuilder, WalletProvider};
 use alloy::rpc::client::RpcClient;
 use alloy::signers::local::PrivateKeySigner;
@@ -21,10 +20,7 @@ pub(crate) enum ProviderKind {
 pub(crate) async fn build_node_provider(
     config: &ProviderConfig,
     provider: ProviderKind,
-) -> FillProvider<
-    impl TxFiller<Ethereum> + WalletProvider<Wallet = EthereumWallet> + 'static,
-    impl Provider<Ethereum> + Clone + 'static,
-> {
+) -> impl Provider<Ethereum> + WalletProvider<Wallet = EthereumWallet> + Clone + 'static {
     let max_retries = config.max_retries;
     let retry_backoff = config.retry_backoff;
     let provider_layers = ServiceBuilder::new()


### PR DESCRIPTION
## Summary

No longer needed as we have migrated to alloy v2 that allows EIP-7594 blobs in `TransactionRequest`

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

