### PR TITLE
fix(backpressure): block ingestion under backpressure

### DIFF
--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -1,0 +1,57 @@
+use tokio::sync::watch;
+
+/// Admission gate for internal pipeline sources.
+///
+/// This is deliberately separate from RPC transaction acceptance. `true` means
+/// the block pipeline can accept more work; `false` means command sources should
+/// stop forwarding new work until downstream lag clears.
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionGate {
+    tx: watch::Sender<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PipelineAdmissionReceiver {
+    rx: watch::Receiver<bool>,
+}
+
+impl PipelineAdmissionGate {
+    pub fn open() -> (Self, PipelineAdmissionReceiver) {
+        let (tx, rx) = watch::channel(true);
+        (Self { tx }, PipelineAdmissionReceiver { rx })
+    }
+
+    pub fn subscribe(&self) -> PipelineAdmissionReceiver {
+        PipelineAdmissionReceiver {
+            rx: self.tx.subscribe(),
+        }
+    }
+
+    pub fn set_open(&self) {
+        self.set(true);
+    }
+
+    pub fn set_closed(&self) {
+        self.set(false);
+    }
+
+    pub fn set(&self, open: bool) {
+        let _ = self.tx.send_if_modified(|current| {
+            if *current == open {
+                return false;
+            }
+            *current = open;
+            true
+        });
+    }
+}
+
+impl PipelineAdmissionReceiver {
+    pub fn is_open(&self) -> bool {
+        *self.rx.borrow()
+    }
+
+    pub async fn wait_until_open(&mut self) {
+        let _ = self.rx.wait_for(|open| *open).await;
+    }
+}

--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -15,24 +15,22 @@ pub struct PipelineAdmissionReceiver {
     rx: watch::Receiver<bool>,
 }
 
+impl Default for PipelineAdmissionGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PipelineAdmissionGate {
-    pub fn open() -> (Self, PipelineAdmissionReceiver) {
-        let (tx, rx) = watch::channel(true);
-        (Self { tx }, PipelineAdmissionReceiver { rx })
+    pub fn new() -> Self {
+        let (tx, _) = watch::channel(true);
+        Self { tx }
     }
 
     pub fn subscribe(&self) -> PipelineAdmissionReceiver {
         PipelineAdmissionReceiver {
             rx: self.tx.subscribe(),
         }
-    }
-
-    pub fn set_open(&self) {
-        self.set(true);
-    }
-
-    pub fn set_closed(&self) {
-        self.set(false);
     }
 
     pub fn set(&self, open: bool) {

--- a/lib/backpressure/src/gate.rs
+++ b/lib/backpressure/src/gate.rs
@@ -2,10 +2,13 @@ use tokio::sync::watch;
 
 /// Admission gate for internal pipeline sources.
 ///
-/// This is deliberately separate from RPC transaction acceptance. `true` means
-/// the block pipeline can accept more work; `false` means command sources should
-/// stop forwarding new work until downstream lag clears.
-#[derive(Debug, Clone)]
+/// Driven by the same backpressure condition as RPC transaction acceptance
+/// (the monitor closes the gate exactly when it suspends acceptance), but
+/// delivered over a separate channel so command sources don't depend on the
+/// RPC-facing state type. `true` means the block pipeline can accept more
+/// work; `false` means command sources should stop forwarding new work until
+/// downstream lag clears.
+#[derive(Debug)]
 pub struct PipelineAdmissionGate {
     tx: watch::Sender<bool>,
 }
@@ -45,11 +48,90 @@ impl PipelineAdmissionGate {
 }
 
 impl PipelineAdmissionReceiver {
+    /// Returns the last gate state set by the monitor. If the monitor has
+    /// stopped (sender dropped), keeps reporting the last state it set.
     pub fn is_open(&self) -> bool {
         *self.rx.borrow()
     }
 
+    /// Waits until the gate is open.
+    ///
+    /// If the gate sender is dropped while the gate is closed, this future
+    /// never resolves: the gate freezes in its last state, consistent with
+    /// [`Self::is_open`]. The sender is owned by the backpressure monitor,
+    /// a critical task that only exits on node shutdown, so a frozen-closed
+    /// gate just parks the source until the pipeline is torn down.
     pub async fn wait_until_open(&mut self) {
-        let _ = self.rx.wait_for(|open| *open).await;
+        if self.rx.wait_for(|open| *open).await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn gate_starts_open() {
+        let gate = PipelineAdmissionGate::new();
+        let mut rx = gate.subscribe();
+        assert!(rx.is_open());
+        timeout(Duration::from_secs(1), rx.wait_until_open())
+            .await
+            .expect("wait_until_open must resolve immediately on an open gate");
+    }
+
+    #[tokio::test]
+    async fn wait_blocks_while_closed_and_resolves_on_open() {
+        let gate = PipelineAdmissionGate::new();
+        let mut rx = gate.subscribe();
+
+        gate.set(false);
+        assert!(!rx.is_open());
+        assert!(
+            timeout(Duration::from_millis(50), rx.wait_until_open())
+                .await
+                .is_err(),
+            "wait_until_open must not resolve while the gate is closed"
+        );
+
+        let wait = tokio::spawn(async move {
+            rx.wait_until_open().await;
+            rx
+        });
+        gate.set(true);
+        let rx = timeout(Duration::from_secs(1), wait)
+            .await
+            .expect("wait_until_open must resolve once the gate opens")
+            .unwrap();
+        assert!(rx.is_open());
+    }
+
+    #[tokio::test]
+    async fn gate_freezes_in_last_state_when_sender_dropped() {
+        // Dropped while closed: stays closed, wait_until_open never resolves.
+        let gate = PipelineAdmissionGate::new();
+        let mut rx = gate.subscribe();
+        gate.set(false);
+        drop(gate);
+        assert!(!rx.is_open());
+        assert!(
+            timeout(Duration::from_millis(50), rx.wait_until_open())
+                .await
+                .is_err(),
+            "wait_until_open must not resolve after the sender is dropped while closed"
+        );
+
+        // Dropped while open: stays open, wait_until_open resolves.
+        let gate = PipelineAdmissionGate::new();
+        let mut rx = gate.subscribe();
+        drop(gate);
+        assert!(rx.is_open());
+        timeout(Duration::from_secs(1), rx.wait_until_open())
+            .await
+            .expect("wait_until_open must resolve after the sender is dropped while open");
     }
 }

--- a/lib/backpressure/src/lib.rs
+++ b/lib/backpressure/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod gate;
 pub mod metrics;
 pub mod monitor;
 pub mod tracker;
@@ -7,5 +8,6 @@ pub use config::{
     BackpressureConfig, ComponentId, DEFAULT_BATCH_DIFF_LIMIT, DEFAULT_BLOCK_DIFF_LIMIT,
     PipelineCondition,
 };
+pub use gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 pub use monitor::{AdjacentSnapshot, BackpressureMonitor, PipelineSnapshot};
 pub use tracker::PipelineTracker;

--- a/lib/backpressure/src/monitor.rs
+++ b/lib/backpressure/src/monitor.rs
@@ -1,4 +1,5 @@
 use crate::config::{BackpressureConfig, ComponentId, is_pipeline_stage};
+use crate::gate::{PipelineAdmissionGate, PipelineAdmissionReceiver};
 use crate::metrics::MONITOR_METRICS;
 use reth_tasks::Runtime;
 use std::collections::{HashMap, HashSet};
@@ -58,17 +59,24 @@ fn compute_adjacent_snapshots(
 pub struct BackpressureMonitor {
     config: BackpressureConfig,
     acceptance_tx: watch::Sender<TransactionAcceptanceState>,
+    pipeline_gate: PipelineAdmissionGate,
     stop_receiver: watch::Receiver<bool>,
 }
 
 impl BackpressureMonitor {
     pub fn new(config: BackpressureConfig, stop_receiver: watch::Receiver<bool>) -> Self {
         let (acceptance_tx, _) = watch::channel(TransactionAcceptanceState::Accepting);
+        let (pipeline_gate, _) = PipelineAdmissionGate::open();
         Self {
             config,
             acceptance_tx,
+            pipeline_gate,
             stop_receiver,
         }
+    }
+
+    pub fn subscribe_gate(&self) -> PipelineAdmissionReceiver {
+        self.pipeline_gate.subscribe()
     }
 
     pub fn spawn(
@@ -186,6 +194,8 @@ impl BackpressureMonitor {
     }
 
     fn update_acceptance_state(&self, new_state: TransactionAcceptanceState) {
+        self.pipeline_gate
+            .set(matches!(new_state, TransactionAcceptanceState::Accepting));
         self.acceptance_tx.send_if_modified(|current| {
             if *current == new_state {
                 return false;

--- a/lib/backpressure/src/monitor.rs
+++ b/lib/backpressure/src/monitor.rs
@@ -66,7 +66,7 @@ pub struct BackpressureMonitor {
 impl BackpressureMonitor {
     pub fn new(config: BackpressureConfig, stop_receiver: watch::Receiver<bool>) -> Self {
         let (acceptance_tx, _) = watch::channel(TransactionAcceptanceState::Accepting);
-        let (pipeline_gate, _) = PipelineAdmissionGate::open();
+        let pipeline_gate = PipelineAdmissionGate::new();
         Self {
             config,
             acceptance_tx,

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -123,7 +123,6 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         tracing::info!(?role, "Consensus role initialized");
 
         loop {
-            let gate_open = self.pipeline_gate.is_open();
             // Drain any already-queued canonized replays while the gate is open.
             for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
                 if !self.pipeline_gate.is_open() {
@@ -143,6 +142,11 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 }
             }
 
+            // Read the gate after draining so the select guards below see the
+            // post-drain state. The gate may still flip while we are parked in
+            // select! with the recv/produce arms enabled; that bounded one-block
+            // overshoot is acceptable for soft backpressure.
+            let gate_open = self.pipeline_gate.is_open();
             let can_produce = role == ConsensusRole::Leader && gate_open;
 
             tokio::select! {
@@ -240,6 +244,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             "Starting block rebuilds! {rebuild_options:?}, last_block_in_wal: {last_block_in_wal}"
         );
         for block_number in rebuild_options.from_block..=last_block_in_wal {
+            self.pipeline_gate.wait_until_open().await;
             let replay_record = self
                 .block_replay_storage
                 .get_replay_record(block_number)
@@ -257,7 +262,6 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 make_empty,
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
-            self.pipeline_gate.wait_until_open().await;
             if output.send(command).await.is_err() {
                 tracing::info!("Command output channel closed, stopping source");
                 break;

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use async_trait::async_trait;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
@@ -125,12 +126,14 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             let gate_open = self.pipeline_gate.is_open();
             // Drain any already-queued canonized replays while the gate is open.
             for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
-                if !gate_open {
+                if !self.pipeline_gate.is_open() {
                     break;
                 }
                 match self.replays_to_execute.try_recv() {
                     Ok(record) => {
-                        Self::forward_replay(record, &output, &state_reporter).await?;
+                        if !Self::forward_replay(record, &output, &state_reporter).await? {
+                            return Ok(());
+                        }
                     }
                     Err(mpsc::error::TryRecvError::Empty) => break,
                     Err(mpsc::error::TryRecvError::Disconnected) => {
@@ -160,7 +163,9 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         tracing::info!("inbound channel closed");
                         return Ok(());
                     };
-                    Self::forward_replay(record, &output, &state_reporter).await?;
+                    if !Self::forward_replay(record, &output, &state_reporter).await? {
+                        return Ok(());
+                    }
                 }
                 _ = self.pipeline_gate.wait_until_open(), if !gate_open => {}
                 send_res = output.send(BlockCommand::Produce(ProduceCommand)), if can_produce => {
@@ -191,20 +196,25 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             let record = self
                 .block_replay_storage
                 .get_replay_record(block_num)
-                .ok_or_else(|| anyhow::anyhow!("missing replay record for block {block_num}"))?;
-            output
+                .with_context(|| format!("missing replay record for block {block_num}"))?;
+            if output
                 .send(BlockCommand::Replay(Box::new(record)))
                 .await
-                .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+                .is_err()
+            {
+                tracing::info!("Command output channel closed, stopping WAL replay");
+                return Ok(());
+            }
         }
         Ok(())
     }
 
+    /// Returns `false` if the output channel has closed (caller should stop).
     async fn forward_replay(
         record: ReplayRecord,
         output: &mpsc::Sender<BlockCommand>,
         state_reporter: &ComponentStateReporter,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let block_number = record.block_context.block_number;
         let timestamp = record.block_context.timestamp;
         tracing::info!(block_number, "Received canonized block from consensus");
@@ -213,10 +223,11 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
             .await
             .is_err()
         {
-            anyhow::bail!("command output channel closed");
+            tracing::info!("Command output channel closed, stopping source");
+            return Ok(false);
         }
         state_reporter.record_processed(block_number, Some(timestamp), None);
-        Ok(())
+        Ok(true)
     }
 
     async fn send_block_rebuilds(

--- a/node/bin/src/command_source.rs
+++ b/node/bin/src/command_source.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 use std::collections::HashSet;
 use tokio::sync::mpsc;
+use zksync_os_backpressure::PipelineAdmissionReceiver;
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
 use zksync_os_raft::{ConsensusRole, LeadershipSignal};
 use zksync_os_sequencer::execution::block_context_provider::millis_since_epoch;
 use zksync_os_sequencer::model::blocks::{BlockCommand, ProduceCommand, RebuildCommand};
-use zksync_os_storage_api::{ReadReplay, ReadReplayExt, ReplayRecord};
+use zksync_os_storage_api::{ReadReplay, ReplayRecord};
 
 /// Command source for consensus-enabled main node.
 /// Replays local WAL starting from `starting_block` and then produces new blocks when leader.
@@ -21,11 +22,13 @@ pub struct ConsensusNodeCommandSource<Replay> {
     pub rebuild_options: Option<RebuildOptions>,
     /// Inbound channel of canonized blocks. Populated by `BlockCanonizer` with blocks that are canonized
     pub replays_to_execute: mpsc::UnboundedReceiver<ReplayRecord>,
+    /// Internal pipeline admission gate driven by backpressure monitoring.
+    pub pipeline_gate: PipelineAdmissionReceiver,
     /// Current leadership status from consensus.
     pub leadership: LeadershipSignal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RebuildOptions {
     pub from_block: u64,
     pub blocks_to_empty: HashSet<u64>,
@@ -37,6 +40,7 @@ pub struct RebuildOptions {
 pub struct ExternalNodeCommandSource {
     pub up_to_block: Option<u64>,
     pub replays_for_sequencer: mpsc::Receiver<ReplayRecord>,
+    pub pipeline_gate: PipelineAdmissionReceiver,
 }
 
 #[async_trait]
@@ -84,17 +88,11 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
             replay_until
         );
 
-        self.block_replay_storage
-            .forward_range_with(
-                self.starting_block,
-                replay_until,
-                output.clone(),
-                |record| BlockCommand::Replay(Box::new(record)),
-            )
+        self.forward_wal_replays(self.starting_block, replay_until, &output)
             .await?;
 
-        if let Some(rebuild_options) = &self.rebuild_options {
-            self.send_block_rebuilds(rebuild_options, last_block_in_wal, &output)
+        if let Some(rebuild_options) = self.rebuild_options.clone() {
+            self.send_block_rebuilds(&rebuild_options, last_block_in_wal, &output)
                 .await?;
         }
 
@@ -110,6 +108,8 @@ impl<Replay: ReadReplay> PipelineComponent for ConsensusNodeCommandSource<Replay
 }
 
 impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
+    const MAX_REPLAYS_TO_DRAIN_PER_LOOP: usize = 32;
+
     /// This method kicks in after all local canonized Replayed Records (WAL) are replayed.
     /// Produces `Produce` commands only when the node is the leader.
     async fn run_loop(
@@ -122,7 +122,29 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         tracing::info!(?role, "Consensus role initialized");
 
         loop {
+            let gate_open = self.pipeline_gate.is_open();
+            // Drain any already-queued canonized replays while the gate is open.
+            for _ in 0..Self::MAX_REPLAYS_TO_DRAIN_PER_LOOP {
+                if !gate_open {
+                    break;
+                }
+                match self.replays_to_execute.try_recv() {
+                    Ok(record) => {
+                        Self::forward_replay(record, &output, &state_reporter).await?;
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        tracing::info!("inbound channel closed");
+                        return Ok(());
+                    }
+                }
+            }
+
+            let can_produce = role == ConsensusRole::Leader && gate_open;
+
             tokio::select! {
+                biased;
+
                 res = leadership.wait_for_change() => {
                     if res.is_err() {
                         anyhow::bail!("leader watch channel closed");
@@ -133,29 +155,15 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                         role = new_role;
                     }
                 }
-                maybe_record = self.replays_to_execute.recv() => {
+                maybe_record = self.replays_to_execute.recv(), if gate_open => {
                     let Some(record) = maybe_record else {
                         tracing::info!("inbound channel closed");
                         return Ok(());
                     };
-                    let block_number = record.block_context.block_number;
-                    let timestamp = record.block_context.timestamp;
-                    tracing::info!(
-                        block_number,
-                        role = ?role,
-                        "Received canonized block from consensus",
-                    );
-                    if output
-                        .send(BlockCommand::Replay(Box::new(record)))
-                        .await
-                        .is_err()
-                    {
-                        tracing::info!("Command output channel closed, stopping source");
-                        break;
-                    }
-                    state_reporter.record_processed(block_number, Some(timestamp), None);
+                    Self::forward_replay(record, &output, &state_reporter).await?;
                 }
-                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if role == ConsensusRole::Leader => {
+                _ = self.pipeline_gate.wait_until_open(), if !gate_open => {}
+                send_res = output.send(BlockCommand::Produce(ProduceCommand)), if can_produce => {
                     if send_res.is_err() {
                         tracing::info!("Command output channel closed, stopping source");
                         break;
@@ -172,8 +180,47 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
         Ok(())
     }
 
+    async fn forward_wal_replays(
+        &mut self,
+        start: u64,
+        end: u64,
+        output: &mpsc::Sender<BlockCommand>,
+    ) -> anyhow::Result<()> {
+        for block_num in start..=end {
+            self.pipeline_gate.wait_until_open().await;
+            let record = self
+                .block_replay_storage
+                .get_replay_record(block_num)
+                .ok_or_else(|| anyhow::anyhow!("missing replay record for block {block_num}"))?;
+            output
+                .send(BlockCommand::Replay(Box::new(record)))
+                .await
+                .map_err(|_| anyhow::anyhow!("command output channel closed"))?;
+        }
+        Ok(())
+    }
+
+    async fn forward_replay(
+        record: ReplayRecord,
+        output: &mpsc::Sender<BlockCommand>,
+        state_reporter: &ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let block_number = record.block_context.block_number;
+        let timestamp = record.block_context.timestamp;
+        tracing::info!(block_number, "Received canonized block from consensus");
+        if output
+            .send(BlockCommand::Replay(Box::new(record)))
+            .await
+            .is_err()
+        {
+            anyhow::bail!("command output channel closed");
+        }
+        state_reporter.record_processed(block_number, Some(timestamp), None);
+        Ok(())
+    }
+
     async fn send_block_rebuilds(
-        &self,
+        &mut self,
         rebuild_options: &RebuildOptions,
         last_block_in_wal: u64,
         output: &mpsc::Sender<BlockCommand>,
@@ -199,6 +246,7 @@ impl<Replay: ReadReplay> ConsensusNodeCommandSource<Replay> {
                 make_empty,
                 reset_timestamp: rebuild_options.reset_timestamps,
             }));
+            self.pipeline_gate.wait_until_open().await;
             if output.send(command).await.is_err() {
                 tracing::info!("Command output channel closed, stopping source");
                 break;
@@ -223,7 +271,11 @@ impl PipelineComponent for ExternalNodeCommandSource {
         output: mpsc::Sender<BlockCommand>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        while let Some(record) = self.replays_for_sequencer.recv().await {
+        loop {
+            self.pipeline_gate.wait_until_open().await;
+            let Some(record) = self.replays_for_sequencer.recv().await else {
+                break;
+            };
             let block_number = record.block_context.block_number;
             let timestamp = record.block_context.timestamp;
             let txs = record.transactions.len();

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1244,6 +1244,7 @@ async fn run_main_node_pipeline(
     );
 
     let monitor = BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver);
+    let pipeline_gate = monitor.subscribe_gate();
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
     let (applied_block_number_sender, applied_block_number_receiver) =
@@ -1259,6 +1260,7 @@ async fn run_main_node_pipeline(
                 .clone()
                 .map(Into::into),
             replays_to_execute,
+            pipeline_gate,
             leadership,
         })
         .pipe(BlockExecutor {
@@ -1512,11 +1514,13 @@ async fn run_en_pipeline(
 
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());
+    let pipeline_gate = monitor.subscribe_gate();
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ExternalNodeCommandSource {
             replays_for_sequencer,
             up_to_block: config.sequencer_config.en_sync_up_to_block,
+            pipeline_gate,
         })
         .pipe(BlockExecutor {
             block_context_provider,


### PR DESCRIPTION
## Summary

Introduce `PipelineAdmissionGate` — a `watch::Sender<bool>` wrapper in `lib/backpressure` — driven by `BackpressureMonitor` and wired through both `ConsensusNodeCommandSource` and `ExternalNodeCommandSource`.

When the monitor detects pipeline lag (and flips the acceptance state to `NotAccepting`), the gate closes and command sources pause forwarding work into the pipeline. Once lag clears and the state returns to `Accepting`, the gate re-opens and ingestion resumes automatically.

Concretely:
- `BackpressureMonitor` sets the gate in `update_acceptance_state`, mirroring the RPC acceptance signal.
- `ConsensusNodeCommandSource` respects the gate during WAL replay, block rebuilds, and in the main produce loop (both the replay recv arm and the produce arm are disabled while the gate is closed; a `wait_until_open` wakeup arm re-enters the loop as soon as the gate opens).
- `ExternalNodeCommandSource` calls `wait_until_open()` before each `recv()` so EN replay also pauses under backpressure.
