### PR TITLE
refactor(l1-watcher): decouple initialization from constructor

### DIFF
--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -1,6 +1,6 @@
 use crate::committed_batch_provider::CommittedBatchProvider;
-use crate::watcher::{L1Watcher, L1WatcherError};
-use crate::{L1WatcherConfig, ProcessL1Event, util};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
@@ -41,42 +41,49 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
         sl_block_initial_finality_init_at: u64,
         l1_chain_id: u64,
         commit_submitted_rx: Option<watch::Receiver<u64>>,
-    ) -> anyhow::Result<L1Watcher> {
-        let last_committed_batch = finality.get_finality_status().last_committed_batch;
+    ) -> anyhow::Result<L1Watcher<()>> {
         tracing::info!(
             sl_block_initial_finality_init_at,
-            last_committed_batch,
             config.max_blocks_to_process,
             ?config.poll_interval,
             zk_chain_address = ?zk_chain.address(),
             "initializing L1 commit watcher"
         );
-        let last_l1_block = util::find_l1_commit_block_by_batch_number(
-            zk_chain.clone(),
-            last_committed_batch,
-            config.max_blocks_to_process,
-        )
-        .await?;
-        tracing::info!(last_l1_block, "resolved on L1");
 
-        let this = Self {
-            next_batch_number: last_committed_batch + 1,
-            sl_block_initial_finality_init_at,
-            startup_last_committed_batch: last_committed_batch,
-            committed_batch_provider,
-            finality,
-            commit_submitted_rx,
-        };
+        let provider = zk_chain.provider().clone();
+        let address = (*zk_chain.address()).into();
+        let max_blocks_to_process = config.max_blocks_to_process;
+
+        let resolve_start = resolver(move |()| async move {
+            let last_committed_batch = finality.get_finality_status().last_committed_batch;
+            let last_l1_block = util::find_l1_commit_block_by_batch_number(
+                zk_chain,
+                last_committed_batch,
+                max_blocks_to_process,
+            )
+            .await?;
+            tracing::info!(last_committed_batch, last_l1_block, "resolved on L1");
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                next_batch_number: last_committed_batch + 1,
+                sl_block_initial_finality_init_at,
+                startup_last_committed_batch: last_committed_batch,
+                committed_batch_provider,
+                finality,
+                commit_submitted_rx,
+            });
+            // We start from the last L1 block as it may contain more committed batches apart
+            // from the last one.
+            Ok((last_l1_block, processor))
+        });
+
         L1Watcher::new(
             config,
-            zk_chain.provider().clone(),
-            (*zk_chain.address()).into(),
-            // We start from last L1 block as it may contain more committed batches apart from the last
-            // one.
-            last_l1_block,
+            provider,
+            address,
             None,
             l1_chain_id,
-            Box::new(this),
+            resolve_start,
         )
         .await
     }

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -1,6 +1,6 @@
 use crate::committed_batch_provider::CommittedBatchProvider;
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
-use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
+use crate::watcher::{L1WatcherError, StartResolver};
+use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::rpc::types::Log;
 use tokio::sync::watch;
 use zksync_os_batch_types::DiscoveredCommittedBatch;
@@ -41,7 +41,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
         sl_block_initial_finality_init_at: u64,
         l1_chain_id: u64,
         commit_submitted_rx: Option<watch::Receiver<u64>>,
-    ) -> anyhow::Result<L1Watcher<()>> {
+    ) -> anyhow::Result<StartResolver<(), Self>> {
         tracing::info!(
             sl_block_initial_finality_init_at,
             config.max_blocks_to_process,
@@ -54,7 +54,7 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
         let address = (*zk_chain.address()).into();
         let max_blocks_to_process = config.max_blocks_to_process;
 
-        let resolve_start = resolver(move |()| async move {
+        let resolve_start = move |()| async move {
             let last_committed_batch = finality.get_finality_status().last_committed_batch;
             let last_l1_block = util::find_l1_commit_block_by_batch_number(
                 zk_chain,
@@ -64,28 +64,20 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
             .await?;
             tracing::info!(last_committed_batch, last_l1_block, "resolved on L1");
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 next_batch_number: last_committed_batch + 1,
                 sl_block_initial_finality_init_at,
                 startup_last_committed_batch: last_committed_batch,
                 committed_batch_provider,
                 finality,
                 commit_submitted_rx,
-            });
+            };
             // We start from the last L1 block as it may contain more committed batches apart
             // from the last one.
             Ok((last_l1_block, processor))
-        });
+        };
 
-        L1Watcher::new(
-            config,
-            provider,
-            address,
-            None,
-            l1_chain_id,
-            resolve_start,
-        )
-        .await
+        StartResolver::new(config, provider, address, None, l1_chain_id, resolve_start).await
     }
 }
 

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -1,5 +1,6 @@
-use crate::watcher::{L1Watcher, L1WatcherError};
-use crate::{CommittedBatchProvider, L1WatcherConfig, ProcessL1Event, util};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::{CommittedBatchProvider, L1WatcherConfig, ProcessL1Event,
+    ProcessRawEvents, util};
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
@@ -41,39 +42,48 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         l1_chain_id: u64,
-    ) -> anyhow::Result<L1Watcher> {
-        let current_l1_block = zk_chain.provider().get_block_number().await?;
-        let last_executed_batch = finality.get_finality_status().last_executed_batch;
+    ) -> anyhow::Result<L1Watcher<()>> {
         tracing::info!(
-            current_l1_block,
-            last_executed_batch,
             config.max_blocks_to_process,
             ?config.poll_interval,
             zk_chain_address = ?zk_chain.address(),
             "initializing L1 execute watcher"
         );
-        let last_l1_block =
-            util::find_l1_execute_block_by_batch_number(zk_chain.clone(), last_executed_batch)
-                .await?;
-        tracing::info!(last_l1_block, "resolved on L1");
 
-        let this = Self {
-            inner: ExecuteWatcherState {
-                next_batch_number: last_executed_batch + 1,
-                committed_batch_provider,
-                finality,
-            },
-        };
+        let provider = zk_chain.provider().clone();
+        let address = (*zk_chain.address()).into();
+
+        let resolve_start = resolver(move |()| async move {
+            let current_l1_block = zk_chain.provider().get_block_number().await?;
+            let last_executed_batch = finality.get_finality_status().last_executed_batch;
+            let last_l1_block =
+                util::find_l1_execute_block_by_batch_number(zk_chain, last_executed_batch).await?;
+            tracing::info!(
+                current_l1_block,
+                last_executed_batch,
+                last_l1_block,
+                "resolved on L1"
+            );
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                inner: ExecuteWatcherState {
+                    next_batch_number: last_executed_batch + 1,
+                    committed_batch_provider,
+                    finality,
+                },
+            });
+            // We start from the last L1 block as it may contain more executed batches apart
+            // from the last one.
+            Ok((last_l1_block, processor))
+        });
+
         L1Watcher::new(
             config,
-            zk_chain.provider().clone(),
-            (*zk_chain.address()).into(),
-            // We start from last L1 block as it may contain more executed batches apart from the last
-            // one.
-            last_l1_block,
+            provider,
+            address,
             None,
             l1_chain_id,
-            Box::new(this),
+            resolve_start,
         )
         .await
     }
@@ -85,39 +95,49 @@ impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
         zk_chain: ZkChain<NodeProvider>,
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
-    ) -> anyhow::Result<L1Watcher> {
-        let current_l1_block = zk_chain.provider().get_block_number().await?;
-        let last_finalized_executed_batch =
-            finality.get_finality_status().last_finalized_executed_batch;
+    ) -> anyhow::Result<L1Watcher<()>> {
         tracing::info!(
-            current_l1_block,
-            last_finalized_executed_batch,
             config.max_blocks_to_process,
             ?config.poll_interval,
             zk_chain_address = ?zk_chain.address(),
             "initializing finalized L1 execute watcher"
         );
-        let last_l1_block = util::find_l1_execute_block_by_batch_number(
-            zk_chain.clone(),
-            last_finalized_executed_batch,
-        )
-        .await?;
-        tracing::info!(last_l1_block, "resolved on L1");
 
-        let this = Self {
-            inner: ExecuteWatcherState {
-                next_batch_number: last_finalized_executed_batch + 1,
-                committed_batch_provider,
-                finality,
-            },
-        };
+        let provider = zk_chain.provider().clone();
+        let address = (*zk_chain.address()).into();
+
+        let resolve_start = resolver(move |()| async move {
+            let current_l1_block = zk_chain.provider().get_block_number().await?;
+            let last_finalized_executed_batch =
+                finality.get_finality_status().last_finalized_executed_batch;
+            let last_l1_block = util::find_l1_execute_block_by_batch_number(
+                zk_chain,
+                last_finalized_executed_batch,
+            )
+            .await?;
+            tracing::info!(
+                current_l1_block,
+                last_finalized_executed_batch,
+                last_l1_block,
+                "resolved on L1"
+            );
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                inner: ExecuteWatcherState {
+                    next_batch_number: last_finalized_executed_batch + 1,
+                    committed_batch_provider,
+                    finality,
+                },
+            });
+            Ok((last_l1_block, processor))
+        });
+
         Ok(L1Watcher::new_finalized(
             config,
-            zk_chain.provider().clone(),
-            (*zk_chain.address()).into(),
-            last_l1_block,
+            provider,
+            address,
             None,
-            Box::new(this),
+            resolve_start,
         ))
     }
 }

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -1,6 +1,5 @@
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
-use crate::{CommittedBatchProvider, L1WatcherConfig, ProcessL1Event,
-    ProcessRawEvents, util};
+use crate::watcher::{L1WatcherError, StartResolver};
+use crate::{CommittedBatchProvider, L1WatcherConfig, ProcessL1Event, util};
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use zksync_os_contract_interface::IExecutor::BlockExecution;
@@ -42,7 +41,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
         l1_chain_id: u64,
-    ) -> anyhow::Result<L1Watcher<()>> {
+    ) -> anyhow::Result<StartResolver<(), Self>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -53,7 +52,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
         let provider = zk_chain.provider().clone();
         let address = (*zk_chain.address()).into();
 
