### PR TITLE
feat(l1): use deployment block as lower bound for binsearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15262,10 +15262,7 @@ name = "zksync_os_alloy_ext"
 version = "0.20.5"
 dependencies = [
  "alloy",
- "anyhow",
- "async-trait",
  "serde",
- "serde_json",
  "tokio",
  "tracing",
  "zksync_os_contract_interface",
@@ -15322,6 +15319,7 @@ dependencies = [
  "zksync_os_contract_interface",
  "zksync_os_external_price_api",
  "zksync_os_operator_signer",
+ "zksync_os_provider",
  "zksync_os_types",
 ]
 
@@ -15407,6 +15405,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "vise",
+ "zksync_os_provider",
 ]
 
 [[package]]
@@ -15489,6 +15488,7 @@ dependencies = [
  "zksync_os_api",
  "zksync_os_contract_interface",
  "zksync_os_l1_watcher",
+ "zksync_os_provider",
  "zksync_os_storage_api",
  "zksync_os_types",
 ]
@@ -15527,6 +15527,7 @@ dependencies = [
  "zksync_os_merkle_tree_api",
  "zksync_os_multivm",
  "zksync_os_network",
+ "zksync_os_provider",
  "zksync_os_replay_archive",
  "zksync_os_rpc_api",
  "zksync_os_server",
@@ -15603,6 +15604,7 @@ dependencies = [
  "zksync_os_observability",
  "zksync_os_operator_signer",
  "zksync_os_pipeline",
+ "zksync_os_provider",
  "zksync_os_types",
 ]
 
@@ -15627,6 +15629,7 @@ dependencies = [
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
  "zksync_os_mempool",
+ "zksync_os_provider",
  "zksync_os_storage_api",
  "zksync_os_types",
 ]
@@ -15845,6 +15848,19 @@ dependencies = [
  "zksync_os_rocksdb",
  "zksync_os_storage_api",
  "zksync_os_types",
+]
+
+[[package]]
+name = "zksync_os_provider"
+version = "0.20.4"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -16199,6 +16215,7 @@ dependencies = [
  "zksync_os_operator_signer",
  "zksync_os_pipeline",
  "zksync_os_priority_tree",
+ "zksync_os_provider",
  "zksync_os_raft",
  "zksync_os_replay_archive",
  "zksync_os_reth_compat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15852,7 +15852,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_os_provider"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "lib/tx_validators",
     "lib/backpressure",
     "lib/alloy_ext",
+    "lib/provider",
 ]
 resolver = "3"
 default-members = ["node/bin"]
@@ -286,6 +287,7 @@ zksync-os-revm = { git = "https://github.com/matter-labs/zksync-os-revm", tag = 
 revm = { version = "=38.0.0", features = ["optional_balance_check"] }
 
 # "Local" dependencies
+zksync_os_provider = { version = "=0.20.5", path = "lib/provider" }
 zksync_os_contract_interface = { version = "=0.20.5", path = "lib/contract_interface" }
 zksync_os_consensus_types = { version = "=0.20.5", path = "lib/consensus_types" }
 zksync_os_crypto = { version = "=0.20.5", path = "lib/crypto" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 [dependencies]
 zksync_os_server.workspace = true
 zksync_os_alloy_ext.workspace = true
+zksync_os_provider.workspace = true
 zksync_os_contract_interface.workspace = true
 zksync_os_tx_validators.workspace = true
 zksync_os_types.workspace = true

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,7 +27,7 @@ use tempfile::TempDir;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::network::Zksync;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
@@ -273,7 +273,7 @@ impl TestEnvironment {
 #[derive(Debug)]
 pub struct Tester {
     l1: AnvilL1,
-    pub l2_provider: EthDynProvider,
+    pub l2_provider: NodeProvider,
     /// ZKsync OS-specific provider. Generally prefer to use `l2_provider` as we strive for the
     /// system to be Ethereum-compatible. But this can be useful if you need to assert custom fields
     /// that are only present in ZKsync OS response types (`l2ToL1Logs`, `commitTx`, etc).
@@ -295,7 +295,7 @@ pub struct Tester {
     l2_rpc_address: String,
     status_server_url: String,
     gateway_rpc_url: Option<String>,
-    sl_provider: EthDynProvider,
+    sl_provider: NodeProvider,
     log_state: NodeLogState,
     chain_layout: ChainLayout<'static>,
     owned_supporting_nodes: Vec<SupportingNode>,
@@ -352,7 +352,7 @@ impl Tester {
         config.l1_sender_config.pubdata_mode = None;
     }
 
-    pub fn l1_provider(&self) -> &EthDynProvider {
+    pub fn l1_provider(&self) -> &NodeProvider {
         &self.l1.provider
     }
 
@@ -360,16 +360,16 @@ impl Tester {
         &self.l1.wallet
     }
 
-    pub fn sl_provider(&self) -> &EthDynProvider {
+    pub fn sl_provider(&self) -> &NodeProvider {
         &self.sl_provider
     }
 
     /// Returns the gateway provider if a gateway RPC URL is configured, `None` otherwise.
     /// Use this when calling [`L1State::fetch`] or [`L1State::fetch_finalized`].
-    pub fn gateway_eth_provider(&self) -> Option<DynProvider> {
+    pub fn gateway_eth_provider(&self) -> Option<NodeProvider> {
         self.gateway_rpc_url
             .as_ref()
-            .map(|_| self.sl_provider.clone().erased())
+            .map(|_| self.sl_provider.clone())
     }
 
     pub async fn gateway_provider(&self) -> anyhow::Result<Option<DynProvider<Zksync>>> {
@@ -741,20 +741,20 @@ impl Tester {
                 tracing::info!(%err, ?dur, "retrying connection to L2 node");
             })
             .await?;
-            EthDynProvider::new(sl_provider)
+            NodeProvider::new(sl_provider)
         } else {
             l1.provider.clone()
         };
         let gateway_eth_provider = gateway_rpc_url.as_ref().map(|_| sl_provider.clone());
         let prover_tester = ProverTester::new(
-            EthDynProvider::new(l1.provider.clone()),
+            NodeProvider::new(l1.provider.clone()),
             gateway_eth_provider,
-            EthDynProvider::new(l2_provider.clone()),
+            NodeProvider::new(l2_provider.clone()),
             DynProvider::new(l2_zk_provider.clone()),
         );
         let tester = Tester {
             l1,
-            l2_provider: EthDynProvider::new(l2_provider.clone()),
+            l2_provider: NodeProvider::new(l2_provider.clone()),
             l2_zk_provider: DynProvider::new(l2_zk_provider.clone()),
             l2_wallet,
             prover_tester,
@@ -790,7 +790,7 @@ impl StoppedTester {
         &self.config
     }
 
-    pub fn l1_provider(&self) -> &EthDynProvider {
+    pub fn l1_provider(&self) -> &NodeProvider {
         &self.l1.provider
     }
 
@@ -1028,7 +1028,7 @@ async fn shutdown_runtime(runtime: Runtime) -> anyhow::Result<()> {
 
 async fn ensure_test_wallet_funded(
     l1: &AnvilL1,
-    l2_provider: &EthDynProvider,
+    l2_provider: &NodeProvider,
     l2_zk_provider: &DynProvider<Zksync>,
     l2_wallet: &EthereumWallet,
 ) -> anyhow::Result<()> {
@@ -1283,13 +1283,14 @@ async fn wait_for_gateway_readiness(
 
     (|| async {
         let gateway_provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::new(PrivateKeySigner::random()))
             .connect(gateway_rpc_url)
             .await
             .with_context(|| format!("failed to connect to gateway RPC at {gateway_rpc_url}"))?;
 
         L1State::fetch_finalized(
-            DynProvider::new(l1.provider.clone()),
-            Some(DynProvider::new(gateway_provider)),
+            l1.provider.clone(),
+            Some(NodeProvider::new(gateway_provider)),
             bridgehub_address,
             chain_id,
         )
@@ -1311,7 +1312,7 @@ async fn wait_for_gateway_readiness(
 #[derive(Debug, Clone)]
 pub struct AnvilL1 {
     pub address: String,
-    pub provider: EthDynProvider,
+    pub provider: NodeProvider,
     pub wallet: EthereumWallet,
 
     // Temporary directory that holds uncompressed l1-state.json used to initialize Anvil's state.
@@ -1366,7 +1367,7 @@ impl AnvilL1 {
 
         Ok(Self {
             address,
-            provider: EthDynProvider::new(provider),
+            provider: NodeProvider::new(provider),
             wallet,
             _tempdir: Arc::new(tempdir),
         })

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,13 +27,13 @@ use tempfile::TempDir;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::network::Zksync;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_network::NodeRecord;
+use zksync_os_provider::NodeProvider;
 use zksync_os_server::config::{Config, ProviderConfig};
 pub use zksync_os_server::config::{DeploymentFilterConfig, PolicyServiceConfig};
 use zksync_os_server::default_protocol_version::{

--- a/integration-tests/src/prover_tester.rs
+++ b/integration-tests/src/prover_tester.rs
@@ -3,25 +3,25 @@ use alloy::primitives::{U256, keccak256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::Filter;
 use std::time::Duration;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::network::Zksync;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::l1_discovery::L1State;
 
 #[derive(Debug)]
 pub struct ProverTester {
-    l1_provider: EthDynProvider,
-    gateway_provider: Option<EthDynProvider>,
-    l2_provider: EthDynProvider,
+    l1_provider: NodeProvider,
+    gateway_provider: Option<NodeProvider>,
+    l2_provider: NodeProvider,
     l2_zk_provider: DynProvider<Zksync>,
 }
 
 impl ProverTester {
     /// Create a new client targeting the given base URL
     pub fn new(
-        l1_provider: EthDynProvider,
-        gateway_provider: Option<EthDynProvider>,
-        l2_provider: EthDynProvider,
+        l1_provider: NodeProvider,
+        gateway_provider: Option<NodeProvider>,
+        l2_provider: NodeProvider,
         l2_zk_provider: DynProvider<Zksync>,
     ) -> Self {
         Self {
@@ -38,8 +38,8 @@ impl ProverTester {
 
         // Get L1/SL state which contains diamond proxy address
         let l1_state = L1State::fetch(
-            self.l1_provider.clone().erased(),
-            self.gateway_provider.as_ref().map(|p| p.clone().erased()),
+            self.l1_provider.clone(),
+            self.gateway_provider.clone(),
             bridgehub_address,
             chain_id,
         )
@@ -60,8 +60,8 @@ impl ProverTester {
 
         // Get L1/SL state which contains diamond proxy address
         let l1_state = L1State::fetch(
-            self.l1_provider.clone().erased(),
-            self.gateway_provider.as_ref().map(|p| p.clone().erased()),
+            self.l1_provider.clone(),
+            self.gateway_provider.clone(),
             bridgehub_address,
             chain_id,
         )

--- a/integration-tests/src/prover_tester.rs
+++ b/integration-tests/src/prover_tester.rs
@@ -3,10 +3,10 @@ use alloy::primitives::{U256, keccak256};
 use alloy::providers::{DynProvider, Provider};
 use alloy::rpc::types::Filter;
 use std::time::Duration;
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::network::Zksync;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::l1_discovery::L1State;
+use zksync_os_provider::NodeProvider;
 
 #[derive(Debug)]
 pub struct ProverTester {

--- a/integration-tests/src/upgrade/default_upgrade.rs
+++ b/integration-tests/src/upgrade/default_upgrade.rs
@@ -4,18 +4,18 @@ use alloy::{
 };
 
 use crate::upgrade::interfaces::{self, FacetCut, ProposedUpgrade};
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 
 #[derive(Debug)]
 pub struct DefaultUpgrade {
-    instance: interfaces::DefaultUpgrade::DefaultUpgradeInstance<EthDynProvider>,
+    instance: interfaces::DefaultUpgrade::DefaultUpgradeInstance<NodeProvider>,
     proposed_upgrade: ProposedUpgrade,
 }
 
 impl DefaultUpgrade {
     /// Deploys the DefaultUpgrade contract on L1.
     pub async fn deploy(
-        l1_provider: &EthDynProvider,
+        l1_provider: &NodeProvider,
         proposed_upgrade: &ProposedUpgrade,
     ) -> anyhow::Result<Self> {
         let instance = interfaces::DefaultUpgrade::deploy(l1_provider.clone()).await?;

--- a/integration-tests/src/upgrade/tester.rs
+++ b/integration-tests/src/upgrade/tester.rs
@@ -18,10 +18,10 @@ use alloy::providers::utils::Eip1559Estimator;
 use alloy::providers::{PendingTransactionBuilder, Provider};
 use alloy::rpc::types::{TransactionInput, TransactionReceipt, TransactionRequest};
 use anyhow::Context;
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi as _;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::l1_discovery::L1State;
+use zksync_os_provider::NodeProvider;
 use zksync_os_server::config::Config;
 use zksync_os_types::{
     L1PriorityTxType, L1TxType, ProtocolSemanticVersion, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE,

--- a/integration-tests/src/upgrade/tester.rs
+++ b/integration-tests/src/upgrade/tester.rs
@@ -15,10 +15,10 @@ use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy::providers::ext::AnvilApi;
 use alloy::providers::utils::Eip1559Estimator;
-use alloy::providers::{DynProvider, PendingTransactionBuilder, Provider};
+use alloy::providers::{PendingTransactionBuilder, Provider};
 use alloy::rpc::types::{TransactionInput, TransactionReceipt, TransactionRequest};
 use anyhow::Context;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi as _;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -35,33 +35,33 @@ use zksync_os_types::{
 pub struct UpgradeTester<'a> {
     pub tester: &'a Tester,
     // Bridgehub contract on L1
-    pub bridgehub_l1: zksync_os_contract_interface::Bridgehub<DynProvider>,
+    pub bridgehub_l1: zksync_os_contract_interface::Bridgehub<NodeProvider>,
     // Bridgehub contract on SL
-    pub bridgehub_sl: interfaces::Bridgehub::BridgehubInstance<EthDynProvider>,
+    pub bridgehub_sl: interfaces::Bridgehub::BridgehubInstance<NodeProvider>,
     // Bridgehub owner address on SL
     pub bridgehub_owner_sl: Address,
     // CTM contract on SL
-    pub ctm_sl: interfaces::ChainTypeManager::ChainTypeManagerInstance<EthDynProvider>,
+    pub ctm_sl: interfaces::ChainTypeManager::ChainTypeManagerInstance<NodeProvider>,
     // CTM owner address on SL
     pub ctm_owner_sl: Address,
     // CTM contract on L1
-    pub ctm_l1: interfaces::ChainTypeManager::ChainTypeManagerInstance<EthDynProvider>,
+    pub ctm_l1: interfaces::ChainTypeManager::ChainTypeManagerInstance<NodeProvider>,
     // CTM owner address on L1
     pub ctm_owner_l1: Address,
     // L1 chain admin contract
-    pub l1_chain_admin: interfaces::ChainAdmin::ChainAdminInstance<EthDynProvider>,
+    pub l1_chain_admin: interfaces::ChainAdmin::ChainAdminInstance<NodeProvider>,
     // L1 chain admin owner address
     pub l1_chain_admin_owner: Address,
     // Server notifier contract on L1
-    pub l1_server_notifier: interfaces::ServerNotifier::ServerNotifierInstance<EthDynProvider>,
+    pub l1_server_notifier: interfaces::ServerNotifier::ServerNotifierInstance<NodeProvider>,
     // L1 chain admin for gateway contract address
     pub l1_chain_admin_gateway: Option<Address>,
     // Diamond proxy on the settlement layer
-    pub diamond_proxy_sl: interfaces::ZkChain::ZkChainInstance<EthDynProvider>,
+    pub diamond_proxy_sl: interfaces::ZkChain::ZkChainInstance<NodeProvider>,
     // Diamond proxy owner address
     pub diamond_proxy_admin_sl: Address,
     // Bytecode supplier contract
-    pub bytecode_supplier: interfaces::BytecodesSupplier::BytecodesSupplierInstance<EthDynProvider>,
+    pub bytecode_supplier: interfaces::BytecodesSupplier::BytecodesSupplierInstance<NodeProvider>,
     // L2 chain id
     pub chain_id: u64,
     // Current protocol version
@@ -191,7 +191,7 @@ impl<'a> UpgradeTester<'a> {
 
         let bridgehub_address_l1 = tester.l2_zk_provider.get_bridgehub_contract().await?;
         let l1_state = L1State::fetch(
-            tester.l1_provider().clone().erased(),
+            tester.l1_provider().clone(),
             tester.gateway_eth_provider(),
             bridgehub_address_l1,
             chain_id,

--- a/integration-tests/tests/node/batcher.rs
+++ b/integration-tests/tests/node/batcher.rs
@@ -15,7 +15,7 @@ async fn fetch_l1_state(tester: &Tester) -> anyhow::Result<L1State> {
     let chain_id = tester.l2_provider.get_chain_id().await?;
     let bridgehub_address = tester.l2_zk_provider.get_bridgehub_contract().await?;
     L1State::fetch(
-        tester.l1_provider().clone().erased(),
+        tester.l1_provider().clone(),
         tester.gateway_eth_provider(),
         bridgehub_address,
         chain_id,

--- a/integration-tests/tests/node/mempool.rs
+++ b/integration-tests/tests/node/mempool.rs
@@ -6,7 +6,7 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use futures::FutureExt;
 use std::time::Duration;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthWalletProvider;
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
 use zksync_os_server::config::FeeConfig;

--- a/integration-tests/tests/node/mempool.rs
+++ b/integration-tests/tests/node/mempool.rs
@@ -6,9 +6,9 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use futures::FutureExt;
 use std::time::Duration;
-use zksync_os_provider::EthWalletProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_server::config::FeeConfig;
 
 #[test_multisetup([CURRENT_TO_L1])]

--- a/integration-tests/tests/node/restart.rs
+++ b/integration-tests/tests/node/restart.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthWalletProvider;
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -102,7 +102,7 @@ async fn fetch_l1_state(tester: &Tester) -> anyhow::Result<L1State> {
     let chain_id = tester.l2_provider.get_chain_id().await?;
     let bridgehub_address = tester.l2_zk_provider.get_bridgehub_contract().await?;
     L1State::fetch(
-        tester.l1_provider().clone().erased(),
+        tester.l1_provider().clone(),
         tester.gateway_eth_provider(),
         bridgehub_address,
         chain_id,

--- a/integration-tests/tests/node/restart.rs
+++ b/integration-tests/tests/node/restart.rs
@@ -10,7 +10,6 @@ use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
-use zksync_os_provider::EthWalletProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -19,6 +18,7 @@ use zksync_os_integration_tests::config::{ChainLayout, load_chain_config};
 use zksync_os_integration_tests::provider::ZksyncTestingProvider;
 use zksync_os_integration_tests::rpc_recorder::RpcRecordConfig;
 use zksync_os_integration_tests::{CURRENT_TO_L1, StoppedTester, Tester, test_multisetup};
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_server::INTERNAL_CONFIG_FILE_NAME;
 use zksync_os_server::config::Config;
 

--- a/integration-tests/tests/protocol/erc20.rs
+++ b/integration-tests/tests/protocol/erc20.rs
@@ -6,7 +6,6 @@ use alloy::providers::{PendingTransactionBuilder, Provider};
 use alloy::rpc::types::TransactionReceipt;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolValue;
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
@@ -14,6 +13,7 @@ use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::TestERC20::TestERC20Instance;
 use zksync_os_integration_tests::contracts::{IL2AssetRouter, L1AssetRouter, TestERC20};
 use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_GATEWAY, Tester, test_multisetup};
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::{L2ToL1Log, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, ZkTxType};
 
 #[test_multisetup([CURRENT_TO_L1, NEXT_TO_GATEWAY])]

--- a/integration-tests/tests/protocol/erc20.rs
+++ b/integration-tests/tests/protocol/erc20.rs
@@ -6,7 +6,7 @@ use alloy::providers::{PendingTransactionBuilder, Provider};
 use alloy::rpc::types::TransactionReceipt;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolValue;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
@@ -154,7 +154,7 @@ async fn erc20_withdrawal(tester: Tester) -> anyhow::Result<()> {
 async fn deploy_l1_token_and_mint(
     tester: &Tester,
     mint_amount: U256,
-) -> anyhow::Result<TestERC20Instance<EthDynProvider>> {
+) -> anyhow::Result<TestERC20Instance<NodeProvider>> {
     let l1_erc20 = TestERC20::deploy(
         tester.l1_provider().clone(),
         U256::ZERO,
@@ -173,7 +173,7 @@ async fn deploy_l1_token_and_mint(
 
 async fn deposit_erc20(
     tester: &Tester,
-    l1_erc20: &TestERC20Instance<EthDynProvider>,
+    l1_erc20: &TestERC20Instance<NodeProvider>,
     to: Address,
     amount: U256,
 ) -> anyhow::Result<TransactionReceipt> {

--- a/integration-tests/tests/protocol/interop.rs
+++ b/integration-tests/tests/protocol/interop.rs
@@ -10,7 +10,6 @@ use alloy::{
     sol_types::{SolCall, SolType, SolValue},
 };
 use anyhow::{Context, Result};
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
@@ -18,6 +17,7 @@ use zksync_os_integration_tests::assert_traits::ProviderAssert;
 use zksync_os_integration_tests::{
     GatewayTester, Tester, assert_traits::ReceiptAssert, contracts::TestERC20,
 };
+use zksync_os_provider::NodeProvider;
 use zksync_os_rpc_api::types::LogProofTarget;
 use zksync_os_types::{
     L1PriorityTxType, L1TxType, L2_INTEROP_CENTER_ADDRESS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE,

--- a/integration-tests/tests/protocol/interop.rs
+++ b/integration-tests/tests/protocol/interop.rs
@@ -10,7 +10,7 @@ use alloy::{
     sol_types::{SolCall, SolType, SolValue},
 };
 use anyhow::{Context, Result};
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
@@ -216,7 +216,7 @@ fn build_second_bridge_calldata(
 async fn setup_l1_token_on_chain_a(
     chain_a: &Tester,
     l2_recipient: Address,
-) -> Result<(TestERC20::TestERC20Instance<EthDynProvider>, U256, [u8; 32])> {
+) -> Result<(TestERC20::TestERC20Instance<NodeProvider>, U256, [u8; 32])> {
     let deposit_amount = U256::from(1_000_000) * U256::from(10).pow(U256::from(18));
 
     // Deploy TestERC20 on L1 and mint to the L1 wallet.
@@ -282,7 +282,7 @@ async fn setup_l1_token_on_chain_a(
 /// chain in a multi-chain test setup.
 async fn deposit_erc20_to_chain(
     chain: &Tester,
-    l1_erc20: &TestERC20::TestERC20Instance<EthDynProvider>,
+    l1_erc20: &TestERC20::TestERC20Instance<NodeProvider>,
     to: Address,
     amount: U256,
 ) -> Result<TransactionReceipt> {

--- a/integration-tests/tests/rpc/api.rs
+++ b/integration-tests/tests/rpc/api.rs
@@ -7,7 +7,7 @@ use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use regex::Regex;
 use std::time::Duration;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::IExecutor::BlockCommit;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -281,7 +281,7 @@ async fn estimate_gas_without_balance(tester: Tester) -> anyhow::Result<()> {
 
 #[tracing::instrument(skip(provider))]
 async fn fetch_batch_commitment(
-    provider: &EthDynProvider,
+    provider: &NodeProvider,
     filter_id: U256,
     expected_batch_number: u64,
 ) -> B256 {
@@ -334,7 +334,7 @@ async fn get_storage_proof(tester: Tester) -> anyhow::Result<()> {
 
     // Get L1 state which contains diamond proxy address
     let l1_state = L1State::fetch(
-        tester.l1_provider().clone().erased(),
+        tester.l1_provider().clone(),
         tester.gateway_eth_provider(),
         bridgehub_address,
         chain_id,

--- a/integration-tests/tests/rpc/api.rs
+++ b/integration-tests/tests/rpc/api.rs
@@ -7,7 +7,6 @@ use alloy::sol_types::SolEvent;
 use anyhow::Context as _;
 use regex::Regex;
 use std::time::Duration;
-use zksync_os_provider::NodeProvider;
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::IExecutor::BlockCommit;
 use zksync_os_contract_interface::l1_discovery::L1State;
@@ -17,6 +16,7 @@ use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
 use zksync_os_integration_tests::{
     CURRENT_TO_L1, NEXT_TO_GATEWAY, TestEnvironment, Tester, test_multisetup,
 };
+use zksync_os_provider::NodeProvider;
 use zksync_os_rpc_api::types::BatchStorageProof;
 use zksync_os_server::config::FeeConfig;
 

--- a/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
+++ b/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 use std::env;
 use std::str::FromStr;
 use tracing::info;
-use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::contracts::{TracingPrimary, TracingSecondary};
+use zksync_os_provider::NodeProvider;
 
 const ZKSYNC_URL_ENV: &str = "JS_TRACER_ZKSYNC_RPC_URL";
 const RETH_URL_ENV: &str = "JS_TRACER_RETH_RPC_URL";

--- a/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
+++ b/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::env;
 use std::str::FromStr;
 use tracing::info;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::contracts::{TracingPrimary, TracingSecondary};
 
 const ZKSYNC_URL_ENV: &str = "JS_TRACER_ZKSYNC_RPC_URL";
@@ -47,8 +47,8 @@ async fn compare_js_tracer_outputs_between_nodes() -> anyhow::Result<()> {
         .connect(&reth_url)
         .await?;
 
-    let zksync_provider = EthDynProvider::new(zksync_provider);
-    let reth_provider = EthDynProvider::new(reth_provider);
+    let zksync_provider = NodeProvider::new(zksync_provider);
+    let reth_provider = NodeProvider::new(reth_provider);
 
     // Deploy helper contracts on both nodes.
     let secondary_init_value = U256::from(7);
@@ -213,7 +213,7 @@ fn configure_call_request(req: &mut TransactionRequest, from: alloy::primitives:
 }
 
 async fn trace_with_js(
-    provider: &EthDynProvider,
+    provider: &NodeProvider,
     request: TransactionRequest,
     tracer_code: &str,
 ) -> anyhow::Result<Value> {

--- a/integration-tests/tests/rpc/debug/tracing.rs
+++ b/integration-tests/tests/rpc/debug/tracing.rs
@@ -10,12 +10,12 @@ use alloy::rpc::types::trace::geth::{
 };
 use alloy::sol_types::{Revert, SolCall, SolError};
 use std::collections::HashMap;
-use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, ReceiptAssert, ReceiptsAssert};
 use zksync_os_integration_tests::contracts::{
     Counter, EventEmitter, TracingPrimary, TracingSecondary,
 };
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
+use zksync_os_provider::NodeProvider;
 use zksync_os_server::config::FeeConfig;
 
 fn check_call_frame(

--- a/integration-tests/tests/rpc/debug/tracing.rs
+++ b/integration-tests/tests/rpc/debug/tracing.rs
@@ -10,7 +10,7 @@ use alloy::rpc::types::trace::geth::{
 };
 use alloy::sol_types::{Revert, SolCall, SolError};
 use std::collections::HashMap;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, ReceiptAssert, ReceiptsAssert};
 use zksync_os_integration_tests::contracts::{
     Counter, EventEmitter, TracingPrimary, TracingSecondary,
@@ -333,7 +333,7 @@ async fn check_tx_equivalency<
 >(
     name: &str,
     tester: &Tester,
-    f: impl Fn(EthDynProvider) -> Fut,
+    f: impl Fn(NodeProvider) -> Fut,
 ) -> anyhow::Result<()> {
     tracing::info!(name, "checking trace equivalence");
     let l1_call_frame = f(tester.l1_provider().clone())
@@ -352,7 +352,7 @@ async fn check_tx_equivalency<
 async fn check_call_equivalency<Fut: Future<Output = anyhow::Result<TransactionRequest>>>(
     name: &str,
     tester: &Tester,
-    f: impl Fn(EthDynProvider) -> Fut,
+    f: impl Fn(NodeProvider) -> Fut,
 ) -> anyhow::Result<()> {
     tracing::info!(name, "checking trace equivalence");
     let l1_tx_request = f(tester.l1_provider().clone()).await?;

--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -6,10 +6,10 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use anyhow::Result;
 use tokio::time::{Duration, timeout};
-use zksync_os_provider::EthWalletProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::{DeploymentFilterConfig, GatewayTester};
+use zksync_os_provider::EthWalletProvider;
 
 /// The default rich wallet address (derived from the well-known test private key).
 const AUTHORIZED_DEPLOYER: &str = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";

--- a/integration-tests/tests/rpc/deployment_filter.rs
+++ b/integration-tests/tests/rpc/deployment_filter.rs
@@ -6,7 +6,7 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use anyhow::Result;
 use tokio::time::{Duration, timeout};
-use zksync_os_alloy_ext::dyn_wallet_provider::EthWalletProvider;
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::{DeploymentFilterConfig, GatewayTester};

--- a/integration-tests/tests/rpc/filter.rs
+++ b/integration-tests/tests/rpc/filter.rs
@@ -5,7 +5,7 @@ use alloy::providers::Provider;
 use alloy::rpc::json_rpc::RpcRecv;
 use alloy::rpc::types::{Filter, Log, Transaction, TransactionRequest};
 use alloy::sol_types::SolEvent;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::contracts::EventEmitter::{EventEmitterInstance, TestEvent};
@@ -191,7 +191,7 @@ impl FilterSuite for PendingTxSuite<true> {
 }
 
 struct NewLogsSuite {
-    event_emitter: EventEmitterInstance<EthDynProvider>,
+    event_emitter: EventEmitterInstance<NodeProvider>,
 }
 
 impl FilterSuite for NewLogsSuite {

--- a/integration-tests/tests/rpc/filter.rs
+++ b/integration-tests/tests/rpc/filter.rs
@@ -5,11 +5,11 @@ use alloy::providers::Provider;
 use alloy::rpc::json_rpc::RpcRecv;
 use alloy::rpc::types::{Filter, Log, Transaction, TransactionRequest};
 use alloy::sol_types::SolEvent;
-use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::contracts::EventEmitter::{EventEmitterInstance, TestEvent};
 use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_provider::NodeProvider;
 
 trait FilterSuite: Sized {
     type Expected: RpcRecv + PartialEq;

--- a/integration-tests/tests/rpc/pubsub.rs
+++ b/integration-tests/tests/rpc/pubsub.rs
@@ -8,7 +8,7 @@ use alloy::rpc::types::{Filter, Header, Log, Transaction, TransactionRequest};
 use alloy::sol_types::SolEvent;
 use futures::StreamExt;
 use tokio::time::error::Elapsed;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::contracts::EventEmitter::{EventEmitterInstance, TestEvent};
@@ -157,7 +157,7 @@ impl PubsubSuite for PendingTxSuite<true> {
 }
 
 struct NewLogsSuite {
-    event_emitter: EventEmitterInstance<EthDynProvider>,
+    event_emitter: EventEmitterInstance<NodeProvider>,
 }
 
 impl PubsubSuite for NewLogsSuite {

--- a/integration-tests/tests/rpc/pubsub.rs
+++ b/integration-tests/tests/rpc/pubsub.rs
@@ -8,11 +8,11 @@ use alloy::rpc::types::{Filter, Header, Log, Transaction, TransactionRequest};
 use alloy::sol_types::SolEvent;
 use futures::StreamExt;
 use tokio::time::error::Elapsed;
-use zksync_os_provider::NodeProvider;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::EventEmitter;
 use zksync_os_integration_tests::contracts::EventEmitter::{EventEmitterInstance, TestEvent};
 use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_provider::NodeProvider;
 
 trait PubsubSuite: Sized {
     type Expected: RpcRecv + PartialEq;

--- a/integration-tests/tests/rpc/storage_proof.rs
+++ b/integration-tests/tests/rpc/storage_proof.rs
@@ -100,7 +100,7 @@ async fn verify_storage_proof_with_l1_contract() -> anyhow::Result<()> {
     let bridgehub_address = tester.l2_zk_provider.get_bridgehub_contract().await?;
     tracing::info!(?bridgehub_address, chain_id, "fetched L1 state");
     let l1_state = L1State::fetch(
-        tester.l1_provider().clone().erased(),
+        tester.l1_provider().clone(),
         tester.gateway_eth_provider(),
         bridgehub_address,
         chain_id,
@@ -247,7 +247,7 @@ async fn verify_storage_proof_empty_slot() -> anyhow::Result<()> {
     let chain_id = tester.l2_provider.get_chain_id().await?;
     tracing::info!(?bridgehub_address, chain_id, "fetched L1 state");
     let l1_state = L1State::fetch(
-        tester.l1_provider().clone().erased(),
+        tester.l1_provider().clone(),
         tester.gateway_eth_provider(),
         bridgehub_address,
         chain_id,

--- a/lib/alloy_ext/Cargo.toml
+++ b/lib/alloy_ext/Cargo.toml
@@ -15,9 +15,6 @@ zksync_os_rpc_api.workspace = true
 zksync_os_types.workspace = true
 
 alloy = { workspace = true, default-features = false, features = ["json-rpc", "rpc-types"] }
-async-trait.workspace = true
-anyhow.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/lib/alloy_ext/src/lib.rs
+++ b/lib/alloy_ext/src/lib.rs
@@ -1,9 +1,10 @@
 //! ZKsync-specific extensions to the alloy ecosystem.
 //!
 //! - [`network`]: the [`alloy::network::Network`] implementation for ZKsync OS.
-//! - [`dyn_wallet_provider`]: an object-safe wrapper over [`alloy::providers::Provider<Ethereum>`].
 //! - [`provider`]: the [`provider::ZksyncApi`] trait exposing `zks_*` RPC methods.
+//!
+//! The object-safe, wallet-capable provider wrapper lives in the `zksync_os_provider` crate as
+//! `NodeProvider` (it had to move below `contract_interface` so the latter can be generic over it).
 
-pub mod dyn_wallet_provider;
 pub mod network;
 pub mod provider;

--- a/lib/base_token_adjuster/Cargo.toml
+++ b/lib/base_token_adjuster/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 zksync_os_alloy_ext.workspace = true
+zksync_os_provider.workspace = true
 vise.workspace = true
 
 tokio = { workspace = true, features = ["time"] }

--- a/lib/base_token_adjuster/src/lib.rs
+++ b/lib/base_token_adjuster/src/lib.rs
@@ -3,7 +3,7 @@ use alloy::network::{Ethereum, TransactionBuilder};
 use alloy::primitives::Address;
 use alloy::primitives::utils::format_ether;
 use alloy::providers::ext::DebugApi;
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
 use alloy::rpc::types::TransactionReceipt;
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use anyhow::Context;
@@ -12,7 +12,7 @@ use num::{BigUint, ToPrimitive};
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
-use zksync_os_alloy_ext::dyn_wallet_provider::{EthDynProvider, EthWalletProvider};
+use zksync_os_provider::{NodeProvider, EthWalletProvider};
 use zksync_os_contract_interface::{
     IChainAdminOwnable::{self, IChainAdminOwnableInstance},
     IERC20, ZkChain,
@@ -81,14 +81,14 @@ pub struct BaseTokenPriceUpdater {
     price_api_client: Box<dyn PriceApiClient>,
     config: BaseTokenPriceUpdaterConfig,
     last_l1_ratio: Ratio<BigUint>,
-    chain_admin_contract: IChainAdminOwnableInstance<EthDynProvider, Ethereum>,
+    chain_admin_contract: IChainAdminOwnableInstance<NodeProvider, Ethereum>,
     token_multiplier_setter_address: Option<Address>,
     zk_chain_address: Address,
     token_price_sender: watch::Sender<Option<TokenPricesForFees>>,
 }
 
 async fn register_operator(
-    provider: &mut EthDynProvider,
+    provider: &mut NodeProvider,
     signer_config: SignerConfig,
 ) -> anyhow::Result<Address> {
     let address = signer_config
@@ -110,9 +110,9 @@ async fn register_operator(
 
 impl BaseTokenPriceUpdater {
     pub async fn new(
-        zk_chain_l1: ZkChain<DynProvider>,
-        zk_chain_gateway: Option<ZkChain<DynProvider>>,
-        mut l1_provider: EthDynProvider,
+        zk_chain_l1: ZkChain<NodeProvider>,
+        zk_chain_gateway: Option<ZkChain<NodeProvider>>,
+        mut l1_provider: NodeProvider,
         base_token_adjuster_config: BaseTokenPriceUpdaterConfig,
         external_price_api_client_config: ExternalPriceApiClientConfig,
         token_price_sender: watch::Sender<Option<TokenPricesForFees>>,
@@ -226,7 +226,7 @@ impl BaseTokenPriceUpdater {
         token_address: Address,
         token_address_override: Option<Address>,
         decimals_override: Option<u8>,
-        l1_provider: &EthDynProvider,
+        l1_provider: &NodeProvider,
     ) -> anyhow::Result<APIToken> {
         let token_address = token_address_override.unwrap_or(token_address);
         match token_address {
@@ -486,7 +486,7 @@ impl BaseTokenPriceUpdater {
 }
 
 async fn validate_tx_receipt(
-    provider: &EthDynProvider,
+    provider: &NodeProvider,
     receipt: TransactionReceipt,
 ) -> anyhow::Result<()> {
     if receipt.status() {

--- a/lib/base_token_adjuster/src/lib.rs
+++ b/lib/base_token_adjuster/src/lib.rs
@@ -2,8 +2,8 @@ use crate::metrics::{METRICS, OperationResult, OperationResultLabels};
 use alloy::network::{Ethereum, TransactionBuilder};
 use alloy::primitives::Address;
 use alloy::primitives::utils::format_ether;
-use alloy::providers::ext::DebugApi;
 use alloy::providers::Provider;
+use alloy::providers::ext::DebugApi;
 use alloy::rpc::types::TransactionReceipt;
 use alloy::rpc::types::trace::geth::{CallConfig, GethDebugTracingOptions};
 use anyhow::Context;
@@ -12,7 +12,6 @@ use num::{BigUint, ToPrimitive};
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 use tokio::sync::watch;
-use zksync_os_provider::{NodeProvider, EthWalletProvider};
 use zksync_os_contract_interface::{
     IChainAdminOwnable::{self, IChainAdminOwnableInstance},
     IERC20, ZkChain,
@@ -24,6 +23,7 @@ use zksync_os_external_price_api::{
     APIToken, ExternalPriceApiClientConfig, PriceApiClient, ZK_L1_ADDRESS,
 };
 use zksync_os_operator_signer::SignerConfig;
+use zksync_os_provider::{EthWalletProvider, NodeProvider};
 use zksync_os_types::{TokenApiRatio, TokenPricesForFees};
 
 mod metrics;

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -6,10 +6,10 @@ use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256, address};
 use alloy::providers::Provider;
 use anyhow::Context;
-use zksync_os_provider::NodeProvider;
 use backon::{ConstantBuilder, Retryable};
 use std::fmt::Debug;
 use std::time::Duration;
+use zksync_os_provider::NodeProvider;
 
 /// Standard L2 bridgehub address — present at the same well-known address on every Gateway.
 pub const L2_BRIDGEHUB_ADDRESS: Address = address!("0x0000000000000000000000000000000000010002");

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -4,8 +4,9 @@ use crate::settlement_layer_intervals::SettlementLayerIntervals;
 use crate::{Bridgehub, MultisigCommitter, PubdataPricingMode, ZkChain};
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256, address};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
 use anyhow::Context;
+use zksync_os_provider::NodeProvider;
 use backon::{ConstantBuilder, Retryable};
 use std::fmt::Debug;
 use std::time::Duration;
@@ -27,10 +28,10 @@ pub enum BatchVerificationSL {
 
 #[derive(Clone, Debug)]
 pub struct L1State {
-    pub bridgehub_l1: Bridgehub<DynProvider>,
-    pub bridgehub_sl: Bridgehub<DynProvider>,
-    pub diamond_proxy_l1: ZkChain<DynProvider>,
-    pub diamond_proxy_sl: ZkChain<DynProvider>,
+    pub bridgehub_l1: Bridgehub<NodeProvider>,
+    pub bridgehub_sl: Bridgehub<NodeProvider>,
+    pub diamond_proxy_l1: ZkChain<NodeProvider>,
+    pub diamond_proxy_sl: ZkChain<NodeProvider>,
     pub validator_timelock_sl: Address,
     pub batch_verification: BatchVerificationSL,
     pub last_committed_batch: u64,
@@ -68,8 +69,8 @@ impl L1State {
     /// proxy is resolved from it so historical batches committed on the Gateway can still be
     /// looked up via [`SettlementLayerIntervals::resolve_proxy`].
     pub async fn fetch(
-        l1_provider: DynProvider,
-        gateway_provider: Option<DynProvider>,
+        l1_provider: NodeProvider,
+        gateway_provider: Option<NodeProvider>,
         bridgehub_address_l1: Address,
         l2_chain_id: u64,
     ) -> anyhow::Result<Self> {
@@ -192,8 +193,8 @@ impl L1State {
     }
 
     async fn validate_chain_ids(
-        bridgehub_l1: &Bridgehub<DynProvider>,
-        bridgehub_sl: &Bridgehub<DynProvider>,
+        bridgehub_l1: &Bridgehub<NodeProvider>,
+        bridgehub_sl: &Bridgehub<NodeProvider>,
         l2_chain_id: u64,
     ) -> anyhow::Result<()> {
         let all_chain_ids_l1 = bridgehub_l1.get_all_zk_chain_chain_ids().await?;
@@ -223,8 +224,8 @@ impl L1State {
     /// NOTE: This should only be called on the main node as ENs will observe pending changes that
     /// are being submitted by the main node.
     pub async fn fetch_finalized(
-        l1_provider: DynProvider,
-        gateway_provider: Option<DynProvider>,
+        l1_provider: NodeProvider,
+        gateway_provider: Option<NodeProvider>,
         bridgehub_address: Address,
         chain_id: u64,
     ) -> anyhow::Result<Self> {
@@ -291,7 +292,7 @@ impl L1State {
 }
 
 async fn fetch_finalized_executed_batch(
-    zk_chain_sl: &ZkChain<DynProvider>,
+    zk_chain_sl: &ZkChain<NodeProvider>,
 ) -> anyhow::Result<(u64, u64)> {
     let finalized_sl_block_number = zk_chain_sl
         .provider()
@@ -316,7 +317,7 @@ async fn fetch_finalized_executed_batch(
 
 /// Waits until the pending SL state matches the latest finalized SL block.
 async fn wait_to_finalize<T: Debug + PartialEq, Fut: Future<Output = crate::Result<T>>>(
-    provider: &DynProvider,
+    provider: &NodeProvider,
     f: impl Fn(BlockId) -> Fut,
 ) -> anyhow::Result<(u64, T)> {
     /// Ethereum blocks are mined every ~12 seconds on average, but we wait in 1-second intervals

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -16,6 +16,7 @@ use alloy::eips::BlockId;
 use alloy::network::Ethereum;
 use alloy::primitives::{Address, B256, TxHash, U256};
 use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 
 alloy::sol! {
     // `Messaging.sol`
@@ -508,15 +509,14 @@ impl<P: Provider> MessageRoot<P> {
             .map(|n| n.saturating_to())
             .enrich("interopRootLogId", Some(block_id))
     }
+}
 
-    pub async fn code_exists_at_block(&self, block_id: BlockId) -> alloy::contract::Result<bool> {
-        let code = self
-            .provider()
-            .get_code_at(*self.address())
-            .block_id(block_id)
-            .await?;
-
-        Ok(!code.0.is_empty())
+impl MessageRoot<NodeProvider> {
+    /// L1 block at which this message root contract was deployed, used as the lower bound for
+    /// binary searches over L1 history. Convenience over [`NodeProvider::deployment_block`] that
+    /// the provider caches per address.
+    pub async fn deployment_block(&self) -> anyhow::Result<u64> {
+        self.provider().deployment_block(self.address).await
     }
 }
 
@@ -763,6 +763,15 @@ impl<P: Provider> MultisigCommitter<P> {
 #[derive(Clone, Debug)]
 pub struct ZkChain<P: Provider> {
     instance: IZKChainInstance<P, Ethereum>,
+}
+
+impl ZkChain<NodeProvider> {
+    /// L1 block at which this diamond proxy was deployed, used as the lower bound for binary
+    /// searches over L1 history. Convenience over [`NodeProvider::deployment_block`] that the
+    /// provider caches per address.
+    pub async fn deployment_block(&self) -> anyhow::Result<u64> {
+        self.provider().deployment_block(*self.address()).await
+    }
 }
 
 impl<P: Provider> ZkChain<P> {

--- a/lib/contract_interface/src/settlement_layer_intervals.rs
+++ b/lib/contract_interface/src/settlement_layer_intervals.rs
@@ -1,9 +1,10 @@
 use crate::{Bridgehub, IChainAssetHandler, ZkChain, is_method_missing};
 use alloy::primitives::{Address, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
 use anyhow::Context;
 use std::fmt;
 use std::sync::Arc;
+use zksync_os_provider::NodeProvider;
 
 /// Settlement layer that a chain was committing to during a given batch range.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,7 +34,7 @@ pub struct SettlementLayerInterval {
     pub first_batch: u64,
     pub last_batch: Option<u64>,
     /// Diamond proxy on `settlement_layer`.
-    pub proxy: ZkChain<DynProvider>,
+    pub proxy: ZkChain<NodeProvider>,
 }
 
 impl fmt::Display for SettlementLayerInterval {
@@ -75,8 +76,8 @@ impl SettlementLayerIntervals {
     /// chain that the configured `gateway_provider` cannot serve.
     pub async fn discover(
         chain_asset_handler: Address,
-        diamond_proxy_l1: ZkChain<DynProvider>,
-        gateway_provider: Option<DynProvider>,
+        diamond_proxy_l1: ZkChain<NodeProvider>,
+        gateway_provider: Option<NodeProvider>,
         l2_chain_id: u64,
     ) -> anyhow::Result<Self> {
         let raw_intervals = find_settlement_layer_intervals(
@@ -190,7 +191,7 @@ impl SettlementLayerIntervals {
 /// - `MAX_ALLOWED_NUMBER_OF_MIGRATIONS = 2` on-chain, so at most two cycles are supported.
 async fn find_settlement_layer_intervals(
     chain_asset_handler: Address,
-    provider: DynProvider,
+    provider: NodeProvider,
     chain_id: u64,
 ) -> anyhow::Result<Vec<RawSettlementLayerInterval>> {
     let cah = IChainAssetHandler::new(chain_asset_handler, provider);

--- a/lib/genesis/Cargo.toml
+++ b/lib/genesis/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 [dependencies]
 zksync_os_types.workspace = true
 zksync_os_l1_watcher.workspace = true
+zksync_os_provider.workspace = true
 zksync_os_contract_interface.workspace = true
 zksync_os_storage_api.workspace = true
 

--- a/lib/genesis/src/lib.rs
+++ b/lib/genesis/src/lib.rs
@@ -2,7 +2,8 @@ use alloy::consensus::{EMPTY_OMMER_ROOT_HASH, Header};
 use alloy::eips::eip1559::INITIAL_BASE_FEE;
 use alloy::hex;
 use alloy::primitives::{Address, B64, B256, Bloom, Sealable, Sealed, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -123,7 +124,7 @@ pub struct GenesisUpgradeTxInfo {
 #[derive(Clone)]
 pub struct Genesis {
     input_source: Arc<dyn GenesisInputSource>,
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     state: OnceCell<GenesisState>,
     genesis_upgrade_tx: OnceCell<GenesisUpgradeTxInfo>,
     chain_id: u64,
@@ -143,7 +144,7 @@ impl Debug for Genesis {
 impl Genesis {
     pub fn new(
         input_source: Arc<dyn GenesisInputSource>,
-        zk_chain: ZkChain<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
         chain_id: u64,
     ) -> Self {
         Self {
@@ -332,27 +333,17 @@ async fn build_genesis(
 }
 
 async fn load_genesis_upgrade_tx(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
 ) -> anyhow::Result<GenesisUpgradeTxInfo> {
     let zk_chain_address = *zk_chain.address();
     let provider = zk_chain.provider().clone();
-    let current_l1_block = zk_chain.provider().get_block_number().await?;
-    // Find the block when the zk chain was deployed or fallback to [0; latest_block] in localhost case.
-    let from_block = zksync_os_l1_watcher::util::find_l1_block_by_predicate(
-        Arc::new(zk_chain),
-        0,
-        |_zk, _block| async { Ok(true) },
-    )
-    .await?;
-    let to_block = if from_block == 0 {
-        current_l1_block
-    } else {
-        from_block
-    };
+    // The `GenesisUpgrade` event is emitted in the diamond proxy's deployment block, so the search
+    // collapses to that single block (`0` when undeployed, e.g. localhost — scans the genesis block).
+    let deployment_block = zk_chain.deployment_block().await?;
     let event_sig = GenesisUpgrade::SIGNATURE_HASH;
     let filter = Filter::new()
-        .from_block(from_block)
-        .to_block(to_block)
+        .from_block(deployment_block)
+        .to_block(deployment_block)
         .event_signature(event_sig)
         .address(zk_chain_address);
     let logs = provider.get_logs(&filter).await?;

--- a/lib/genesis/src/lib.rs
+++ b/lib/genesis/src/lib.rs
@@ -3,7 +3,6 @@ use alloy::eips::eip1559::INITIAL_BASE_FEE;
 use alloy::hex;
 use alloy::primitives::{Address, B64, B256, Bloom, Sealable, Sealed, U256};
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -20,6 +19,7 @@ use zk_os_basic_system::system_implementation::flat_storage_model::{
 };
 use zksync_os_contract_interface::IL1GenesisUpgrade::GenesisUpgrade;
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_provider::NodeProvider;
 use zksync_os_storage_api::BlockContext;
 use zksync_os_types::{ConfigFormat, ExecutionVersion, L1UpgradeEnvelope, ProtocolSemanticVersion};
 

--- a/lib/l1_sender/Cargo.toml
+++ b/lib/l1_sender/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 zksync_os_alloy_ext.workspace = true
+zksync_os_provider.workspace = true
 zksync_os_contract_interface.workspace = true
 zksync_os_observability.workspace = true
 zksync_os_pipeline.workspace = true

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -28,7 +28,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthWalletProvider;
+use zksync_os_provider::EthWalletProvider;
 use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState, StateLabel};
 use zksync_os_pipeline::{PeekableReceiver, SendAndRecordExt};

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -28,10 +28,10 @@ use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
-use zksync_os_provider::EthWalletProvider;
 use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState, StateLabel};
 use zksync_os_pipeline::{PeekableReceiver, SendAndRecordExt};
+use zksync_os_provider::EthWalletProvider;
 
 /// Component-specific state for the L1 sender.
 pub enum L1SenderState {

--- a/lib/l1_sender/src/pipeline_component.rs
+++ b/lib/l1_sender/src/pipeline_component.rs
@@ -3,7 +3,7 @@ use crate::config::L1SenderConfig;
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use tokio::sync::{mpsc, watch};
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
@@ -11,7 +11,7 @@ use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 /// Generic L1 Sender pipeline component
 /// Can be used for commit, prove, or execute operations
 pub struct L1Sender<C> {
-    pub provider: EthDynProvider,
+    pub provider: NodeProvider,
     pub config: L1SenderConfig<C>,
     pub to_address: Address,
     pub gateway: bool,

--- a/lib/l1_sender/src/pipeline_component.rs
+++ b/lib/l1_sender/src/pipeline_component.rs
@@ -3,10 +3,10 @@ use crate::config::L1SenderConfig;
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use tokio::sync::{mpsc, watch};
-use zksync_os_provider::NodeProvider;
 use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_provider::NodeProvider;
 
 /// Generic L1 Sender pipeline component
 /// Can be used for commit, prove, or execute operations

--- a/lib/l1_sender/src/upgrade_gatekeeper.rs
+++ b/lib/l1_sender/src/upgrade_gatekeeper.rs
@@ -1,10 +1,11 @@
 use crate::commands::{L1SenderCommand, commit::CommitCommand};
-use alloy::{eips::BlockId, providers::DynProvider};
+use alloy::eips::BlockId;
 use anyhow::Context as _;
 use async_trait::async_trait;
 use std::cmp::Ordering;
 use tokio::sync::mpsc;
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_provider::NodeProvider;
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
 use zksync_os_types::ProtocolSemanticVersion;
@@ -13,11 +14,11 @@ use zksync_os_types::ProtocolSemanticVersion;
 /// Makes sure that batches are only passed to L1 if batch version matches the current protocol version.
 #[derive(Debug)]
 pub struct UpgradeGatekeeper {
-    zk_chain_sl: ZkChain<DynProvider>,
+    zk_chain_sl: ZkChain<NodeProvider>,
 }
 
 impl UpgradeGatekeeper {
-    pub fn new(zk_chain_sl: ZkChain<DynProvider>) -> Self {
+    pub fn new(zk_chain_sl: ZkChain<NodeProvider>) -> Self {
         Self { zk_chain_sl }
     }
 

--- a/lib/l1_sender/src/upgrade_gatekeeper.rs
+++ b/lib/l1_sender/src/upgrade_gatekeeper.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use std::cmp::Ordering;
 use tokio::sync::mpsc;
 use zksync_os_contract_interface::ZkChain;
-use zksync_os_provider::NodeProvider;
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::ProtocolSemanticVersion;
 
 /// Receives Batches with proofs - potentially with incompatible protocol version.

--- a/lib/l1_watcher/Cargo.toml
+++ b/lib/l1_watcher/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+zksync_os_provider.workspace = true
 zksync_os_contract_interface.workspace = true
 zksync_os_storage_api.workspace = true
 zksync_os_types.workspace = true

--- a/lib/l1_watcher/src/block_updates.rs
+++ b/lib/l1_watcher/src/block_updates.rs
@@ -1,6 +1,7 @@
 use alloy::eips::BlockId;
 use alloy::primitives::BlockNumber;
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use reth_tasks::Runtime;
 use std::time::Duration;
 use tokio::sync::watch;
@@ -19,7 +20,7 @@ pub struct BlockUpdates {
 }
 
 pub fn run(
-    provider: DynProvider,
+    provider: NodeProvider,
     runtime: &Runtime,
     task_name: &'static str,
     poll_interval: Duration,
@@ -49,7 +50,7 @@ pub fn run(
 }
 
 async fn poll_latest(
-    provider: &DynProvider,
+    provider: &NodeProvider,
     l1_head: &watch::Sender<BlockUpdates>,
 ) -> alloy::transports::TransportResult<()> {
     let latest_block = provider.get_block_number().await?;
@@ -65,7 +66,7 @@ async fn poll_latest(
 }
 
 async fn poll_finalized(
-    provider: &DynProvider,
+    provider: &NodeProvider,
     l1_head: &watch::Sender<BlockUpdates>,
 ) -> alloy::transports::TransportResult<()> {
     let finalized_block = provider

--- a/lib/l1_watcher/src/block_updates.rs
+++ b/lib/l1_watcher/src/block_updates.rs
@@ -1,10 +1,10 @@
 use alloy::eips::BlockId;
 use alloy::primitives::BlockNumber;
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use reth_tasks::Runtime;
 use std::time::Duration;
 use tokio::sync::watch;
+use zksync_os_provider::NodeProvider;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BlockBoundary {

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -1,12 +1,12 @@
 use crate::committed_batch_provider::CommittedBatchProvider;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_provider::NodeProvider;
 use zksync_os_storage_api::WriteFinality;
 
 /// Watches settlement-layer commit events and advances the committed finality frontier.

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -1,7 +1,7 @@
 use crate::committed_batch_provider::CommittedBatchProvider;
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
@@ -35,7 +35,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
     #[allow(clippy::too_many_arguments)]
     pub async fn create_watcher(
         config: L1WatcherConfig,
-        zk_chain: ZkChain<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         sl_block_initial_finality_init_at: u64,
@@ -93,7 +93,7 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
 
     async fn process_event(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         report: ReportCommittedBatchRangeZKsyncOS,
         log: Log,
     ) -> Result<(), L1WatcherError> {

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -1,6 +1,5 @@
 use crate::util;
 use alloy::primitives::BlockNumber;
-use zksync_os_provider::NodeProvider;
 use anyhow::Context;
 use futures::stream::{self, StreamExt};
 use rangemap::RangeInclusiveMap;
@@ -14,6 +13,7 @@ use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_contract_interface::models::StoredBatchInfo;
 use zksync_os_contract_interface::settlement_layer_intervals::SettlementLayerIntervals;
+use zksync_os_provider::NodeProvider;
 
 const INIT_MAX_PARALLEL_BATCH_FETCHES: usize = 10;
 const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -1,6 +1,6 @@
 use crate::util;
 use alloy::primitives::BlockNumber;
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use anyhow::Context;
 use futures::stream::{self, StreamExt};
 use rangemap::RangeInclusiveMap;
@@ -227,7 +227,7 @@ fn startup_batch_numbers(
 /// Resolves a committed batch from L1 by first finding the block that committed it and then
 /// decoding the corresponding stored batch data.
 async fn fetch_batch(
-    diamond_proxy_sl: &ZkChain<DynProvider>,
+    diamond_proxy_sl: &ZkChain<NodeProvider>,
     batch_number: u64,
     max_l1_blocks_to_scan: u64,
 ) -> anyhow::Result<DiscoveredCommittedBatch> {

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -1,11 +1,11 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, CommittedBatchProvider, L1WatcherConfig, ProcessL1Event, util};
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_provider::NodeProvider;
 use zksync_os_storage_api::WriteFinality;
 
 /// Watches settlement-layer execution events and advances the executed finality frontier.

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -1,6 +1,7 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, CommittedBatchProvider, L1WatcherConfig, ProcessL1Event, util};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
@@ -37,7 +38,7 @@ struct ExecuteWatcherState<Finality> {
 impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
     pub async fn create_watcher(
         config: L1WatcherConfig,
-        zk_chain: ZkChain<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         l1_chain_id: u64,
@@ -84,7 +85,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
 impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
     pub async fn create_finalized_watcher(
         config: L1WatcherConfig,
-        zk_chain: ZkChain<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         block_updates: watch::Receiver<BlockUpdates>,
@@ -207,7 +208,7 @@ impl<Finality: WriteFinality> ProcessL1Event for L1ExecuteWatcher<Finality> {
 
     async fn process_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         batch_execute: BlockExecution,
         _log: Log,
     ) -> Result<(), L1WatcherError> {
@@ -226,7 +227,7 @@ impl<Finality: WriteFinality> ProcessL1Event for L1FinalizedExecuteWatcher<Final
 
     async fn process_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         batch_execute: BlockExecution,
         _log: Log,
     ) -> Result<(), L1WatcherError> {

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -1,13 +1,13 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, ChainId, U256};
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use tokio::sync::watch;
 use zksync_os_contract_interface::ServerNotifier::MigrateFromGateway;
 use zksync_os_contract_interface::{Bridgehub, ServerNotifier::MigrateToGateway, ZkChain};
 use zksync_os_mempool::subpools::sl_chain_id::SlChainIdSubpool;
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::SystemTxEnvelope;
 
 /// Watches for both `MigrateToGateway` and `MigrateFromGateway` events on L1 in a single

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -1,7 +1,7 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, ChainId, U256};
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use tokio::sync::watch;
@@ -32,8 +32,8 @@ pub struct GatewayMigrationWatcher {
 impl GatewayMigrationWatcher {
     #[allow(clippy::too_many_arguments)]
     pub async fn create_watcher(
-        zk_chain: ZkChain<DynProvider>,
-        bridgehub: Bridgehub<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
+        bridgehub: Bridgehub<NodeProvider>,
         l2_chain_id: ChainId,
         l1_chain_id: ChainId,
         gw_chain_id: ChainId,
@@ -107,7 +107,7 @@ impl ProcessRawEvents for GatewayMigrationWatcher {
 
     async fn process_raw_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let Some(&topic0) = log.topic0() else {

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::ruint::FromUintError;
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -166,7 +166,7 @@ impl ProcessRawEvents for InteropWatcher {
 
     async fn process_raw_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let event = NewInteropRoot::decode_log(&log.inner)?.data;

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -1,5 +1,4 @@
 use alloy::primitives::ruint::FromUintError;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -13,6 +12,7 @@ use zksync_os_contract_interface::settlement_layer_intervals::{
     IntervalSettlementLayer, SettlementLayerIntervals,
 };
 use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::IndexedInteropRoot;
 
 use crate::sl_aware_watcher::{SegmentSpec, SlAwareL1Watcher};

--- a/lib/l1_watcher/src/migration_finalized_watcher.rs
+++ b/lib/l1_watcher/src/migration_finalized_watcher.rs
@@ -1,12 +1,12 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, U256};
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use tokio::sync::watch;
 use zksync_os_contract_interface::settlement_layer_intervals::SettlementLayerIntervals;
 use zksync_os_contract_interface::{Bridgehub, IChainAssetHandler::MigrationFinalized, ZkChain};
+use zksync_os_provider::NodeProvider;
 
 /// Watches for `MigrationFinalized(uint256 indexed chainId, uint256 migrationNumber, ...)` events
 /// emitted by the `IChainAssetHandler` contract on the current settlement layer.

--- a/lib/l1_watcher/src/migration_finalized_watcher.rs
+++ b/lib/l1_watcher/src/migration_finalized_watcher.rs
@@ -1,7 +1,7 @@
 use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, U256};
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use tokio::sync::watch;
@@ -29,8 +29,8 @@ impl MigrationFinalizedWatcher {
     /// destination's view of finalized migrations) and decides whether to spawn the watcher.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_watcher(
-        zk_chain: ZkChain<DynProvider>,
-        bridgehub_sl: Bridgehub<DynProvider>,
+        zk_chain: ZkChain<NodeProvider>,
+        bridgehub_sl: Bridgehub<NodeProvider>,
         intervals: &SettlementLayerIntervals,
         l2_chain_id: u64,
         l1_chain_id: u64,
@@ -119,7 +119,7 @@ impl ProcessRawEvents for MigrationFinalizedWatcher {
 
     async fn process_raw_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let Some(&topic0) = log.topic0() else {

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -1,7 +1,6 @@
 use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
 use crate::{BlockUpdates, L1WatcherConfig, SegmentSpec, SlAwareL1Watcher, util};
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -13,6 +12,7 @@ use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::settlement_layer_intervals::{
     IntervalSettlementLayer, SettlementLayerIntervals,
 };
+use zksync_os_provider::NodeProvider;
 use zksync_os_storage_api::{PersistedBatch, WriteBatch};
 
 /// Watches finalized commit and execute events together and persists only irreversibly executed

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -1,7 +1,7 @@
 use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
 use crate::{BlockUpdates, L1WatcherConfig, SegmentSpec, SlAwareL1Watcher, util};
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -153,7 +153,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
 
     async fn parse_committed_batch(
         &self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         report: ReportCommittedBatchRangeZKsyncOS,
         log: Log,
     ) -> Result<DiscoveredCommittedBatch, L1WatcherError> {
@@ -171,7 +171,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
 
     async fn process_commit(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         report: ReportCommittedBatchRangeZKsyncOS,
         log: Log,
     ) -> Result<(), L1WatcherError> {
@@ -256,7 +256,7 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
 
     async fn process_raw_event(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let event_signature = log.topics()[0];

--- a/lib/l1_watcher/src/settlement_layer_watcher.rs
+++ b/lib/l1_watcher/src/settlement_layer_watcher.rs
@@ -1,6 +1,6 @@
 use alloy::eips::BlockId;
 use alloy::primitives::Address;
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use std::time::Duration;
 use tokio::sync::watch;
 use zksync_os_contract_interface::ZkChain;
@@ -17,7 +17,7 @@ use zksync_os_contract_interface::ZkChain;
 /// Waiting for all three conditions prevents the node from restarting prematurely — before the
 /// old settlement layer has finalised all the batches that were in-flight at migration time.
 pub struct SettlementLayerWatcher {
-    diamond_proxy_l1: ZkChain<DynProvider>,
+    diamond_proxy_l1: ZkChain<NodeProvider>,
     /// Value of `getSettlementLayer()` at the time the node started.
     initial_settlement_layer: Address,
     poll_interval: Duration,
@@ -28,7 +28,7 @@ pub struct SettlementLayerWatcher {
 
 impl SettlementLayerWatcher {
     pub fn new(
-        diamond_proxy_l1: ZkChain<DynProvider>,
+        diamond_proxy_l1: ZkChain<NodeProvider>,
         initial_settlement_layer: Address,
         poll_interval: Duration,
         migration_triggered: watch::Receiver<Option<u64>>,

--- a/lib/l1_watcher/src/settlement_layer_watcher.rs
+++ b/lib/l1_watcher/src/settlement_layer_watcher.rs
@@ -1,9 +1,9 @@
 use alloy::eips::BlockId;
 use alloy::primitives::Address;
-use zksync_os_provider::NodeProvider;
 use std::time::Duration;
 use tokio::sync::watch;
 use zksync_os_contract_interface::ZkChain;
+use zksync_os_provider::NodeProvider;
 
 /// Polls `getSettlementLayer()` on the L1 diamond proxy and terminates the process once all three
 /// conditions are simultaneously satisfied:

--- a/lib/l1_watcher/src/sl_aware_watcher.rs
+++ b/lib/l1_watcher/src/sl_aware_watcher.rs
@@ -1,7 +1,7 @@
 use crate::watcher::L1Watcher;
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::ValueOrArray;
 use std::collections::VecDeque;
 use tokio::sync::watch;
@@ -14,7 +14,7 @@ use tokio::sync::watch;
 #[derive(Clone, Debug)]
 pub struct SegmentSpec {
     /// Provider for the settlement layer this segment is scanned on.
-    pub provider: DynProvider,
+    pub provider: NodeProvider,
     /// Block updates for the segment's settlement-layer provider.
     pub block_updates: watch::Receiver<BlockUpdates>,
     /// Contract address(es) whose logs the segment scans (e.g. the chain's diamond proxy or a

--- a/lib/l1_watcher/src/sl_aware_watcher.rs
+++ b/lib/l1_watcher/src/sl_aware_watcher.rs
@@ -1,10 +1,10 @@
 use crate::watcher::L1Watcher;
 use crate::{BlockUpdates, L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::ValueOrArray;
 use std::collections::VecDeque;
 use tokio::sync::watch;
+use zksync_os_provider::NodeProvider;
 
 /// Description of a single settlement-layer segment that [`SlAwareL1Watcher`] should scan, in
 /// isolation, before advancing to the next one. `end_block = None` marks the open-ended (live)

--- a/lib/l1_watcher/src/traits.rs
+++ b/lib/l1_watcher/src/traits.rs
@@ -1,8 +1,8 @@
 use crate::watcher::L1WatcherError;
 use alloy::primitives::B256;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
+use zksync_os_provider::NodeProvider;
 
 /// A "raw" event processor that works with decoded logs.
 /// Provides more flexibility compared to [`ProcessL1Event`], but requires the author

--- a/lib/l1_watcher/src/traits.rs
+++ b/lib/l1_watcher/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::watcher::L1WatcherError;
 use alloy::primitives::B256;
-use alloy::providers::DynProvider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 
@@ -40,7 +40,7 @@ pub trait ProcessRawEvents: Send + Sync + 'static {
     /// storing a stale provider reference; single-SL processors can ignore it.
     async fn process_raw_event(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         event: Log,
     ) -> Result<(), L1WatcherError>;
 }
@@ -70,7 +70,7 @@ where
 
     async fn process_raw_event(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         log: Log,
     ) -> Result<(), L1WatcherError> {
         let sol_event = T::SolEvent::decode_log(&log.inner)?.data;
@@ -105,7 +105,7 @@ pub trait ProcessL1Event {
     /// [`ProcessRawEvents::process_raw_event`].
     async fn process_event(
         &mut self,
-        provider: &DynProvider,
+        provider: &NodeProvider,
         event: Self::WatchedEvent,
         log: Log,
     ) -> Result<(), L1WatcherError>;

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -2,7 +2,8 @@ use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::BlockNumber;
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +20,7 @@ use zksync_os_types::L1PriorityEnvelope;
 /// `L1PriorityEnvelope` into `L1Subpool`.
 pub struct L1TxWatcher {
     next_l1_priority_id: u64,
-    zk_chain_sl: ZkChain<DynProvider>,
+    zk_chain_sl: ZkChain<NodeProvider>,
     cached_total_priority_ops_resp: Option<u64>,
     l1_subpool: L1Subpool,
 }
@@ -27,8 +28,8 @@ pub struct L1TxWatcher {
 impl L1TxWatcher {
     pub async fn create_watcher(
         config: L1WatcherConfig,
-        zk_chain_l1: ZkChain<DynProvider>,
-        zk_chain_sl: ZkChain<DynProvider>,
+        zk_chain_l1: ZkChain<NodeProvider>,
+        zk_chain_sl: ZkChain<NodeProvider>,
         l1_subpool: L1Subpool,
         next_l1_priority_id: u64,
         block_updates: watch::Receiver<BlockUpdates>,
@@ -67,13 +68,18 @@ impl L1TxWatcher {
 }
 
 async fn find_l1_block_by_priority_id(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     next_l1_priority_id: u64,
 ) -> anyhow::Result<BlockNumber> {
-    util::find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| async move {
-        let res = zk.get_total_priority_txs_at_block(block.into()).await?;
-        Ok(res >= next_l1_priority_id)
-    })
+    let deployment_block = zk_chain.deployment_block().await?;
+    util::find_l1_block_by_predicate(
+        Arc::new(zk_chain),
+        deployment_block,
+        move |zk, block| async move {
+            let res = zk.get_total_priority_txs_at_block(block.into()).await?;
+            Ok(res >= next_l1_priority_id)
+        },
+    )
     .await
 }
 
@@ -86,7 +92,7 @@ impl ProcessL1Event for L1TxWatcher {
 
     async fn process_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         tx: L1PriorityEnvelope,
         _log: Log,
     ) -> Result<(), L1WatcherError> {

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -3,7 +3,6 @@ use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::BlockNumber;
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::Log;
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,6 +10,7 @@ use tokio::sync::watch;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_mempool::subpools::l1::L1Subpool;
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::L1PriorityEnvelope;
 
 /// Watches L1 priority transaction events and feeds them into the L1 transaction subpool.

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -7,7 +7,6 @@ use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
 use alloy::dyn_abi::SolType;
 use alloy::primitives::{Address, B256, BlockNumber, ChainId, U256};
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use blake2::{Blake2s256, Digest};
@@ -20,6 +19,7 @@ use zksync_os_contract_interface::ServerNotifier::UpgradeTimestampUpdated;
 use zksync_os_contract_interface::is_method_missing;
 use zksync_os_contract_interface::{Bridgehub, ZkChain};
 use zksync_os_mempool::subpools::upgrade::UpgradeSubpool;
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::{
     L1UpgradeEnvelope, ProtocolSemanticVersion, ProtocolSemanticVersionError, UpgradeInfo,
     UpgradeMetadata,

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -6,7 +6,8 @@ use crate::watcher::{L1Watcher, L1WatcherError};
 use crate::{BlockUpdates, L1WatcherConfig, ProcessL1Event, util};
 use alloy::dyn_abi::SolType;
 use alloy::primitives::{Address, B256, BlockNumber, ChainId, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use blake2::{Blake2s256, Digest};
@@ -44,8 +45,8 @@ const UPGRADE_DATA_LOOKBEHIND_BLOCKS: u64 = 2_500_000;
 ///   `EVMBytecodePublished` events — these live on L1 regardless of settlement layer.
 pub struct L1UpgradeTxWatcher {
     l2_chain_id: ChainId,
-    provider_l1: DynProvider,
-    provider_sl: DynProvider,
+    provider_l1: NodeProvider,
+    provider_sl: NodeProvider,
     bridgehub_l1: Address,
     /// Address of the bytecode supplier contract on L1 (used to scan EVMBytecodePublished events)
     bytecode_supplier_address: Address,
@@ -65,9 +66,9 @@ impl L1UpgradeTxWatcher {
     pub async fn create_watcher(
         config: L1WatcherConfig,
         l2_chain_id: ChainId,
-        bridgehub_l1: Bridgehub<DynProvider>,
-        zk_chain_l1: ZkChain<DynProvider>,
-        zk_chain_sl: ZkChain<DynProvider>,
+        bridgehub_l1: Bridgehub<NodeProvider>,
+        zk_chain_l1: ZkChain<NodeProvider>,
+        zk_chain_sl: ZkChain<NodeProvider>,
         bytecode_supplier_address: Address,
         current_protocol_version: ProtocolSemanticVersion,
         upgrade_subpool: UpgradeSubpool,
@@ -621,7 +622,7 @@ impl ProcessL1Event for L1UpgradeTxWatcher {
 
     async fn process_event(
         &mut self,
-        _provider: &DynProvider,
+        _provider: &NodeProvider,
         request: L1UpgradeRequest,
         _log: Log,
     ) -> Result<(), L1WatcherError> {
@@ -733,7 +734,7 @@ pub enum UpgradeTxWatcherError {
 /// means the mapping is empty for that version. Returns `None` if the method is missing on the
 /// deployed CTM (pre-V31).
 async fn get_upgrade_cut_data_block(
-    provider: &DynProvider,
+    provider: &NodeProvider,
     ctm_address: Address,
     raw_protocol_version: U256,
 ) -> anyhow::Result<Option<u64>> {
@@ -746,7 +747,7 @@ async fn get_upgrade_cut_data_block(
 }
 
 async fn fetch_upgrade_cut_log_at(
-    provider: &DynProvider,
+    provider: &NodeProvider,
     ctm_address: Address,
     raw_protocol_version: U256,
     block: u64,
@@ -767,15 +768,20 @@ async fn fetch_upgrade_cut_log_at(
 }
 
 async fn find_l1_block_by_protocol_version(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     protocol_version: ProtocolSemanticVersion,
 ) -> anyhow::Result<BlockNumber> {
     let protocol_version = protocol_version.packed()?;
 
-    util::find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| async move {
-        let res = zk.get_raw_protocol_version(block.into()).await?;
-        Ok(res >= protocol_version)
-    })
+    let deployment_block = zk_chain.deployment_block().await?;
+    util::find_l1_block_by_predicate(
+        Arc::new(zk_chain),
+        deployment_block,
+        move |zk, block| async move {
+            let res = zk.get_raw_protocol_version(block.into()).await?;
+            Ok(res >= protocol_version)
+        },
+    )
     .await
 }
 

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -2,7 +2,7 @@ use crate::watcher::L1WatcherError;
 use alloy::consensus::Transaction;
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, BlockNumber, TxHash, U256};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -15,6 +15,7 @@ use zksync_os_contract_interface::IChainAssetHandler;
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
 use zksync_os_contract_interface::{Bridgehub, IExecutor, MessageRoot, ZkChain};
+use zksync_os_provider::NodeProvider;
 use zksync_os_types::ProtocolSemanticVersion;
 
 pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
@@ -26,7 +27,7 @@ pub const ANVIL_L1_CHAIN_ID: u64 = 31337;
 /// [`MigrationCompleteWatcher`][crate::MigrationCompleteWatcher] (on the current settlement layer)
 /// to determine the block from which to start scanning for migration events.
 pub async fn find_block_by_migration_number(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     chain_asset_handler: Address,
     chain_id: u64,
     migration_number: u64,
@@ -47,7 +48,12 @@ pub async fn find_block_by_migration_number(
         return Ok(latest);
     }
 
-    find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| {
+    // The chain's diamond proxy deployment block is a safe lower bound for CAH searches: the proxy
+    // can only exist when the bridgehub ecosystem (including CAH, when present) is at least
+    // partially up. The predicate still guards against CAH being absent for the V30→V31 migration
+    // window where the proxy existed before CAH was deployed.
+    let start_block = zk_chain.deployment_block().await?;
+    find_l1_block_by_predicate(Arc::new(zk_chain), start_block, move |zk, block| {
         let instance = instance.clone();
         async move {
             let code = zk
@@ -74,35 +80,32 @@ pub async fn find_block_by_migration_number(
 /// Rough calculations: 10min * 10 req/s * 1000 blocks/req = 600 * 10 * 1000 = 6_000_000
 const MAX_L1_BLOCKS_TO_SCAN_LINEARLY: u64 = 6_000_000;
 
+/// Binary-searches `[start_block_number, latest]` for the first block at which `predicate` returns
+/// `true`. The predicate must be monotonic over the search range (caller's responsibility).
+///
+/// **Caller must ensure `start_block_number >= contract.deployment_block`** — the predicate is
+/// invoked without a code-presence guard, so calling it at blocks where the contract is not yet
+/// deployed will produce undefined results (typically an RPC error or a `false`-returning revert).
 pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool>>>(
-    zk_chain: Arc<ZkChain<DynProvider>>,
+    zk_chain: Arc<ZkChain<NodeProvider>>,
     start_block_number: BlockNumber,
-    predicate: impl Fn(Arc<ZkChain<DynProvider>>, u64) -> Fut,
+    predicate: impl Fn(Arc<ZkChain<NodeProvider>>, u64) -> Fut,
 ) -> anyhow::Result<BlockNumber> {
     let latest = zk_chain.provider().get_block_number().await?;
 
-    let guarded_predicate =
-        async |zk: Arc<ZkChain<DynProvider>>, block: u64| -> anyhow::Result<bool> {
-            if !zk.code_exists_at_block(block.into()).await? {
-                // return early if contract is not deployed yet - otherwise `predicate` might fail
-                return Ok(false);
-            }
-            predicate(zk, block).await
-        };
-
     // Ensure the predicate is true by the upper bound, or bail early.
-    if !guarded_predicate(zk_chain.clone(), latest).await? {
+    if !predicate(zk_chain.clone(), latest).await? {
         anyhow::bail!(
             "Condition not satisfied up to latest block: contract not deployed yet \
              or target not reached.",
         );
     }
 
-    // Binary search on [0, latest] for the first block where predicate is true.
+    // Binary search on [start_block_number, latest] for the first block where predicate is true.
     let (mut lo, mut hi) = (start_block_number, latest);
     while lo < hi {
         let mid = (lo + hi) / 2;
-        if guarded_predicate(zk_chain.clone(), mid).await? {
+        if predicate(zk_chain.clone(), mid).await? {
             hi = mid;
         } else {
             lo = mid + 1;
@@ -117,7 +120,7 @@ pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool
 /// if there is not any.
 async fn find_last_matching_event<E: SolEvent + Debug>(
     address: Address,
-    provider: &DynProvider,
+    provider: &NodeProvider,
     start_block_number: BlockNumber,
     max_blocks_to_scan: u64,
     predicate: impl Fn(&E) -> bool,
@@ -188,7 +191,7 @@ async fn find_last_matching_event<E: SolEvent + Debug>(
 ///
 /// Batch `batch_number` MUST have been committed before `start_block_number`.
 async fn find_latest_l1_revert(
-    zk_chain: &ZkChain<DynProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     batch_number: u64,
     start_block_number: BlockNumber,
     max_blocks_to_scan: u64,
@@ -212,21 +215,26 @@ async fn find_latest_l1_revert(
 /// `b` CAN contain commit event for `B` that happened either before `T` or after `T` but MUST NOT
 /// contain both. See comments inside the implementation for more details.
 pub async fn find_l1_commit_block_by_batch_number(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     batch_number: u64,
     max_l1_blocks_to_scan: u64,
 ) -> anyhow::Result<BlockNumber> {
-    let is_batch_committed = move |zk: Arc<ZkChain<DynProvider>>, block: BlockNumber| async move {
+    let is_batch_committed = move |zk: Arc<ZkChain<NodeProvider>>, block: BlockNumber| async move {
         let res = zk.get_total_batches_committed(block.into()).await?;
         Ok(res >= batch_number)
     };
+    let deployment_block = zk_chain.deployment_block().await?;
     // This predicate is not monotonic because committed batches can be reverted. Even then, this
     // binary search will find **some** L1 block that commits our batch. If revert and another commit
     // happen after the found L1 block, then we will find them as handled by logic in the rest of the
     // function. If there are none, then we will not find anything and return this L1 block as a
     // result.
-    let l1_block_with_commit =
-        find_l1_block_by_predicate(Arc::new(zk_chain.clone()), 0, is_batch_committed).await?;
+    let l1_block_with_commit = find_l1_block_by_predicate(
+        Arc::new(zk_chain.clone()),
+        deployment_block,
+        is_batch_committed,
+    )
+    .await?;
     tracing::debug!(
         batch_number,
         l1_block_with_commit,
@@ -285,22 +293,27 @@ pub async fn find_l1_commit_block_by_batch_number(
 ///
 /// Returns latest L1 block is there is none.
 pub async fn find_l1_execute_block_by_batch_number(
-    zk_chain: ZkChain<DynProvider>,
+    zk_chain: ZkChain<NodeProvider>,
     batch_number: u64,
 ) -> anyhow::Result<BlockNumber> {
     // Execution cannot be reverted, so unlike in `find_l1_commit_block_by_batch_number`, we do not need
     // to take L1 reverts into account here.
-    find_l1_block_by_predicate(Arc::new(zk_chain), 0, move |zk, block| async move {
-        let res = zk.get_total_batches_executed(block.into()).await?;
-        Ok(res >= batch_number)
-    })
+    let deployment_block = zk_chain.deployment_block().await?;
+    find_l1_block_by_predicate(
+        Arc::new(zk_chain),
+        deployment_block,
+        move |zk, block| async move {
+            let res = zk.get_total_batches_executed(block.into()).await?;
+            Ok(res >= batch_number)
+        },
+    )
     .await
 }
 
 /// Finds the first L1 block where `interopRootLogId >= next_interop_root_id`.
 /// Uses binary search for efficiency.
 pub async fn find_l1_block_by_interop_root_id(
-    bridgehub: Bridgehub<DynProvider>,
+    bridgehub: Bridgehub<NodeProvider>,
     next_interop_root_id: u64,
 ) -> anyhow::Result<BlockNumber> {
     if next_interop_root_id == 0 {
@@ -314,27 +327,27 @@ pub async fn find_l1_block_by_interop_root_id(
     ));
 
     let latest = message_root.provider().get_block_number().await?;
+    // The provider's cache resolves (and remembers) the MessageRoot deployment block, giving the
+    // search a tight lower bound without a per-iteration code-existence guard.
+    let deployment_block = message_root.deployment_block().await?;
 
-    let guarded_predicate =
-        async |message_root: Arc<MessageRoot<DynProvider>>, block: u64| -> anyhow::Result<bool> {
-            if !message_root.code_exists_at_block(block.into()).await? {
-                return Ok(false);
-            }
+    let predicate =
+        async |message_root: Arc<MessageRoot<NodeProvider>>, block: u64| -> anyhow::Result<bool> {
             let res = message_root.interop_root_log_id(block.into()).await?;
             Ok(res >= next_interop_root_id)
         };
 
-    if !guarded_predicate(message_root.clone(), latest).await? {
+    if !predicate(message_root.clone(), latest).await? {
         anyhow::bail!(
             "Condition not satisfied up to latest block: contract not deployed yet \
              or target not reached.",
         );
     }
 
-    let (mut lo, mut hi) = (0, latest);
+    let (mut lo, mut hi) = (deployment_block, latest);
     while lo < hi {
         let mid = (lo + hi) / 2;
-        if guarded_predicate(message_root.clone(), mid).await? {
+        if predicate(message_root.clone(), mid).await? {
             hi = mid;
         } else {
             lo = mid + 1;
@@ -348,7 +361,7 @@ pub async fn find_l1_block_by_interop_root_id(
 /// committed in `l1_block_number`. Returns `None` if requested batch has not been committed in
 /// the given L1 block.
 pub async fn fetch_stored_batch_data(
-    zk_chain: &ZkChain<DynProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     l1_block_number: BlockNumber,
     batch_number: u64,
 ) -> anyhow::Result<Option<DiscoveredCommittedBatch>> {
@@ -389,7 +402,7 @@ pub async fn fetch_stored_batch_data(
 /// Fetches batch commit transaction and extra data from L1 required to construct `CommitedBatch`.
 /// Retries if the transaction is pending (exists but has no block number yet) or not yet visible.
 pub async fn fetch_committed_batch_data(
-    zk_chain: &ZkChain<DynProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     tx_hash: TxHash,
 ) -> Result<ExtendedCommitBatchInfo, L1WatcherError> {
     let tx = (|| async {

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -2,9 +2,9 @@ use crate::metrics::METRICS;
 use crate::{BlockBoundary, BlockUpdates, L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::Provider;
-use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Filter, Log, ValueOrArray};
 use tokio::sync::watch;
+use zksync_os_provider::NodeProvider;
 
 /// An abstract watcher for events.
 /// Handles polling for new blocks and extracting logs,

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -1,7 +1,8 @@
 use crate::metrics::METRICS;
 use crate::{BlockBoundary, BlockUpdates, L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
-use alloy::providers::{DynProvider, Provider};
+use alloy::providers::Provider;
+use zksync_os_provider::NodeProvider;
 use alloy::rpc::types::{Filter, Log, ValueOrArray};
 use tokio::sync::watch;
 
@@ -12,7 +13,7 @@ use tokio::sync::watch;
 /// May be run unbounded (live tail) or bounded by `end_block` (used by
 /// [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) to scan a closed segment to completion).
 pub struct L1Watcher {
-    provider: DynProvider,
+    provider: NodeProvider,
     address: ValueOrArray<Address>,
     next_block: BlockNumber,
     /// `Some(eb)` makes the watcher exit `run` once `next_block > eb`. `None` runs forever.
@@ -27,7 +28,7 @@ impl L1Watcher {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         config: L1WatcherConfig,
-        provider: DynProvider,
+        provider: NodeProvider,
         block_updates: watch::Receiver<BlockUpdates>,
         address: ValueOrArray<Address>,
         next_block: BlockNumber,
@@ -56,7 +57,7 @@ impl L1Watcher {
 
     pub(crate) fn new_finalized(
         config: L1WatcherConfig,
-        provider: DynProvider,
+        provider: NodeProvider,
         block_updates: watch::Receiver<BlockUpdates>,
         address: ValueOrArray<Address>,
         next_block: BlockNumber,

--- a/lib/provider/Cargo.toml
+++ b/lib/provider/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zksync_os_contract_interface"
+name = "zksync_os_provider"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -10,14 +10,16 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-zksync_os_provider.workspace = true
-
-alloy = { workspace = true, default-features = false, features = ["contract", "providers"] }
+alloy = { workspace = true, default-features = false, features = [
+    "json-rpc",
+    "rpc-types",
+    "providers",
+    "rpc-client",
+    "transports",
+] }
+async-trait.workspace = true
 anyhow.workspace = true
-backon.workspace = true
-futures.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
-vise.workspace = true
-structdiff.workspace = true
-thiserror.workspace = true

--- a/lib/provider/src/lib.rs
+++ b/lib/provider/src/lib.rs
@@ -1,3 +1,11 @@
+//! The node's canonical Ethereum-network provider.
+//!
+//! [`NodeProvider`] is an object-safe, wallet-capable wrapper over
+//! [`alloy::providers::Provider<Ethereum>`] used everywhere the node talks to an L1, Gateway, or L2
+//! RPC. On top of the plain provider it caches per-address contract deployment blocks (see
+//! [`NodeProvider::deployment_block`]), so the many startup binary searches over L1 history can use
+//! a tight lower bound without each rediscovering it.
+
 use alloy::consensus::{BlockHeader, TrieAccount};
 use alloy::eips::eip1559::Eip1559Estimation;
 use alloy::eips::eip2930::AccessListResult;
@@ -23,6 +31,9 @@ use alloy::rpc::types::{
 use alloy::transports::TransportResult;
 use serde_json::value::RawValue;
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
 
 /// A version of `Provider<Ethereum> + WalletProvider<Ethereum, Wallet = EthereumWallet>` that is
 /// object safe. Has a blanket implementation for the aforementioned constraints.
@@ -53,59 +64,119 @@ where
     }
 }
 
+/// Per-address cache of contract deployment blocks. Cloning a [`NodeProvider`] shares this cache
+/// (it sits behind an `Arc`), so all derived contract instances and watchers resolve each address
+/// at most once. Each address gets its own [`OnceCell`] so concurrent lookups for the same address
+/// run the binary search exactly once and the rest await its result.
+type DeploymentBlockCache = Arc<Mutex<HashMap<Address, Arc<OnceCell<u64>>>>>;
+
 /// A version of `DynProvider` that exposes `wallet()` and `wallet_mut()` as defined in
 /// `EthWalletProvider`. Also uses `Box` instead of `Arc` to make sure the wallets are mutable.
-pub struct EthDynProvider(Box<dyn EthWalletProvider + 'static>);
+///
+/// Carries a shared [`DeploymentBlockCache`]; see [`NodeProvider::deployment_block`].
+pub struct NodeProvider {
+    inner: Box<dyn EthWalletProvider + 'static>,
+    deployment_blocks: DeploymentBlockCache,
+}
 
-impl EthDynProvider {
-    /// Creates a new [`EthDynProvider`] by erasing the type.
+impl NodeProvider {
+    /// Creates a new [`NodeProvider`] by erasing the type.
     pub fn new<P: EthWalletProvider + 'static>(provider: P) -> Self {
-        Self(Box::new(provider))
+        Self {
+            inner: Box::new(provider),
+            deployment_blocks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns the block at which `address` first had non-empty code, i.e. its deployment block.
+    /// Returns `0` if `address` has no code at the latest block (not deployed on this chain), which
+    /// keeps it usable as a binary-search lower bound on chains where the contract is absent (e.g.
+    /// local Anvil setups).
+    ///
+    /// The result is cached per address and shared across clones; the underlying binary search over
+    /// `eth_getCode` runs at most once per address for the lifetime of the cache.
+    pub async fn deployment_block(&self, address: Address) -> anyhow::Result<u64> {
+        let cell = {
+            let mut guard = self
+                .deployment_blocks
+                .lock()
+                .expect("deployment block cache mutex poisoned");
+            guard.entry(address).or_default().clone()
+        };
+        let block = cell
+            .get_or_try_init(|| Self::discover_deployment_block(self, address))
+            .await?;
+        Ok(*block)
+    }
+
+    /// Binary-searches for the first block where `address` has non-empty code. See
+    /// [`Self::deployment_block`] for the `0` fallback semantics.
+    async fn discover_deployment_block(&self, address: Address) -> anyhow::Result<u64> {
+        let latest = self.get_block_number().await?;
+        let code_at_latest = self.get_code_at(address).block_id(latest.into()).await?;
+        if code_at_latest.0.is_empty() {
+            return Ok(0);
+        }
+        let (mut lo, mut hi) = (0u64, latest);
+        while lo < hi {
+            let mid = (lo + hi) / 2;
+            let code = self.get_code_at(address).block_id(mid.into()).await?;
+            if !code.0.is_empty() {
+                hi = mid;
+            } else {
+                lo = mid + 1;
+            }
+        }
+        tracing::debug!(%address, deployment_block = lo, "discovered contract deployment block");
+        Ok(lo)
     }
 }
 
-impl Clone for EthDynProvider {
+impl Clone for NodeProvider {
     fn clone(&self) -> Self {
-        EthDynProvider(self.dyn_clone())
+        NodeProvider {
+            inner: self.inner.dyn_clone(),
+            deployment_blocks: self.deployment_blocks.clone(),
+        }
     }
 }
 
-impl std::fmt::Debug for EthDynProvider {
+impl std::fmt::Debug for NodeProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("DynProvider")
+        f.debug_tuple("NodeProvider")
             .field(&"<dyn Provider>")
             .finish()
     }
 }
 
 //
-// The rest of the file contains trait implementations for `EthDynProvider` that just invoke `self.0.<method>` inside
+// The rest of the file contains trait implementations for `NodeProvider` that just invoke `self.inner.<method>` inside
 //
 
 #[async_trait::async_trait]
-impl Provider<Ethereum> for EthDynProvider {
+impl Provider<Ethereum> for NodeProvider {
     fn root(&self) -> &RootProvider<Ethereum> {
-        self.0.root()
+        self.inner.root()
     }
 
     fn client(&self) -> ClientRef<'_> {
-        self.0.client()
+        self.inner.client()
     }
 
     fn weak_client(&self) -> WeakClient {
-        self.0.weak_client()
+        self.inner.weak_client()
     }
 
     fn get_accounts(&self) -> ProviderCall<NoParams, Vec<Address>> {
-        self.0.get_accounts()
+        self.inner.get_accounts()
     }
 
     fn get_blob_base_fee(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.0.get_blob_base_fee()
+        self.inner.get_blob_base_fee()
     }
 
     fn get_block_number(&self) -> ProviderCall<NoParams, U64, BlockNumber> {
-        self.0.get_block_number()
+        self.inner.get_block_number()
     }
 
     // alloy 2.0 changed the `get_header` -> `get_block` fallback that 1.x had, so only JSON-RPC
@@ -130,14 +201,14 @@ impl Provider<Ethereum> for EthDynProvider {
     }
 
     fn call(&self, tx: <Ethereum as Network>::TransactionRequest) -> EthCall<Ethereum, Bytes> {
-        self.0.call(tx)
+        self.inner.call(tx)
     }
 
     fn call_many<'req>(
         &self,
         bundles: &'req [Bundle],
     ) -> EthCallMany<'req, Ethereum, Vec<Vec<EthCallResponse>>> {
-        self.0.call_many(bundles)
+        self.inner.call_many(bundles)
     }
 
     fn simulate<'req>(
@@ -147,36 +218,36 @@ impl Provider<Ethereum> for EthDynProvider {
         &'req SimulatePayload,
         Vec<SimulatedBlock<<Ethereum as Network>::BlockResponse>>,
     > {
-        self.0.simulate(payload)
+        self.inner.simulate(payload)
     }
 
     fn get_chain_id(&self) -> ProviderCall<NoParams, U64, u64> {
-        self.0.get_chain_id()
+        self.inner.get_chain_id()
     }
 
     fn create_access_list<'a>(
         &self,
         request: &'a <Ethereum as Network>::TransactionRequest,
     ) -> RpcWithBlock<&'a <Ethereum as Network>::TransactionRequest, AccessListResult> {
-        self.0.create_access_list(request)
+        self.inner.create_access_list(request)
     }
 
     fn estimate_gas(
         &self,
         tx: <Ethereum as Network>::TransactionRequest,
     ) -> EthCall<Ethereum, U64, u64> {
-        self.0.estimate_gas(tx)
+        self.inner.estimate_gas(tx)
     }
 
     async fn estimate_eip1559_fees_with(
         &self,
         estimator: Eip1559Estimator,
     ) -> TransportResult<Eip1559Estimation> {
-        self.0.estimate_eip1559_fees_with(estimator).await
+        self.inner.estimate_eip1559_fees_with(estimator).await
     }
 
     async fn estimate_eip1559_fees(&self) -> TransportResult<Eip1559Estimation> {
-        self.0.estimate_eip1559_fees().await
+        self.inner.estimate_eip1559_fees().await
     }
 
     async fn get_fee_history(
@@ -185,57 +256,57 @@ impl Provider<Ethereum> for EthDynProvider {
         last_block: BlockNumberOrTag,
         reward_percentiles: &[f64],
     ) -> TransportResult<FeeHistory> {
-        self.0
+        self.inner
             .get_fee_history(block_count, last_block, reward_percentiles)
             .await
     }
 
     fn get_gas_price(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.0.get_gas_price()
+        self.inner.get_gas_price()
     }
 
     fn get_account_info(&self, address: Address) -> RpcWithBlock<Address, AccountInfo> {
-        self.0.get_account_info(address)
+        self.inner.get_account_info(address)
     }
 
     fn get_account(&self, address: Address) -> RpcWithBlock<Address, TrieAccount> {
-        self.0.get_account(address)
+        self.inner.get_account(address)
     }
 
     fn get_balance(&self, address: Address) -> RpcWithBlock<Address, U256, U256> {
-        self.0.get_balance(address)
+        self.inner.get_balance(address)
     }
 
     fn get_block(&self, block: BlockId) -> EthGetBlock<<Ethereum as Network>::BlockResponse> {
-        self.0.get_block(block)
+        self.inner.get_block(block)
     }
 
     fn get_block_by_hash(
         &self,
         hash: BlockHash,
     ) -> EthGetBlock<<Ethereum as Network>::BlockResponse> {
-        self.0.get_block_by_hash(hash)
+        self.inner.get_block_by_hash(hash)
     }
 
     fn get_block_by_number(
         &self,
         number: BlockNumberOrTag,
     ) -> EthGetBlock<<Ethereum as Network>::BlockResponse> {
-        self.0.get_block_by_number(number)
+        self.inner.get_block_by_number(number)
     }
 
     async fn get_block_transaction_count_by_hash(
         &self,
         hash: BlockHash,
     ) -> TransportResult<Option<u64>> {
-        self.0.get_block_transaction_count_by_hash(hash).await
+        self.inner.get_block_transaction_count_by_hash(hash).await
     }
 
     async fn get_block_transaction_count_by_number(
         &self,
         block_number: BlockNumberOrTag,
     ) -> TransportResult<Option<u64>> {
-        self.0
+        self.inner
             .get_block_transaction_count_by_number(block_number)
             .await
     }
@@ -244,52 +315,52 @@ impl Provider<Ethereum> for EthDynProvider {
         &self,
         block: BlockId,
     ) -> ProviderCall<(BlockId,), Option<Vec<<Ethereum as Network>::ReceiptResponse>>> {
-        self.0.get_block_receipts(block)
+        self.inner.get_block_receipts(block)
     }
 
     fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
-        self.0.get_code_at(address)
+        self.inner.get_code_at(address)
     }
 
     async fn watch_blocks(&self) -> TransportResult<FilterPollerBuilder<B256>> {
-        self.0.watch_blocks().await
+        self.inner.watch_blocks().await
     }
 
     async fn watch_pending_transactions(&self) -> TransportResult<FilterPollerBuilder<B256>> {
-        self.0.watch_pending_transactions().await
+        self.inner.watch_pending_transactions().await
     }
 
     async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
-        self.0.watch_logs(filter).await
+        self.inner.watch_logs(filter).await
     }
 
     async fn watch_full_pending_transactions(
         &self,
     ) -> TransportResult<FilterPollerBuilder<<Ethereum as Network>::TransactionResponse>> {
-        self.0.watch_full_pending_transactions().await
+        self.inner.watch_full_pending_transactions().await
     }
 
     async fn get_filter_changes_dyn(&self, id: U256) -> TransportResult<FilterChanges> {
-        self.0.get_filter_changes_dyn(id).await
+        self.inner.get_filter_changes_dyn(id).await
     }
 
     async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
-        self.0.get_filter_logs(id).await
+        self.inner.get_filter_logs(id).await
     }
 
     async fn uninstall_filter(&self, id: U256) -> TransportResult<bool> {
-        self.0.uninstall_filter(id).await
+        self.inner.uninstall_filter(id).await
     }
 
     async fn watch_pending_transaction(
         &self,
         config: PendingTransactionConfig,
     ) -> Result<PendingTransaction, PendingTransactionError> {
-        self.0.watch_pending_transaction(config).await
+        self.inner.watch_pending_transaction(config).await
     }
 
     async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
-        self.0.get_logs(filter).await
+        self.inner.get_logs(filter).await
     }
 
     fn get_proof(
@@ -297,7 +368,7 @@ impl Provider<Ethereum> for EthDynProvider {
         address: Address,
         keys: Vec<StorageKey>,
     ) -> RpcWithBlock<(Address, Vec<StorageKey>), EIP1186AccountProofResponse> {
-        self.0.get_proof(address, keys)
+        self.inner.get_proof(address, keys)
     }
 
     fn get_storage_at(
@@ -305,14 +376,14 @@ impl Provider<Ethereum> for EthDynProvider {
         address: Address,
         key: U256,
     ) -> RpcWithBlock<(Address, U256), StorageValue> {
-        self.0.get_storage_at(address, key)
+        self.inner.get_storage_at(address, key)
     }
 
     fn get_transaction_by_hash(
         &self,
         hash: TxHash,
     ) -> ProviderCall<(TxHash,), Option<<Ethereum as Network>::TransactionResponse>> {
-        self.0.get_transaction_by_hash(hash)
+        self.inner.get_transaction_by_hash(hash)
     }
 
     fn get_transaction_by_sender_nonce(
@@ -320,7 +391,7 @@ impl Provider<Ethereum> for EthDynProvider {
         sender: Address,
         nonce: u64,
     ) -> ProviderCall<(Address, U64), Option<<Ethereum as Network>::TransactionResponse>> {
-        self.0.get_transaction_by_sender_nonce(sender, nonce)
+        self.inner.get_transaction_by_sender_nonce(sender, nonce)
     }
 
     fn get_transaction_by_block_hash_and_index(
@@ -328,7 +399,7 @@ impl Provider<Ethereum> for EthDynProvider {
         block_hash: B256,
         index: usize,
     ) -> ProviderCall<(B256, Index), Option<<Ethereum as Network>::TransactionResponse>> {
-        self.0
+        self.inner
             .get_transaction_by_block_hash_and_index(block_hash, index)
     }
 
@@ -337,7 +408,7 @@ impl Provider<Ethereum> for EthDynProvider {
         block_hash: B256,
         index: usize,
     ) -> ProviderCall<(B256, Index), Option<Bytes>> {
-        self.0
+        self.inner
             .get_raw_transaction_by_block_hash_and_index(block_hash, index)
     }
 
@@ -347,7 +418,7 @@ impl Provider<Ethereum> for EthDynProvider {
         index: usize,
     ) -> ProviderCall<(BlockNumberOrTag, Index), Option<<Ethereum as Network>::TransactionResponse>>
     {
-        self.0
+        self.inner
             .get_transaction_by_block_number_and_index(block_number, index)
     }
 
@@ -356,26 +427,26 @@ impl Provider<Ethereum> for EthDynProvider {
         block_number: BlockNumberOrTag,
         index: usize,
     ) -> ProviderCall<(BlockNumberOrTag, Index), Option<Bytes>> {
-        self.0
+        self.inner
             .get_raw_transaction_by_block_number_and_index(block_number, index)
     }
 
     fn get_raw_transaction_by_hash(&self, hash: TxHash) -> ProviderCall<(TxHash,), Option<Bytes>> {
-        self.0.get_raw_transaction_by_hash(hash)
+        self.inner.get_raw_transaction_by_hash(hash)
     }
 
     fn get_transaction_count(
         &self,
         address: Address,
     ) -> RpcWithBlock<Address, U64, u64, fn(U64) -> u64> {
-        self.0.get_transaction_count(address)
+        self.inner.get_transaction_count(address)
     }
 
     fn get_transaction_receipt(
         &self,
         hash: TxHash,
     ) -> ProviderCall<(TxHash,), Option<<Ethereum as Network>::ReceiptResponse>> {
-        self.0.get_transaction_receipt(hash)
+        self.inner.get_transaction_receipt(hash)
     }
 
     async fn get_uncle(
@@ -383,34 +454,34 @@ impl Provider<Ethereum> for EthDynProvider {
         tag: BlockId,
         idx: u64,
     ) -> TransportResult<Option<<Ethereum as Network>::BlockResponse>> {
-        self.0.get_uncle(tag, idx).await
+        self.inner.get_uncle(tag, idx).await
     }
 
     async fn get_uncle_count(&self, tag: BlockId) -> TransportResult<u64> {
-        self.0.get_uncle_count(tag).await
+        self.inner.get_uncle_count(tag).await
     }
 
     fn get_max_priority_fee_per_gas(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.0.get_max_priority_fee_per_gas()
+        self.inner.get_max_priority_fee_per_gas()
     }
 
     async fn new_block_filter(&self) -> TransportResult<U256> {
-        self.0.new_block_filter().await
+        self.inner.new_block_filter().await
     }
 
     async fn new_filter(&self, filter: &Filter) -> TransportResult<U256> {
-        self.0.new_filter(filter).await
+        self.inner.new_filter(filter).await
     }
 
     async fn new_pending_transactions_filter(&self, full: bool) -> TransportResult<U256> {
-        self.0.new_pending_transactions_filter(full).await
+        self.inner.new_pending_transactions_filter(full).await
     }
 
     async fn send_raw_transaction(
         &self,
         encoded_tx: &[u8],
     ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
-        self.0.send_raw_transaction(encoded_tx).await
+        self.inner.send_raw_transaction(encoded_tx).await
     }
 
     async fn send_raw_transaction_conditional(
@@ -418,7 +489,7 @@ impl Provider<Ethereum> for EthDynProvider {
         encoded_tx: &[u8],
         conditional: TransactionConditional,
     ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
-        self.0
+        self.inner
             .send_raw_transaction_conditional(encoded_tx, conditional)
             .await
     }
@@ -427,44 +498,44 @@ impl Provider<Ethereum> for EthDynProvider {
         &self,
         tx: <Ethereum as Network>::TransactionRequest,
     ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
-        self.0.send_transaction(tx).await
+        self.inner.send_transaction(tx).await
     }
 
     async fn send_tx_envelope(
         &self,
         tx: <Ethereum as Network>::TxEnvelope,
     ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
-        self.0.send_tx_envelope(tx).await
+        self.inner.send_tx_envelope(tx).await
     }
 
     async fn send_transaction_internal(
         &self,
         tx: SendableTx<Ethereum>,
     ) -> TransportResult<PendingTransactionBuilder<Ethereum>> {
-        self.0.send_transaction_internal(tx).await
+        self.inner.send_transaction_internal(tx).await
     }
 
     async fn sign_transaction(
         &self,
         tx: <Ethereum as Network>::TransactionRequest,
     ) -> TransportResult<Bytes> {
-        self.0.sign_transaction(tx).await
+        self.inner.sign_transaction(tx).await
     }
 
     fn syncing(&self) -> ProviderCall<NoParams, SyncStatus> {
-        self.0.syncing()
+        self.inner.syncing()
     }
 
     fn get_client_version(&self) -> ProviderCall<NoParams, String> {
-        self.0.get_client_version()
+        self.inner.get_client_version()
     }
 
     fn get_sha3(&self, data: &[u8]) -> ProviderCall<(String,), B256> {
-        self.0.get_sha3(data)
+        self.inner.get_sha3(data)
     }
 
     fn get_net_version(&self) -> ProviderCall<NoParams, U64, u64> {
-        self.0.get_net_version()
+        self.inner.get_net_version()
     }
 
     async fn raw_request_dyn(
@@ -472,25 +543,25 @@ impl Provider<Ethereum> for EthDynProvider {
         method: Cow<'static, str>,
         params: &RawValue,
     ) -> TransportResult<Box<RawValue>> {
-        self.0.raw_request_dyn(method, params).await
+        self.inner.raw_request_dyn(method, params).await
     }
 
     fn transaction_request(&self) -> <Ethereum as Network>::TransactionRequest {
-        self.0.transaction_request()
+        self.inner.transaction_request()
     }
 }
 
-impl EthWalletProvider for EthDynProvider {
+impl EthWalletProvider for NodeProvider {
     fn dyn_clone(&self) -> Box<dyn EthWalletProvider> {
-        self.0.dyn_clone()
+        self.inner.dyn_clone()
     }
 
     fn wallet(&self) -> &EthereumWallet {
-        self.0.wallet()
+        self.inner.wallet()
     }
 
     fn wallet_mut(&mut self) -> &mut EthereumWallet {
-        self.0.wallet_mut()
+        self.inner.wallet_mut()
     }
 }
 
@@ -510,7 +581,7 @@ mod tests {
             .disable_recommended_fillers()
             .wallet(EthereumWallet::default())
             .connect_mocked_client(asserter.clone());
-        let provider = EthDynProvider::new(provider);
+        let provider = NodeProvider::new(provider);
 
         asserter.push_failure(ErrorPayload {
             code: -39001,

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -23,6 +23,7 @@ jemalloc = [
 
 [dependencies]
 zksync_os_alloy_ext.workspace = true
+zksync_os_provider.workspace = true
 zksync_os_l1_sender.workspace = true
 zksync_os_l1_watcher.workspace = true
 zksync_os_mempool.workspace = true

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -56,7 +56,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 use zksync_os_backpressure::{BackpressureMonitor, PipelineTracker};
 use zksync_os_base_token_adjuster::BaseTokenPriceUpdater;
 use zksync_os_batch_verification::{
@@ -210,8 +210,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         // wait: calling fetch_finalized on them would spuriously fail when a concurrently
         // running batcher node keeps submitting new batch transactions.
         L1State::fetch_finalized(
-            l1_provider.clone().erased(),
-            gateway_provider.as_ref().map(|p| p.clone().erased()),
+            l1_provider.clone(),
+            gateway_provider.clone(),
             bridgehub_address,
             chain_id,
         )
@@ -219,8 +219,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         .expect("failed to fetch finalized L1 state")
     } else {
         L1State::fetch(
-            l1_provider.clone().erased(),
-            gateway_provider.as_ref().map(|p| p.clone().erased()),
+            l1_provider.clone(),
+            gateway_provider.clone(),
             bridgehub_address,
             chain_id,
         )
@@ -229,7 +229,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     };
     let settles_on_gateway = l1_state.settles_on_gateway();
     let l1_block_updates = block_updates::run(
-        l1_provider.clone().erased(),
+        l1_provider.clone(),
         runtime,
         "l1 block updates",
         config.l1_watcher_config.poll_interval,
@@ -237,7 +237,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     );
     let gateway_block_updates = gateway_provider.as_ref().map(|provider| {
         block_updates::run(
-            provider.clone().erased(),
+            provider.clone(),
             runtime,
             "gateway block updates",
             config.l1_watcher_config.poll_interval,
@@ -1171,7 +1171,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 #[allow(clippy::too_many_arguments)]
 async fn run_main_node_pipeline(
     config: &Config,
-    sl_provider: EthDynProvider,
+    sl_provider: NodeProvider,
     node_state_on_startup: NodeStateOnStartup,
     block_replay_storage: impl WriteReplay + Clone,
     runtime: &Runtime,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -56,7 +56,6 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
-use zksync_os_provider::NodeProvider;
 use zksync_os_backpressure::{BackpressureMonitor, PipelineTracker};
 use zksync_os_base_token_adjuster::BaseTokenPriceUpdater;
 use zksync_os_batch_verification::{
@@ -99,6 +98,7 @@ use zksync_os_network::service::{NetworkService, PeerVerifyBatch, PeerVerifyBatc
 use zksync_os_observability::GENERAL_METRICS;
 use zksync_os_pipeline::Pipeline;
 use zksync_os_priority_tree::PriorityTreeManager;
+use zksync_os_provider::NodeProvider;
 use zksync_os_raft::{
     BlockCanonizationEngine, ConsensusRuntimeParts, LeadershipSignal, init_consensus,
     loopback_consensus,

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -9,7 +9,7 @@ use alloy::rpc::client::RpcClient;
 use alloy::signers::local::PrivateKeySigner;
 use tower::ServiceBuilder;
 use vise::{EncodeLabelSet, EncodeLabelValue};
-use zksync_os_alloy_ext::dyn_wallet_provider::EthDynProvider;
+use zksync_os_provider::NodeProvider;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "provider", rename_all = "snake_case")]
@@ -21,7 +21,7 @@ pub(crate) enum ProviderKind {
 pub(crate) async fn build_node_provider(
     config: &ProviderConfig,
     provider: ProviderKind,
-) -> EthDynProvider {
+) -> NodeProvider {
     let max_retries = config.max_retries;
     let retry_backoff = config.retry_backoff;
     let provider_layers = ServiceBuilder::new()
@@ -42,5 +42,5 @@ pub(crate) async fn build_node_provider(
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(PrivateKeySigner::random()))
         .connect_client(client);
-    EthDynProvider::new(provider)
+    NodeProvider::new(provider)
 }


### PR DESCRIPTION
## Summary

At startup the `l1_watcher` runs a series of binary searches over L1 history to locate the L1 blocks for the last committed/executed batch, priority transactions, protocol-version upgrades, migrations, and
  interop roots. Each search spanned `[0, latest]` and, on every iteration, issued an extra `eth_getCode` call to guard against probing a block where the contract wasn't deployed yet - roughly **2 RPC calls × 
  ~log₂(latest)** iterations per search, multiplied across ~6 searches.
  
  Most of that range is empty: nothing relevant exists before the chain's contracts were deployed. By anchoring each search at the contract's deployment block, we both shrink the search range and drop the
  per-iteration code-presence guard.

### What changed

  - `l1_watcher`: every binary-search site now starts from the contract's deployment block instead of 0, and `find_l1_block_by_predicate` no longer issues a per-iteration `eth_getCode` guard (the caller guarantees
  `start_block >= deployment_block`). The `start_block` parameter is retained because the commit search's revert-rescan must restart from the revert block, not the deployment block, to find the post-revert commit.
  - `contract_interface`: removed the previously eager deployment-block discovery from `L1State::fetch` / `SettlementLayerIntervals::discover` - discovery is now lazy, on first search.
  - Workspace-wide rename `EthDynProvider` -> `NodeProvider` and removal of `.erased()` calls feeding the contract interface.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

