### PR TITLE
feat(observability): distinguish between default and non-default values in config metrics

### DIFF
--- a/lib/observability/src/prometheus.rs
+++ b/lib/observability/src/prometheus.rs
@@ -51,7 +51,7 @@ impl PrometheusExporterConfig {
         let job_id = "zksync-pushgateway";
         let namespace =
             env::var("POD_NAMESPACE").unwrap_or_else(|_| "UNKNOWN_NAMESPACE".to_owned());
-        let pod = env::var("POD_NAME").unwrap_or_else(|_| "UNKNOWN_POD".to_owned());
+        let pod = env::var("HOSTNAME").unwrap_or_else(|_| "UNKNOWN_POD".to_owned());
         format!("{base_url}/metrics/job/{job_id}/namespace/{namespace}/pod/{pod}")
     }
 

--- a/node/bin/src/config/metrics.rs
+++ b/node/bin/src/config/metrics.rs
@@ -4,9 +4,12 @@ use vise::{EncodeLabelSet, Info, LabeledFamily, Metrics};
 
 use super::Config;
 
-#[derive(Debug, EncodeLabelSet)]
+const SECRET_PLACEHOLDER: &str = "<secret>";
+
+#[derive(Debug, PartialEq, Eq, EncodeLabelSet)]
 struct ValueLabel {
     value: String,
+    is_default: bool,
 }
 
 #[derive(Debug, Metrics)]
@@ -61,14 +64,9 @@ pub(crate) fn report_static_config_metrics(config: &Config) {
 }
 
 fn report_flat_config_metrics<C: DescribeConfig>(config: &C, prefix: &str) {
-    for (key, value) in SerializerOptions::default()
-        .with_secret_placeholder("<secret>")
-        .flat(true)
-        .serialize(config)
-    {
+    for (key, value) in flat_config_labels(config) {
         let name = format!("{prefix}_{key}");
-        let value = stringify_config_value(value);
-        let _ = CONFIG_METRICS.values[&name].set(ValueLabel { value });
+        let _ = CONFIG_METRICS.values[&name].set(value);
     }
 }
 
@@ -88,6 +86,25 @@ fn stringify_config_value(value: Value) -> String {
     sanitize_label_value(value)
 }
 
+fn flat_config_labels<C: DescribeConfig>(config: &C) -> Vec<(String, ValueLabel)> {
+    let non_default_values = SerializerOptions::diff_with_default()
+        .with_secret_placeholder(SECRET_PLACEHOLDER)
+        .flat(true)
+        .serialize(config);
+
+    SerializerOptions::default()
+        .with_secret_placeholder(SECRET_PLACEHOLDER)
+        .flat(true)
+        .serialize(config)
+        .into_iter()
+        .map(|(key, value)| {
+            let value = stringify_config_value(value);
+            let is_default = !non_default_values.contains_key(&key);
+            (key, ValueLabel { value, is_default })
+        })
+        .collect()
+}
+
 fn sanitize_label_value(value: String) -> String {
     value
         .replace('"', "'")
@@ -97,7 +114,20 @@ fn sanitize_label_value(value: String) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use serde_json::{Value, json};
+    use smart_config::{DescribeConfig, DeserializeConfig, testing};
+
+    #[derive(Debug, DescribeConfig, DeserializeConfig)]
+    struct TestConfig {
+        #[config(default_t = 10)]
+        defaulted: u64,
+        #[config(default_t = 20)]
+        overridden: u64,
+        #[config(default_t = 30)]
+        overridden_to_default: u64,
+    }
 
     #[test]
     fn stringify_config_value_formats_label_values() {
@@ -108,6 +138,39 @@ mod tests {
         assert_eq!(
             super::stringify_config_value(json!(["0x36615Cf349d7F6344891B1e7CA7C72883F5dc049"])),
             "['0x36615Cf349d7F6344891B1e7CA7C72883F5dc049']"
+        );
+    }
+
+    #[test]
+    fn flat_config_labels_mark_default_values() {
+        let config = testing::test::<TestConfig>(smart_config::config! {
+            "overridden": 25,
+            "overridden_to_default": 30,
+        })
+        .unwrap();
+
+        let labels: HashMap<_, _> = super::flat_config_labels(&config).into_iter().collect();
+
+        assert_eq!(
+            labels.get("defaulted").unwrap(),
+            &super::ValueLabel {
+                value: "10".to_owned(),
+                is_default: true,
+            }
+        );
+        assert_eq!(
+            labels.get("overridden").unwrap(),
+            &super::ValueLabel {
+                value: "25".to_owned(),
+                is_default: false,
+            }
+        );
+        assert_eq!(
+            labels.get("overridden_to_default").unwrap(),
+            &super::ValueLabel {
+                value: "30".to_owned(),
+                is_default: true,
+            }
         );
     }
 }


### PR DESCRIPTION
## Summary

Add `is_default` label to config metrics,  this way we can have a list of non-default config values.
I also changed push exporter to use HOSTNAME instead of POD_NAME as recommended by devops.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

