### PR TITLE
refactor(sequencer): do not require starting block in BCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16127,7 +16127,7 @@ dependencies = [
  "tracing",
  "vise",
  "zk_ee 0.1.0 (git+https://github.com/matter-labs/zksync-os?tag=v0.3.1-interface-v0.1.3)",
- "zksync_os_gas_adjuster",
+ "zksync_os_contract_interface",
  "zksync_os_genesis",
  "zksync_os_interface",
  "zksync_os_mempool",

--- a/lib/genesis/src/lib.rs
+++ b/lib/genesis/src/lib.rs
@@ -211,6 +211,36 @@ fn account_properties_flat_key(address: Address) -> B256 {
     )
 }
 
+pub fn genesis_header() -> Sealed<Header> {
+    let header = Header {
+        parent_hash: B256::ZERO,
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
+        beneficiary: Address::ZERO,
+        // for now state root is zero
+        state_root: B256::ZERO,
+        transactions_root: B256::ZERO,
+        receipts_root: B256::ZERO,
+        logs_bloom: Bloom::ZERO,
+        difficulty: U256::ZERO,
+        number: 0,
+        gas_limit: 5_000,
+        gas_used: 0,
+        timestamp: 0,
+        extra_data: Default::default(),
+        mix_hash: B256::ZERO,
+        nonce: B64::ZERO,
+        base_fee_per_gas: Some(INITIAL_BASE_FEE),
+        withdrawals_root: None,
+        blob_gas_used: None,
+        excess_blob_gas: None,
+        parent_beacon_block_root: None,
+        requests_hash: None,
+        block_access_list_hash: None,
+        slot_number: None,
+    };
+    header.seal_slow()
+}
+
 async fn build_genesis(
     genesis_input_source: &dyn GenesisInputSource,
     chain_id: u64,
@@ -280,33 +310,7 @@ async fn build_genesis(
         ));
     }
 
