### PR TITLE
feat: Support EIP-7702 set-code transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15250,7 +15250,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.1.0#b8ecfb814326afd527a43c84abc96e007a28df05"
+source = "git+https://github.com/matter-labs/zksync-os-revm?branch=use-prague-for-atlasv3#1fdc2863068b3c221a0bc17663f5ab9427972ae2"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15250,7 +15250,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?branch=use-prague-for-atlasv3#1fdc2863068b3c221a0bc17663f5ab9427972ae2"
+source = "git+https://github.com/matter-labs/zksync-os-revm?branch=cancun-7702-no-pectra#a9ed083eede45ecfa81970365da5d2bd93de9d81"
 dependencies = [
  "auto_impl",
  "revm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15915,6 +15915,7 @@ dependencies = [
  "reth-storage-api",
  "reth-trie-common",
  "zksync_os_api",
+ "zksync_os_interface",
  "zksync_os_storage_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ reth-provider = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5d
 reth-rpc-eth-types = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5dbc253019df5b68f4b231f55daeb2e00" }
 reth-tasks = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5dbc253019df5b68f4b231f55daeb2e00" }
 
-zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", branch = "use-prague-for-atlasv3" }
+zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", branch = "cancun-7702-no-pectra" }
 revm = { version = "=38.0.0", features = ["optional_balance_check"] }
 
 # "Local" dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ reth-provider = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5d
 reth-rpc-eth-types = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5dbc253019df5b68f4b231f55daeb2e00" }
 reth-tasks = { git = "https://github.com/itegulov/reth.git", rev = "ff8afdc5dbc253019df5b68f4b231f55daeb2e00" }
 
-zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = "v0.1.0" }
+zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", branch = "use-prague-for-atlasv3" }
 revm = { version = "=38.0.0", features = ["optional_balance_check"] }
 
 # "Local" dependencies

--- a/integration-tests/tests/rpc/call.rs
+++ b/integration-tests/tests/rpc/call.rs
@@ -50,13 +50,14 @@ async fn call_fail(tester: Tester) -> anyhow::Result<()> {
         })
         .expect_to_fail("EIP-4844 transactions are not supported")
         .await;
+    // EIP-7702 transactions are supported, but they require a concrete `to` address.
     tester
         .l2_provider
         .call(TransactionRequest {
             authorization_list: Some(vec![]),
             ..Default::default()
         })
-        .expect_to_fail("EIP-7702 transactions are not supported")
+        .expect_to_fail("EIP-7702 transactions require a `to` address")
         .await;
 
     // Block not found errors

--- a/integration-tests/tests/rpc/eip7702.rs
+++ b/integration-tests/tests/rpc/eip7702.rs
@@ -1,0 +1,127 @@
+use alloy::eips::eip7702::Authorization;
+use alloy::network::{EthereumWallet, TransactionBuilder, TransactionBuilder7702};
+use alloy::primitives::U256;
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::signers::SignerSync;
+use alloy::signers::local::PrivateKeySigner;
+use zksync_os_integration_tests::assert_traits::ReceiptAssert;
+use zksync_os_integration_tests::contracts::Counter;
+use zksync_os_integration_tests::contracts::Counter::CounterInstance;
+use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+
+/// End-to-end test for EIP-7702 (set-code transactions).
+///
+/// 1. A sponsor (the rich wallet) sends a type-0x04 transaction that carries an authorization
+///    signed by a fresh EOA (`authority`) delegating it to a `Counter` contract, and in the same
+///    transaction calls `increment(7)` against the authority. This exercises the full path:
+///    mempool acceptance, authorization-list application by ZKsync OS, and execution of the
+///    delegate's code in the authority's context.
+/// 2. We assert the authority's code is the delegation designator `0xef0100 || counter` and that
+///    the increment wrote to the authority's own storage.
+/// 3. The (now delegated) authority then sends its *own* transaction. This exercises reth's
+///    `validate_sender_bytecode`, which reads the sender's delegation bytecode via
+///    `bytecode_by_hash` and only admits the transaction because the code is an EIP-7702
+///    designator.
+#[test_multisetup([CURRENT_TO_L1])]
+async fn delegate_and_call(tester: Tester) -> anyhow::Result<()> {
+    let provider = tester.l2_provider.clone();
+    let sponsor = tester.l2_wallet.default_signer().address();
+    let chain_id = provider.get_chain_id().await?;
+
+    // Deploy the contract that the EOA will delegate to.
+    let counter = Counter::deploy(provider.clone()).await?;
+    let counter_address = *counter.address();
+
+    // A fresh EOA that will delegate its code. It starts with nonce 0 and no code.
+    let authority_signer = PrivateKeySigner::random();
+    let authority = authority_signer.address();
+    assert!(
+        provider.get_code_at(authority).await?.is_empty(),
+        "authority must start as a plain EOA"
+    );
+
+    // Fund the authority up front so it can later submit its own (delegated) transaction.
+    provider
+        .send_transaction(
+            alloy::rpc::types::TransactionRequest::default()
+                .with_to(authority)
+                .with_value(U256::from(1_000_000_000_000_000_000u64)),
+        )
+        .await?
+        .expect_successful_receipt()
+        .await?;
+
+    // The authority signs an authorization delegating itself to the counter contract.
+    let authorization = Authorization {
+        chain_id: U256::from(chain_id),
+        address: counter_address,
+        nonce: provider.get_transaction_count(authority).await?,
+    };
+    let signature = authority_signer.sign_hash_sync(&authorization.signature_hash())?;
+    let signed_authorization = authorization.into_signed(signature);
+
+    // Sponsored type-0x04 transaction: delegate `authority -> counter` and, in the same tx, call
+    // `increment(7)` against the authority. `from` is the sponsor, so the sponsor pays for gas.
+    let delegate_and_call = counter
+        .increment(U256::from(7))
+        .into_transaction_request()
+        .with_from(sponsor)
+        .with_to(authority)
+        .with_authorization_list(vec![signed_authorization]);
+    provider
+        .send_transaction(delegate_and_call)
+        .await?
+        .expect_successful_receipt()
+        .await?;
+
+    // The authority's code must now be the EIP-7702 delegation designator `0xef0100 || counter`.
+    let code = provider.get_code_at(authority).await?;
+    let mut expected_designator = vec![0xef, 0x01, 0x00];
+    expected_designator.extend_from_slice(counter_address.as_slice());
+    assert_eq!(
+        code.as_ref(),
+        expected_designator.as_slice(),
+        "authority code should be the 7702 delegation designator"
+    );
+
+    // The increment ran in the authority's context, so the counter lives in the authority's
+    // storage (the original counter contract is untouched).
+    let authority_counter = CounterInstance::new(authority, provider.clone());
+    assert_eq!(
+        authority_counter.counter().call().await?,
+        U256::from(7),
+        "increment should have written to the authority's storage"
+    );
+    assert_eq!(
+        counter.counter().call().await?,
+        U256::ZERO,
+        "the delegate contract's own storage must be untouched"
+    );
+
+    // The delegated EOA now submits its OWN transaction. Reth's mempool validator reads its
+    // delegation bytecode (via `bytecode_by_hash`) and admits it precisely because the code is a
+    // 7702 designator. Without that, a sender-with-code would be rejected.
+    let authority_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::new(authority_signer))
+        .connect(tester.l2_rpc_url())
+        .await?;
+    authority_provider
+        .send_transaction(
+            counter
+                .increment(U256::from(5))
+                .into_transaction_request()
+                .with_from(authority)
+                .with_to(authority),
+        )
+        .await?
+        .expect_successful_receipt()
+        .await?;
+
+    assert_eq!(
+        authority_counter.counter().call().await?,
+        U256::from(12),
+        "delegated EOA should be able to send its own transaction and bump its counter"
+    );
+
+    Ok(())
+}

