### PR TITLE
fix: consensus test retries, temporary solution

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,6 +41,14 @@ threads-required = 2
 filter = 'test(~consensus)'
 threads-required = 6
 
+# PR profile inherits the default settings but retries flaky consensus tests.
+[profile.pr]
+inherits = "default"
+
+[[profile.pr.overrides]]
+filter = 'test(~consensus)'
+retries = 2
+
 # Fast profile for local development — excludes the slowest integration tests.
 # Usage: cargo nextest run -p zksync_os_integration_tests --profile fast
 [profile.fast]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
   #################################################
   test:
     runs-on: matterlabs-ci-runner-high-performance
+    env:
+      NEXTEST_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || 'default' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -87,16 +89,17 @@ jobs:
         uses: ./.github/actions/runner-setup
 
       - name: Run tests
-        run: cargo nextest run --release --workspace ${NEXTEST_ITERATIONS}
+        run: cargo nextest run --release --workspace --profile "${NEXTEST_PROFILE}" ${NEXTEST_ITERATIONS}
 
       - name: Upload test results
         if: always() && !cancelled()
         uses: EnricoMi/publish-unit-test-result-action@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 # v2.20.0
         with:
           check_name: 'Test results'
-          files: target/nextest/default/${{ env.TEST_RESULTS_XML }}
+          files: target/nextest/${{ env.NEXTEST_PROFILE }}/${{ env.TEST_RESULTS_XML }}
           action_fail_on_inconclusive: true
           compare_to_earlier_commit: false # Do not compare with `main` due to different number of iterations
+          report_individual_runs: true
 
 
   # Temporary disable code coverage measurements in main due to llvm-cov issue with rustc v1.89:

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -757,7 +757,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     let l1_subpool = L1Subpool::new(10);
     runtime.spawn_critical_task(
-        "gateway migration watcher",
+        "L1 transaction watcher",
         L1TxWatcher::create_watcher(
             config.l1_watcher_config.clone().into(),
             node_startup_state.l1_state.diamond_proxy_l1.clone(),

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -757,7 +757,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     let l1_subpool = L1Subpool::new(10);
     runtime.spawn_critical_task(
-        "L1 transaction watcher",
+        "gateway migration watcher",
         L1TxWatcher::create_watcher(
             config.l1_watcher_config.clone().into(),
             node_startup_state.l1_state.diamond_proxy_l1.clone(),


### PR DESCRIPTION
## Summary
We have some flaky consensus tests. I would guess that on average everybody has to do 1 re-run of tests for their PR, sometimes more. This is not good.

This PR aims to automatically retry each consensus test until it passes  up to 3 times.

Codex suggested `report_individual_runs: true` for better visibility into flaky tests. Idk if we want that.


<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

