### PR TITLE
test: fix flaky recovery test

### DIFF
--- a/integration-tests/tests/node/replay_archive.rs
+++ b/integration-tests/tests/node/replay_archive.rs
@@ -68,6 +68,9 @@ async fn encrypted_replay_archive_recovers_node_storage_end_to_end(
     let rocks_db_path = tester.config().general_config.rocks_db_path.clone();
     let stopped = tester.stop().await?;
 
+    // Make sure the node stopped writing to rocksdb before we remove it for recovery.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     tokio::fs::remove_dir_all(&rocks_db_path)
         .await
         .with_context(|| format!("failed to remove node storage {}", rocks_db_path.display()))?;


### PR DESCRIPTION
## Summary

`remove_dir_all` fails if the process still writes to the dir

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