-        let resolve_start = resolver(move |()| async move {
+        let resolve_start = move |()| async move {
             let current_l1_block = zk_chain.provider().get_block_number().await?;
             let last_executed_batch = finality.get_finality_status().last_executed_batch;
             let last_l1_block =
@@ -65,27 +64,19 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
                 "resolved on L1"
             );
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 inner: ExecuteWatcherState {
                     next_batch_number: last_executed_batch + 1,
                     committed_batch_provider,
                     finality,
                 },
-            });
+            };
             // We start from the last L1 block as it may contain more executed batches apart
             // from the last one.
             Ok((last_l1_block, processor))
-        });
+        };
 
-        L1Watcher::new(
-            config,
-            provider,
-            address,
-            None,
-            l1_chain_id,
-            resolve_start,
-        )
-        .await
+        StartResolver::new(config, provider, address, None, l1_chain_id, resolve_start).await
     }
 }
 
@@ -95,7 +86,7 @@ impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
         zk_chain: ZkChain<NodeProvider>,
         committed_batch_provider: CommittedBatchProvider,
         finality: Finality,
-    ) -> anyhow::Result<L1Watcher<()>> {
+    ) -> anyhow::Result<StartResolver<(), Self>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -106,7 +97,7 @@ impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
         let provider = zk_chain.provider().clone();
         let address = (*zk_chain.address()).into();
 
-        let resolve_start = resolver(move |()| async move {
+        let resolve_start = move |()| async move {
             let current_l1_block = zk_chain.provider().get_block_number().await?;
             let last_finalized_executed_batch =
                 finality.get_finality_status().last_finalized_executed_batch;
@@ -122,17 +113,17 @@ impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
                 "resolved on L1"
             );
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 inner: ExecuteWatcherState {
                     next_batch_number: last_finalized_executed_batch + 1,
                     committed_batch_provider,
                     finality,
                 },
-            });
+            };
             Ok((last_l1_block, processor))
-        });
+        };
 
-        Ok(L1Watcher::new_finalized(
+        Ok(StartResolver::new_finalized(
             config,
             provider,
             address,

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -1,4 +1,4 @@
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::watcher::{L1WatcherError, StartResolver};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, ChainId, U256};
 use alloy::rpc::types::{Log, Topic};
@@ -38,7 +38,7 @@ impl GatewayMigrationWatcher {
         gw_chain_id: ChainId,
         config: L1WatcherConfig,
         sl_chain_id_subpool: SlChainIdSubpool,
-    ) -> anyhow::Result<L1Watcher<u64>> {
+    ) -> anyhow::Result<StartResolver<u64, Self>> {
         let server_notifier_contract = zk_chain.get_server_notifier_address().await?;
         let provider = zk_chain.provider().clone();
 
@@ -49,7 +49,7 @@ impl GatewayMigrationWatcher {
             "initializing gateway migration watcher"
         );
 
-        let resolve_start = resolver(move |next_migration_number: u64| async move {
+        let resolve_start = move |next_migration_number: u64| async move {
             let chain_asset_handler_address = bridgehub.chain_asset_handler_address().await?;
             let next_l1_block = util::find_block_by_migration_number(
                 zk_chain.clone(),
@@ -64,7 +64,7 @@ impl GatewayMigrationWatcher {
                 "gateway migration watcher starting from migration #{next_migration_number}"
             );
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 l2_chain_id,
                 l1_chain_id,
                 gw_chain_id,
@@ -72,11 +72,11 @@ impl GatewayMigrationWatcher {
                 // Due to legacy reasons we saved first migration number as 0 when it should
                 // have been 1.
                 next_migration_number: next_migration_number.max(1),
-            });
+            };
             Ok((next_l1_block, processor))
-        });
+        };
 
-        L1Watcher::new(
+        StartResolver::new(
             config,
             provider,
             server_notifier_contract.into(),

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -1,4 +1,4 @@
-use crate::watcher::{L1Watcher, L1WatcherError};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, ChainId, U256};
 use alloy::rpc::types::{Log, Topic};
@@ -36,46 +36,53 @@ impl GatewayMigrationWatcher {
         l2_chain_id: ChainId,
         l1_chain_id: ChainId,
         gw_chain_id: ChainId,
-        next_migration_number: u64,
         config: L1WatcherConfig,
         sl_chain_id_subpool: SlChainIdSubpool,
-    ) -> anyhow::Result<L1Watcher> {
+    ) -> anyhow::Result<L1Watcher<u64>> {
         let server_notifier_contract = zk_chain.get_server_notifier_address().await?;
-        let chain_asset_handler_address = bridgehub.chain_asset_handler_address().await?;
-
-        let next_l1_block = util::find_block_by_migration_number(
-            zk_chain.clone(),
-            chain_asset_handler_address,
-            l2_chain_id,
-            next_migration_number,
-        )
-        .await?;
+        let provider = zk_chain.provider().clone();
 
         tracing::info!(
             contract = %server_notifier_contract,
-            starting_l1_block = next_l1_block,
             l1_chain_id,
             gw_chain_id,
-            "gateway migration watcher starting from migration #{next_migration_number}"
+            "initializing gateway migration watcher"
         );
 
-        let this = Self {
-            l2_chain_id,
-            l1_chain_id,
-            gw_chain_id,
-            sl_chain_id_subpool,
-            // Due to legacy reasons we saved first migration number as 0 when it should have been 1.
-            next_migration_number: next_migration_number.max(1),
-        };
+        let resolve_start = resolver(move |next_migration_number: u64| async move {
+            let chain_asset_handler_address = bridgehub.chain_asset_handler_address().await?;
+            let next_l1_block = util::find_block_by_migration_number(
+                zk_chain.clone(),
+                chain_asset_handler_address,
+                l2_chain_id,
+                next_migration_number,
+            )
+            .await?;
+
+            tracing::info!(
+                starting_l1_block = next_l1_block,
+                "gateway migration watcher starting from migration #{next_migration_number}"
+            );
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                l2_chain_id,
+                l1_chain_id,
+                gw_chain_id,
+                sl_chain_id_subpool,
+                // Due to legacy reasons we saved first migration number as 0 when it should
+                // have been 1.
+                next_migration_number: next_migration_number.max(1),
+            });
+            Ok((next_l1_block, processor))
+        });
 
         L1Watcher::new(
             config,
-            zk_chain.provider().clone(),
+            provider,
             server_notifier_contract.into(),
-            next_l1_block,
             None,
             l1_chain_id,
-            Box::new(this),
+            resolve_start,
         )
         .await
     }

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -14,7 +14,7 @@ use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
 use zksync_os_provider::NodeProvider;
 use zksync_os_types::IndexedInteropRoot;
 
-use crate::sl_aware_watcher::{SegmentSpec, SlAwareL1Watcher};
+use crate::sl_aware_watcher::{SegmentSpec, SlAwareL1Watcher, segment_resolver};
 use crate::util::{find_l1_block_by_interop_root_id, find_l1_execute_block_by_batch_number};
 use crate::watcher::L1WatcherError;
 use crate::{L1WatcherConfig, ProcessRawEvents};
@@ -36,96 +36,112 @@ pub struct InteropWatcher {
 impl InteropWatcher {
     /// Builds the watcher if the chain has at least one Gateway interval. Returns `Ok(None)`
     /// for chains that have only ever settled on L1 — those have no interop roots to watch.
-    pub async fn create_watcher(
+    pub fn create_watcher(
         intervals: SettlementLayerIntervals,
         config: L1WatcherConfig,
         l2_chain_id: u64,
-        starting_interop_root_id: u64,
         interop_roots_subpool: InteropRootsSubpool,
-    ) -> anyhow::Result<Option<SlAwareL1Watcher>> {
-        let mut segments = Vec::new();
-        for interval in intervals.intervals() {
-            // L1 intervals never emit interop roots; skip them outright.
-            let IntervalSettlementLayer::Gateway(_) = interval.settlement_layer else {
-                continue;
-            };
-            // Empty intervals are possible when a migration closes without committing anything
-            // (`first_batch > last_batch`). Nothing to scan.
-            if interval
+    ) -> anyhow::Result<Option<SlAwareL1Watcher<u64>>> {
+        // Whether there is anything to watch depends only on the (static) interval layout, so we
+        // can decide Some/None up front without resolving any block windows.
+        let has_gateway_segment = intervals.intervals().iter().any(|interval| {
+            matches!(
+                interval.settlement_layer,
+                IntervalSettlementLayer::Gateway(_)
+            ) && interval
                 .last_batch
-                .is_some_and(|lb| interval.first_batch > lb)
-            {
-                continue;
-            }
-
-            let gw_zk_chain = &interval.proxy;
-            let bridgehub = Bridgehub::new(
-                L2_BRIDGEHUB_ADDRESS,
-                gw_zk_chain.provider().clone(),
-                l2_chain_id,
-            );
-            let message_root = bridgehub.message_root_address().await.with_context(|| {
-                format!("failed to fetch message_root address for interval {interval}")
-            })?;
-
-            // The chain's `interop_root_id` cursor carries over across migrations, so the same
-            // value is the floor anchor on every segment — `find_l1_block_by_interop_root_id`
-            // resolves it to the correct block on whichever SL we point it at.
-            let start_block = find_l1_block_by_interop_root_id(
-                bridgehub.clone(),
-                starting_interop_root_id,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to find {} block for interop_root_id={starting_interop_root_id} \
-                     in interval {interval}",
-                    interval.settlement_layer
-                )
-            })?;
-            // End block is chosen pessimistically: it's the GW block where last batch was executed,
-            // hence we could import extra roots that were never picked up during the interval.
-            // This is not a problem though as mempool will not serve them in the next interval as
-            // interop is not possible on L1. The slight tradeoff here is that they will be stuck
-            // in memory until the next restart.
-            let end_block = match interval.last_batch {
-                Some(last_batch) => Some(
-                    find_l1_execute_block_by_batch_number(gw_zk_chain.clone(), last_batch)
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "failed to find Gateway execute block for batch #{last_batch} \
-                                 in interval {interval}"
-                            )
-                        })?,
-                ),
-                None => None,
-            };
-
-            tracing::info!(
-                ?interval,
-                message_root = ?message_root,
-                start_block,
-                ?end_block,
-                "scheduling interop watcher segment"
-            );
-            segments.push(SegmentSpec {
-                provider: gw_zk_chain.provider().clone(),
-                address: message_root.into(),
-                start_block,
-                end_block,
-            });
-        }
-        if segments.is_empty() {
+                .is_none_or(|lb| interval.first_batch <= lb)
+        });
+        if !has_gateway_segment {
             tracing::info!("chain has no Gateway intervals; skipping interop roots watcher");
             return Ok(None);
         }
 
-        let processor = Self {
-            starting_interop_root_id,
-            interop_roots_subpool,
-        };
-        SlAwareL1Watcher::new(config, segments, Box::new(processor)).map(Some)
+        let resolve_segments = segment_resolver(move |starting_interop_root_id: u64| async move {
+            let mut segments = Vec::new();
+            for interval in intervals.intervals() {
+                // L1 intervals never emit interop roots; skip them outright.
+                let IntervalSettlementLayer::Gateway(_) = interval.settlement_layer else {
+                    continue;
+                };
+                // Empty intervals are possible when a migration closes without committing
+                // anything (`first_batch > last_batch`). Nothing to scan.
+                if interval
+                    .last_batch
+                    .is_some_and(|lb| interval.first_batch > lb)
+                {
+                    continue;
+                }
+
+
+                let gw_zk_chain = &interval.proxy;
+                let bridgehub = Bridgehub::new(
+                    L2_BRIDGEHUB_ADDRESS,
+                    gw_zk_chain.provider().clone(),
+                    l2_chain_id,
+                );
+                let message_root = bridgehub.message_root_address().await.with_context(|| {
+                    format!("failed to fetch message_root address for interval {interval}")
+                })?;
+
+                // The chain's `interop_root_id` cursor carries over across migrations, so the
+                // same value is the floor anchor on every segment —
+                // `find_l1_block_by_interop_root_id` resolves it to the correct block on
+                // whichever SL we point it at.
+                let start_block =
+                    find_l1_block_by_interop_root_id(bridgehub.clone(), starting_interop_root_id)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to find {} block for \
+                                 interop_root_id={starting_interop_root_id} in interval \
+                                 {interval}",
+                                interval.settlement_layer
+                            )
+                        })?;
+                // End block is chosen pessimistically: it's the GW block where last batch was
+                // executed, hence we could import extra roots that were never picked up during
+                // the interval. This is not a problem though as mempool will not serve them in
+                // the next interval as interop is not possible on L1. The slight tradeoff here
+                // is that they will be stuck in memory until the next restart.
+                let end_block = match interval.last_batch {
+                    Some(last_batch) => Some(
+                        find_l1_execute_block_by_batch_number(gw_zk_chain.clone(), last_batch)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "failed to find Gateway execute block for batch \
+                                     #{last_batch} in interval {interval}"
+                                )
+                            })?,
+                    ),
+                    None => None,
+                };
+
+                tracing::info!(
+                    ?interval,
+                    message_root = ?message_root,
+                    start_block,
+                    ?end_block,
+                    "scheduling interop watcher segment"
+                );
+                segments.push(SegmentSpec {
+                    provider: gw_zk_chain.provider().clone(),
+
+                    address: message_root.into(),
+                    start_block,
+                    end_block,
+                });
+            }
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                starting_interop_root_id,
+                interop_roots_subpool,
+            });
+            Ok((segments, processor))
+        });
+
+        Ok(Some(SlAwareL1Watcher::new(config, resolve_segments)))
     }
 }
 

