### PR TITLE
feat(provider): add fallback when `finalized` is not supported

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -741,20 +741,20 @@ impl Tester {
                 tracing::info!(%err, ?dur, "retrying connection to L2 node");
             })
             .await?;
-            NodeProvider::new(sl_provider)
+            NodeProvider::new(sl_provider).await
         } else {
             l1.provider.clone()
         };
         let gateway_eth_provider = gateway_rpc_url.as_ref().map(|_| sl_provider.clone());
         let prover_tester = ProverTester::new(
-            NodeProvider::new(l1.provider.clone()),
+            NodeProvider::new(l1.provider.clone()).await,
             gateway_eth_provider,
-            NodeProvider::new(l2_provider.clone()),
+            NodeProvider::new(l2_provider.clone()).await,
             DynProvider::new(l2_zk_provider.clone()),
         );
         let tester = Tester {
             l1,
-            l2_provider: NodeProvider::new(l2_provider.clone()),
+            l2_provider: NodeProvider::new(l2_provider.clone()).await,
             l2_zk_provider: DynProvider::new(l2_zk_provider.clone()),
             l2_wallet,
             prover_tester,
@@ -1290,7 +1290,7 @@ async fn wait_for_gateway_readiness(
 
         L1State::fetch_finalized(
             l1.provider.clone(),
-            Some(NodeProvider::new(gateway_provider)),
+            Some(NodeProvider::new(gateway_provider).await),
             bridgehub_address,
             chain_id,
         )
@@ -1367,7 +1367,7 @@ impl AnvilL1 {
 
         Ok(Self {
             address,
-            provider: NodeProvider::new(provider),
+            provider: NodeProvider::new(provider).await,
             wallet,
             _tempdir: Arc::new(tempdir),
         })

--- a/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
+++ b/integration-tests/tests/rpc/debug/js_tracer_cross_node.rs
@@ -47,8 +47,8 @@ async fn compare_js_tracer_outputs_between_nodes() -> anyhow::Result<()> {
         .connect(&reth_url)
         .await?;
 
-    let zksync_provider = NodeProvider::new(zksync_provider);
-    let reth_provider = NodeProvider::new(reth_provider);
+    let zksync_provider = NodeProvider::new(zksync_provider).await;
+    let reth_provider = NodeProvider::new(reth_provider).await;
 
     // Deploy helper contracts on both nodes.
     let secondary_init_value = U256::from(7);

--- a/lib/provider/src/lib.rs
+++ b/lib/provider/src/lib.rs
@@ -64,6 +64,45 @@ where
     }
 }
 
+/// Optional RPC features the underlying provider may or may not support, probed once when the
+/// [`NodeProvider`] is constructed.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderCapabilities {
+    /// Whether the RPC understands the `finalized`/`safe` block tags. When false, finalized/safe
+    /// lookups degrade to the latest block.
+    pub finalized_tag: bool,
+    /// Whether the RPC implements `eth_getHeaderBy*`. When false, header lookups use
+    /// `eth_getBlockBy*` instead.
+    pub get_header: bool,
+}
+
+impl ProviderCapabilities {
+    /// Probes `provider` once to determine which optional features it supports.
+    async fn detect(provider: &impl Provider<Ethereum>) -> Self {
+        // `latest` always exists, so a failure here means `eth_getHeaderBy*` is unsupported.
+        let get_header = match provider.get_header(BlockId::latest()).await {
+            Ok(_) => true,
+            Err(err) => {
+                tracing::info!(%err, "provider lacks eth_getHeaderBy*; using eth_getBlockBy*");
+                false
+            }
+        };
+        // Probe the finalized tag with whichever block-fetch method we just confirmed works.
+        let finalized_tag = if get_header {
+            provider.get_header(BlockId::finalized()).await.is_ok()
+        } else {
+            provider.get_block(BlockId::finalized()).await.is_ok()
+        };
+        if !finalized_tag {
+            tracing::info!("provider lacks the `finalized` block tag; degrading to latest");
+        }
+        Self {
+            get_header,
+            finalized_tag,
+        }
+    }
+}
+
 /// Per-address cache of contract deployment blocks. Cloning a [`NodeProvider`] shares this cache
 /// (it sits behind an `Arc`), so all derived contract instances and watchers resolve each address
 /// at most once. Each address gets its own [`OnceCell`] so concurrent lookups for the same address
@@ -76,16 +115,25 @@ type DeploymentBlockCache = Arc<Mutex<HashMap<Address, Arc<OnceCell<u64>>>>>;
 /// Carries a shared [`DeploymentBlockCache`]; see [`NodeProvider::deployment_block`].
 pub struct NodeProvider {
     inner: Box<dyn EthWalletProvider + 'static>,
+    capabilities: ProviderCapabilities,
     deployment_blocks: DeploymentBlockCache,
 }
 
 impl NodeProvider {
-    /// Creates a new [`NodeProvider`] by erasing the type.
-    pub fn new<P: EthWalletProvider + 'static>(provider: P) -> Self {
+    /// Creates a new [`NodeProvider`] by erasing the type, probing the provider once for its
+    /// optional [`ProviderCapabilities`].
+    pub async fn new<P: EthWalletProvider + 'static>(provider: P) -> Self {
+        let capabilities = ProviderCapabilities::detect(&provider).await;
         Self {
             inner: Box::new(provider),
+            capabilities,
             deployment_blocks: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Returns the optional features the underlying provider was detected to support.
+    pub fn capabilities(&self) -> ProviderCapabilities {
+        self.capabilities
     }
 
     /// Returns the block at which `address` first had non-empty code, i.e. its deployment block.
@@ -136,6 +184,7 @@ impl Clone for NodeProvider {
     fn clone(&self) -> Self {
         NodeProvider {
             inner: self.inner.dyn_clone(),
+            capabilities: self.capabilities,
             deployment_blocks: self.deployment_blocks.clone(),
         }
     }
@@ -179,10 +228,9 @@ impl Provider<Ethereum> for NodeProvider {
         self.inner.get_block_number()
     }
 
-    // alloy 2.0 changed the `get_header` -> `get_block` fallback that 1.x had, so only JSON-RPC
-    // errors with -32601 code from `eth_getHeaderBy*` now propagate instead of degrading to
-    // `eth_getBlockBy*`. Upstream nodes return varying error codes for unsupported
-    // methods, so restore the pre-2.0 behavior of falling back on any error.
+    // Dispatch based on the capabilities probed at construction (see `ProviderCapabilities`)
+    // instead of trying-and-failing: skip `eth_getHeaderBy*` when unsupported, and degrade
+    // finalized/safe lookups straight to the latest block when the tags are unsupported.
     async fn get_block_number_by_id(
         &self,
         block_id: BlockId,
@@ -191,11 +239,18 @@ impl Provider<Ethereum> for NodeProvider {
             BlockId::Number(BlockNumberOrTag::Number(num)) => Ok(Some(num)),
             BlockId::Number(BlockNumberOrTag::Latest) => self.get_block_number().await.map(Some),
             _ => {
-                if let Ok(header) = self.get_header(block_id).await {
-                    return Ok(header.map(|h| h.number()));
+                if (block_id.is_finalized() || block_id.is_safe())
+                    && !self.capabilities.finalized_tag
+                {
+                    // If `finalized`/`safe` are not supported we presume immediate finality like it
+                    // is with Besu: https://besu.hyperledger.org/private-networks/concepts/poa
+                    return self.get_block_number().await.map(Some);
                 }
-                let block = self.get_block(block_id).await?;
-                Ok(block.map(|b| b.header().number()))
+                if self.capabilities.get_header {
+                    Ok(self.get_header(block_id).await?.map(|h| h.number()))
+                } else {
+                    Ok(self.get_block(block_id).await?.map(|b| b.header().number()))
+                }
             }
         }
     }
@@ -570,36 +625,97 @@ mod tests {
     use super::*;
     use alloy::providers::ProviderBuilder;
     use alloy::rpc::json_rpc::ErrorPayload;
-    use alloy::rpc::types::Block;
+    use alloy::rpc::types::{Block, Header};
     use alloy::transports::mock::Asserter;
     use std::borrow::Cow;
 
-    #[tokio::test]
-    async fn get_block_number_by_id_falls_back_when_get_header_errors() {
-        let asserter = Asserter::new();
-        let provider = ProviderBuilder::new()
+    fn mocked_provider(asserter: &Asserter) -> impl EthWalletProvider {
+        ProviderBuilder::new()
             .disable_recommended_fillers()
             .wallet(EthereumWallet::default())
-            .connect_mocked_client(asserter.clone());
-        let provider = NodeProvider::new(provider);
+            .connect_mocked_client(asserter.clone())
+    }
 
-        asserter.push_failure(ErrorPayload {
+    fn header_with_number(number: u64) -> Header {
+        let mut block: Block = Block::default();
+        block.header.inner.number = number;
+        block.header
+    }
+
+    fn block_with_number(number: u64) -> Block {
+        let mut block: Block = Block::default();
+        block.header.inner.number = number;
+        block
+    }
+
+    fn unsupported_method() -> ErrorPayload {
+        ErrorPayload {
             code: -39001,
             message: Cow::Borrowed("custom upstream error"),
             data: None,
-        });
-        let mut block: Block = Block::default();
-        block.header.inner.number = 42;
-        asserter.push_success(&block);
+        }
+    }
 
+    #[tokio::test]
+    async fn uses_get_header_when_supported() {
+        let asserter = Asserter::new();
+        // Probe: get_header(latest) ok -> get_header supported; get_header(finalized) ok ->
+        // finalized supported.
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&header_with_number(1));
+        let provider = NodeProvider::new(mocked_provider(&asserter)).await;
+        assert!(provider.capabilities().get_header);
+        assert!(provider.capabilities().finalized_tag);
+
+        // The lookup itself resolves via get_header.
+        asserter.push_success(&header_with_number(42));
         let result = provider
             .get_block_number_by_id(BlockId::finalized())
             .await
-            .expect("fallback to get_block should succeed");
+            .expect("get_header lookup should succeed");
         assert_eq!(result, Some(42));
-        assert!(
-            asserter.read_q().is_empty(),
-            "both mock responses should be consumed",
-        );
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_get_block_when_get_header_unsupported() {
+        let asserter = Asserter::new();
+        // Probe: get_header(latest) fails -> get_header unsupported; get_block(finalized) ok ->
+        // finalized supported.
+        asserter.push_failure(unsupported_method());
+        asserter.push_success(&block_with_number(1));
+        let provider = NodeProvider::new(mocked_provider(&asserter)).await;
+        assert!(!provider.capabilities().get_header);
+        assert!(provider.capabilities().finalized_tag);
+
+        // The lookup resolves via get_block, never touching get_header.
+        asserter.push_success(&block_with_number(42));
+        let result = provider
+            .get_block_number_by_id(BlockId::finalized())
+            .await
+            .expect("get_block lookup should succeed");
+        assert_eq!(result, Some(42));
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn degrades_to_latest_when_finalized_unsupported() {
+        let asserter = Asserter::new();
+        // Probe: get_header(latest) ok -> get_header supported; get_header(finalized) fails ->
+        // finalized unsupported.
+        asserter.push_success(&header_with_number(1));
+        asserter.push_failure(unsupported_method());
+        let provider = NodeProvider::new(mocked_provider(&asserter)).await;
+        assert!(provider.capabilities().get_header);
+        assert!(!provider.capabilities().finalized_tag);
+
+        // The lookup degrades straight to get_block_number (latest), issuing no header/block call.
+        asserter.push_success(&U64::from(99));
+        let result = provider
+            .get_block_number_by_id(BlockId::finalized())
+            .await
+            .expect("degraded latest lookup should succeed");
+        assert_eq!(result, Some(99));
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
     }
 }

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -42,5 +42,5 @@ pub(crate) async fn build_node_provider(
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::new(PrivateKeySigner::random()))
         .connect_client(client);
-    NodeProvider::new(provider)
+    NodeProvider::new(provider).await
 }


### PR DESCRIPTION
## Summary

Ditto, needed for Besu as it does not support safe/finalized when run in QBFT mode

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

