### PR TITLE
perf(merkle-tree): Move read proof generation to PIG

### DIFF
--- a/lib/batch_types/src/block_merkle_tree_data.rs
+++ b/lib/batch_types/src/block_merkle_tree_data.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::B256;
-use zksync_os_merkle_tree_api::{BatchTreeProof, TreeBatchOutput, TreeOperation};
+use zksync_os_merkle_tree_api::{BatchTreeProof, TreeBatchOutput};
 
 /// Data necessary for the Merkle tree to produce a self-contained proof of batch storage update
 /// as a result of block execution. This proof is then used by the proof input generator.
@@ -15,25 +15,7 @@ pub struct BlockMerkleTreeData {
     /// Unique storage slots read, but not written to, during block execution. The order matches to the order of read ops
     /// in [`Self.proof`].
     pub read_keys: Vec<B256>,
-    /// Batch proof of the storage update.
+    /// Batch proof of the storage update. Only proves a proof of `written_keys`. The proof for `read_keys`
+    /// is obtained asynchronously.
     pub proof: BatchTreeProof,
-}
-
-impl BlockMerkleTreeData {
-    pub fn keys_and_ops(&self) -> impl Iterator<Item = (B256, TreeOperation)> {
-        assert_eq!(self.proof.operations.len(), self.written_keys.len());
-        assert_eq!(self.proof.read_operations.len(), self.read_keys.len());
-
-        let written = self
-            .written_keys
-            .iter()
-            .copied()
-            .zip(self.proof.operations.iter().copied());
-        let read = self
-            .read_keys
-            .iter()
-            .copied()
-            .zip(self.proof.read_operations.iter().copied());
-        written.chain(read)
-    }
 }

--- a/lib/merkle_tree_api/src/flat.rs
+++ b/lib/merkle_tree_api/src/flat.rs
@@ -140,15 +140,19 @@ impl BatchTreeProof {
         leaf_count_before_update: u64,
     ) -> impl Iterator<Item = ((u8, u64), B256)> {
         let mut sibling_hashes = vec![];
-        Self::zip_leaves(
-            &Blake2Hasher,
-            tree_depth,
-            leaf_count_before_update,
-            self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
-            self.hashes.iter(),
-            Some(&mut sibling_hashes),
-        )
-        .expect("invalid batch tree proof");
+
+        // `zip_leaves` will error if `sorted_leaves` are empty, which can be handled correctly in this context.
+        if !self.sorted_leaves.is_empty() {
+            Self::zip_leaves(
+                &Blake2Hasher,
+                tree_depth,
+                leaf_count_before_update,
+                self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
+                self.hashes.iter(),
+                Some(&mut sibling_hashes),
+            )
+            .expect("invalid batch tree proof");
+        }
 
         sibling_hashes
             .into_iter()

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -203,6 +203,11 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> ProverInputGenerator<
     }
 }
 
