### PR TITLE
test(consensus): ignore flaky consensus integration tests

### DIFF
--- a/integration-tests/tests/consensus_node/mod.rs
+++ b/integration-tests/tests/consensus_node/mod.rs
@@ -260,6 +260,7 @@ async fn consensus_can_be_reenabled_after_clearing_raft_history() -> anyhow::Res
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_cluster_forms_with_three_nodes_and_replicates_blocks() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))
@@ -343,6 +344,7 @@ async fn consensus_cluster_send_raw_transaction_sync_accepts_leader_and_replica(
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_cluster_rotates_leader_after_failure() -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()
         .with_consensus_secret_keys(consensus_test_keys(3))

--- a/integration-tests/tests/consensus_node/restarted_node_catchup.rs
+++ b/integration-tests/tests/consensus_node/restarted_node_catchup.rs
@@ -526,6 +526,7 @@ async fn consensus_restarted_node_catches_up_after_long_transaction_storm() -> a
 }
 
 #[test_log::test(tokio::test)]
+#[ignore = "flaky; @romanbrodetski is working on it"]
 async fn consensus_restarted_node_catches_up_while_transaction_storm_continues()
 -> anyhow::Result<()> {
     let mut cluster = MultiNodeTester::builder()


### PR DESCRIPTION
## Summary
- mark three flaky consensus integration tests as ignored
- reuse the existing consensus flaky-test ignore reason

## Verification
- cargo fmt --all -- --check