--- a/integration-tests/tests/rpc/eip7702.rs
+++ b/integration-tests/tests/rpc/eip7702.rs
@@ -7,7 +7,7 @@ use alloy::signers::local::PrivateKeySigner;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::Counter;
 use zksync_os_integration_tests::contracts::Counter::CounterInstance;
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, test_multisetup};
 
 /// End-to-end test for EIP-7702 (set-code transactions).
 ///
@@ -22,7 +22,7 @@ use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
 ///    `validate_sender_bytecode`, which reads the sender's delegation bytecode via
 ///    `bytecode_by_hash` and only admits the transaction because the code is an EIP-7702
 ///    designator.
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
 async fn delegate_and_call(tester: Tester) -> anyhow::Result<()> {
     let provider = tester.l2_provider.clone();
     let sponsor = tester.l2_wallet.default_signer().address();

--- a/integration-tests/tests/rpc/eip7702.rs
+++ b/integration-tests/tests/rpc/eip7702.rs
@@ -7,7 +7,7 @@ use alloy::signers::local::PrivateKeySigner;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::Counter;
 use zksync_os_integration_tests::contracts::Counter::CounterInstance;
-use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, test_multisetup};
+use zksync_os_integration_tests::{NEXT_TO_GATEWAY, Tester, test_multisetup};
 
 /// End-to-end test for EIP-7702 (set-code transactions).
 ///
@@ -22,7 +22,10 @@ use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, test_m
 ///    `validate_sender_bytecode`, which reads the sender's delegation bytecode via
 ///    `bytecode_by_hash` and only admits the transaction because the code is an EIP-7702
 ///    designator.
