### PR TITLE
fix: patch computational_native_used calculation

### DIFF
--- a/node/bin/src/batcher/seal_criteria.rs
+++ b/node/bin/src/batcher/seal_criteria.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::U256;
 use std::collections::HashSet;
 use zk_ee::{common_structs::MAX_NUMBER_OF_LOGS, system::MAX_NATIVE_COMPUTATIONAL};
 use zksync_os_batcher_metrics::BATCHER_METRICS;
@@ -40,7 +41,7 @@ impl BatchInfoAccumulator {
     }
 
     pub fn add(&mut self, block_output: &BlockOutput, replay_record: &ReplayRecord) -> &Self {
-        self.native_cycles += block_output.computational_native_used;
+        self.native_cycles += computational_native_used(block_output, replay_record);
         self.pubdata_bytes += block_output.pubdata.len() as u64;
         self.l2_to_l1_logs_count += block_output
             .tx_results
@@ -180,4 +181,28 @@ impl BatchInfoAccumulator {
             .pubdata_per_batch
             .observe(self.pubdata_bytes);
     }
+}
+
+// In some cases, zksync os incorrectly calculates `computational_native_used`
+// so we re-calculate it as `native_used - pubdata_used * native_per_pubdata`
+// and take maximum of what we computed locally and what zksync os returns.
+//
+// TODO: get rid of method and just use `block_output.computational_native_used` after v30 proving support is removed.
+fn computational_native_used(block_output: &BlockOutput, replay_record: &ReplayRecord) -> u64 {
+    let native_used = block_output
+        .tx_results
+        .iter()
+        .flatten()
+        .map(|tx| tx.computational_native_used)
+        .sum::<u64>();
+
+    let native_per_pubdata = replay_record.block_context.pubdata_price
+        / replay_record.block_context.native_price.max(U256::ONE);
+    let pubdata_native_used = native_per_pubdata
+        .saturating_mul(U256::from(block_output.pubdata.len()))
+        .saturating_to::<u64>();
+
+    let zksync_os_computational_native_used = block_output.computational_native_used;
+    let local_computational_native_used = native_used.saturating_sub(pubdata_native_used);
+    zksync_os_computational_native_used.max(local_computational_native_used)
 }

--- a/node/bin/src/batcher/seal_criteria.rs
+++ b/node/bin/src/batcher/seal_criteria.rs
@@ -193,7 +193,7 @@ fn computational_native_used(block_output: &BlockOutput, replay_record: &ReplayR
         .tx_results
         .iter()
         .flatten()
-        .map(|tx| tx.computational_native_used)
+        .map(|tx| tx.native_used)
         .sum::<u64>();
 
     let native_per_pubdata = replay_record.block_context.pubdata_price


### PR DESCRIPTION
## Summary

Patches `computational_native_used` so it properly reflects effective cycles in some specific cases.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

