### PR TITLE
fix(ci): set finalized block polling interval to 100ms in local_dev.yaml

### DIFF
--- a/local-chains/local_dev.yaml
+++ b/local-chains/local_dev.yaml
@@ -4,6 +4,7 @@
 
 l1_watcher:
   poll_interval: 100ms
+  finalized_poll_interval: 100ms
   confirmations: 0
 
 l1_sender:


### PR DESCRIPTION
## Summary

The normal poll value is set to 100ms for CI, set the finalized polling time to same value. Should help with testing speed.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