--- a/lib/l1_watcher/src/interop_watcher.rs
+++ b/lib/l1_watcher/src/interop_watcher.rs
@@ -14,7 +14,7 @@ use zksync_os_mempool::subpools::interop_roots::InteropRootsSubpool;
 use zksync_os_provider::NodeProvider;
 use zksync_os_types::IndexedInteropRoot;
 
-use crate::sl_aware_watcher::{SegmentSpec, SlAwareL1Watcher, segment_resolver};
+use crate::sl_aware_watcher::{SegmentResolver, SegmentSpec};
 use crate::util::{find_l1_block_by_interop_root_id, find_l1_execute_block_by_batch_number};
 use crate::watcher::L1WatcherError;
 use crate::{L1WatcherConfig, ProcessRawEvents};
@@ -26,8 +26,9 @@ use crate::{L1WatcherConfig, ProcessRawEvents};
 /// `IndexedInteropRoot` into `InteropRootsSubpool`.
 ///
 /// To support a chain that has migrated GW → L1 (or GW → L1 → GW → …), the watcher walks every
-/// Gateway interval — historical and active — via [`SlAwareL1Watcher`]. Each historical Gateway
-/// segment is bounded by the L1/SL block where the last included interop root was emitted.
+/// Gateway interval — historical and active — via [`SlAwareL1Watcher`](crate::SlAwareL1Watcher).
+/// Each historical Gateway segment is bounded by the L1/SL block where the last included interop
+/// root was emitted.
 pub struct InteropWatcher {
     starting_interop_root_id: u64,
     interop_roots_subpool: InteropRootsSubpool,
@@ -41,7 +42,7 @@ impl InteropWatcher {
         config: L1WatcherConfig,
         l2_chain_id: u64,
         interop_roots_subpool: InteropRootsSubpool,
-    ) -> anyhow::Result<Option<SlAwareL1Watcher<u64>>> {
+    ) -> anyhow::Result<Option<SegmentResolver<u64, Self>>> {
         // Whether there is anything to watch depends only on the (static) interval layout, so we
         // can decide Some/None up front without resolving any block windows.
         let has_gateway_segment = intervals.intervals().iter().any(|interval| {
@@ -57,7 +58,7 @@ impl InteropWatcher {
             return Ok(None);
         }
 
-        let resolve_segments = segment_resolver(move |starting_interop_root_id: u64| async move {
+        let resolve_segments = move |starting_interop_root_id: u64| async move {
             let mut segments = Vec::new();
             for interval in intervals.intervals() {
                 // L1 intervals never emit interop roots; skip them outright.
@@ -72,7 +73,6 @@ impl InteropWatcher {
                 {
                     continue;
                 }
-
 
                 let gw_zk_chain = &interval.proxy;
                 let bridgehub = Bridgehub::new(
@@ -127,21 +127,20 @@ impl InteropWatcher {
                 );
                 segments.push(SegmentSpec {
                     provider: gw_zk_chain.provider().clone(),
-
                     address: message_root.into(),
                     start_block,
                     end_block,
                 });
             }
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 starting_interop_root_id,
                 interop_roots_subpool,
-            });
+            };
             Ok((segments, processor))
-        });
+        };
 
-        Ok(Some(SlAwareL1Watcher::new(config, resolve_segments)))
+        Ok(Some(SegmentResolver::new(config, resolve_segments)))
     }
 }
 

--- a/lib/l1_watcher/src/migration_finalized_watcher.rs
+++ b/lib/l1_watcher/src/migration_finalized_watcher.rs
@@ -1,4 +1,4 @@
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::watcher::{L1WatcherError, StartResolver};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, U256};
 use alloy::rpc::types::{Log, Topic};
@@ -36,7 +36,7 @@ impl MigrationFinalizedWatcher {
         l1_chain_id: u64,
         config: L1WatcherConfig,
         last_finalized_migration: watch::Sender<u64>,
-    ) -> anyhow::Result<Option<L1Watcher<()>>> {
+    ) -> anyhow::Result<Option<StartResolver<(), Self>>> {
         let active_migration_number = (intervals.intervals().len() - 1) as u64;
         let sl_migration_number: u64 = bridgehub_sl
             .migration_number(l2_chain_id)
@@ -64,7 +64,7 @@ impl MigrationFinalizedWatcher {
         let chain_asset_handler = bridgehub_sl.chain_asset_handler_address().await?;
         let provider = zk_chain.provider().clone();
 
-        let resolve_start = resolver(move |()| async move {
+        let resolve_start = move |()| async move {
             // todo: not necessary to run binary search here, just use latest
             let starting_block = util::find_block_by_migration_number(
                 zk_chain,
@@ -82,14 +82,14 @@ impl MigrationFinalizedWatcher {
                 "migration finalized watcher starting"
             );
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 l2_chain_id,
                 last_finalized_migration,
-            });
+            };
             Ok((starting_block, processor))
-        });
+        };
 
-        let watcher = L1Watcher::new(
+        let resolver = StartResolver::new(
             config,
             provider,
             chain_asset_handler.into(),
@@ -98,7 +98,7 @@ impl MigrationFinalizedWatcher {
             resolve_start,
         )
         .await?;
-        Ok(Some(watcher))
+        Ok(Some(resolver))
     }
 }
 

--- a/lib/l1_watcher/src/migration_finalized_watcher.rs
+++ b/lib/l1_watcher/src/migration_finalized_watcher.rs
@@ -1,4 +1,4 @@
-use crate::watcher::{L1Watcher, L1WatcherError};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
 use crate::{L1WatcherConfig, ProcessRawEvents, util};
 use alloy::primitives::{B256, U256};
 use alloy::rpc::types::{Log, Topic};
@@ -36,7 +36,7 @@ impl MigrationFinalizedWatcher {
         l1_chain_id: u64,
         config: L1WatcherConfig,
         last_finalized_migration: watch::Sender<u64>,
-    ) -> anyhow::Result<Option<L1Watcher>> {
+    ) -> anyhow::Result<Option<L1Watcher<()>>> {
         let active_migration_number = (intervals.intervals().len() - 1) as u64;
         let sl_migration_number: u64 = bridgehub_sl
             .migration_number(l2_chain_id)
@@ -62,34 +62,40 @@ impl MigrationFinalizedWatcher {
         }
 
         let chain_asset_handler = bridgehub_sl.chain_asset_handler_address().await?;
-        // todo: not necessary to run binary search here, just use latest
-        let starting_block = util::find_block_by_migration_number(
-            zk_chain.clone(),
-            chain_asset_handler,
-            l2_chain_id,
-            active_migration_number,
-        )
-        .await?;
+        let provider = zk_chain.provider().clone();
 
-        tracing::info!(
-            contract = %chain_asset_handler,
-            l2_chain_id,
-            starting_block,
-            active_migration_number,
-            "migration finalized watcher starting"
-        );
+        let resolve_start = resolver(move |()| async move {
+            // todo: not necessary to run binary search here, just use latest
+            let starting_block = util::find_block_by_migration_number(
+                zk_chain,
+                chain_asset_handler,
+                l2_chain_id,
+                active_migration_number,
+            )
+            .await?;
+
+            tracing::info!(
+                contract = %chain_asset_handler,
+                l2_chain_id,
+                starting_block,
+                active_migration_number,
+                "migration finalized watcher starting"
+            );
+
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                l2_chain_id,
+                last_finalized_migration,
+            });
+            Ok((starting_block, processor))
+        });
 
         let watcher = L1Watcher::new(
             config,
-            zk_chain.provider().clone(),
+            provider,
             chain_asset_handler.into(),
-            starting_block,
             None,
             l1_chain_id,
-            Box::new(Self {
-                l2_chain_id,
-                last_finalized_migration,
-            }),
+            resolve_start,
         )
         .await?;
         Ok(Some(watcher))

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -1,7 +1,7 @@
-use crate::sl_aware_watcher::segment_resolver;
+use crate::sl_aware_watcher::SegmentResolver;
 use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