-    let header = Header {
-        parent_hash: B256::ZERO,
-        ommers_hash: EMPTY_OMMER_ROOT_HASH,
-        beneficiary: Address::ZERO,
-        // for now state root is zero
-        state_root: B256::ZERO,
-        transactions_root: B256::ZERO,
-        receipts_root: B256::ZERO,
-        logs_bloom: Bloom::ZERO,
-        difficulty: U256::ZERO,
-        number: 0,
-        gas_limit: 5_000,
-        gas_used: 0,
-        timestamp: 0,
-        extra_data: Default::default(),
-        mix_hash: B256::ZERO,
-        nonce: B64::ZERO,
-        base_fee_per_gas: Some(INITIAL_BASE_FEE),
-        withdrawals_root: None,
-        blob_gas_used: None,
-        excess_blob_gas: None,
-        parent_beacon_block_root: None,
-        requests_hash: None,
-        block_access_list_hash: None,
-        slot_number: None,
-    };
-
+    let header = genesis_header();
     let context = BlockContext {
         chain_id,
         block_number: 0,
@@ -326,7 +330,7 @@ async fn build_genesis(
     Ok(GenesisState {
         storage_logs: storage_logs.into_iter().collect(),
         preimages,
-        header: header.seal_slow(),
+        header,
         context,
         expected_genesis_root: genesis_input.genesis_root,
     })

--- a/lib/sequencer/Cargo.toml
+++ b/lib/sequencer/Cargo.toml
@@ -18,8 +18,8 @@ zksync_os_storage_api.workspace = true
 zksync_os_types.workspace = true
 zksync_os_multivm.workspace = true
 zksync_os_tx_validators.workspace = true
-zksync_os_gas_adjuster.workspace = true
 zksync_os_metadata.workspace = true
+zksync_os_contract_interface.workspace = true
 
 zk_ee.workspace = true
 zk_os_basic_system.workspace = true

--- a/lib/sequencer/src/execution/block_context_provider.rs
+++ b/lib/sequencer/src/execution/block_context_provider.rs
@@ -1,19 +1,24 @@
 use crate::execution::fee_provider::{FeeParams, FeeProvider};
 use crate::execution::metrics::EXECUTION_METRICS;
-use crate::model::blocks::{BlockCommand, InvalidTxPolicy, PreparedBlockCommand, SealPolicy};
-use alloy::consensus::Sealed;
-use alloy::primitives::{Address, TxHash, U256};
+use crate::model::blocks::{
+    BlockCommand, InvalidTxPolicy, PreparedBlockCommand, RebuildCommand, SealPolicy,
+};
+use alloy::primitives::{Address, BlockHash, TxHash, U256};
 use anyhow::Context as _;
 use futures::StreamExt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::{sync::watch, time::Instant};
+use zksync_os_contract_interface::settlement_layer_intervals::{
+    IntervalSettlementLayer, SettlementLayerIntervals,
+};
+use zksync_os_genesis::genesis_header;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_mempool::{MarkingTxStream, Pool};
+use zksync_os_storage_api::BlockContext;
 use zksync_os_storage_api::ReplayRecord;
-use zksync_os_storage_api::{BlockContext, BlockHashes};
 use zksync_os_types::{
-    BlockOutput, BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion, SystemTxEnvelope,
-    SystemTxType, ZkEnvelope, ZkTransaction,
+    BlockOutput, BlockStartCursors, ExecutionVersion, SystemTxEnvelope, SystemTxType, ZkEnvelope,
+    ZkTransaction,
 };
 
 /// Component that turns `BlockCommand`s into `PreparedBlockCommand`s.
@@ -27,376 +32,402 @@ use zksync_os_types::{
 ///  it doesn't tolerate jumps in L1 priority IDs.
 ///  this is easily fixable if needed.
 pub struct BlockContextProvider<Subpool> {
-    next_cursors: BlockStartCursors,
+    fee_provider: FeeProvider,
     pool: Pool<Subpool>,
-    block_hashes_for_next_block: BlockHashes,
-    previous_block_timestamp: u64,
-    next_block_number: u64,
-    block_time: Duration,
-    max_transactions_in_block: usize,
-    chain_id: u64,
-    gas_limit: u64,
-    pubdata_limit: u64,
-    interop_roots_per_block: u64,
-    service_block_delay: Duration,
+    config: Config,
+    last_block: Option<LastBlock>,
     next_interop_tx_allowed_after: Instant,
-    /// Protocol version to be used for the next produced block.
-    /// Can change in runtime in case of upgrades.
-    protocol_version: ProtocolSemanticVersion,
-    sl_chain_id_at_startup: u64,
     /// L2 chain id of the chain's currently-active settlement layer. Can change in runtime if there
     /// is a migration in the process.
     current_sl_chain_id: u64,
-    /// L1 chain id, fixed at startup.
-    l1_chain_id: u64,
-    /// Whether the one-time `SetSLChainId` system transaction has already been included.
-    /// Initialized to `true` on restart when already at v31+, since it must have been
-    /// included in a prior run. Also set to `true` during replay when a v31 block is
-    /// encountered. Only `false` on fresh v31 genesis or pre-v31 chains that haven't
-    /// upgraded yet.
-    sl_chain_id_set: bool,
-    fee_collector_address: Address,
     last_constructed_block_ctx_sender: watch::Sender<Option<BlockContext>>,
-    fee_provider: FeeProvider,
+}
+
+pub struct Config {
+    pub l2_chain_id: u64,
+    pub l1_chain_id: u64,
+    pub gas_limit: u64,
+    pub pubdata_limit: u64,
+    pub fee_collector_address: Address,
+    pub block_time: Duration,
+    pub service_block_delay: Duration,
+    pub max_transactions_in_block: usize,
+    pub interop_roots_per_block: u64,
+}
+
+struct LastBlock {
+    record: ReplayRecord,
+    hash: BlockHash,
+    next_cursors: BlockStartCursors,
 }
 
 impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        next_cursors: BlockStartCursors,
-        pool: Pool<Subpool>,
-        block_hashes_for_next_block: BlockHashes,
-        previous_block_timestamp: u64,
-        next_block_number: u64,
-        block_time: Duration,
-        max_transactions_in_block: usize,
-        chain_id: u64,
-        gas_limit: u64,
-        pubdata_limit: u64,
-        interop_roots_per_block: u64,
-        service_block_delay: Duration,
-        protocol_version: ProtocolSemanticVersion,
-        sl_chain_id_at_startup: u64,
-        l1_chain_id: u64,
-        fee_collector_address: Address,
-        last_constructed_block_ctx_sender: watch::Sender<Option<BlockContext>>,
         fee_provider: FeeProvider,
+        pool: Pool<Subpool>,
+        config: Config,
+        intervals: &SettlementLayerIntervals,
+        last_constructed_block_ctx_sender: watch::Sender<Option<BlockContext>>,
     ) -> Self {
-        // If we're already past v31 and not on the very first block, the SetSLChainId tx
-        // must have been included in a previous run. For v31 itself at block > 1, it was also
-        // already included (either via upgrade or genesis). This flag may also be updated
-        // during replay in `apply_block_output`.
-        let sl_chain_id_set = protocol_version.minor >= 31 && next_block_number > 1;
+        let current_sl_chain_id = match intervals.current_settlement_layer() {
+            IntervalSettlementLayer::L1 => config.l1_chain_id,
+            IntervalSettlementLayer::Gateway(gw_chain_id) => *gw_chain_id,
+        };
         Self {
-            next_cursors,
-            pool,
-            block_hashes_for_next_block,
-            previous_block_timestamp,
-            next_block_number,
-            block_time,
-            max_transactions_in_block,
-            chain_id,
-            gas_limit,
-            pubdata_limit,
-            interop_roots_per_block,
-            service_block_delay,
-            next_interop_tx_allowed_after: Instant::now(),
-            protocol_version,
-            sl_chain_id_at_startup,
-            current_sl_chain_id: sl_chain_id_at_startup,
-            l1_chain_id,
-            sl_chain_id_set,
-            fee_collector_address,
-            last_constructed_block_ctx_sender,
             fee_provider,
+            pool,
+            config,
+            last_block: None,
+            next_interop_tx_allowed_after: Instant::now(),
+            current_sl_chain_id,
+            last_constructed_block_ctx_sender,
         }
     }
 
     /// `true` when the chain currently settles on a Gateway (i.e. its tracked SL chain id
     /// differs from L1's).
     fn settles_on_gateway(&self) -> bool {
-        self.current_sl_chain_id != self.l1_chain_id
+        self.current_sl_chain_id != self.config.l1_chain_id
     }
 
-    pub fn next_block_number(&self) -> u64 {
-        self.next_block_number
+    pub fn last_block_number(&self) -> Option<u64> {
+        self.last_block
+            .as_ref()
+            .map(|b| b.record.block_context.block_number)
     }
 
     pub async fn prepare_command(
         &mut self,
         block_command: BlockCommand,
-    ) -> anyhow::Result<PreparedBlockCommand<'_>> {
-        let prepared_command = match block_command {
-            BlockCommand::Produce(_) => {
-                let fee_params = self.fee_provider.produce_fee_params().await?;
-                self.pool
-                    .update_pending_block_fees(fee_params.eip1559_basefee.saturating_to(), None);
-                let block_number = self.next_block_number;
-                // Create stream:
-                // - If available, upgrade tx goes first (expected to be the only tx in the block, enforced by sequencer).
-                // - L1 transactions first, then L2 transactions.
-                let best_txs = self
-                    .pool
-                    .best_transactions_stream(
-                        self.next_interop_tx_allowed_after,
-                        self.settles_on_gateway(),
+    ) -> anyhow::Result<Option<PreparedBlockCommand<'_>>> {
+        match block_command {
+            BlockCommand::Produce(_) => self.produce().await,
+            BlockCommand::Replay(record) => self.replay(record).await,
+            BlockCommand::Rebuild(rebuild) => self.rebuild(rebuild).await,
+        }
+    }
+
+    async fn produce(&mut self) -> anyhow::Result<Option<PreparedBlockCommand<'_>>> {
+        let LastBlock {
+            record: previous_record,
+            hash: previous_block_hash,
+            next_cursors,
+        } = self
+            .last_block
+            .take()
+            .expect("tried to produce a block without replaying at least one record");
+        let fee_params = self.fee_provider.produce_fee_params().await?;
+        self.pool
+            .update_pending_block_fees(fee_params.eip1559_basefee.saturating_to(), None);
+        let block_number = previous_record.block_context.block_number + 1;
+        // Create stream:
+        // - If available, upgrade tx goes first (expected to be the only tx in the block, enforced by sequencer).
+        // - L1 transactions first, then L2 transactions.
+        let best_txs = self
+            .pool
+            .best_transactions_stream(
+                self.next_interop_tx_allowed_after,
+                self.settles_on_gateway(),
+            )
+            .await
+            .context("mempool is closed")?;
+
+        let timestamp = (millis_since_epoch() / 1000) as u64;
+
+        // Check if we peeked an upgrade transaction info.
+        // It is possible that we peek an upgrade with version <= self.protocol_version
+        // since we do not consume patch upgrades when replaying/rebuilding blocks. Such upgrade can be safely skipped.
+        let (protocol_version, force_preimages) = if let Some(upgrade_metadata) =
+            best_txs.upgrade_metadata
+            && upgrade_metadata.protocol_version > previous_record.protocol_version
+        {
+            tracing::info!(
+                block_number,
+                ?upgrade_metadata,
+                "including protocol upgrade transaction in the block"
+            );
+            // Invariant: transactions sent through this stream must be ready for execution, e.g.
+            // transaction should not be sent until timestamp is reached.
+            // We add some margin of error for timestamp comparison.
+            let current_timestamp = timestamp.saturating_add(5);
+            anyhow::ensure!(
+                upgrade_metadata.timestamp <= current_timestamp,
+                "upgrade transaction with timestamp {} received too early at {}; tx: {upgrade_metadata:?}",
+                upgrade_metadata.timestamp,
+                current_timestamp
+            );
+            (
+                upgrade_metadata.protocol_version,
+                upgrade_metadata.force_preimages.clone(),
+            )
+        } else {
+            (previous_record.protocol_version.clone(), Vec::new())
+        };
+
+        let execution_version: ExecutionVersion = (&protocol_version)
+            .try_into()
+            .context("Cannot instantiate a block for unsupported execution version")?;
+
+        // Append a SetSLChainId system transaction exactly once: when the protocol
+        // version is v31 (either via upgrade from v30, or on the first block of a
+        // fresh v31 chain). After it fires once, the condition can never trigger again.
+        let (tx_source, expect_sl_chain_id_tx_after_upgrade) = if protocol_version.minor == 31
+            && (previous_record.protocol_version.minor < 31
+                || previous_record.block_context.block_number == 0)
+        {
+            let sl_chain_id_tx = SystemTxEnvelope::set_sl_chain_id(
+                self.current_sl_chain_id,
+                // We use `u64::MAX` as a placeholder, since it is not an actual migration
+                u64::MAX,
+            );
+            let tx_source = MarkingTxStream::unmarkable(best_txs.stream.stream.chain(
+                futures::stream::once(async move { ZkTransaction::from(sl_chain_id_tx) }),
+            ));
+            (tx_source, true)
+        } else {
+            (best_txs.stream, false)
+        };
+
+        let FeeParams {
+            eip1559_basefee,
+            native_price,
+            pubdata_price,
+        } = fee_params;
+        let block_context = BlockContext {
+            eip1559_basefee,
+            native_price,
+            pubdata_price,
+            block_number,
+            timestamp,
+            chain_id: self.config.l2_chain_id,
+            coinbase: self.config.fee_collector_address,
+            block_hashes: previous_record
+                .block_context
+                .block_hashes
+                .push(previous_block_hash),
+            gas_limit: self.config.gas_limit,
+            pubdata_limit: self.config.pubdata_limit,
+            // todo: initialize as source of randomness, i.e. the value of prevRandao
+            mix_hash: Default::default(),
+            execution_version: execution_version as u32,
+            blob_fee: U256::ONE,
+        };
+        self.last_constructed_block_ctx_sender
+            .send_replace(Some(block_context));
+        Ok(Some(PreparedBlockCommand {
+            block_context,
+            tx_source,
+            seal_policy: SealPolicy::Decide(
+                self.config.block_time,
+                self.config.max_transactions_in_block,
+            ),
+            invalid_tx_policy: InvalidTxPolicy::RejectAndContinue {
+                mark_in_source: true,
+            },
+            metrics_label: "produce",
+            protocol_version,
+            expected_block_output_hash: None,
+            previous_block_timestamp: previous_record.block_context.timestamp,
+            force_preimages,
+            expect_sl_chain_id_tx_after_upgrade,
+            starting_cursors: next_cursors.clone(),
+            interop_roots_per_block: self.config.interop_roots_per_block,
+            strict_subpool_cleanup: true,
+        }))
+    }
+
+    async fn replay(
+        &mut self,
+        record: Box<ReplayRecord>,
+    ) -> anyhow::Result<Option<PreparedBlockCommand<'_>>> {
+        if record.block_context.block_number == 0 {
+            self.last_block = Some(LastBlock {
+                record: *record,
+                hash: genesis_header().hash(),
+                next_cursors: Default::default(),
+            });
+            return Ok(None);
+        }
+
+        if let Some(LastBlock {
+            record: last_record,
+            ..
+        }) = &self.last_block
+        {
+            anyhow::ensure!(
+                last_record.block_context.block_number + 1 == record.block_context.block_number,
+                "blocks received our of order: last block was {}, but received {}",
+                last_record.block_context.block_number,
+                record.block_context.block_number
+            );
+            anyhow::ensure!(
+                last_record.block_context.timestamp == record.previous_block_timestamp,
+                "inconsistent previous block timestamp: last block was {}, but received {}",
+                last_record.block_context.timestamp,
+                record.previous_block_timestamp
+            );
+            anyhow::ensure!(
+                last_record.block_context.block_hashes.0[1..]
+                    == record.block_context.block_hashes.0[..255],
+                "inconsistent previous block hashes: last block's (#{}) was {:?}, but received new block's {:?}",
+                last_record.block_context.block_number,
+                last_record.block_context.block_hashes,
+                record.block_context.block_hashes
+            );
+        }
+
+        let expect_sl_chain_id_tx_after_upgrade = record
+            .transactions
+            .windows(2)
+            .find(|window| {
+                matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
+                    && matches!(
+                        window[1].as_system_tx_type(),
+                        Some(SystemTxType::SetSLChainId(_, _))
                     )
-                    .await
-                    .context("mempool is closed")?;
+            })
+            .is_some();
 
-                let timestamp = (millis_since_epoch() / 1000) as u64;
+        Ok(Some(PreparedBlockCommand {
+            block_context: record.block_context,
+            seal_policy: SealPolicy::UntilExhausted {
+                allowed_to_finish_early: false,
+            },
+            invalid_tx_policy: InvalidTxPolicy::Abort,
+            tx_source: MarkingTxStream::unmarkable(futures::stream::iter(record.transactions)),
+            metrics_label: "replay",
+            protocol_version: record.protocol_version,
+            expected_block_output_hash: Some(record.block_output_hash),
+            previous_block_timestamp: record.previous_block_timestamp,
+            force_preimages: record.force_preimages,
+            expect_sl_chain_id_tx_after_upgrade,
+            starting_cursors: record.starting_cursors,
+            interop_roots_per_block: self.config.interop_roots_per_block,
+            strict_subpool_cleanup: false,
+        }))
+    }
 
-                // Check if we peeked an upgrade transaction info.
-                // It is possible that we peek an upgrade with version <= self.protocol_version
-                // since we do not consume patch upgrades when replaying/rebuilding blocks. Such upgrade can be safely skipped.
-                let force_preimages = if let Some(upgrade_metadata) = best_txs.upgrade_metadata
-                    && upgrade_metadata.protocol_version > self.protocol_version
-                {
-                    tracing::info!(
-                        block_number,
-                        ?upgrade_metadata,
-                        "including protocol upgrade transaction in the block"
-                    );
-                    // Invariant: transactions sent through this stream must be ready for execution, e.g.
-                    // transaction should not be sent until timestamp is reached.
-                    // We add some margin of error for timestamp comparison.
-                    let current_timestamp = timestamp.saturating_add(5);
-                    anyhow::ensure!(
-                        upgrade_metadata.timestamp <= current_timestamp,
-                        "upgrade transaction with timestamp {} received too early at {}; tx: {upgrade_metadata:?}",
-                        upgrade_metadata.timestamp,
-                        current_timestamp
-                    );
-                    self.protocol_version = upgrade_metadata.protocol_version.clone();
-                    upgrade_metadata.force_preimages.clone()
+    async fn rebuild(
+        &mut self,
+        rebuild: Box<RebuildCommand>,
+    ) -> anyhow::Result<Option<PreparedBlockCommand<'_>>> {
+        let (previous_block_timestamp, next_cursors, block_hashes) =
+            if let Some(last_block) = self.last_block.as_ref() {
+                (
+                    last_block.record.block_context.timestamp,
+                    last_block.next_cursors.clone(),
+                    last_block
+                        .record
+                        .block_context
+                        .block_hashes
+                        .push(last_block.hash),
+                )
+            } else {
+                (
+                    rebuild.replay_record.previous_block_timestamp,
+                    rebuild.replay_record.starting_cursors,
+                    rebuild.replay_record.block_context.block_hashes,
+                )
+            };
+
+        let block_number = rebuild.replay_record.block_context.block_number;
+        let (execution_version, protocol_version) = (
+            rebuild.replay_record.block_context.execution_version,
+            rebuild.replay_record.protocol_version,
+        );
+
+        if rebuild.make_empty
+            && rebuild
+                .replay_record
+                .transactions
+                .iter()
+                .any(|tx| matches!(tx.envelope(), ZkEnvelope::Upgrade(_)))
+        {
+            anyhow::bail!(
+                "Cannot make an empty block when there is an upgrade transaction in the replay record for block {}",
+                block_number
+            );
+        }
+
+        let timestamp = if rebuild.reset_timestamp {
+            (millis_since_epoch() / 1000) as u64
+        } else {
+            rebuild.replay_record.block_context.timestamp
+        };
+        let block_context = BlockContext {
+            eip1559_basefee: rebuild.replay_record.block_context.eip1559_basefee,
+            native_price: rebuild.replay_record.block_context.native_price,
+            pubdata_price: rebuild.replay_record.block_context.pubdata_price,
+            block_number,
+            timestamp,
+            blob_fee: rebuild.replay_record.block_context.blob_fee,
+            chain_id: self.config.l2_chain_id,
+            coinbase: self.config.fee_collector_address,
+            block_hashes,
+            gas_limit: self.config.gas_limit,
+            pubdata_limit: self.config.pubdata_limit,
+            // todo: initialize as source of randomness, i.e. the value of prevRandao
+            mix_hash: Default::default(),
+            execution_version,
+        };
+        let txs = if rebuild.make_empty {
+            Vec::new()
+        } else {
+            let first_l1_tx = rebuild
+                .replay_record
+                .transactions
+                .iter()
+                .find(|tx| matches!(tx.envelope(), ZkEnvelope::L1(_)));
+            // It's possible that we haven't processed some L1 transaction from previous blocks when rebuilding.
+            // In that case we shouldn't consider next L1 txs when rebuilding.
+            let filter_l1_txs =
+                if let Some(ZkEnvelope::L1(l1_tx)) = first_l1_tx.map(|tx| tx.envelope()) {
+                    l1_tx.priority_id() != next_cursors.l1_priority_id
                 } else {
-                    Vec::new()
+                    false
                 };
-
-                let execution_version: ExecutionVersion = (&self.protocol_version)
-                    .try_into()
-                    .context("Cannot instantiate a block for unsupported execution version")?;
-
-                // Append a SetSLChainId system transaction exactly once: when the protocol
-                // version is v31 (either via upgrade from v30, or on the first block of a
-                // fresh v31 chain). After it fires once, `sl_chain_id_set` prevents it from
-                // ever triggering again.
-                let (tx_source, expect_sl_chain_id_tx_after_upgrade) = if !self.sl_chain_id_set
-                    && self.protocol_version.minor == 31
-                {
-                    self.sl_chain_id_set = true;
-                    let sl_chain_id_tx = SystemTxEnvelope::set_sl_chain_id(
-                        self.sl_chain_id_at_startup,
-                        // We use `u64::MAX` as a placeholder, since it is not an actual migration
-                        u64::MAX,
-                    );
-                    let tx_source = MarkingTxStream::unmarkable(best_txs.stream.stream.chain(
-                        futures::stream::once(async move { ZkTransaction::from(sl_chain_id_tx) }),
-                    ));
-                    (tx_source, true)
-                } else {
-                    (best_txs.stream, false)
-                };
-
-                let FeeParams {
-                    eip1559_basefee,
-                    native_price,
-                    pubdata_price,
-                } = fee_params;
-                let block_context = BlockContext {
-                    eip1559_basefee,
-                    native_price,
-                    pubdata_price,
-                    block_number,
-                    timestamp,
-                    chain_id: self.chain_id,
-                    coinbase: self.fee_collector_address,
-                    block_hashes: self.block_hashes_for_next_block,
-                    gas_limit: self.gas_limit,
-                    pubdata_limit: self.pubdata_limit,
-                    // todo: initialize as source of randomness, i.e. the value of prevRandao
-                    mix_hash: Default::default(),
-                    execution_version: execution_version as u32,
-                    blob_fee: U256::ONE,
-                };
-                self.last_constructed_block_ctx_sender
-                    .send_replace(Some(block_context));
-                PreparedBlockCommand {
-                    block_context,
-                    tx_source,
-                    seal_policy: SealPolicy::Decide(
-                        self.block_time,
-                        self.max_transactions_in_block,
-                    ),
-                    invalid_tx_policy: InvalidTxPolicy::RejectAndContinue {
-                        mark_in_source: true,
-                    },
-                    metrics_label: "produce",
-                    protocol_version: self.protocol_version.clone(),
-                    expected_block_output_hash: None,
-                    previous_block_timestamp: self.previous_block_timestamp,
-                    force_preimages,
-                    expect_sl_chain_id_tx_after_upgrade,
-                    starting_cursors: self.next_cursors.clone(),
-                    interop_roots_per_block: self.interop_roots_per_block,
-                    strict_subpool_cleanup: true,
-                }
-            }
-            BlockCommand::Replay(record) => {
-                anyhow::ensure!(
-                    self.next_block_number == record.block_context.block_number,
-                    "blocks received our of order: {} in component state, {} in resolved ReplayRecord",
-                    self.next_block_number,
-                    record.block_context.block_number
-                );
-                anyhow::ensure!(
-                    self.previous_block_timestamp == record.previous_block_timestamp,
-                    "inconsistent previous block timestamp: {} in component state, {} in resolved ReplayRecord",
-                    self.previous_block_timestamp,
-                    record.previous_block_timestamp
-                );
-                anyhow::ensure!(
-                    self.block_hashes_for_next_block == record.block_context.block_hashes,
-                    "inconsistent previous block hashes: {} in component state, {} in resolved ReplayRecord",
-                    self.previous_block_timestamp,
-                    record.previous_block_timestamp
-                );
-
-                let expect_sl_chain_id_tx_after_upgrade = record
+            if filter_l1_txs {
+                rebuild
+                    .replay_record
                     .transactions
-                    .windows(2)
-                    .find(|window| {
-                        matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
-                            && matches!(
-                                window[1].as_system_tx_type(),
-                                Some(SystemTxType::SetSLChainId(_, _))
-                            )
-                    })
-                    .is_some();
-
-                PreparedBlockCommand {
-                    block_context: record.block_context,
-                    seal_policy: SealPolicy::UntilExhausted {
-                        allowed_to_finish_early: false,
-                    },
-                    invalid_tx_policy: InvalidTxPolicy::Abort,
-                    tx_source: MarkingTxStream::unmarkable(futures::stream::iter(
-                        record.transactions,
-                    )),
-                    metrics_label: "replay",
-                    protocol_version: record.protocol_version,
-                    expected_block_output_hash: Some(record.block_output_hash),
-                    previous_block_timestamp: self.previous_block_timestamp,
-                    force_preimages: record.force_preimages,
-                    expect_sl_chain_id_tx_after_upgrade,
-                    starting_cursors: record.starting_cursors,
-                    interop_roots_per_block: self.interop_roots_per_block,
-                    strict_subpool_cleanup: false,
-                }
-            }
-            BlockCommand::Rebuild(rebuild) => {
-                let block_number = rebuild.replay_record.block_context.block_number;
-                let (execution_version, protocol_version) = (
-                    rebuild.replay_record.block_context.execution_version,
-                    rebuild.replay_record.protocol_version,
-                );
-
-                if rebuild.make_empty
-                    && rebuild
-                        .replay_record
-                        .transactions
-                        .iter()
-                        .any(|tx| matches!(tx.envelope(), ZkEnvelope::Upgrade(_)))
-                {
-                    anyhow::bail!(
-                        "Cannot make an empty block when there is an upgrade transaction in the replay record for block {}",
-                        block_number
-                    );
-                }
-
-                let timestamp = if rebuild.reset_timestamp {
-                    (millis_since_epoch() / 1000) as u64
-                } else {
-                    rebuild.replay_record.block_context.timestamp
-                };
-                let block_context = BlockContext {
-                    eip1559_basefee: rebuild.replay_record.block_context.eip1559_basefee,
-                    native_price: rebuild.replay_record.block_context.native_price,
-                    pubdata_price: rebuild.replay_record.block_context.pubdata_price,
-                    block_number,
-                    timestamp,
-                    blob_fee: rebuild.replay_record.block_context.blob_fee,
-                    chain_id: self.chain_id,
-                    coinbase: self.fee_collector_address,
-                    block_hashes: self.block_hashes_for_next_block,
-                    gas_limit: self.gas_limit,
-                    pubdata_limit: self.pubdata_limit,
-                    // todo: initialize as source of randomness, i.e. the value of prevRandao
-                    mix_hash: Default::default(),
-                    execution_version,
-                };
-                let txs = if rebuild.make_empty {
-                    Vec::new()
-                } else {
-                    let first_l1_tx = rebuild
-                        .replay_record
-                        .transactions
-                        .iter()
-                        .find(|tx| matches!(tx.envelope(), ZkEnvelope::L1(_)));
-                    // It's possible that we haven't processed some L1 transaction from previous blocks when rebuilding.
-                    // In that case we shouldn't consider next L1 txs when rebuilding.
-                    let filter_l1_txs =
-                        if let Some(ZkEnvelope::L1(l1_tx)) = first_l1_tx.map(|tx| tx.envelope()) {
-                            l1_tx.priority_id() != self.next_cursors.l1_priority_id
-                        } else {
-                            false
-                        };
-                    if filter_l1_txs {
-                        rebuild
-                            .replay_record
-                            .transactions
-                            .into_iter()
-                            .filter(|tx| !matches!(tx.envelope(), ZkEnvelope::L1(_)))
-                            .collect()
-                    } else {
-                        rebuild.replay_record.transactions
-                    }
-                };
-
-                let expect_sl_chain_id_tx_after_upgrade = txs
-                    .windows(2)
-                    .find(|window| {
-                        matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
-                            && matches!(
-                                window[1].as_system_tx_type(),
-                                Some(SystemTxType::SetSLChainId(_, _))
-                            )
-                    })
-                    .is_some();
-
-                PreparedBlockCommand {
-                    expect_sl_chain_id_tx_after_upgrade,
-                    block_context,
-                    tx_source: MarkingTxStream::unmarkable(futures::stream::iter(txs)),
-                    seal_policy: SealPolicy::UntilExhausted {
-                        allowed_to_finish_early: true,
-                    },
-                    invalid_tx_policy: InvalidTxPolicy::RejectAndContinue {
-                        mark_in_source: false,
-                    },
-                    metrics_label: "rebuild",
-                    protocol_version,
-                    expected_block_output_hash: None,
-                    previous_block_timestamp: self.previous_block_timestamp,
-                    force_preimages: rebuild.replay_record.force_preimages,
-                    starting_cursors: self.next_cursors.clone(),
-                    interop_roots_per_block: self.interop_roots_per_block,
-                    strict_subpool_cleanup: false,
-                }
+                    .into_iter()
+                    .filter(|tx| !matches!(tx.envelope(), ZkEnvelope::L1(_)))
+                    .collect()
+            } else {
+                rebuild.replay_record.transactions
             }
         };
 
-        Ok(prepared_command)
+        let expect_sl_chain_id_tx_after_upgrade = txs
+            .windows(2)
+            .find(|window| {
+                matches!(window[0].envelope(), ZkEnvelope::Upgrade(_))
+                    && matches!(
+                        window[1].as_system_tx_type(),
+                        Some(SystemTxType::SetSLChainId(_, _))
+                    )
+            })
+            .is_some();
+
+        Ok(Some(PreparedBlockCommand {
+            expect_sl_chain_id_tx_after_upgrade,
+            block_context,
+            tx_source: MarkingTxStream::unmarkable(futures::stream::iter(txs)),
+            seal_policy: SealPolicy::UntilExhausted {
+                allowed_to_finish_early: true,
+            },
+            invalid_tx_policy: InvalidTxPolicy::RejectAndContinue {
+                mark_in_source: false,
+            },
+            metrics_label: "rebuild",
+            protocol_version,
+            expected_block_output_hash: None,
+            previous_block_timestamp,
+            force_preimages: rebuild.replay_record.force_preimages,
+            starting_cursors: next_cursors,
+            interop_roots_per_block: self.config.interop_roots_per_block,
+            strict_subpool_cleanup: false,
+        }))
     }
 
     pub fn purge_transactions(&self, tx_hashes: Vec<TxHash>) {
@@ -409,57 +440,29 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
         replay_record: &ReplayRecord,
         strict_subpool_cleanup: bool,
     ) {
-        let canonical_header = {
-            let (legacy_header, hash) = block_output.header.clone().into_parts();
-            let header = alloy::consensus::Header {
-                parent_hash: legacy_header.parent_hash,
-                ommers_hash: legacy_header.ommers_hash,
-                beneficiary: legacy_header.beneficiary,
-                state_root: legacy_header.state_root,
-                transactions_root: legacy_header.transactions_root,
-                receipts_root: legacy_header.receipts_root,
-                logs_bloom: legacy_header.logs_bloom,
-                difficulty: legacy_header.difficulty,
-                number: legacy_header.number,
-                gas_limit: legacy_header.gas_limit,
-                gas_used: legacy_header.gas_used,
-                timestamp: legacy_header.timestamp,
-                extra_data: legacy_header.extra_data,
-                mix_hash: legacy_header.mix_hash,
-                nonce: legacy_header.nonce,
-                base_fee_per_gas: legacy_header.base_fee_per_gas,
-                withdrawals_root: legacy_header.withdrawals_root,
-                blob_gas_used: legacy_header.blob_gas_used,
-                excess_blob_gas: legacy_header.excess_blob_gas,
-                parent_beacon_block_root: legacy_header.parent_beacon_block_root,
-                requests_hash: legacy_header.requests_hash,
-                block_access_list_hash: None,
-                slot_number: None,
-            };
-            Sealed::new_unchecked(header, hash)
-        };
+        let mut next_cursors = replay_record.starting_cursors.clone();
         let outcome = self
             .pool
             .on_canonical_state_change(
-                canonical_header,
+                block_output.header.clone(),
                 &block_output.account_diffs,
                 replay_record,
                 strict_subpool_cleanup,
             )
             .await;
         if let Some(last_l1_priority_id) = outcome.last_l1_priority_id {
-            self.next_cursors.l1_priority_id = last_l1_priority_id + 1;
+            next_cursors.l1_priority_id = last_l1_priority_id + 1;
             EXECUTION_METRICS
                 .next_l1_priority_id
-                .set(self.next_cursors.l1_priority_id);
+                .set(next_cursors.l1_priority_id);
         }
         if let Some(last_interop_log_id) = outcome.last_interop_log_id {
-            self.next_interop_tx_allowed_after = Instant::now() + self.service_block_delay;
-            self.next_cursors.interop_root_id = last_interop_log_id + 1;
+            self.next_interop_tx_allowed_after = Instant::now() + self.config.service_block_delay;
+            next_cursors.interop_root_id = last_interop_log_id + 1;
         }
 
         if let Some(last_migration_number) = outcome.last_migration_number {
-            self.next_cursors.migration_number = last_migration_number + 1;
+            next_cursors.migration_number = last_migration_number + 1;
         }
         if let Some(target_sl_chain_id) = outcome.last_sl_chain_id_target {
             // Subsequent produced blocks will gate interop traffic on the new value (in particular:
@@ -476,32 +479,15 @@ impl<Subpool: L2Subpool> BlockContextProvider<Subpool> {
             }
         }
         if let Some(last_interop_fee_number) = outcome.last_interop_fee_number {
-            self.next_cursors.interop_fee_number = last_interop_fee_number + 1;
+            next_cursors.interop_fee_number = last_interop_fee_number + 1;
         }
 
-        // We update protocol version here, so that we take into account replay records with protocol version bumps.
-        self.protocol_version = replay_record.protocol_version.clone();
-        // If a replayed block is at v31, the SetSLChainId tx was already included — mark it as done
-        // to prevent the produce path from inserting a duplicate.
-        if self.protocol_version.minor == 31 {
-            self.sl_chain_id_set = true;
-        }
-
-        // Advance `block_hashes_for_next_block`.
-        let last_block_hash = block_output.header.hash();
-        self.block_hashes_for_next_block = BlockHashes(
-            self.block_hashes_for_next_block
-                .0
-                .into_iter()
-                .skip(1)
-                .chain([U256::from_be_bytes(last_block_hash.0)])
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap(),
-        );
-        self.next_block_number += 1;
-        self.previous_block_timestamp = block_output.header.timestamp;
         self.fee_provider.on_canonical_state_change(replay_record);
+        self.last_block = Some(LastBlock {
+            record: replay_record.clone(),
+            hash: block_output.header.hash(),
+            next_cursors,
+        })
     }
 }
 

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -79,11 +79,10 @@ where
             tracing::info!("Command {cmd} received by BlockExecutor");
             let cmd_type = cmd.command_type();
             state_reporter.enter_state(SequencerState::WaitingForApplier);
-            wait_for_block_applier(
-                &mut self.applied_block_number_receiver,
-                self.block_context_provider.next_block_number() - 1,
-            )
-            .await?;
+            if let Some(last_block_number) = self.block_context_provider.last_block_number() {
+                wait_for_block_applier(&mut self.applied_block_number_receiver, last_block_number)
+                    .await?;
+            }
 
             // For Produce commands: check limit (will await indefinitely if limit reached) and increment counter
             if matches!(cmd, BlockCommand::Produce(_))
@@ -100,7 +99,10 @@ where
             }
             state_reporter.enter_state(SequencerState::WaitingForTransaction);
 