+#[tracing::instrument(
+    level = "debug",
+    skip_all,
+    fields(block_number = replay_record.block_context.block_number)
+)]
 fn compute_prover_input(
     replay_record: &ReplayRecord,
     state_handle: impl ReadStateHistory,
@@ -219,10 +224,20 @@ fn compute_prover_input(
         .map(|tx| tx.clone().encode())
         .collect::<VecDeque<_>>();
 
-    // FIXME: measure as a separate stage?
+    PROVER_INPUT_GENERATOR_METRICS
+        .batch_proof_read_keys
+        .observe(tree_view.read_keys.len());
+    let read_proof_latency =
+        PROVER_INPUT_GENERATOR_METRICS.prover_input_generation[&"read_proof"].start();
     let read_proof = versioned_tree
         .get_proof(&tree_view.read_keys)
         .expect("cannot get batch proof for read tree keys");
+    let read_proof_latency = read_proof_latency.observe();
+    tracing::debug!(
+        read_keys.len = tree_view.read_keys.len(),
+        ?read_proof_latency,
+        "generated read proof"
+    );
 
     let prover_input_generation_latency =
         PROVER_INPUT_GENERATOR_METRICS.prover_input_generation[&"prover_input_generation"].start();
@@ -325,6 +340,7 @@ fn compute_prover_input(
 }
 
 const LEN_BUCKETS: Buckets = Buckets::exponential(1.0..=1000.0, 2.0);
+const LARGE_LEN_BUCKETS: Buckets = Buckets::exponential(10.0..=10_000.0, 2.0);
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.001..=30.0, 2.0);
 
 #[derive(Debug, Metrics)]
@@ -332,6 +348,15 @@ const LATENCIES_FAST: Buckets = Buckets::exponential(0.001..=30.0, 2.0);
 struct ProverInputGeneratorMetrics {
     #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = LATENCIES_FAST)]
     prover_input_generation: LabeledFamily<&'static str, Histogram<Duration>>,
+    /// Number of distinct tree entries read (but not written) per block.
+    #[metrics(buckets = LEN_BUCKETS)]
+    batch_proof_read_keys: Histogram<usize>,
+    /// Number of sorted leaves included in the batch update proof for a single block.
+    #[metrics(buckets = LEN_BUCKETS)]
+    batch_proof_sorted_leaves: Histogram<usize>,
+    /// Number of intermediate (aka sibling) hashes included in the batch update proof for a single block.
+    #[metrics(buckets = LARGE_LEN_BUCKETS)]
+    batch_proof_hashes: Histogram<usize>,
     /// Number of unexpected existing storage slots queried per block. Positive values are abnormal.
     #[metrics(buckets = LEN_BUCKETS)]
     unexpected_queried_keys: Histogram<usize>,

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -219,6 +219,11 @@ fn compute_prover_input(
         .map(|tx| tx.clone().encode())
         .collect::<VecDeque<_>>();
 
+    // FIXME: measure as a separate stage?
+    let read_proof = versioned_tree
+        .get_proof(&tree_view.read_keys)
+        .expect("cannot get batch proof for read tree keys");
+
     let prover_input_generation_latency =
         PROVER_INPUT_GENERATOR_METRICS.prover_input_generation[&"prover_input_generation"].start();
     let proving_version = ProvingVersion::try_from(replay_record.protocol_version.clone())
@@ -263,7 +268,7 @@ fn compute_prover_input(
                     last_block_timestamp: replay_record.previous_block_timestamp,
                 },
                 da_commitment_scheme,
-                TreeOutputAdapter::new(tree_view).with_fallback(versioned_tree),
+                TreeOutputAdapter::new(tree_view, read_proof).with_fallback(versioned_tree),
                 state_view,
                 list_source,
             )
@@ -301,7 +306,7 @@ fn compute_prover_input(
                     last_block_timestamp: replay_record.previous_block_timestamp,
                 },
                 da_commitment_scheme,
-                TreeOutputAdapter::new(tree_view).with_fallback(versioned_tree),
+                TreeOutputAdapter::new(tree_view, read_proof).with_fallback(versioned_tree),
                 state_view,
                 list_source,
             )

--- a/node/bin/src/prover_input_generator/tree_adapter.rs
+++ b/node/bin/src/prover_input_generator/tree_adapter.rs
@@ -1,5 +1,6 @@
 use super::PROVER_INPUT_GENERATOR_METRICS;
 use alloy::primitives::B256;
+use anyhow::Context;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::thread;
 use zk_ee::utils::Bytes32;
@@ -8,8 +9,8 @@ use zk_os_basic_system_prev::system_implementation::flat_storage_model::FlatStor
 use zk_os_forward_system::run::{LeafProof, ReadStorage, ReadStorageTree};
 use zksync_os_batch_types::BlockMerkleTreeData;
 use zksync_os_merkle_tree::{
-    Blake2Hasher, HashTree, Leaf, MerkleTree, MerkleTreeProver, RocksDBWrapper, TreeOperation,
-    api::flat,
+    BatchTreeProof, Blake2Hasher, HashTree, Leaf, MerkleTree, MerkleTreeProver, RocksDBWrapper,
+    TreeOperation, api::flat,
 };
 
 const TREE_DEPTH: u8 = 64;
@@ -65,19 +66,49 @@ impl Drop for TreeOutputAdapter {
 }
 
 impl TreeOutputAdapter {
-    pub(super) fn new(tree_data: BlockMerkleTreeData) -> Self {
-        let key_to_index: HashMap<_, _> = tree_data.keys_and_ops().collect();
-        let sibling_hashes = tree_data
+    /// Unites proof data from `tree_data.proof` (a batch proof for `tree_data.written_keys`)
+    /// and `read_proof` (which is a batch proof for `tree_data.read_keys`).
+    pub(super) fn new(tree_data: BlockMerkleTreeData, read_proof: BatchTreeProof) -> Self {
+        assert_eq!(
+            tree_data.proof.operations.len(),
+            tree_data.written_keys.len()
+        );
+        assert!(tree_data.proof.read_operations.is_empty());
+        assert_eq!(read_proof.read_operations.len(), tree_data.read_keys.len());
+        assert!(read_proof.operations.is_empty());
+
+        let written = tree_data
+            .written_keys
+            .iter()
+            .copied()
+            .zip(tree_data.proof.operations.iter().copied());
+        let read = tree_data
+            .read_keys
+            .iter()
+            .copied()
+            .zip(read_proof.read_operations.iter().copied());
+        let key_to_op: HashMap<_, _> = written.chain(read).collect();
+
+        // Some sibling hashes may be duplicated in `proof` and `read_proof`, but since we collect
+        // them in a `HashMap`, this is fine.
+        let sibling_hashes: HashMap<_, _> = tree_data
             .proof
             .sibling_hashes(TREE_DEPTH, tree_data.input.leaf_count)
+            .chain(read_proof.sibling_hashes(TREE_DEPTH, tree_data.input.leaf_count))
             .map(|(location, hash)| (location, hash.0.into()))
             .collect();
 
+        let mut sorted_leaves = tree_data.proof.sorted_leaves;
+        let mut read_sorted_leaves = read_proof.sorted_leaves;
+        // Some leaves may be repeated in `sorted_leaves` and `read_sorted_leaves`, which is fine since we unite them
+        // in a `BTreeMap`.
+        sorted_leaves.append(&mut read_sorted_leaves);
+
         Self {
-            queried_proofs: HashSet::with_capacity(tree_data.proof.sorted_leaves.len()),
+            queried_proofs: HashSet::with_capacity(sorted_leaves.len()),
             leaf_count_before_update: tree_data.input.leaf_count,
-            sorted_leaves: tree_data.proof.sorted_leaves,
-            key_to_op: key_to_index,
+            sorted_leaves,
+            key_to_op,
             sibling_hashes,
         }
     }
@@ -178,6 +209,14 @@ impl VersionedMerkleTree {
             cached_missing_key_to_prev_index: HashMap::new(),
             cached_proofs: HashMap::new(),
         }
+    }
+
+    pub(super) fn get_proof(&self, keys: &[B256]) -> anyhow::Result<BatchTreeProof> {
+        let (proof, _) = self
+            .inner
+            .prove(self.version, keys)?
+            .with_context(|| format!("missing tree version {}", self.version))?;
+        Ok(proof)
     }
 
     fn read(&mut self, key: B256) -> Option<B256> {

--- a/node/bin/src/prover_input_generator/tree_adapter.rs
+++ b/node/bin/src/prover_input_generator/tree_adapter.rs
@@ -104,6 +104,21 @@ impl TreeOutputAdapter {
         // in a `BTreeMap`.
         sorted_leaves.append(&mut read_sorted_leaves);
 
+        // Report joint proof metrics.
+        PROVER_INPUT_GENERATOR_METRICS
+            .batch_proof_sorted_leaves
+            .observe(sorted_leaves.len());
+        PROVER_INPUT_GENERATOR_METRICS
+            .batch_proof_hashes
+            .observe(sibling_hashes.len());
+        tracing::debug!(
+            written_keys.len = tree_data.written_keys.len(),
+            read_keys.len = tree_data.read_keys.len(),
+            sorted_leaves.len = sorted_leaves.len(),
+            sibling_hashes.len = sibling_hashes.len(),
+            "created joint batch proof for state update"
+        );
+
         Self {
             queried_proofs: HashSet::with_capacity(sorted_leaves.len()),
             leaf_count_before_update: tree_data.input.leaf_count,

--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -128,6 +128,9 @@ impl PipelineComponent for TreeManager {
             assert_eq!(last_processed_block, last_block_number);
 
             // Forward each block downstream.
+            //
+            // **IMPORTANT.** Since downstream components (e.g., the proof input generator) read tree data,
+            // it is vital that the tree is fully persisted before block data is sent downstream.
             for tree_block in tree_blocks {
                 output.send_and_record(tree_block, &state_reporter)?;
             }
@@ -196,10 +199,8 @@ impl TreeManager {
                 (entry, write.key)
             })
             .unzip();
-        let read_keys: Vec<_> = read_keys.into_iter().collect();
         let block_number = block_output.header.number;
         let write_count = written_keys.len();
-        let read_count = read_keys.len();
 
         let (root_hash, leaf_count) =
             patched_tree.root_info(block_number - 1)?.with_context(|| {
@@ -209,15 +210,11 @@ impl TreeManager {
             root_hash,
             leaf_count,
         };
-        let (tree_output, update_proof) =
-            patched_tree.extend_with_proof(&tree_entries, &read_keys)?;
+        let (tree_output, update_proof) = patched_tree.extend_with_proof(&tree_entries, &[])?;
 
         tracing::debug!(
             block_number = block_number,
             written_keys.len = written_keys.len(),
-            read_keys.len = read_keys.len(),
-            proof.sorted_leaves.len = update_proof.sorted_leaves.len(),
-            proof.hashes.len = update_proof.hashes.len(),
             input = ?tree_input,
             output = ?tree_output,
             "Processed tree update"
@@ -227,26 +224,15 @@ impl TreeManager {
         TREE_METRICS
             .entry_time
             .observe(block_time / (write_count.max(1) as u32));
-        TREE_METRICS
-            .entry_time_with_reads
-            .observe(block_time / ((write_count + read_count).max(1) as u32));
         TREE_METRICS.unique_leafs.set(tree_output.leaf_count);
         TREE_METRICS.processing_range.observe(write_count);
-        TREE_METRICS.block_number.set(block_number);
-        TREE_METRICS.processing_read_range.observe(read_count);
-        TREE_METRICS
-            .update_proof_sorted_leaves
-            .observe(update_proof.sorted_leaves.len());
-        TREE_METRICS
-            .update_proof_hashes
-            .observe(update_proof.hashes.len());
         TREE_METRICS.block_number.set(block_number);
 
         let tree_data = BlockMerkleTreeData {
             input: tree_input,
             output: tree_output,
             proof: update_proof,
-            read_keys,
+            read_keys: read_keys.into_iter().collect(),
             written_keys,
         };
         Ok(TreeBlock {
@@ -260,6 +246,7 @@ impl TreeManager {
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.0000001..=1.0, 2.0);
 const BLOCK_RANGE_SIZE: Buckets = Buckets::exponential(1.0..=1000.0, 2.0);
 
+// FIXME: remove unused metrics
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "tree")]
 pub struct TreeMetrics {

--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -110,16 +110,9 @@ impl PipelineComponent for TreeManager {
                 .iter()
                 .map(|block| block.tree.written_keys.len())
                 .sum::<usize>();
-            let total_reads = tree_blocks
-                .iter()
-                .map(|block| block.tree.read_keys.len())
-                .sum::<usize>();
             TREE_METRICS
                 .amortized_entry_time
                 .observe(range_time / total_writes.max(1) as u32);
-            TREE_METRICS
-                .amortized_entry_time_with_reads
-                .observe(range_time / (total_reads + total_writes).max(1) as u32);
 
             last_processed_block = self
                 .tree
@@ -210,6 +203,12 @@ impl TreeManager {
             root_hash,
             leaf_count,
         };
+        // We intentionally do not query a proof for *read* keys here. (Instead, it will be queried in the proof input generator
+        // on the main node.) This makes tree updates faster, and makes it possible to parallelize I/O for proof input generation
+        // for different blocks. At the same time, we *do* query a proof for writes; it is free in terms of I/O compared
+        // to updating a tree without a proof, and while it is possible to query an update proof afterward, it'd need
+        // to cover some corner cases which are more naturally handled synchronously (e.g., getting a Merkle path for the last leaf
+        // if there are inserts).
         let (tree_output, update_proof) = patched_tree.extend_with_proof(&tree_entries, &[])?;
 
         tracing::debug!(
@@ -246,51 +245,35 @@ impl TreeManager {
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.0000001..=1.0, 2.0);
 const BLOCK_RANGE_SIZE: Buckets = Buckets::exponential(1.0..=1000.0, 2.0);
 
-// FIXME: remove unused metrics
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "tree")]
-pub struct TreeMetrics {
+struct TreeMetrics {
     /// Merkle tree update latency per written entry. Does not include flushing block contents to disk.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub entry_time: Histogram<Duration>,
+    entry_time: Histogram<Duration>,
     /// Merkle tree update latency per written entry. May be amortized across multiple blocks. Includes flushing to disk.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub amortized_entry_time: Histogram<Duration>,
-    /// Merkle tree update latency per read / written entry. Does not include flushing block contents to disk.
-    #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub entry_time_with_reads: Histogram<Duration>,
-    /// Merkle tree update latency per read / written entry. May be amortized across multiple blocks. Includes flushing to disk.
-    #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub amortized_entry_time_with_reads: Histogram<Duration>,
+    amortized_entry_time: Histogram<Duration>,
     /// Latency to process a single block in the tree. Does not include flushing block contents to disk.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub block_time: Histogram<Duration>,
+    block_time: Histogram<Duration>,
     /// Latency to process a single block in the tree. May be amortized across multiple blocks. Includes flushing to disk.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub amortized_block_time: Histogram<Duration>,
+    amortized_block_time: Histogram<Duration>,
     /// Latency to process a range of blocks in the tree (including flushing).
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub range_time: Histogram<Duration>,
+    range_time: Histogram<Duration>,
     /// Latency to flush tree updates to disk.
     #[metrics(unit = Unit::Seconds, buckets = LATENCIES_FAST)]
-    pub flush_time: Histogram<Duration>,
+    flush_time: Histogram<Duration>,
     /// Number of unique leaves in the Merkle tree.
-    pub unique_leafs: Gauge<u64>,
+    unique_leafs: Gauge<u64>,
     /// Number of distinct tree entries written per block.
     #[metrics(buckets = BLOCK_RANGE_SIZE)]
-    pub processing_range: Histogram<usize>,
-    /// Number of distinct tree entries read (but not written) per block.
-    #[metrics(buckets = BLOCK_RANGE_SIZE)]
-    pub processing_read_range: Histogram<usize>,
-    /// Number of sorted leaves included in the batch update proof for a single block.
-    #[metrics(buckets = BLOCK_RANGE_SIZE)]
-    pub update_proof_sorted_leaves: Histogram<usize>,
-    /// Number of intermediate (aka sibling) hashes included in the batch update proof for a single block.
-    #[metrics(buckets = BLOCK_RANGE_SIZE)]
-    pub update_proof_hashes: Histogram<usize>,
+    processing_range: Histogram<usize>,
 
-    pub block_number: Gauge<BlockNumber>,
+    block_number: Gauge<BlockNumber>,
 }
 
 #[vise::register]
-pub(crate) static TREE_METRICS: vise::Global<TreeMetrics> = vise::Global::new();
+static TREE_METRICS: vise::Global<TreeMetrics> = vise::Global::new();


### PR DESCRIPTION
## Summary

Moves Merkle tree proof generation for keys read in a block to the proof input generator. Previously, this proof was generated in the tree manager.

This makes tree updates faster. There is some I/O overhead, but it could be compensated by parallelization (multiple blocks can be processed by PIG in parallel). For nodes that don't run a PIG, the change is a straightforward speed-up.

