### PR TITLE
test: wait for wallet re-funding after batch revert in restart test

### DIFF
--- a/integration-tests/tests/node/restart.rs
+++ b/integration-tests/tests/node/restart.rs
@@ -313,6 +313,9 @@ async fn node_recovers_from_l1_batch_revert_after_restart_v30() -> anyhow::Resul
     let mut restarted_config = restarted.config().clone();
     make_full_pipeline_config(&mut restarted_config);
     let restarted = restarted.restart_with_config(restarted_config).await?;
+    // The initial L1->L2 deposit was in the reverted batch, so the wallet balance is 0 after
+    // the revert. Wait for the priority operation to be re-included before sending transactions.
+    restarted.wait_for_initial_deposit().await?;
 
     let executed_receipt = restarted
         .l2_provider


### PR DESCRIPTION
## Summary

- `node_recovers_from_l1_batch_revert_after_restart_v30` was flakily failing in CI with `sender does not have enough funds (0) to cover transaction fees`
- After reverting a committed-but-not-executed batch to batch 0, the L1→L2 deposit that funded the test wallet is rolled back — the wallet balance drops to exactly 0 on L2 and the original priority operation returns to the L1 priority queue
- The final `restart_with_config` call goes through `start_with_config(..., false)` which skips `wait_for_initial_deposit`, so a race existed between the node re-including the pending deposit and the test's next `send_transaction`
- Fix: call `wait_for_initial_deposit()` after the final restart so the wallet is guaranteed to be funded before sending post-revert transactions (either the priority op was already re-included and the balance check passes immediately, or a fresh deposit is sent and awaited)