-            let prepared_command = self.block_context_provider.prepare_command(cmd).await?;
+            let Some(prepared_command) = self.block_context_provider.prepare_command(cmd).await?
+            else {
+                continue;
+            };
 
             state_reporter.enter_state(SequencerState::InitializingVm);
 

--- a/lib/sequencer/src/execution/fee_provider.rs
+++ b/lib/sequencer/src/execution/fee_provider.rs
@@ -45,7 +45,6 @@ pub struct FeeProvider {
 impl FeeProvider {
     pub fn new(
         fee_config: FeeConfig,
-        previous_block_fee_params: Option<FeeParams>,
         pubdata_price_provider: watch::Receiver<Option<U256>>,
         blob_fill_ratio_provider: watch::Receiver<Option<Ratio<u64>>>,
         token_price_provider: watch::Receiver<Option<TokenPricesForFees>>,
@@ -53,7 +52,7 @@ impl FeeProvider {
     ) -> Self {
         Self {
             fee_config,
-            previous_block_fee_params,
+            previous_block_fee_params: None,
             pubdata_price_provider,
             blob_fill_ratio_provider,
             token_price_provider,

--- a/lib/storage_api/src/model.rs
+++ b/lib/storage_api/src/model.rs
@@ -173,6 +173,20 @@ pub struct BlockContext {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BlockHashes(pub [U256; 256]);
 
+impl BlockHashes {
+    pub fn push(self, block_hash: B256) -> Self {
+        Self(
+            self.0
+                .into_iter()
+                .skip(1)
+                .chain([U256::from_be_bytes(block_hash.0)])
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
+    }
+}
+
 impl Default for BlockHashes {
     fn default() -> Self {
         Self([U256::ZERO; 256])

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -402,7 +402,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         last_finalized_executed_batch: l1_state.last_finalized_executed_batch,
     });
 
-    // `starting_block` - the block number to go through the pipeline.
+    // `starting_block` - the first block to go through the pipeline. Invariant: a replay record for
+    // this block must already exist. Note that this holds for `starting_block=0` as genesis is
+    // always present in the system.
     let starting_block = if node_startup_state.l1_state.last_committed_batch > 0 {
         // todo: ideally this should be searched through p2p networking instead of RPC
         //       but too many things depend on this being initialized here right now
@@ -1780,15 +1782,15 @@ fn determine_starting_block(
                 .block_replay_storage_last_block
                 .saturating_sub(config.general_config.min_blocks_to_replay as u64),
             // We need to replay old unexecuted blocks to rebuild and execute the batches they are in
-            node_startup_state.last_l1_executed_block + 1,
+            node_startup_state.last_l1_executed_block,
             // Repositories' persistence may have fallen behind - we need to replay blocks to rebuild it
-            node_startup_state.repositories_persisted_block + 1,
+            node_startup_state.repositories_persisted_block,
             // In the current tree implementation this will always be ahead of `last_l1_executed_block`,
             // but this may change if we make tree persistence async (like elsewhere)
-            node_startup_state.tree_last_block + 1,
+            node_startup_state.tree_last_block,
             // For compacted state, we need to replay all blocks that were not persisted yet.
             // For FullDiffs state (default) - this is always ahead of `last_l1_executed_block`.
-            state.block_range_available().end() + 1,
+            *state.block_range_available().end(),
             // If block rebuild (aka block reversion) is configured, we should ensure we replay
             // all the blocks we are rebuilding
             config
@@ -1801,7 +1803,7 @@ fn determine_starting_block(
         .min()
         .unwrap();
 
-        if last_matching_block + 1 < want_to_start_from {
+        if last_matching_block < want_to_start_from {
             tracing::warn!(
                 last_matching_block,
                 want_to_start_from,
@@ -1809,9 +1811,10 @@ fn determine_starting_block(
             );
         }
 
-        (last_matching_block + 1).min(want_to_start_from)
+        last_matching_block.min(want_to_start_from)
     };
 
+    // Ignore genesis here as we never actually run it in sequencer
     if desired_starting_block > 0
         && desired_starting_block < state.block_range_available().start() + 1
     {

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -50,7 +50,6 @@ use anyhow::Context;
 use jsonrpsee::http_client::HttpClient;
 use priority_tree_pipeline_step::PriorityTreePipelineStep;
 use reth_tasks::Runtime;
-use ruint::aliases::U256;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -119,8 +118,8 @@ use zksync_os_storage::db::{BlockReplayStorage, ExecutedBatchStorage};
 use zksync_os_storage::in_memory::Finality;
 use zksync_os_storage::lazy::RepositoryManager;
 use zksync_os_storage_api::{
-    BlockHashes, FinalityStatus, ReadFinality, ReadReplay, ReadRepository, ReadStateHistory,
-    ReplayRecord, WriteReplay, WriteRepository, WriteState,
+    FinalityStatus, ReadFinality, ReadReplay, ReadRepository, ReadStateHistory, ReplayRecord,
+    WriteReplay, WriteRepository, WriteState,
 };
 use zksync_os_types::{
     BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion, PubdataMode,
@@ -419,8 +418,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         // Some batches committed - starting from an already committed batch
         determine_starting_block(&config, &node_startup_state, &state, last_matching_block)
     } else {
-        // No batches committed - starting from block/batch 1.
-        1
+        // No batches committed - starting from genesis.
+        0
     };
 
     tracing::info!(
@@ -662,8 +661,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let interop_roots_subpool =
         InteropRootsSubpool::new(config.sequencer_config.interop_roots_per_tx);
 
-    // If we start from the very first block, we should start by sending upgrade tx for genesis.
-    if starting_block == 1 {
+    // If we start from genesis, we should start by sending upgrade tx for genesis.
+    if starting_block == 0 {
         let genesis_upgrade = genesis.genesis_upgrade_tx().await;
         let upgrade_tx = UpgradeInfo {
             tx: Some(genesis_upgrade.tx.clone()),
@@ -829,26 +828,17 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     // ========== Start BlockContextProvider and its state ===========
     tracing::info!("Initializing BlockContextProvider");
 
-    let previous_block_timestamp: u64 = first_replay_record
-        .as_ref()
-        .map_or(0, |record| record.previous_block_timestamp); // if no previous block, assume genesis block
-
-    let block_hashes_for_next_block = first_replay_record
-        .as_ref()
-        .map(|record| record.block_context.block_hashes)
-        .unwrap_or_else(|| block_hashes_for_first_block(&repositories));
-
     let (token_price_sender, token_price_receiver) = watch::channel(None);
     let interop_fee_token_price_receiver = token_price_receiver.clone();
-    let previous_block_fee_params = if starting_block == 1 {
+    let previous_block_fee_params = if starting_block == 0 {
         None
     } else {
         let prev_record = block_replay_storage
-            .get_replay_record(starting_block - 1)
+            .get_replay_record(starting_block)
             .unwrap_or_else(|| {
                 panic!(
-                    "Missing replay record for block `starting_block - 1` = {}",
-                    starting_block - 1
+                    "Missing replay record for block `starting_block` = {}",
+                    starting_block
                 )
             });
         Some(FeeParams {
@@ -878,25 +868,22 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         l2_subpool.clone(),
     );
     let block_context_provider = BlockContextProvider::new(
-        next_cursors,
-        pool,
-        block_hashes_for_next_block,
-        previous_block_timestamp,
-        starting_block,
-        config.sequencer_config.block_time,
-        config.sequencer_config.max_transactions_in_block,
-        chain_id,
-        config.sequencer_config.block_gas_limit,
-        config.sequencer_config.block_pubdata_limit_bytes,
-        // We set the value to the same as for the batch, since it should be enforced by batcher, but don't want to exceed it for the block
-        config.batcher_config.interop_roots_per_batch_limit,
-        config.sequencer_config.service_block_delay,
-        current_protocol_version.clone(),
-        node_startup_state.l1_state.sl_chain_id,
-        node_startup_state.l1_state.l1_chain_id,
-        config.sequencer_config.fee_collector_address,
-        last_constructed_block_ctx_sender,
         fee_provider,
+        pool,
+        zksync_os_sequencer::execution::block_context_provider::Config {
+            l2_chain_id: chain_id,
+            l1_chain_id: node_startup_state.l1_state.l1_chain_id,
+            gas_limit: config.sequencer_config.block_gas_limit,
+            pubdata_limit: config.sequencer_config.block_pubdata_limit_bytes,
+            fee_collector_address: config.sequencer_config.fee_collector_address,
+            block_time: config.sequencer_config.block_time,
+            service_block_delay: config.sequencer_config.service_block_delay,
+            max_transactions_in_block: config.sequencer_config.max_transactions_in_block,
+            // We set the value to the same as for the batch, since it should be enforced by batcher, but don't want to exceed it for the block
+            interop_roots_per_block: config.batcher_config.interop_roots_per_batch_limit,
+        },
+        &node_startup_state.l1_state.settlement_layer_intervals,
+        last_constructed_block_ctx_sender,
     );
 
     // ========== Start L1 Upgrade Watcher ===========
@@ -1212,7 +1199,7 @@ async fn run_main_node_pipeline(
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
     let (applied_block_number_sender, applied_block_number_receiver) =
-        watch::channel(starting_block - 1);
+        watch::channel(starting_block.saturating_sub(1));
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ConsensusNodeCommandSource {
@@ -1473,7 +1460,7 @@ async fn run_en_pipeline(
             .join(INTERNAL_CONFIG_FILE_NAME),
     );
     let (applied_block_number_sender, applied_block_number_receiver) =
-        watch::channel(starting_block - 1);
+        watch::channel(starting_block.saturating_sub(1));
 
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());
@@ -1564,16 +1551,6 @@ async fn run_en_pipeline(
         clear_failing_block_config_task(finality, internal_config_manager),
     );
     monitor.spawn(runtime, snapshot_rx)
-}
-
-fn block_hashes_for_first_block(repositories: &dyn ReadRepository) -> BlockHashes {
-    let mut block_hashes = BlockHashes::default();
-    let genesis_block = repositories
-        .get_block_by_number(0)
-        .expect("Failed to read genesis block from repositories")
-        .expect("Missing genesis block in repositories");
-    block_hashes.0[255] = U256::from_be_slice(genesis_block.hash().as_slice());
-    block_hashes
 }
 
 fn init_and_report_internal_config_manager(
@@ -1822,9 +1799,7 @@ fn determine_starting_block(
         ]
         .into_iter()
         .min()
-        .unwrap()
-        // We don't execute the genesis block (number 0) - the earliest we can start is `0`
-        .max(1);
+        .unwrap();
 
         if last_matching_block + 1 < want_to_start_from {
             tracing::warn!(
@@ -1837,7 +1812,9 @@ fn determine_starting_block(
         (last_matching_block + 1).min(want_to_start_from)
     };
 
-    if desired_starting_block < state.block_range_available().start() + 1 {
+    if desired_starting_block > 0
+        && desired_starting_block < state.block_range_available().start() + 1
+    {
         // This may only happen with Compacted State. This means that the block we want to rerun was already compacted.
         // This can be fixed by manually removing the storage persistence - which will force the node to start from block 1.
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -110,9 +110,7 @@ use zksync_os_revm_consistency_checker::node::RevmConsistencyChecker;
 use zksync_os_rpc::{EthCallHandler, RpcStorage};
 use zksync_os_rpc_api::eth::EthApiClient;
 use zksync_os_sequencer::execution::block_context_provider::BlockContextProvider;
-use zksync_os_sequencer::execution::{
-    BlockApplier, BlockCanonizer, BlockExecutor, FeeParams, FeeProvider,
-};
+use zksync_os_sequencer::execution::{BlockApplier, BlockCanonizer, BlockExecutor, FeeProvider};
 use zksync_os_status_server::run_status_server;
 use zksync_os_storage::db::{BlockReplayStorage, ExecutedBatchStorage};
 use zksync_os_storage::in_memory::Finality;
@@ -832,29 +830,11 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     let (token_price_sender, token_price_receiver) = watch::channel(None);
     let interop_fee_token_price_receiver = token_price_receiver.clone();
-    let previous_block_fee_params = if starting_block == 0 {
-        None
-    } else {
-        let prev_record = block_replay_storage
-            .get_replay_record(starting_block)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Missing replay record for block `starting_block` = {}",
-                    starting_block
-                )
-            });
-        Some(FeeParams {
-            eip1559_basefee: prev_record.block_context.eip1559_basefee,
-            native_price: prev_record.block_context.native_price,
-            pubdata_price: prev_record.block_context.pubdata_price,
-        })
-    };
 
     // todo: `BlockContextProvider` initialization and its dependencies
     // should be moved to `sequencer`
     let fee_provider = FeeProvider::new(
         config.fee_config.clone().into(),
-        previous_block_fee_params,
         pubdata_price_receiver,
         blob_fill_ratio_receiver,
         token_price_receiver,


### PR DESCRIPTION
## Summary

`BlockContextProvider` (BCP) previously had to be primed at startup with a snapshot of the previous block's state - block number, timestamp, block hashes, protocol version, SL chain id, and the
  `sl_chain_id_set` flag. This made initialization fragile and duplicated state that already lives in `ReplayRecord`s.

This refactor makes BCP derive all per-block state from the records it replays. The genesis block (#0) is now replayed to bootstrap that state instead of being skipped, so the node starts from block `0`
  rather than `1`.

### Key changes
  - **BCP holds `last_block: Option<LastBlock>`** instead of a dozen mutable fields. Each replayed/produced block updates it; `produce`/`rebuild` derive the next block's number, timestamp, and `block_hashes` 
  from the previous record.
  - **`prepare_command` now returns `Option<PreparedBlockCommand>`.** Replaying genesis (#0) seeds `last_block` and returns `None` (no block to execute); `BlockExecutor` skips and continues.
  - **Static params grouped into a `Config` struct**, replacing the `#[allow(clippy::too_many_arguments)]` constructor.
  - **SL chain id is derived from `SettlementLayerIntervals`** at construction, dropping the `sl_chain_id_set` / `sl_chain_id_at_startup` / `protocol_version` bookkeeping fields. The one-shot `SetSLChainId` tx
  is now gated on the previous record's protocol version (`< 31` or block `0`).
  - **`genesis_header()` extracted** as a public fn in `zksync-os-genesis` (reused by genesis build and by BCP to compute the genesis block hash).
  - **`BlockHashes::push(hash)`** helper added; inlined hash-ring advancement logic removed.
  - **Startup (`node/bin`) simplified**: starts from block `0`, removes `block_hashes_for_first_block`, and no longer special-cases `starting_block - 1`.


<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

