### PR TITLE
feat(l1-sender): Make confirmation requirement configurable

### DIFF
--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -2,12 +2,12 @@ use std::marker::PhantomData;
 use std::time::Duration;
 use zksync_os_operator_signer::SignerConfig;
 
-/// Default number of confirmations required for transactions settled directly on L1.
+/// Default confirmations required when settling directly on L1.
 pub const DEFAULT_REQUIRED_CONFIRMATIONS_L1: u64 = 3;
-/// Default number of confirmations required for transactions settled on a Gateway.
+/// Default confirmations required when settling on a Gateway.
 ///
-/// In case there's only one chain connected to gateway, it is very likely that there will be not
-/// enough block production to reach 3 confirmations for such transactions.
+/// Kept low because a Gateway with a single connected chain may not produce enough blocks to reach
+/// the L1 default.
 pub const DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
 
 /// Configuration of L1 sender.
@@ -33,11 +33,7 @@ pub struct L1SenderConfig<Input> {
     /// Maximum time to wait for a transaction to be included on L1.
     pub transaction_timeout: Duration,
 
-    /// Number of confirmations (settlement-layer blocks, inclusive of the inclusion block) a
-    /// transaction must accumulate before it is treated as confirmed.
-    ///
-    /// Defaults differ by settlement layer: [`DEFAULT_REQUIRED_CONFIRMATIONS_L1`] for L1 and
-    /// [`DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY`] for Gateway.
+    /// Settlement-layer blocks (inclusive of the inclusion block) before a transaction is confirmed.
     pub required_confirmations: u64,
 
     /// Use Fusaka blob transaction format if the timestamp has passed.

--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -2,6 +2,14 @@ use std::marker::PhantomData;
 use std::time::Duration;
 use zksync_os_operator_signer::SignerConfig;
 
+/// Default number of confirmations required for transactions settled directly on L1.
+pub const DEFAULT_REQUIRED_CONFIRMATIONS_L1: u64 = 3;
+/// Default number of confirmations required for transactions settled on a Gateway.
+///
+/// In case there's only one chain connected to gateway, it is very likely that there will be not
+/// enough block production to reach 3 confirmations for such transactions.
+pub const DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
+
 /// Configuration of L1 sender.
 #[derive(Clone, Debug)]
 pub struct L1SenderConfig<Input> {
@@ -24,6 +32,13 @@ pub struct L1SenderConfig<Input> {
 
     /// Maximum time to wait for a transaction to be included on L1.
     pub transaction_timeout: Duration,
+
+    /// Number of confirmations (settlement-layer blocks, inclusive of the inclusion block) a
+    /// transaction must accumulate before it is treated as confirmed.
+    ///
+    /// Defaults differ by settlement layer: [`DEFAULT_REQUIRED_CONFIRMATIONS_L1`] for L1 and
+    /// [`DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY`] for Gateway.
+    pub required_confirmations: u64,
 
     /// Use Fusaka blob transaction format if the timestamp has passed.
     pub fusaka_upgrade_timestamp: u64,

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -66,10 +66,6 @@ const METHOD_NOT_FOUND_CODE: i64 = -32601;
 type TransactionReceiptFuture = BoxFuture<'static, anyhow::Result<TransactionReceipt>>;
 type PendingTx<Input> = (TransactionReceiptFuture, Input, Instant);
 
-const REQUIRED_CONFIRMATIONS_L1: u64 = 3;
-/// In case there's only one chain connected to gateway, it is very likely that there will be not enough block production
-/// to reach 3 confirmations for such transactions
-const REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
 const OPERATOR_METRICS_POLL_INTERVAL: Duration = Duration::from_secs(60);
 /// Per-tx gas limit used when `eth_simulateV1` cannot produce a usable estimate.
 /// Sized to cover the bounded set of commit/prove/execute calls.
@@ -413,11 +409,7 @@ where
 
     fn wait_for_confirmed_receipt(&self, tx_hash: B256) -> TransactionReceiptFuture {
         let provider = self.provider.clone();
-        let required_confirmations = if self.gateway {
-            REQUIRED_CONFIRMATIONS_GATEWAY
-        } else {
-            REQUIRED_CONFIRMATIONS_L1
-        };
+        let required_confirmations = self.config.required_confirmations;
         let timeout = self.config.transaction_timeout;
         async move {
             let started_at = Instant::now();

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1074,8 +1074,7 @@ pub struct L1SenderConfig {
     #[config(default_t = 600 * TimeUnit::Seconds)]
     pub transaction_timeout: Duration,
 
-    /// Number of confirmations (L1 blocks, inclusive of the inclusion block) a transaction must
-    /// accumulate before it is treated as confirmed.
+    /// L1 blocks (inclusive of the inclusion block) before a transaction is confirmed.
     #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_L1)]
     pub required_confirmations: u64,
 
@@ -1191,8 +1190,7 @@ pub struct GatewaySenderConfig {
     #[config(default_t = 600 * TimeUnit::Seconds)]
     pub transaction_timeout: Duration,
 
-    /// Number of confirmations (Gateway blocks, inclusive of the inclusion block) a transaction
-    /// must accumulate before it is treated as confirmed.
+    /// Gateway blocks (inclusive of the inclusion block) before a transaction is confirmed.
     #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY)]
     pub required_confirmations: u64,
 }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -24,6 +24,9 @@ use zksync_os_config_validation_macros::ConfigValidate;
 use zksync_os_l1_sender::commands::commit::CommitCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
+use zksync_os_l1_sender::config::{
+    DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY, DEFAULT_REQUIRED_CONFIRMATIONS_L1,
+};
 use zksync_os_mempool::SubPoolLimit;
 use zksync_os_network::{NodeRecord, PeerId, SecretKey};
 use zksync_os_observability::LogFormat;
@@ -1071,6 +1074,11 @@ pub struct L1SenderConfig {
     #[config(default_t = 600 * TimeUnit::Seconds)]
     pub transaction_timeout: Duration,
 
+    /// Number of confirmations (L1 blocks, inclusive of the inclusion block) a transaction must
+    /// accumulate before it is treated as confirmed.
+    #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_L1)]
+    pub required_confirmations: u64,
+
     /// Use Fusaka blob transaction format if the timestamp has passed.
     ///
     /// Defaults to `2^64-1` which is practically never. This is needed for local setup as anvil
@@ -1182,6 +1190,11 @@ pub struct GatewaySenderConfig {
     /// Maximum time to wait for a Gateway transaction to be included.
     #[config(default_t = 600 * TimeUnit::Seconds)]
     pub transaction_timeout: Duration,
+
+    /// Number of confirmations (Gateway blocks, inclusive of the inclusion block) a transaction
+    /// must accumulate before it is treated as confirmed.
+    #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY)]
+    pub required_confirmations: u64,
 }
 
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
@@ -1944,6 +1957,7 @@ impl L1SenderConfig {
             command_limit: self.command_limit,
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
+            required_confirmations: self.required_confirmations,
             fusaka_upgrade_timestamp: self.fusaka_upgrade_timestamp,
             phantom_data: Default::default(),
         }
@@ -2002,6 +2016,7 @@ impl GatewaySenderConfig {
             command_limit: self.command_limit,
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
+            required_confirmations: self.required_confirmations,
             // Gateway transactions never carry blobs, so the EIP-7594 cutover does not apply.
             fusaka_upgrade_timestamp: u64::MAX,
             phantom_data: Default::default(),
@@ -2395,6 +2410,7 @@ mod tests {
                 command_limit: 16,
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),
+                required_confirmations: DEFAULT_REQUIRED_CONFIRMATIONS_L1,
                 fusaka_upgrade_timestamp: u64::MAX,
                 enabled: true,
                 pubdata_mode: Some(PubdataMode::Blobs),


### PR DESCRIPTION
## Summary

Confirmation requirement was constant before(3 for L1, 1 for GW) - here it was made configurable, as 3 confirmations causes some pain especially while working with tests.