-use crate::{L1WatcherConfig, SegmentSpec, SlAwareL1Watcher, util};
+use crate::{L1WatcherConfig, SegmentSpec, util};
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::Context;
@@ -34,9 +34,9 @@ pub struct L1PersistBatchWatcher<BatchStorage> {
 }
 
 impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
-    /// Builds an [`SlAwareL1Watcher`] that walks every settlement-layer interval still relevant
-    /// to persistence, in order. Per-segment block resolution happens here; event scanning
-    /// happens lazily inside the watcher's `run()` loop.
+    /// Builds an [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) that walks every settlement-layer
+    /// interval still relevant to persistence, in order. Per-segment block resolution happens
+    /// here; event scanning happens lazily inside the watcher's `run()` loop.
     ///
     /// The migration contract requires `totalBatchesCommitted == totalBatchesExecuted` before a
     /// chain can migrate off an SL (`Migrator.sol`), so each closed interval is self-contained:
@@ -46,7 +46,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
         config: L1WatcherConfig,
         intervals: SettlementLayerIntervals,
         batch_storage: BatchStorage,
-    ) -> SlAwareL1Watcher<()> {
+    ) -> SegmentResolver<(), Self> {
         tracing::info!(
             num_intervals = intervals.intervals().len(),
             config.max_blocks_to_process,
@@ -58,7 +58,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
 
         // Per-segment block resolution (and the starting `last_persisted_batch`) are deferred to
         // the watcher's `run()`; only static dependencies are captured here.
-        let resolve_segments = segment_resolver(move |()| async move {
+        let resolve_segments = move |()| async move {
             let last_persisted_batch = batch_storage.latest_batch();
             tracing::info!(
                 last_persisted_batch,
@@ -129,7 +129,6 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
 
                 segments.push(SegmentSpec {
                     provider: zk_chain.provider().clone(),
-
                     address: (*zk_chain.address()).into(),
                     start_block,
                     end_block,
@@ -141,16 +140,16 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 "no settlement layer intervals are pending persistence"
             );
 
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 batch_storage,
                 committed_batches: HashMap::new(),
                 last_processed_commit_batch: last_persisted_batch,
                 last_persisted_batch_on_start: last_persisted_batch,
-            });
+            };
             Ok((segments, processor))
-        });
+        };
 
-        SlAwareL1Watcher::new(config, resolve_segments)
+        SegmentResolver::new(config, resolve_segments)
     }
 
     async fn parse_committed_batch(

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -1,3 +1,4 @@
+use crate::sl_aware_watcher::segment_resolver;
 use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
 use crate::{L1WatcherConfig, SegmentSpec, SlAwareL1Watcher, util};
@@ -41,100 +42,115 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
     /// chain can migrate off an SL (`Migrator.sol`), so each closed interval is self-contained:
     /// every commit on that SL has a matching execute on the same SL, and the in-memory
     /// `committed_batches` map is empty at interval boundaries.
-    pub async fn create_watcher(
+    pub fn create_watcher(
         config: L1WatcherConfig,
         intervals: SettlementLayerIntervals,
         batch_storage: BatchStorage,
-    ) -> anyhow::Result<SlAwareL1Watcher> {
-        let last_persisted_batch = batch_storage.latest_batch();
+    ) -> SlAwareL1Watcher<()> {
         tracing::info!(
-            last_persisted_batch,
             num_intervals = intervals.intervals().len(),
             config.max_blocks_to_process,
             ?config.poll_interval,
             "initializing L1 persist batch watcher"
         );
 
-        // Build segment specs from the relevant intervals. The first non-skipped segment is
-        // adjusted to start at `last_persisted_batch` (so we re-validate it on resume), unless
-        // we're at genesis — in which case `0` triggers the batch-0 fast path inside
-        // `find_l1_commit_block_by_batch_number`.
-        let mut segments = Vec::new();
-        let mut is_first = true;
-        for interval in intervals.intervals() {
-            // Empty interval: a migration can close without any new batches on the SL.
-            if interval
-                .last_batch
-                .is_some_and(|lb| interval.first_batch > lb)
-            {
-                continue;
+        let max_blocks_to_process = config.max_blocks_to_process;
+
+        // Per-segment block resolution (and the starting `last_persisted_batch`) are deferred to
+        // the watcher's `run()`; only static dependencies are captured here.
+        let resolve_segments = segment_resolver(move |()| async move {
+            let last_persisted_batch = batch_storage.latest_batch();
+            tracing::info!(
+                last_persisted_batch,
+                "resolving L1 persist batch watcher segments"
+            );
+
+            // Build segment specs from the relevant intervals. The first non-skipped segment
+            // is adjusted to start at `last_persisted_batch` (so we re-validate it on resume),
+            // unless we're at genesis — in which case `0` triggers the batch-0 fast path
+            // inside `find_l1_commit_block_by_batch_number`.
+            let mut segments = Vec::new();
+            let mut is_first = true;
+            for interval in intervals.intervals() {
+                // Empty interval: a migration can close without any new batches on the SL.
+                if interval
+                    .last_batch
+                    .is_some_and(|lb| interval.first_batch > lb)
+                {
+                    continue;
+                }
+                // Wholly behind `last_persisted_batch`: nothing left to validate or persist.
+                if interval
+                    .last_batch
+                    .is_some_and(|lb| last_persisted_batch > lb)
+                {
+                    continue;
+                }
+
+                let zk_chain = &interval.proxy;
+                let first_batch = if is_first {
+                    anyhow::ensure!(
+                        interval.first_batch <= last_persisted_batch + 1,
+                        "first SL interval ({interval}) must start at or before first non-persisted batch ({})",
+                        last_persisted_batch + 1
+                    );
+                    last_persisted_batch
+                } else {
+                    // First batch in the interval might not have been committed yet. We
+                    // resolve the canonical start of the segment from the previous batch's
+                    // import block.
+                    interval.first_batch - 1
+                };
+                is_first = false;
+
+                let start_block = util::find_l1_commit_block_by_batch_number(
+                    zk_chain.clone(),
+                    first_batch,
+                    max_blocks_to_process,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to find L1 commit for batch #{first_batch} in interval {interval}"
+                    )
+                })?;
+                let end_block = match interval.last_batch {
+                    Some(last_batch) => Some(
+                        util::find_l1_execute_block_by_batch_number(zk_chain.clone(), last_batch)
+                            .await
+                            .with_context(|| {
+                                format!(
+                                    "failed to find L1 execute for batch #{last_batch} in interval {interval}"
+                                )
+                            })?,
+                    ),
+                    None => None,
+                };
+
+                segments.push(SegmentSpec {
+                    provider: zk_chain.provider().clone(),
+
+                    address: (*zk_chain.address()).into(),
+                    start_block,
+                    end_block,
+                });
             }
-            // Wholly behind `last_persisted_batch`: nothing left to validate or persist here.
-            if interval
-                .last_batch
-                .is_some_and(|lb| last_persisted_batch > lb)
-            {
-                continue;
-            }
 
-            let zk_chain = &interval.proxy;
-            let first_batch = if is_first {
-                anyhow::ensure!(
-                    interval.first_batch <= last_persisted_batch + 1,
-                    "first SL interval ({interval}) must start at or before first non-persisted batch ({})",
-                    last_persisted_batch + 1
-                );
-                last_persisted_batch
-            } else {
-                // First batch in the interval might not have been committed yet. We resolve the
-                // canonical start of the segment from the previous batch's import block.
-                interval.first_batch - 1
-            };
-            is_first = false;
+            anyhow::ensure!(
+                !segments.is_empty(),
+                "no settlement layer intervals are pending persistence"
+            );
 
-            let start_block = util::find_l1_commit_block_by_batch_number(
-                zk_chain.clone(),
-                first_batch,
-                config.max_blocks_to_process,
-            )
-            .await
-            .with_context(|| {
-                format!("failed to find L1 commit for batch #{first_batch} in interval {interval}")
-            })?;
-            let end_block = match interval.last_batch {
-                Some(last_batch) => Some(
-                    util::find_l1_execute_block_by_batch_number(zk_chain.clone(), last_batch)
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "failed to find L1 execute for batch #{last_batch} in interval {interval}"
-                            )
-                        })?,
-                ),
-                None => None,
-            };
-
-            segments.push(SegmentSpec {
-                provider: zk_chain.provider().clone(),
-                address: (*zk_chain.address()).into(),
-                start_block,
-                end_block,
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                batch_storage,
+                committed_batches: HashMap::new(),
+                last_processed_commit_batch: last_persisted_batch,
+                last_persisted_batch_on_start: last_persisted_batch,
             });
-        }
+            Ok((segments, processor))
+        });
 