-#[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]
+///
+/// EIP-7702 is a V6/AtlasV3 feature — there are no set-code txs on AtlasV2 (V5), so this only
+/// runs on the V6 setup.
+#[test_multisetup([NEXT_TO_GATEWAY])]
 async fn delegate_and_call(tester: Tester) -> anyhow::Result<()> {
     let provider = tester.l2_provider.clone();
     let sponsor = tester.l2_wallet.default_signer().address();

--- a/integration-tests/tests/rpc/fill_transaction.rs
+++ b/integration-tests/tests/rpc/fill_transaction.rs
@@ -154,6 +154,7 @@ async fn fill_transaction_fail(tester: Tester) -> anyhow::Result<()> {
     )
     .await;
 
+    // EIP-7702 transactions are supported, but they require a concrete `to` address.
     expect_fill_transaction_to_fail(
         &tester,
         TransactionRequest {
@@ -161,7 +162,7 @@ async fn fill_transaction_fail(tester: Tester) -> anyhow::Result<()> {
             authorization_list: Some(vec![]),
             ..Default::default()
         },
-        "EIP-7702 transactions are not supported",
+        "EIP-7702 transactions require a `to` address",
     )
     .await;
 

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -2,6 +2,7 @@ mod api;
 mod call;
 mod debug;
 mod deployment_filter;
+mod eip7702;
 mod fill_transaction;
 mod filter;
 mod policy_client;

--- a/lib/mempool/src/subpools/l2.rs
+++ b/lib/mempool/src/subpools/l2.rs
@@ -149,7 +149,10 @@ pub fn in_memory(
         let chain_spec = zk_provider_factory.chain_spec();
         RethPool::new(
             EthTransactionValidatorBuilder::new(zk_provider_factory, EthEvmConfig::new(chain_spec))
-                .no_prague()
+                // EIP-7702 (set-code) transactions require the Prague fork to be active in the
+                // validator. The builder derives this from the chain spec (Prague-activated in
+                // `ZkProviderFactory`), so we must NOT disable it here. `eip7702` already
+                // defaults to enabled.
                 .with_max_tx_input_bytes(validator_config.max_input_bytes)
                 // set tx_fee_cap to 0, effectively disabling the tx fee checks in the reth mempool
                 // this is necessary to process transactions with more than 1e18 tx fee

--- a/lib/mempool/src/subpools/l2.rs
+++ b/lib/mempool/src/subpools/l2.rs
@@ -149,10 +149,10 @@ pub fn in_memory(
         let chain_spec = zk_provider_factory.chain_spec();
         RethPool::new(
             EthTransactionValidatorBuilder::new(zk_provider_factory, EthEvmConfig::new(chain_spec))
-                // EIP-7702 (set-code) transactions require the Prague fork to be active in the
-                // validator. The builder derives this from the chain spec (Prague-activated in
-                // `ZkProviderFactory`), so we must NOT disable it here. `eip7702` already
-                // defaults to enabled.
+                // Keep Prague active (do not call `.no_prague()`): it gates EIP-7702 acceptance
+                // and the delegated-sender bytecode rule, both required here. Prague also enables
+                // the EIP-7623 calldata-gas floor in the validator's intrinsic-gas check, which
+                // execution keeps off — so the mempool is only ever stricter, never laxer.
                 .with_max_tx_input_bytes(validator_config.max_input_bytes)
                 // set tx_fee_cap to 0, effectively disabling the tx fee checks in the reth mempool
                 // this is necessary to process transactions with more than 1e18 tx fee

--- a/lib/reth_compat/Cargo.toml
+++ b/lib/reth_compat/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 
 [dependencies]
 zksync_os_storage_api.workspace = true
+zksync_os_interface.workspace = true
 
 zk_os_api.workspace = true
 

--- a/lib/reth_compat/src/provider.rs
+++ b/lib/reth_compat/src/provider.rs
@@ -28,6 +28,7 @@ use std::fmt::Debug;
 use std::ops::{RangeBounds, RangeInclusive};
 use std::sync::Arc;
 use zk_os_api::helpers::{get_balance, get_nonce};
+use zksync_os_interface::traits::PreimageSource;
 use zksync_os_storage_api::{ReadRepository, ReadStateHistory, ViewState};
 
 #[derive(Debug, Clone)]
@@ -46,10 +47,13 @@ impl<State: ReadStateHistory, Repository: ReadRepository> ZkProviderFactory<Stat
             .into_parts();
         let builder = ChainSpecBuilder::default()
             .chain(Chain::from(chain_id))
-            // Activate everything up to Cancun
-            // todo: does it make sense to active Cancun if we do not support 4844 transactions?
-            //       maybe drop down to Shanghai?
-            .cancun_activated()
+            // Activate everything up to Prague. Prague (Pectra) is required so that reth's
+            // mempool validator accepts EIP-7702 (set-code) transactions: it only admits type
+            // 0x04 txs when `fork_tracker.is_prague_activated()` is true, which is seeded from
+            // this chain spec. ZKsync OS itself executes 7702 unconditionally via the RLP path,
+            // so activating Prague here only affects mempool admission (this chain spec is not
+            // used for block execution or gas pricing).
+            .prague_activated()
             .genesis(Genesis {
                 // todo: evaluate whether genesis config needs to be tweaked
                 config: ChainConfig::default(),
@@ -161,12 +165,43 @@ impl<State: ReadStateHistory> AccountReader for ZkProvider<State> {
 }
 
 impl<ReadStorage: ReadStateHistory> BytecodeReader for ZkProvider<ReadStorage> {
-    fn bytecode_by_hash(&self, _code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
-        unimplemented!(
-            "reth mempool only calls this for EIP-7702 transactions which we do not support yet"
-        )
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        // reth's mempool validator calls this from `validate_sender_bytecode` once Prague is
+        // active: a sender that has bytecode is only allowed to send transactions if that
+        // bytecode is an EIP-7702 delegation designator (i.e. the account is a delegated EOA).
+        //
+        // ZKsync OS stores a delegation as the 23-byte designator `0xef0100 || address`
+        // (see `EIP7702_DELEGATION_MARKER` in zksync-os), padded with trailing zeroes in the
+        // preimage. revm's 7702 parser requires the bytecode to be *exactly* 23 bytes, so we
+        // trim the padding before constructing it. Regular contract bytecode is returned
+        // verbatim and reth (correctly) rejects such an account as a sender.
+        let mut view = self
+            .state
+            .state_view_at(self.latest_block)
+            .map_err(|_| ProviderError::StateAtBlockPruned(self.latest_block))?;
+        let Some(full_bytecode) = view.get_preimage(*code_hash) else {
+            return Ok(None);
+        };
+        let bytecode = if full_bytecode.len() >= EIP7702_DELEGATION_DESIGNATOR_LEN
+            && full_bytecode.starts_with(&EIP7702_DELEGATION_PREFIX)
+        {
+            Bytecode::new_raw_checked(Bytes::copy_from_slice(
+                &full_bytecode[..EIP7702_DELEGATION_DESIGNATOR_LEN],
+            ))
+            .map_err(ProviderError::other)?
+        } else {
+            Bytecode::new_raw(full_bytecode.into())
+        };
+        Ok(Some(bytecode))
     }
 }
+
+/// First three bytes of an EIP-7702 delegation designator: the `0xef01` magic followed by the
+/// version byte `0x00`. Matches `EIP7702_DELEGATION_MARKER` used by ZKsync OS when installing
+/// delegation code.
+const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
+/// Full length of an EIP-7702 delegation designator: 3-byte prefix + 20-byte address.
+const EIP7702_DELEGATION_DESIGNATOR_LEN: usize = 23;
 
 //
 //

--- a/lib/reth_compat/src/provider.rs
+++ b/lib/reth_compat/src/provider.rs
@@ -29,7 +29,9 @@ use std::ops::{RangeBounds, RangeInclusive};
 use std::sync::Arc;
 use zk_os_api::helpers::{get_balance, get_nonce};
 use zksync_os_interface::traits::PreimageSource;
-use zksync_os_storage_api::{ReadRepository, ReadStateHistory, ViewState};
+use zksync_os_storage_api::{
+    ReadRepository, ReadStateHistory, ViewState, eip7702_delegation_designator,
+};
 
 #[derive(Debug, Clone)]
 pub struct ZkProviderFactory<State, Repository> {
@@ -166,15 +168,10 @@ impl<State: ReadStateHistory> AccountReader for ZkProvider<State> {
 
 impl<ReadStorage: ReadStateHistory> BytecodeReader for ZkProvider<ReadStorage> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
-        // reth's mempool validator calls this from `validate_sender_bytecode` once Prague is
-        // active: a sender that has bytecode is only allowed to send transactions if that
-        // bytecode is an EIP-7702 delegation designator (i.e. the account is a delegated EOA).
-        //
-        // ZKsync OS stores a delegation as the 23-byte designator `0xef0100 || address`
-        // (see `EIP7702_DELEGATION_MARKER` in zksync-os), padded with trailing zeroes in the
-        // preimage. revm's 7702 parser requires the bytecode to be *exactly* 23 bytes, so we
-        // trim the padding before constructing it. Regular contract bytecode is returned
-        // verbatim and reth (correctly) rejects such an account as a sender.
+        // Called from reth's `validate_sender_bytecode` once Prague is active: a sender with
+        // bytecode may only send txs if that bytecode is a 7702 delegation designator. The
+        // designator must be trimmed to exactly 23 bytes; regular bytecode is returned verbatim
+        // (and reth rejects such a sender).
         let mut view = self
             .state
             .state_view_at(self.latest_block)
@@ -182,26 +179,14 @@ impl<ReadStorage: ReadStateHistory> BytecodeReader for ZkProvider<ReadStorage> {
         let Some(full_bytecode) = view.get_preimage(*code_hash) else {
             return Ok(None);
         };
-        let bytecode = if full_bytecode.len() >= EIP7702_DELEGATION_DESIGNATOR_LEN
-            && full_bytecode.starts_with(&EIP7702_DELEGATION_PREFIX)
-        {
-            Bytecode::new_raw_checked(Bytes::copy_from_slice(
-                &full_bytecode[..EIP7702_DELEGATION_DESIGNATOR_LEN],
-            ))
-            .map_err(ProviderError::other)?
-        } else {
-            Bytecode::new_raw(full_bytecode.into())
+        let bytecode = match eip7702_delegation_designator(&full_bytecode) {
+            Some(designator) => Bytecode::new_raw_checked(Bytes::copy_from_slice(designator))
+                .map_err(ProviderError::other)?,
+            None => Bytecode::new_raw(full_bytecode.into()),
         };
         Ok(Some(bytecode))
     }
 }
-
-/// First three bytes of an EIP-7702 delegation designator: the `0xef01` magic followed by the
-/// version byte `0x00`. Matches `EIP7702_DELEGATION_MARKER` used by ZKsync OS when installing
-/// delegation code.
-const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
-/// Full length of an EIP-7702 delegation designator: 3-byte prefix + 20-byte address.
-const EIP7702_DELEGATION_DESIGNATOR_LEN: usize = 23;
 
 //
 //

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -244,17 +244,20 @@ where
                         let mut skip_block = false;
                         for tx in txs {
                             if let Err(err) = evm.transact_commit(tx) {
-                                // The checker's revm fork targets Cancun and cannot validate
-                                // EIP-7702 (set-code) transactions, which require Prague. ZKsync OS
-                                // applies them natively, so skip the block rather than tearing down
-                                // the pipeline. Any other execution error is a genuine bug and is
-                                // still propagated.
+                                // Pre-Prague specs (AtlasV1/V2, i.e. execution versions <= V5)
+                                // can't validate EIP-7702 (set-code) transactions, which revm only
+                                // accepts under Prague. The V5 zksync-os binary applies 7702 but
+                                // otherwise keeps the AtlasV2 fee model, so no stock revm spec
+                                // re-executes such a block faithfully — skip it rather than tearing
+                                // down the pipeline. 7702 blocks are fully checked once they reach
+                                // V6 (AtlasV3 -> Prague). Genuine execution errors are still
+                                // propagated.
                                 if is_unsupported_tx_type(&err) {
                                     PUSH_METRICS.revm_blocks_skipped.inc();
                                     tracing::warn!(
                                         block_number = replay_record.block_context.block_number,
                                         "Skipping REVM consistency check for block, transaction type \
-                                         unsupported by the checker's revm: {err}"
+                                         unsupported by the checker's revm spec: {err}"
                                     );
                                     skip_block = true;
                                     break;
@@ -295,11 +298,11 @@ where
     }
 }
 
-/// Whether a revm execution error is a transaction type the checker's revm cannot validate.
+/// Whether a revm execution error is a transaction type the checker's revm spec cannot validate.
 ///
-/// The checker runs against a Cancun-targeted revm fork, so EIP-7702 (set-code) transactions —
-/// which require Prague — are rejected up front with `Eip7702NotSupported`. Such blocks are
-/// skipped instead of failing the pipeline; every other error is treated as a real divergence.
+/// Pre-Prague specs (AtlasV1/V2) reject EIP-7702 (set-code) transactions up front with
+/// `Eip7702NotSupported`. Blocks containing such a tx are skipped rather than failing the
+/// pipeline; every other error is treated as a real divergence.
 fn is_unsupported_tx_type<DBError>(err: &EVMError<DBError, ZKsyncTxError>) -> bool {
     matches!(
         err,

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use revm::ExecuteCommitEvm;
 use revm::context::ContextTr;
 use revm::context_interface::block::BlobExcessGasAndPrice;
+use revm::context_interface::result::{EVMError, InvalidTransaction};
 use revm::database::{CacheDB, EmptyDB};
 use ruint::aliases::B160;
 use std::collections::HashSet;
@@ -16,7 +17,7 @@ use zk_ee::utils::Bytes32;
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
-use zksync_os_revm::{DefaultZk, ZkBuilder, ZkContext, ZkSpecId};
+use zksync_os_revm::{DefaultZk, ZKsyncTxError, ZkBuilder, ZkContext, ZkSpecId};
 use zksync_os_sequencer::model::blocks::AppliedBlock;
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord, ViewState};
 use zksync_os_types::{BlockOutput, ExecutionVersion, SYSTEM_CONTEXT_ADDRESS};
@@ -240,16 +241,36 @@ where
                 match revm_txs {
                     Ok(txs) => {
                         // Commit after each tx
+                        let mut skip_block = false;
                         for tx in txs {
-                            evm.transact_commit(tx)?;
+                            if let Err(err) = evm.transact_commit(tx) {
+                                // The checker's revm fork targets Cancun and cannot validate
+                                // EIP-7702 (set-code) transactions, which require Prague. ZKsync OS
+                                // applies them natively, so skip the block rather than tearing down
+                                // the pipeline. Any other execution error is a genuine bug and is
+                                // still propagated.
+                                if is_unsupported_tx_type(&err) {
+                                    PUSH_METRICS.revm_blocks_skipped.inc();
+                                    tracing::warn!(
+                                        block_number = replay_record.block_context.block_number,
+                                        "Skipping REVM consistency check for block, transaction type \
+                                         unsupported by the checker's revm: {err}"
+                                    );
+                                    skip_block = true;
+                                    break;
+                                }
+                                return Err(err.into());
+                            }
                         }
 
-                        let compare_report = CompareReport::build(
-                            evm.0.db_mut(),
-                            &block_output.storage_writes,
-                            &block_output.account_diffs,
-                        )?;
-                        self.handle_report(block_output, &replay_record, &compare_report)?;
+                        if !skip_block {
+                            let compare_report = CompareReport::build(
+                                evm.0.db_mut(),
+                                &block_output.storage_writes,
+                                &block_output.account_diffs,
+                            )?;
+                            self.handle_report(block_output, &replay_record, &compare_report)?;
+                        }
                     }
                     Err(err) => {
                         // Tx conversion failed (e.g. malformed envelope) — skip
@@ -272,6 +293,18 @@ where
             )?;
         }
     }
+}
+
+/// Whether a revm execution error is a transaction type the checker's revm cannot validate.
+///
+/// The checker runs against a Cancun-targeted revm fork, so EIP-7702 (set-code) transactions —
+/// which require Prague — are rejected up front with `Eip7702NotSupported`. Such blocks are
+/// skipped instead of failing the pipeline; every other error is treated as a real divergence.
+fn is_unsupported_tx_type<DBError>(err: &EVMError<DBError, ZKsyncTxError>) -> bool {
+    matches!(
+        err,
+        EVMError::Transaction(ZKsyncTxError::Base(InvalidTransaction::Eip7702NotSupported))
+    )
 }
 
 /// Read the settlement layer chain id from `SYSTEM_CONTEXT_ADDRESS`, slot 0.

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use revm::ExecuteCommitEvm;
 use revm::context::ContextTr;
 use revm::context_interface::block::BlobExcessGasAndPrice;
-use revm::context_interface::result::{EVMError, InvalidTransaction};
 use revm::database::{CacheDB, EmptyDB};
 use ruint::aliases::B160;
 use std::collections::HashSet;
@@ -17,7 +16,7 @@ use zk_ee::utils::Bytes32;
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
-use zksync_os_revm::{DefaultZk, ZKsyncTxError, ZkBuilder, ZkContext, ZkSpecId};
+use zksync_os_revm::{DefaultZk, ZkBuilder, ZkContext, ZkSpecId};
 use zksync_os_sequencer::model::blocks::AppliedBlock;
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord, ViewState};
 use zksync_os_types::{BlockOutput, ExecutionVersion, SYSTEM_CONTEXT_ADDRESS};
@@ -241,39 +240,16 @@ where
                 match revm_txs {
                     Ok(txs) => {
                         // Commit after each tx
-                        let mut skip_block = false;
                         for tx in txs {
-                            if let Err(err) = evm.transact_commit(tx) {
-                                // Pre-Prague specs (AtlasV1/V2, i.e. execution versions <= V5)
-                                // can't validate EIP-7702 (set-code) transactions, which revm only
-                                // accepts under Prague. The V5 zksync-os binary applies 7702 but
-                                // otherwise keeps the AtlasV2 fee model, so no stock revm spec
-                                // re-executes such a block faithfully — skip it rather than tearing
-                                // down the pipeline. 7702 blocks are fully checked once they reach
-                                // V6 (AtlasV3 -> Prague). Genuine execution errors are still
-                                // propagated.
-                                if is_unsupported_tx_type(&err) {
-                                    PUSH_METRICS.revm_blocks_skipped.inc();
-                                    tracing::warn!(
-                                        block_number = replay_record.block_context.block_number,
-                                        "Skipping REVM consistency check for block, transaction type \
-                                         unsupported by the checker's revm spec: {err}"
-                                    );
-                                    skip_block = true;
-                                    break;
-                                }
-                                return Err(err.into());
-                            }
+                            evm.transact_commit(tx)?;
                         }
 
-                        if !skip_block {
-                            let compare_report = CompareReport::build(
-                                evm.0.db_mut(),
-                                &block_output.storage_writes,
-                                &block_output.account_diffs,
-                            )?;
-                            self.handle_report(block_output, &replay_record, &compare_report)?;
-                        }
+                        let compare_report = CompareReport::build(
+                            evm.0.db_mut(),
+                            &block_output.storage_writes,
+                            &block_output.account_diffs,
+                        )?;
+                        self.handle_report(block_output, &replay_record, &compare_report)?;
                     }
                     Err(err) => {
                         // Tx conversion failed (e.g. malformed envelope) — skip
@@ -296,18 +272,6 @@ where
             )?;
         }
     }
-}
-
-/// Whether a revm execution error is a transaction type the checker's revm spec cannot validate.
-///
-/// Pre-Prague specs (AtlasV1/V2) reject EIP-7702 (set-code) transactions up front with
-/// `Eip7702NotSupported`. Blocks containing such a tx are skipped rather than failing the
-/// pipeline; every other error is treated as a real divergence.
-fn is_unsupported_tx_type<DBError>(err: &EVMError<DBError, ZKsyncTxError>) -> bool {
-    matches!(
-        err,
-        EVMError::Transaction(ZKsyncTxError::Base(InvalidTransaction::Eip7702NotSupported))
-    )
 }
 
 /// Read the settlement layer chain id from `SYSTEM_CONTEXT_ADDRESS`, slot 0.

--- a/lib/revm_consistency_checker/src/revm_state_provider.rs
+++ b/lib/revm_consistency_checker/src/revm_state_provider.rs
@@ -8,35 +8,20 @@ use revm::state::{AccountInfo, Bytecode};
 use ruint::aliases::B160;
 use zk_ee::common_structs::derive_flat_storage_key;
 use zk_ee::utils::Bytes32;
-use zksync_os_storage_api::{BlockHashes, ViewState};
+use zksync_os_storage_api::{BlockHashes, ViewState, eip7702_delegation_designator};
 
 fn fixed_bytes_to_bytes32(x: B256) -> Bytes32 {
     let x: [u8; 32] = x.into();
     x.into()
 }
 
-/// First three bytes of an EIP-7702 delegation designator: the `0xef01` magic followed by the
-/// version byte `0x00`.
-const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
-/// Full length of an EIP-7702 delegation designator: 3-byte prefix + 20-byte address.
-const EIP7702_DELEGATION_DESIGNATOR_LEN: usize = 23;
-
-/// Build a revm [`Bytecode`] from a ZKsync OS preimage.
-///
-/// ZKsync OS stores an EIP-7702 delegation as the 23-byte designator `0xef0100 || address`
-/// padded with trailing zeroes; revm's 7702 parser requires *exactly* 23 bytes, so the padding
-/// is trimmed and the designator is parsed as a proper delegation (so revm follows it on call).
-/// Regular contract bytecode (code + padding + artifacts) is wrapped verbatim.
+/// Build a revm [`Bytecode`] from a ZKsync OS preimage. A 7702 delegation designator is trimmed
+/// to its 23 bytes (so revm follows the delegation); regular bytecode is wrapped verbatim.
 fn bytecode_from_preimage(full_bytecode: &[u8]) -> Bytecode {
-    if full_bytecode.len() >= EIP7702_DELEGATION_DESIGNATOR_LEN
-        && full_bytecode.starts_with(&EIP7702_DELEGATION_PREFIX)
-    {
-        Bytecode::new_raw_checked(Bytes::copy_from_slice(
-            &full_bytecode[..EIP7702_DELEGATION_DESIGNATOR_LEN],
-        ))
-        .expect("valid EIP-7702 delegation designator")
-    } else {
-        Bytecode::new_raw(Bytes::copy_from_slice(full_bytecode))
+    match eip7702_delegation_designator(full_bytecode) {
+        Some(designator) => Bytecode::new_raw_checked(Bytes::copy_from_slice(designator))
+            .expect("valid EIP-7702 delegation designator"),
+        None => Bytecode::new_raw(Bytes::copy_from_slice(full_bytecode)),
     }
 }
 

--- a/lib/revm_consistency_checker/src/revm_state_provider.rs
+++ b/lib/revm_consistency_checker/src/revm_state_provider.rs
@@ -1,6 +1,7 @@
 use crate::helpers::get_unpadded_code;
-use alloy::primitives::{Address, B256, KECCAK256_EMPTY};
+use alloy::primitives::{Address, B256, Bytes, KECCAK256_EMPTY};
 use revm::DatabaseRef;
+use revm::bytecode::BytecodeKind;
 use revm::database_interface::DBErrorMarker;
 use revm::primitives::{StorageKey, StorageValue};
 use revm::state::{AccountInfo, Bytecode};
@@ -12,6 +13,31 @@ use zksync_os_storage_api::{BlockHashes, ViewState};
 fn fixed_bytes_to_bytes32(x: B256) -> Bytes32 {
     let x: [u8; 32] = x.into();
     x.into()
+}
+
+/// First three bytes of an EIP-7702 delegation designator: the `0xef01` magic followed by the
+/// version byte `0x00`.
+const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
+/// Full length of an EIP-7702 delegation designator: 3-byte prefix + 20-byte address.
+const EIP7702_DELEGATION_DESIGNATOR_LEN: usize = 23;
+
+/// Build a revm [`Bytecode`] from a ZKsync OS preimage.
+///
+/// ZKsync OS stores an EIP-7702 delegation as the 23-byte designator `0xef0100 || address`
+/// padded with trailing zeroes; revm's 7702 parser requires *exactly* 23 bytes, so the padding
+/// is trimmed and the designator is parsed as a proper delegation (so revm follows it on call).
+/// Regular contract bytecode (code + padding + artifacts) is wrapped verbatim.
+fn bytecode_from_preimage(full_bytecode: &[u8]) -> Bytecode {
+    if full_bytecode.len() >= EIP7702_DELEGATION_DESIGNATOR_LEN
+        && full_bytecode.starts_with(&EIP7702_DELEGATION_PREFIX)
+    {
+        Bytecode::new_raw_checked(Bytes::copy_from_slice(
+            &full_bytecode[..EIP7702_DELEGATION_DESIGNATOR_LEN],
+        ))
+        .expect("valid EIP-7702 delegation designator")
+    } else {
+        Bytecode::new_raw(Bytes::copy_from_slice(full_bytecode))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -70,7 +96,17 @@ where
                 } else {
                     let bytecode =
                         self.code_by_hash_ref(B256::from(props.bytecode_hash.as_u8_array()))?;
-                    Some(get_unpadded_code(bytecode.bytes_slice(), &props))
+                    Some(match bytecode.kind() {
+                        // A delegation designator is already exactly the 23-byte code; keep it as a
+                        // 7702 bytecode so revm follows the delegation instead of executing
+                        // `0xef01..` as legacy opcodes.
+                        BytecodeKind::Eip7702 => bytecode,
+                        // Legacy preimages still carry padding + artifacts; trim to the unpadded
+                        // code the EVM actually runs.
+                        BytecodeKind::LegacyAnalyzed => {
+                            get_unpadded_code(bytecode.bytes_slice(), &props)
+                        }
+                    })
                 };
 
                 Ok(AccountInfo {
@@ -90,7 +126,7 @@ where
             .state_view
             .clone()
             .get_preimage(code_hash)
-            .map(|bytes| Bytecode::new_raw(bytes.into()))
+            .map(|bytes| bytecode_from_preimage(&bytes))
             .unwrap_or_default())
     }
 

--- a/lib/revm_consistency_checker/src/storage_diff_comp.rs
+++ b/lib/revm_consistency_checker/src/storage_diff_comp.rs
@@ -266,12 +266,13 @@ where
             if code.is_empty() {
                 B256::ZERO
             } else {
+                // Both kinds expose the original (unpadded) code via `original_byte_slice()`:
+                // legacy contract code, or the 23-byte EIP-7702 designator `0xef0100 || address`.
+                // `set_properties_code` detects the delegation marker and reproduces ZKsync OS's
+                // canonical hash for either case, so the same path works for both.
                 match code.kind() {
-                    BytecodeKind::LegacyAnalyzed => calculate_bytecode_hash(code),
-                    BytecodeKind::Eip7702 => {
-                        return Err(anyhow::anyhow!(
-                            "EIP-7702 bytecode is not supported on Consistency Checker"
-                        ));
+                    BytecodeKind::LegacyAnalyzed | BytecodeKind::Eip7702 => {
+                        calculate_bytecode_hash(code)
                     }
                 }
             }

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -6,7 +6,7 @@ use crate::result::RevertError;
 use crate::rpc_storage::{ReadRpcStorage, RpcStorageError};
 use crate::sandbox::{call_trace_simulate, execute, execute_with};
 use alloy::consensus::transaction::Recovered;
-use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy, TxType};
+use alloy::consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy, TxType};
 use alloy::eips::BlockId;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256};
@@ -136,8 +136,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             blob_versioned_hashes: _,
             max_fee_per_blob_gas: _,
             sidecar: _,
-            // todo(EIP-7702)
-            authorization_list: _,
+            authorization_list,
             // EIP-2718 transaction type - ignored
             transaction_type: _,
         } = request;
@@ -250,7 +249,27 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 return Err(EthCallError::Eip4844NotSupported);
             }
             TxType::Eip7702 => {
-                return Err(EthCallError::Eip7702NotSupported);
+                // EIP-7702 transactions must have a concrete `to` address (the bootloader
+                // rejects a create-style 7702 tx). Note we use `unwrap_or_default()` for the
+                // priority fee rather than requiring it: an `authorization_list` forces the
+                // minimal tx type to 7702, so a fee-less `eth_estimateGas`/`eth_fillTransaction`
+                // request must still build successfully.
+                let to = to.into_to().ok_or(EthCallError::Eip7702RequiresToAddress)?;
+                L2Envelope::from(
+                    TxEip7702 {
+                        chain_id,
+                        nonce,
+                        gas_limit,
+                        max_fee_per_gas: gas_price,
+                        max_priority_fee_per_gas: max_priority_fee_per_gas.unwrap_or_default(),
+                        to,
+                        value,
+                        input,
+                        access_list: access_list.unwrap_or_default(),
+                        authorization_list: authorization_list.unwrap_or_default(),
+                    }
+                    .into_signed(signature),
+                )
             }
         };
         Ok(Recovered::new_unchecked(tx, from).into())
@@ -749,9 +768,8 @@ pub enum EthCallError {
     // todo(EIP-4844)
     #[error("EIP-4844 transactions are not supported")]
     Eip4844NotSupported,
-    // todo(EIP-7702)
-    #[error("EIP-7702 transactions are not supported")]
-    Eip7702NotSupported,
+    #[error("EIP-7702 transactions require a `to` address")]
+    Eip7702RequiresToAddress,
     #[error("upgrade transactions cannot be estimated")]
     UpgradeTxNotEstimatable,
     #[error("system transactions cannot be estimated")]

--- a/lib/rpc/src/eth_fill_transaction_handler.rs
+++ b/lib/rpc/src/eth_fill_transaction_handler.rs
@@ -18,9 +18,6 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         if request.has_eip4844_fields() {
             return Err(EthCallError::Eip4844NotSupported);
         }
-        if request.authorization_list.is_some() {
-            return Err(EthCallError::Eip7702NotSupported);
-        }
         if request.gas_price.is_some()
             && (request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some())
         {
@@ -63,10 +60,18 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let mut tx = self
             .create_tx_from_request(request, &block_context, false)?
             .into_envelope();
-        if let (Some(max_fee_per_gas), ZkEnvelope::L2(L2Envelope::Eip1559(inner))) =
-            (max_fee_per_gas, &mut tx)
-        {
-            inner.tx_mut().max_fee_per_gas = max_fee_per_gas;
+        // `create_tx_from_request` sets `max_fee_per_gas` to the *effective* gas price; restore
+        // the caller's requested fee cap on the returned (dynamic-fee) transaction.
+        if let Some(max_fee_per_gas) = max_fee_per_gas {
+            match &mut tx {
+                ZkEnvelope::L2(L2Envelope::Eip1559(inner)) => {
+                    inner.tx_mut().max_fee_per_gas = max_fee_per_gas;
+                }
+                ZkEnvelope::L2(L2Envelope::Eip7702(inner)) => {
+                    inner.tx_mut().max_fee_per_gas = max_fee_per_gas;
+                }
+                _ => {}
+            }
         }
         let raw = tx.encoded_2718().into();
         Ok(FillTransaction { raw, tx })

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -146,6 +146,7 @@ impl<Ok> ToRpcResult<Ok, EthCallError> for Result<Ok, EthCallError> {
                 None,
             ),
             EthCallError::CallFees(_) => invalid_params_rpc_err(err.to_string()),
+            EthCallError::Eip7702RequiresToAddress => invalid_params_rpc_err(err.to_string()),
             EthCallError::Storage(RpcStorageError::BlockNotFound(_)) => {
                 invalid_params_rpc_err(err.to_string())
             }

--- a/lib/storage_api/src/lib.rs
+++ b/lib/storage_api/src/lib.rs
@@ -23,7 +23,9 @@ pub use repository::{
 };
 
 mod state;
-pub use state::{ReadStateHistory, StateError, StateResult, ViewState, WriteState};
+pub use state::{
+    ReadStateHistory, StateError, StateResult, ViewState, WriteState, eip7702_delegation_designator,
+};
 
 pub mod state_override_view;
 pub use state_override_view::OverriddenStateView;

--- a/lib/storage_api/src/state.rs
+++ b/lib/storage_api/src/state.rs
@@ -61,6 +61,21 @@ pub trait WriteState: Send + Sync + 'static {
         J: IntoIterator<Item = (B256, &'a Vec<u8>)>;
 }
 
+/// First three bytes of an EIP-7702 delegation designator: `0xef01` magic + version `0x00`.
+/// Matches `EIP7702_DELEGATION_MARKER` in ZKsync OS.
+const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
+/// Full designator length: 3-byte prefix + 20-byte address.
+const EIP7702_DELEGATION_DESIGNATOR_LEN: usize = 23;
+
+/// If `preimage` starts with a delegation designator, returns the exact 23-byte designator;
+/// ZKsync OS stores it padded with trailing zeroes, but revm's 7702 parser requires exactly
+/// 23 bytes. Returns `None` for regular bytecode.
+pub fn eip7702_delegation_designator(preimage: &[u8]) -> Option<&[u8]> {
+    (preimage.len() >= EIP7702_DELEGATION_DESIGNATOR_LEN
+        && preimage.starts_with(&EIP7702_DELEGATION_PREFIX))
+    .then(|| &preimage[..EIP7702_DELEGATION_DESIGNATOR_LEN])
+}
+
 /// State reader result type.
 pub type StateResult<Ok> = Result<Ok, StateError>;
 

--- a/lib/types/src/transaction/l2.rs
+++ b/lib/types/src/transaction/l2.rs
@@ -406,3 +406,67 @@ impl From<TxType> for alloy::consensus::TxType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::eips::eip2718::{Decodable2718, Encodable2718};
+    use alloy::eips::eip2930::AccessList;
+    use alloy::eips::eip7702::Authorization;
+    use alloy::primitives::{Bytes, U256, address};
+
+    /// EIP-7702 transactions must round-trip through the EIP-2718 (`0x04 || rlp(...)`) encoding
+    /// that ZKsync OS parses on the execution side. This locks the wire format — including the
+    /// authorization list — that the bootloader's `EIP7702Tx` decoder depends on.
+    #[test]
+    fn eip7702_encode_decode_2718_round_trip() {
+        let authorization = Authorization {
+            chain_id: U256::from(1u64),
+            address: address!("0x1111111111111111111111111111111111111111"),
+            nonce: 7,
+        };
+        let signed_authorization =
+            authorization.into_signed(Signature::new(U256::from(1u64), U256::from(2u64), false));
+
+        let tx = TxEip7702 {
+            chain_id: 271,
+            nonce: 3,
+            gas_limit: 100_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000,
+            to: address!("0x2222222222222222222222222222222222222222"),
+            value: U256::from(42u64),
+            access_list: AccessList::default(),
+            authorization_list: vec![signed_authorization],
+            input: Bytes::from_static(&[0xab, 0xcd]),
+        };
+        let envelope = L2Envelope::Eip7702(tx.into_signed(Signature::new(
+            U256::from(3u64),
+            U256::from(4u64),
+            false,
+        )));
+
+        let encoded = envelope.encoded_2718();
+        assert_eq!(encoded[0], 0x04, "type byte must be 0x04 for EIP-7702");
+
+        let decoded = L2Envelope::decode_2718(&mut encoded.as_slice()).expect("decode 7702");
+        let signed = match &decoded {
+            L2Envelope::Eip7702(signed) => signed,
+            other => panic!("expected Eip7702, got {other:?}"),
+        };
+        assert_eq!(
+            signed.tx().to,
+            address!("0x2222222222222222222222222222222222222222")
+        );
+        assert_eq!(signed.tx().value, U256::from(42u64));
+        assert_eq!(signed.tx().nonce, 3);
+        assert_eq!(signed.tx().chain_id, 271);
+        assert_eq!(signed.tx().authorization_list.len(), 1);
+        assert_eq!(
+            signed.tx().authorization_list[0].address,
+            address!("0x1111111111111111111111111111111111111111")
+        );
+        // Full byte-for-byte round trip.
+        assert_eq!(decoded.encoded_2718(), encoded);
+    }
+}


### PR DESCRIPTION
## Summary

Accept and execute type-0x04 (set-code) transactions end-to-end: keep Prague active in the L2 mempool validator so authorization lists are applied, require a concrete `to` address for 7702 txs in call / fill_transaction handlers, and validate delegated-sender bytecode. Adds an end-to-end integration test covering delegate-and-call plus a delegated EOA submitting its own transaction.


<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