-        anyhow::ensure!(
-            !segments.is_empty(),
-            "no settlement layer intervals are pending persistence"
-        );
-
-        let this = Self {
-            batch_storage,
-            committed_batches: HashMap::new(),
-            last_processed_commit_batch: last_persisted_batch,
-            last_persisted_batch_on_start: last_persisted_batch,
-        };
-
-        SlAwareL1Watcher::new(config, segments, Box::new(this))
+        SlAwareL1Watcher::new(config, resolve_segments)
     }
 
     async fn parse_committed_batch(

--- a/lib/l1_watcher/src/sl_aware_watcher.rs
+++ b/lib/l1_watcher/src/sl_aware_watcher.rs
@@ -1,4 +1,4 @@
-use crate::watcher::RunningL1Watcher;
+use crate::watcher::L1Watcher;
 use crate::{L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::rpc::types::ValueOrArray;
@@ -25,6 +25,55 @@ pub struct SegmentSpec {
     pub end_block: Option<BlockNumber>,
 }
 
+/// Boxed async closure that turns a starting point `S` into the full segment list and the
+/// processor `P` that consumes it.
+type ResolveSegmentsFn<S, P> =
+    Box<dyn FnOnce(S) -> BoxFuture<'static, anyhow::Result<(Vec<SegmentSpec>, P)>> + Send>;
+
+/// Deferred constructor for an [`SlAwareL1Watcher`]: turns a starting point `S` into a
+/// ready-to-run watcher once that starting point is finally known.
+///
+/// Mirrors [`StartResolver`](crate::watcher::StartResolver) but yields the full segment list
+/// (each segment's `start_block`/`end_block` resolved via per-segment binary searches) instead
+/// of a single block.
+pub struct SegmentResolver<S, P> {
+    config: L1WatcherConfig,
+    resolve_segments: ResolveSegmentsFn<S, P>,
+}
+
+impl<S, P: ProcessRawEvents> SegmentResolver<S, P> {
+    pub(crate) fn new<Fut>(
+        config: L1WatcherConfig,
+        resolve_segments: impl FnOnce(S) -> Fut + Send + 'static,
+    ) -> Self
+    where
+        Fut: Future<Output = anyhow::Result<(Vec<SegmentSpec>, P)>> + Send + 'static,
+    {
+        Self {
+            config,
+            resolve_segments: Box::new(move |start| Box::pin(resolve_segments(start))),
+        }
+    }
+
+    /// Resolves the starting point into a segment list and processor, producing a ready-to-run
+    /// [`SlAwareL1Watcher`].
+    pub async fn resolve(self, start: S) -> anyhow::Result<SlAwareL1Watcher<P>> {
+        let (segments, processor) = (self.resolve_segments)(start).await?;
+        SlAwareL1Watcher::new(self.config, segments, processor)
+    }
+
+    /// Resolves the starting point and runs the produced watcher. A failure to resolve the
+    /// segments is fatal (panics), matching the previous behavior where resolution happened at
+    /// construction.
+    pub async fn run(self, start: S) {
+        self.resolve(start)
+            .await
+            .expect("failed to resolve SL-aware watcher segments")
+            .run()
+            .await;
+    }
+}
+
 /// Settlement-layer-aware variant of [`L1Watcher`] that walks a chain of SL segments
 /// (L1 → Gateway → L1 → …) in order. Historical segments are scanned to completion once their
 /// `start_block`..=`end_block` window is exhausted; if the final segment is open-ended
@@ -33,56 +82,44 @@ pub struct SegmentSpec {
 /// watcher drains them in order and then exits cleanly — useful for scenarios where the active
 /// settlement layer no longer emits events of interest (e.g. an interop-root watcher on a chain
 /// that has migrated back to L1).
-pub struct SlAwareL1Watcher<S> {
+pub struct SlAwareL1Watcher<P> {
     config: L1WatcherConfig,
-    resolve_segments: SegmentResolver<S>,
+    segments: VecDeque<SegmentSpec>,
+    processor: P,
 }
 
-/// Resolves an SL-aware watcher's segments and processor once the starting point `S` is known.
-///
-/// Mirrors [`StartResolver`](crate::watcher::StartResolver) but yields the full segment list
-/// (each segment's `start_block`/`end_block` resolved via per-segment binary searches) instead
-/// of a single block.
-pub(crate) type SegmentResolver<S> = Box<
-    dyn FnOnce(
-            S,
-        )
-            -> BoxFuture<'static, anyhow::Result<(Vec<SegmentSpec>, Box<dyn ProcessRawEvents>)>>
-        + Send,
->;
-
-/// Builds a [`SegmentResolver`] from an async closure, hiding the `Box::new`/`Box::pin` ceremony.
-pub(crate) fn segment_resolver<S, Fut>(
-    f: impl FnOnce(S) -> Fut + Send + 'static,
-) -> SegmentResolver<S>
-where
-    Fut: std::future::Future<Output = anyhow::Result<(Vec<SegmentSpec>, Box<dyn ProcessRawEvents>)>>
-        + Send
-        + 'static,
-{
-    Box::new(move |s| Box::pin(f(s)))
-}
-
-impl<S> SlAwareL1Watcher<S> {
-    pub fn new(config: L1WatcherConfig, resolve_segments: SegmentResolver<S>) -> Self {
-        Self {
-            config,
-            resolve_segments,
+impl<P: ProcessRawEvents> SlAwareL1Watcher<P> {
+    pub(crate) fn new(
+        config: L1WatcherConfig,
+        segments: Vec<SegmentSpec>,
+        processor: P,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !segments.is_empty(),
+            "SlAwareL1Watcher requires at least one segment"
+        );
+        // Only the final segment may be open-ended. Internal open-ended segments are nonsense
+        // because they'd never yield to the next one.
+        for seg in &segments[..segments.len() - 1] {
+            anyhow::ensure!(
+                seg.end_block.is_some(),
+                "non-final SlAwareL1Watcher segments must be closed"
+            );
         }
+
+        Ok(Self {
+            config,
+            segments: segments.into(),
+            processor,
+        })
     }
 
-    pub async fn run(self, start: S)
-    where
-        S: Send + 'static,
-    {
+    pub async fn run(self) {
         let Self {
             config,
-            resolve_segments,
+            mut segments,
+            mut processor,
         } = self;
-        let (segments, mut processor) = resolve_segments(start)
-            .await
-            .expect("failed to resolve SL-aware watcher segments");
-        let mut segments = validate_segments(segments).expect("invalid SL-aware watcher segments");
         while let Some(segment) = segments.pop_front() {
             processor = run_segment(config.clone(), segment, processor).await;
         }
@@ -92,27 +129,11 @@ impl<S> SlAwareL1Watcher<S> {
     }
 }
 
-fn validate_segments(segments: Vec<SegmentSpec>) -> anyhow::Result<VecDeque<SegmentSpec>> {
-    anyhow::ensure!(
-        !segments.is_empty(),
-        "SlAwareL1Watcher requires at least one segment"
-    );
-    // Only the final segment may be open-ended. Internal open-ended segments are nonsense
-    // because they'd never yield to the next one.
-    for seg in &segments[..segments.len() - 1] {
-        anyhow::ensure!(
-            seg.end_block.is_some(),
-            "non-final SlAwareL1Watcher segments must be closed"
-        );
-    }
-    Ok(segments.into())
-}
-
-async fn run_segment(
+async fn run_segment<P: ProcessRawEvents>(
     config: L1WatcherConfig,
     segment: SegmentSpec,
-    processor: Box<dyn ProcessRawEvents>,
-) -> Box<dyn ProcessRawEvents> {
+    processor: P,
+) -> P {
     tracing::info!(
         "sl-aware watcher activated segment at {:?} for SL blocks=({}-{})",
         segment.address,
@@ -127,7 +148,7 @@ async fn run_segment(
     // executed-batch / migration boundary), so the boundary mode does not matter — `end_block`
     // dominates the cap. The open-ended segment uses the finalized boundary so persistence-style
     // processors only react to irreversibly observed events.
-    let mut watcher = RunningL1Watcher::new_finalized(
+    let mut watcher = L1Watcher::new_finalized(
         config,
         segment.provider,
         segment.address,

--- a/lib/l1_watcher/src/sl_aware_watcher.rs
+++ b/lib/l1_watcher/src/sl_aware_watcher.rs
@@ -1,7 +1,8 @@
-use crate::watcher::L1Watcher;
+use crate::watcher::RunningL1Watcher;
 use crate::{L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::rpc::types::ValueOrArray;
+use futures::future::BoxFuture;
 use std::collections::VecDeque;
 use zksync_os_provider::NodeProvider;
 
@@ -32,44 +33,56 @@ pub struct SegmentSpec {
 /// watcher drains them in order and then exits cleanly — useful for scenarios where the active
 /// settlement layer no longer emits events of interest (e.g. an interop-root watcher on a chain
 /// that has migrated back to L1).
-pub struct SlAwareL1Watcher {
+pub struct SlAwareL1Watcher<S> {
     config: L1WatcherConfig,
-    segments: VecDeque<SegmentSpec>,
-    processor: Box<dyn ProcessRawEvents>,
+    resolve_segments: SegmentResolver<S>,
 }
 
-impl SlAwareL1Watcher {
-    pub fn new(
-        config: L1WatcherConfig,
-        segments: Vec<SegmentSpec>,
-        processor: Box<dyn ProcessRawEvents>,
-    ) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            !segments.is_empty(),
-            "SlAwareL1Watcher requires at least one segment"
-        );
-        // Only the final segment may be open-ended. Internal open-ended segments are nonsense
-        // because they'd never yield to the next one.
-        for seg in &segments[..segments.len() - 1] {
-            anyhow::ensure!(
-                seg.end_block.is_some(),
-                "non-final SlAwareL1Watcher segments must be closed"
-            );
-        }
+/// Resolves an SL-aware watcher's segments and processor once the starting point `S` is known.
+///
+/// Mirrors [`StartResolver`](crate::watcher::StartResolver) but yields the full segment list
+/// (each segment's `start_block`/`end_block` resolved via per-segment binary searches) instead
+/// of a single block.
+pub(crate) type SegmentResolver<S> = Box<
+    dyn FnOnce(
+            S,
+        )
+            -> BoxFuture<'static, anyhow::Result<(Vec<SegmentSpec>, Box<dyn ProcessRawEvents>)>>
+        + Send,
+>;
 
-        Ok(Self {
+/// Builds a [`SegmentResolver`] from an async closure, hiding the `Box::new`/`Box::pin` ceremony.
+pub(crate) fn segment_resolver<S, Fut>(
+    f: impl FnOnce(S) -> Fut + Send + 'static,
+) -> SegmentResolver<S>
+where
+    Fut: std::future::Future<Output = anyhow::Result<(Vec<SegmentSpec>, Box<dyn ProcessRawEvents>)>>
+        + Send
+        + 'static,
+{
+    Box::new(move |s| Box::pin(f(s)))
+}
+
+impl<S> SlAwareL1Watcher<S> {
+    pub fn new(config: L1WatcherConfig, resolve_segments: SegmentResolver<S>) -> Self {
+        Self {
             config,
-            segments: segments.into(),
-            processor,
-        })
+            resolve_segments,
+        }
     }
 
-    pub async fn run(self) {
+    pub async fn run(self, start: S)
+    where
+        S: Send + 'static,
+    {
         let Self {
             config,
-            mut segments,
-            mut processor,
+            resolve_segments,
         } = self;
+        let (segments, mut processor) = resolve_segments(start)
+            .await
+            .expect("failed to resolve SL-aware watcher segments");
+        let mut segments = validate_segments(segments).expect("invalid SL-aware watcher segments");
         while let Some(segment) = segments.pop_front() {
             processor = run_segment(config.clone(), segment, processor).await;
         }
@@ -77,6 +90,22 @@ impl SlAwareL1Watcher {
         // final segment this is unreachable; for one with only closed segments it terminates
         // cleanly after the historical sweep.
     }
+}
+
+fn validate_segments(segments: Vec<SegmentSpec>) -> anyhow::Result<VecDeque<SegmentSpec>> {
+    anyhow::ensure!(
+        !segments.is_empty(),
+        "SlAwareL1Watcher requires at least one segment"
+    );
+    // Only the final segment may be open-ended. Internal open-ended segments are nonsense
+    // because they'd never yield to the next one.
+    for seg in &segments[..segments.len() - 1] {
+        anyhow::ensure!(
+            seg.end_block.is_some(),
+            "non-final SlAwareL1Watcher segments must be closed"
+        );
+    }
+    Ok(segments.into())
 }
 
 async fn run_segment(
@@ -98,7 +127,7 @@ async fn run_segment(
     // executed-batch / migration boundary), so the boundary mode does not matter — `end_block`
     // dominates the cap. The open-ended segment uses the finalized boundary so persistence-style
     // processors only react to irreversibly observed events.
-    let mut watcher = L1Watcher::new_finalized(
+    let mut watcher = RunningL1Watcher::new_finalized(
         config,
         segment.provider,
         segment.address,

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -1,5 +1,5 @@
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
-use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
+use crate::watcher::{L1WatcherError, StartResolver};
+use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::BlockNumber;
 use alloy::providers::Provider;
@@ -30,7 +30,7 @@ impl L1TxWatcher {
         zk_chain_l1: ZkChain<NodeProvider>,
         zk_chain_sl: ZkChain<NodeProvider>,
         l1_subpool: L1Subpool,
-    ) -> anyhow::Result<L1Watcher<u64>> {
+    ) -> anyhow::Result<StartResolver<u64, Self>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -43,28 +43,20 @@ impl L1TxWatcher {
         let address = (*zk_chain_l1.address()).into();
         let l1_chain_id = provider.get_chain_id().await?;
 
-        let resolve_start = resolver(move |next_l1_priority_id: u64| async move {
+        let resolve_start = move |next_l1_priority_id: u64| async move {
             let next_l1_block =
                 find_l1_block_by_priority_id(zk_chain_l1.clone(), next_l1_priority_id).await?;
             tracing::info!(next_l1_block, "resolved on L1");
-            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+            let processor = Self {
                 next_l1_priority_id,
                 zk_chain_sl,
                 cached_total_priority_ops_resp: None,
                 l1_subpool,
-            });
+            };
             Ok((next_l1_block, processor))
-        });
+        };
 
-        L1Watcher::new(
-            config,
-            provider,
-            address,
-            None,
-            l1_chain_id,
-            resolve_start,
-        )
-        .await
+        StartResolver::new(config, provider, address, None, l1_chain_id, resolve_start).await
     }
 }
 

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -1,5 +1,5 @@
-use crate::watcher::{L1Watcher, L1WatcherError};
-use crate::{L1WatcherConfig, ProcessL1Event, util};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
 use alloy::eips::{BlockId, BlockNumberOrTag};
 use alloy::primitives::BlockNumber;
 use alloy::providers::Provider;
@@ -30,8 +30,7 @@ impl L1TxWatcher {
         zk_chain_l1: ZkChain<NodeProvider>,
         zk_chain_sl: ZkChain<NodeProvider>,
         l1_subpool: L1Subpool,
-        next_l1_priority_id: u64,
-    ) -> anyhow::Result<L1Watcher> {
+    ) -> anyhow::Result<L1Watcher<u64>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -40,25 +39,30 @@ impl L1TxWatcher {
             "initializing L1 transaction watcher"
         );
 
-        let next_l1_block =
-            find_l1_block_by_priority_id(zk_chain_l1.clone(), next_l1_priority_id).await?;
+        let provider = zk_chain_l1.provider().clone();
+        let address = (*zk_chain_l1.address()).into();
+        let l1_chain_id = provider.get_chain_id().await?;
 
-        tracing::info!(next_l1_block, "resolved on L1");
+        let resolve_start = resolver(move |next_l1_priority_id: u64| async move {
+            let next_l1_block =
+                find_l1_block_by_priority_id(zk_chain_l1.clone(), next_l1_priority_id).await?;
+            tracing::info!(next_l1_block, "resolved on L1");
+            let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                next_l1_priority_id,
+                zk_chain_sl,
+                cached_total_priority_ops_resp: None,
+                l1_subpool,
+            });
+            Ok((next_l1_block, processor))
+        });
 
-        let this = Self {
-            next_l1_priority_id,
-            zk_chain_sl,
-            cached_total_priority_ops_resp: None,
-            l1_subpool,
-        };
         L1Watcher::new(
             config,
-            zk_chain_l1.provider().clone(),
-            (*zk_chain_l1.address()).into(),
-            next_l1_block,
+            provider,
+            address,
             None,
-            zk_chain_l1.provider().get_chain_id().await?,
-            Box::new(this),
+            l1_chain_id,
+            resolve_start,
         )
         .await
     }

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::util::ANVIL_L1_CHAIN_ID;
-use crate::watcher::{L1Watcher, L1WatcherError};
-use crate::{L1WatcherConfig, ProcessL1Event, util};
+use crate::watcher::{L1Watcher, L1WatcherError, resolver};
+use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
 use alloy::dyn_abi::SolType;
 use alloy::primitives::{Address, B256, BlockNumber, ChainId, U256};
 use alloy::providers::Provider;
@@ -69,9 +69,8 @@ impl L1UpgradeTxWatcher {
         zk_chain_l1: ZkChain<NodeProvider>,
         zk_chain_sl: ZkChain<NodeProvider>,
         bytecode_supplier_address: Address,
-        current_protocol_version: ProtocolSemanticVersion,
         upgrade_subpool: UpgradeSubpool,
-    ) -> anyhow::Result<L1Watcher> {
+    ) -> anyhow::Result<L1Watcher<ProtocolSemanticVersion>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -89,45 +88,57 @@ impl L1UpgradeTxWatcher {
         let ctm_sl = zk_chain_sl.get_chain_type_manager().await?;
         tracing::info!(ctm_sl = ?ctm_sl, "resolved SL chain type manager");
 
-        let last_l1_block = find_l1_block_by_protocol_version(
-            zk_chain_l1.clone(),
-            current_protocol_version.clone(),
-        )
-        .await?;
+        let provider_l1 = zk_chain_l1.provider().clone();
+        let provider_sl = zk_chain_sl.provider().clone();
+
         // The configured bytecode supplier address is used as fallback for pre-v31 CTMs.
         // On v31+ CTMs, `resolve_active_bytecode_supplier` discovers the address dynamically.
         // Sanity check: make sure the fallback address has code deployed.
         anyhow::ensure!(
-            !zk_chain_l1
-                .provider()
+            !provider_l1
                 .get_code_at(bytecode_supplier_address)
                 .await?
                 .is_empty(),
             "Bytecode supplier contract is not deployed at expected address {bytecode_supplier_address:?}"
         );
 
-        tracing::info!(last_l1_block, "checking block starting from");
+        let watcher_provider = provider_l1.clone();
+        let l1_chain_id = provider_l1.get_chain_id().await?;
+        let bridgehub_l1 = *bridgehub_l1.address();
+        let max_blocks_to_process = config.max_blocks_to_process;
 
-        let this = Self {
-            l2_chain_id,
-            provider_l1: zk_chain_l1.provider().clone(),
-            provider_sl: zk_chain_sl.provider().clone(),
-            bridgehub_l1: *bridgehub_l1.address(),
-            bytecode_supplier_address,
-            ctm_l1,
-            ctm_sl,
-            current_protocol_version,
-            upgrade_subpool,
-            max_blocks_to_process: config.max_blocks_to_process,
-        };
+        let resolve_start = resolver(
+            move |current_protocol_version: ProtocolSemanticVersion| async move {
+                let last_l1_block = find_l1_block_by_protocol_version(
+                    zk_chain_l1,
+                    current_protocol_version.clone(),
+                )
+                .await?;
+                tracing::info!(last_l1_block, "checking block starting from");
+
+                let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
+                    l2_chain_id,
+                    provider_l1,
+                    provider_sl,
+                    bridgehub_l1,
+                    bytecode_supplier_address,
+                    ctm_l1,
+                    ctm_sl,
+                    current_protocol_version,
+                    upgrade_subpool,
+                    max_blocks_to_process,
+                });
+                Ok((last_l1_block, processor))
+            },
+        );
+
         L1Watcher::new(
             config,
-            zk_chain_l1.provider().clone(),
+            watcher_provider,
             server_notifier_l1.into(),
-            last_l1_block,
             None,
-            zk_chain_l1.provider().get_chain_id().await?,
-            Box::new(this),
+            l1_chain_id,
+            resolve_start,
         )
         .await
     }

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::util::ANVIL_L1_CHAIN_ID;
-use crate::watcher::{L1Watcher, L1WatcherError, resolver};
-use crate::{L1WatcherConfig, ProcessL1Event, ProcessRawEvents, util};
+use crate::watcher::{L1WatcherError, StartResolver};
+use crate::{L1WatcherConfig, ProcessL1Event, util};
 use alloy::dyn_abi::SolType;
 use alloy::primitives::{Address, B256, BlockNumber, ChainId, U256};
 use alloy::providers::Provider;
@@ -70,7 +70,7 @@ impl L1UpgradeTxWatcher {
         zk_chain_sl: ZkChain<NodeProvider>,
         bytecode_supplier_address: Address,
         upgrade_subpool: UpgradeSubpool,
-    ) -> anyhow::Result<L1Watcher<ProtocolSemanticVersion>> {
+    ) -> anyhow::Result<StartResolver<ProtocolSemanticVersion, Self>> {
         tracing::info!(
             config.max_blocks_to_process,
             ?config.poll_interval,
@@ -107,32 +107,28 @@ impl L1UpgradeTxWatcher {
         let bridgehub_l1 = *bridgehub_l1.address();
         let max_blocks_to_process = config.max_blocks_to_process;
 
-        let resolve_start = resolver(
-            move |current_protocol_version: ProtocolSemanticVersion| async move {
-                let last_l1_block = find_l1_block_by_protocol_version(
-                    zk_chain_l1,
-                    current_protocol_version.clone(),
-                )
-                .await?;
-                tracing::info!(last_l1_block, "checking block starting from");
+        let resolve_start = move |current_protocol_version: ProtocolSemanticVersion| async move {
+            let last_l1_block =
+                find_l1_block_by_protocol_version(zk_chain_l1, current_protocol_version.clone())
+                    .await?;
+            tracing::info!(last_l1_block, "checking block starting from");
 
-                let processor: Box<dyn ProcessRawEvents> = Box::new(Self {
-                    l2_chain_id,
-                    provider_l1,
-                    provider_sl,
-                    bridgehub_l1,
-                    bytecode_supplier_address,
-                    ctm_l1,
-                    ctm_sl,
-                    current_protocol_version,
-                    upgrade_subpool,
-                    max_blocks_to_process,
-                });
-                Ok((last_l1_block, processor))
-            },
-        );
+            let processor = Self {
+                l2_chain_id,
+                provider_l1,
+                provider_sl,
+                bridgehub_l1,
+                bytecode_supplier_address,
+                ctm_l1,
+                ctm_sl,
+                current_protocol_version,
+                upgrade_subpool,
+                max_blocks_to_process,
+            };
+            Ok((last_l1_block, processor))
+        };
 
-        L1Watcher::new(
+        StartResolver::new(
             config,
             watcher_provider,
             server_notifier_l1.into(),

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -12,53 +12,42 @@ enum BlockBoundary {
     Finalized,
 }
 
-/// Resolves a watcher's starting state once the starting point `S` is finally known.
-///
-/// Construction of a watcher only requires its static dependencies; the provider-dependent
-/// binary search that turns a starting point (a priority id, batch number, protocol version, …)
-/// into a concrete `next_block` — together with the processor that consumes the resolved start
-/// point — is deferred into this closure and invoked lazily by [`L1Watcher::run`].
-pub(crate) type StartResolver<S> = Box<
-    dyn FnOnce(S) -> BoxFuture<'static, anyhow::Result<(BlockNumber, Box<dyn ProcessRawEvents>)>>
-        + Send,
->;
+/// Boxed async closure that turns a starting point `S` into a concrete start block and the
+/// processor `P` that consumes it.
+type ResolveStartFn<S, P> =
+    Box<dyn FnOnce(S) -> BoxFuture<'static, anyhow::Result<(BlockNumber, P)>> + Send>;
 
-/// Builds a [`StartResolver`] from an async closure, hiding the `Box::new`/`Box::pin` ceremony.
-pub(crate) fn resolver<S, Fut>(f: impl FnOnce(S) -> Fut + Send + 'static) -> StartResolver<S>
-where
-    Fut: std::future::Future<Output = anyhow::Result<(BlockNumber, Box<dyn ProcessRawEvents>)>>
-        + Send
-        + 'static,
-{
-    Box::new(move |s| Box::pin(f(s)))
-}
-
-/// An abstract, *unstarted* watcher for events.
+/// Deferred constructor for an [`L1Watcher`]: holds the watcher's static dependencies and turns
+/// a starting point `S` into a ready-to-run watcher once that starting point is finally known.
 ///
-/// Holds only the static dependencies needed to poll for blocks and extract logs; the starting
-/// point is supplied later to [`run`](Self::run), which resolves it (via [`StartResolver`]) into
-/// a concrete start block plus processor and then runs the poll loop. This lets watchers be
-/// created in one place and started in another, once the first replayed block is known.
-pub struct L1Watcher<S> {
+/// Constructing a resolver only requires static dependencies; the provider-dependent binary
+/// search that turns a starting point (a priority id, batch number, protocol version, …) into a
+/// concrete `next_block` — together with the processor `P` that consumes the resolved start
+/// point — is deferred into the `resolve_start` closure and invoked by
+/// [`resolve`](Self::resolve). This lets watchers be created in one place and started in
+/// another, once the first replayed block is known.
+pub struct StartResolver<S, P> {
     provider: NodeProvider,
     address: ValueOrArray<Address>,
     /// `Some(eb)` makes the watcher exit once the cursor passes `eb`. `None` runs forever.
     end_block: Option<BlockNumber>,
     max_blocks_to_process: u64,
     block_boundary: BlockBoundary,
-    resolve_start: StartResolver<S>,
+    resolve_start: ResolveStartFn<S, P>,
 }
 
-impl<S> L1Watcher<S> {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn new(
+impl<S, P: ProcessRawEvents> StartResolver<S, P> {
+    pub(crate) async fn new<Fut>(
         config: L1WatcherConfig,
         provider: NodeProvider,
         address: ValueOrArray<Address>,
         end_block: Option<BlockNumber>,
         l1_chain_id: u64,
-        resolve_start: StartResolver<S>,
-    ) -> anyhow::Result<Self> {
+        resolve_start: impl FnOnce(S) -> Fut + Send + 'static,
+    ) -> anyhow::Result<Self>
+    where
+        Fut: Future<Output = anyhow::Result<(BlockNumber, P)>> + Send + 'static,
+    {
         let confirmations = if provider.get_chain_id().await? != l1_chain_id {
             // Gateway case, zero out confirmations.
             0
@@ -72,38 +61,35 @@ impl<S> L1Watcher<S> {
             end_block,
             max_blocks_to_process: config.max_blocks_to_process,
             block_boundary: BlockBoundary::Confirmed { confirmations },
-            resolve_start,
+            resolve_start: Box::new(move |start| Box::pin(resolve_start(start))),
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new_finalized(
+    /// Like [`new`](Self::new), but tails the finalized boundary so the produced watcher only
+    /// reacts to irreversibly observed events.
+    pub(crate) fn new_finalized<Fut>(
         config: L1WatcherConfig,
         provider: NodeProvider,
         address: ValueOrArray<Address>,
         end_block: Option<BlockNumber>,
-        resolve_start: StartResolver<S>,
-    ) -> Self {
+        resolve_start: impl FnOnce(S) -> Fut + Send + 'static,
+    ) -> Self
+    where
+        Fut: Future<Output = anyhow::Result<(BlockNumber, P)>> + Send + 'static,
+    {
         Self {
             provider,
             address,
             end_block,
             max_blocks_to_process: config.max_blocks_to_process,
             block_boundary: BlockBoundary::Finalized,
-            resolve_start,
+            resolve_start: Box::new(move |start| Box::pin(resolve_start(start))),
         }
     }
 
-    /// Resolves the starting point into a concrete start block and processor, then polls for
-    /// new events.
-    ///
-    /// For unbounded watchers (`end_block = None`) this never returns; for bounded watchers it
-    /// returns once the cursor passes `end_block`. A failure to resolve the start block is fatal
-    /// (panics), matching the previous behavior where resolution happened at construction.
-    pub async fn run(self, start: S)
-    where
-        S: Send + 'static,
-    {
+    /// Resolves the starting point into a concrete start block and processor, producing a
+    /// ready-to-run [`L1Watcher`].
+    pub async fn resolve(self, start: S) -> anyhow::Result<L1Watcher<P>> {
         let Self {
             provider,
             address,
@@ -112,10 +98,8 @@ impl<S> L1Watcher<S> {
             block_boundary,
             resolve_start,
         } = self;
-        let (next_block, processor) = resolve_start(start)
-            .await
-            .expect("failed to resolve L1 watcher start block");
-        let mut running = RunningL1Watcher {
+        let (next_block, processor) = resolve_start(start).await?;
+        Ok(L1Watcher {
             provider,
             address,
             next_block,
@@ -123,38 +107,51 @@ impl<S> L1Watcher<S> {
             max_blocks_to_process,
             block_boundary,
             processor,
-        };
-        running.run_inner().await;
+        })
+    }
+
+    /// Resolves the starting point and runs the produced watcher. A failure to resolve the
+    /// start block is fatal (panics), matching the previous behavior where resolution happened
+    /// at construction.
+    pub async fn run(self, start: S) {
+        self.resolve(start)
+            .await
+            .expect("failed to resolve L1 watcher start block")
+            .run()
+            .await;
     }
 }
 
-/// Running state of a watcher whose starting point has already been resolved into a concrete
-/// `next_block` and processor. Owns the poll loop; produced by [`L1Watcher::run`] and used
-/// directly by [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) to scan a single pre-resolved
-/// segment.
-pub(crate) struct RunningL1Watcher {
+/// An abstract watcher for events.
+/// Handles polling for new blocks and extracting logs,
+/// while delegating the actual event processing to the processor `P`.
+///
+/// Produced by [`StartResolver::resolve`] once the starting point has been resolved into a
+/// concrete `next_block` and processor. May be run unbounded (live tail) or bounded by
+/// `end_block` (used by [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) to scan a closed segment
+/// to completion).
+pub struct L1Watcher<P> {
     provider: NodeProvider,
     address: ValueOrArray<Address>,
     next_block: BlockNumber,
-    /// `Some(eb)` makes the watcher exit `run_inner` once `next_block > eb`. `None` runs forever.
+    /// `Some(eb)` makes the watcher exit `run` once `next_block > eb`. `None` runs forever.
     end_block: Option<BlockNumber>,
     max_blocks_to_process: u64,
     block_boundary: BlockBoundary,
-    pub(crate) processor: Box<dyn ProcessRawEvents>,
+    pub(crate) processor: P,
 }
 
-impl RunningL1Watcher {
-    /// Builds a running watcher for a single pre-resolved segment, tailing the finalized boundary
+impl<P: ProcessRawEvents> L1Watcher<P> {
+    /// Builds a watcher for a single pre-resolved segment, tailing the finalized boundary
     /// (closed segments are dominated by `end_block`, so the boundary mode only matters for the
     /// open-ended segment).
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_finalized(
         config: L1WatcherConfig,
         provider: NodeProvider,
         address: ValueOrArray<Address>,
         next_block: BlockNumber,
         end_block: Option<BlockNumber>,
-        processor: Box<dyn ProcessRawEvents>,
+        processor: P,
     ) -> Self {
         Self {
             provider,
@@ -167,7 +164,15 @@ impl RunningL1Watcher {
         }
     }
 
-    /// Runs the poll loop, intended for internal usage in this crate.
+    /// Polls for new events.
+    ///
+    /// For unbounded watchers (`end_block = None`) this never returns; for bounded watchers
+    /// it returns once the cursor passes `end_block`.
+    pub async fn run(mut self) {
+        self.run_inner().await;
+    }
+
+    /// Non-consuming version of `run`, intended for internal usage in this crate.
     pub(crate) async fn run_inner(&mut self) {
         let mut headers = match self.block_boundary {
             BlockBoundary::Confirmed { .. } => self.provider.latest_header_watcher().await,

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -3,6 +3,7 @@ use crate::{L1WatcherConfig, ProcessRawEvents};
 use alloy::primitives::{Address, BlockNumber};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, Log, ValueOrArray};
+use futures::future::BoxFuture;
 use zksync_os_provider::NodeProvider;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -11,33 +12,52 @@ enum BlockBoundary {
     Finalized,
 }
 
-/// An abstract watcher for events.
-/// Handles polling for new blocks and extracting logs,
-/// while delegating the actual event processing to a user-provided processor.
+/// Resolves a watcher's starting state once the starting point `S` is finally known.
 ///
-/// May be run unbounded (live tail) or bounded by `end_block` (used by
-/// [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) to scan a closed segment to completion).
-pub struct L1Watcher {
+/// Construction of a watcher only requires its static dependencies; the provider-dependent
+/// binary search that turns a starting point (a priority id, batch number, protocol version, …)
+/// into a concrete `next_block` — together with the processor that consumes the resolved start
+/// point — is deferred into this closure and invoked lazily by [`L1Watcher::run`].
+pub(crate) type StartResolver<S> = Box<
+    dyn FnOnce(S) -> BoxFuture<'static, anyhow::Result<(BlockNumber, Box<dyn ProcessRawEvents>)>>
+        + Send,
+>;
+
+/// Builds a [`StartResolver`] from an async closure, hiding the `Box::new`/`Box::pin` ceremony.
+pub(crate) fn resolver<S, Fut>(f: impl FnOnce(S) -> Fut + Send + 'static) -> StartResolver<S>
+where
+    Fut: std::future::Future<Output = anyhow::Result<(BlockNumber, Box<dyn ProcessRawEvents>)>>
+        + Send
+        + 'static,
+{
+    Box::new(move |s| Box::pin(f(s)))
+}
+
+/// An abstract, *unstarted* watcher for events.
+///
+/// Holds only the static dependencies needed to poll for blocks and extract logs; the starting
+/// point is supplied later to [`run`](Self::run), which resolves it (via [`StartResolver`]) into
+/// a concrete start block plus processor and then runs the poll loop. This lets watchers be
+/// created in one place and started in another, once the first replayed block is known.
+pub struct L1Watcher<S> {
     provider: NodeProvider,
     address: ValueOrArray<Address>,
-    next_block: BlockNumber,
-    /// `Some(eb)` makes the watcher exit `run` once `next_block > eb`. `None` runs forever.
+    /// `Some(eb)` makes the watcher exit once the cursor passes `eb`. `None` runs forever.
     end_block: Option<BlockNumber>,
     max_blocks_to_process: u64,
     block_boundary: BlockBoundary,
-    pub(crate) processor: Box<dyn ProcessRawEvents>,
+    resolve_start: StartResolver<S>,
 }
 
-impl L1Watcher {
+impl<S> L1Watcher<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         config: L1WatcherConfig,
         provider: NodeProvider,
         address: ValueOrArray<Address>,
-        next_block: BlockNumber,
         end_block: Option<BlockNumber>,
         l1_chain_id: u64,
-        processor: Box<dyn ProcessRawEvents>,
+        resolve_start: StartResolver<S>,
     ) -> anyhow::Result<Self> {
         let confirmations = if provider.get_chain_id().await? != l1_chain_id {
             // Gateway case, zero out confirmations.
@@ -49,14 +69,84 @@ impl L1Watcher {
         Ok(Self {
             provider,
             address,
-            next_block,
             end_block,
             max_blocks_to_process: config.max_blocks_to_process,
             block_boundary: BlockBoundary::Confirmed { confirmations },
-            processor,
+            resolve_start,
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_finalized(
+        config: L1WatcherConfig,
+        provider: NodeProvider,
+        address: ValueOrArray<Address>,
+        end_block: Option<BlockNumber>,
+        resolve_start: StartResolver<S>,
+    ) -> Self {
+        Self {
+            provider,
+            address,
+            end_block,
+            max_blocks_to_process: config.max_blocks_to_process,
+            block_boundary: BlockBoundary::Finalized,
+            resolve_start,
+        }
+    }
+
+    /// Resolves the starting point into a concrete start block and processor, then polls for
+    /// new events.
+    ///
+    /// For unbounded watchers (`end_block = None`) this never returns; for bounded watchers it
+    /// returns once the cursor passes `end_block`. A failure to resolve the start block is fatal
+    /// (panics), matching the previous behavior where resolution happened at construction.
+    pub async fn run(self, start: S)
+    where
+        S: Send + 'static,
+    {
+        let Self {
+            provider,
+            address,
+            end_block,
+            max_blocks_to_process,
+            block_boundary,
+            resolve_start,
+        } = self;
+        let (next_block, processor) = resolve_start(start)
+            .await
+            .expect("failed to resolve L1 watcher start block");
+        let mut running = RunningL1Watcher {
+            provider,
+            address,
+            next_block,
+            end_block,
+            max_blocks_to_process,
+            block_boundary,
+            processor,
+        };
+        running.run_inner().await;
+    }
+}
+
+/// Running state of a watcher whose starting point has already been resolved into a concrete
+/// `next_block` and processor. Owns the poll loop; produced by [`L1Watcher::run`] and used
+/// directly by [`SlAwareL1Watcher`](crate::SlAwareL1Watcher) to scan a single pre-resolved
+/// segment.
+pub(crate) struct RunningL1Watcher {
+    provider: NodeProvider,
+    address: ValueOrArray<Address>,
+    next_block: BlockNumber,
+    /// `Some(eb)` makes the watcher exit `run_inner` once `next_block > eb`. `None` runs forever.
+    end_block: Option<BlockNumber>,
+    max_blocks_to_process: u64,
+    block_boundary: BlockBoundary,
+    pub(crate) processor: Box<dyn ProcessRawEvents>,
+}
+
+impl RunningL1Watcher {
+    /// Builds a running watcher for a single pre-resolved segment, tailing the finalized boundary
+    /// (closed segments are dominated by `end_block`, so the boundary mode only matters for the
+    /// open-ended segment).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_finalized(
         config: L1WatcherConfig,
@@ -76,18 +166,8 @@ impl L1Watcher {
             processor,
         }
     }
-}
 
-impl L1Watcher {
-    /// Polls for new events.
-    ///
-    /// For unbounded watchers (`end_block = None`) this never returns; for bounded watchers
-    /// it returns once the cursor passes `end_block`.
-    pub async fn run(mut self) {
-        self.run_inner().await;
-    }
-
-    /// Non-consuming version of `run`, intended for internal usage in this crate.
+    /// Runs the poll loop, intended for internal usage in this crate.
     pub(crate) async fn run_inner(&mut self) {
         let mut headers = match self.block_boundary {
             BlockBoundary::Confirmed { .. } => self.provider.latest_header_watcher().await,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -569,7 +569,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         )
         .await
         .expect("failed to start L1 commit watcher")
-        .run(),
+        .run(()),
     );
 
     runtime.spawn_critical_task(
@@ -583,7 +583,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         )
         .await
         .expect("failed to start L1 execute watcher")
-        .run(),
+        .run(()),
     );
 
     runtime.spawn_critical_task(
@@ -596,7 +596,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         )
         .await
         .expect("failed to start finalized L1 execute watcher")
-        .run(),
+        .run(()),
     );
 
     let first_replay_record = block_replay_storage.get_replay_record(starting_block);
@@ -688,13 +688,12 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 chain_id,
                 node_startup_state.l1_state.l1_chain_id,
                 config.general_config.gateway_chain_id,
-                next_cursors.migration_number,
                 config.l1_watcher_config.clone().into(),
                 sl_chain_id_subpool.clone(),
             )
             .await
             .expect("failed to start gateway migration watcher")
-            .run(),
+            .run(next_cursors.migration_number),
         );
 
         // Initializes `last_finalized_migration` from the SL's `migrationNumber(chainId)` and,
@@ -713,7 +712,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         .await
         .expect("failed to start migration finalized watcher");
         if let Some(watcher) = migration_finalized_watcher {
-            runtime.spawn_critical_task("migration finalized watcher", watcher.run());
+            runtime.spawn_critical_task("migration finalized watcher", watcher.run(()));
         }
 
         // Crashes the node when getSettlementLayer() changes, forcing a restart against the
@@ -736,13 +735,14 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 .clone(),
             config.l1_watcher_config.clone().into(),
             chain_id,
-            next_cursors.interop_root_id,
             interop_roots_subpool.clone(),
         )
-        .await
         .expect("failed to start L1 interop roots watcher")
         {
-            runtime.spawn_critical_task("interop roots watcher", interop_watcher.run());
+            runtime.spawn_critical_task(
+                "interop roots watcher",
+                interop_watcher.run(next_cursors.interop_root_id),
+            );
         }
     }
 
@@ -754,11 +754,10 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             node_startup_state.l1_state.diamond_proxy_l1.clone(),
             node_startup_state.l1_state.diamond_proxy_sl.clone(),
             l1_subpool.clone(),
-            next_cursors.l1_priority_id,
         )
         .await
         .expect("failed to start L1 transaction watcher")
-        .run(),
+        .run(next_cursors.l1_priority_id),
     );
 
     // Transaction acceptance state - tracks whether we're accepting new transactions
@@ -868,12 +867,11 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             node_startup_state.l1_state.diamond_proxy_l1.clone(),
             node_startup_state.l1_state.diamond_proxy_sl.clone(),
             bytecode_supplier_address,
-            current_protocol_version.clone(),
             upgrade_subpool,
         )
         .await
         .expect("failed to start L1 upgrade transaction watcher")
-        .run(),
+        .run(current_protocol_version.clone()),
     );
 
     // ========== Start L1 Persist Batch Watcher ===========
@@ -901,9 +899,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 settlement_layer_intervals,
                 persistent_batch_storage,
             )
-            .await
-            .expect("failed to start L1 batch persist watcher")
-            .run()
+            .run(())
             .await
         }
     });


### PR DESCRIPTION
## Summary

Refactor L1 watchers so the starting point is supplied at `run()` time instead of at construction. `create_watcher` now only takes static dependencies; the cursor / protocol version / finality-derived start is passed to `run(start)`.

This lets watcher components be created in one place and started in another - e.g. later, once the first replayed block (and thus the starting cursors) is known.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

