### PR TITLE
feat(l1-sender, rpc): Allow inifinite retries through config

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -2238,37 +2238,6 @@ mod tests {
             .unwrap()
     }
 
-    fn parse_l1_sender_config<const N: usize>(env_vars: [(&str, &str); N]) -> L1SenderConfig {
-        let schema = ConfigSchema::new(&L1SenderConfig::DESCRIPTION, "l1_sender");
-        let repo = ConfigRepository::new(&schema).with(Environment::from_iter("", env_vars));
-        repo.single::<L1SenderConfig>().unwrap().parse().unwrap()
-    }
-
-    fn parse_gateway_sender_config<const N: usize>(
-        env_vars: [(&str, &str); N],
-    ) -> GatewaySenderConfig {
-        let schema = ConfigSchema::new(&GatewaySenderConfig::DESCRIPTION, "gateway_sender");
-        let repo = ConfigRepository::new(&schema).with(Environment::from_iter("", env_vars));
-        repo.single::<GatewaySenderConfig>()
-            .unwrap()
-            .parse()
-            .unwrap()
-    }
-
-    #[test]
-    fn l1_sender_rpc_retry_forever_is_enabled_by_default() {
-        let config = parse_l1_sender_config([]);
-
-        assert!(config.rpc_retry_forever);
-    }
-
-    #[test]
-    fn gateway_sender_rpc_retry_forever_is_disabled_by_default() {
-        let config = parse_gateway_sender_config([]);
-
-        assert!(!config.rpc_retry_forever);
-    }
-
     #[test]
     fn replay_archive_config_defaults_to_noop() {
         let config = parse_replay_archive_config([]);

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1056,6 +1056,10 @@ pub struct L1SenderConfig {
     #[config(nest, default)]
     pub force_transaction_resubmission: ForceTransactionResubmissionConfig,
 
+    /// RPC retry overrides for the provider used by L1 sender components.
+    #[config(nest, default)]
+    pub rpc_retry: L1SenderRpcRetryConfig,
+
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     #[config(default_t = 16)]
     pub command_limit: usize,
@@ -1117,6 +1121,27 @@ pub struct ForceTransactionResubmissionConfig {
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
 }
 
+#[derive(Clone, Copy, Debug, Default, DescribeConfig, DeserializeConfig, ConfigValidate)]
+pub struct L1SenderRpcRetryConfig {
+    /// Retry every transport and JSON-RPC error returned to L1 sender components.
+    ///
+    /// This includes non-rate-limit JSON-RPC errors, so only enable it when the sender should keep
+    /// waiting for the RPC endpoint instead of surfacing any RPC failure.
+    #[config(default_t = false)]
+    pub retry_all_errors: bool,
+
+    /// Retry sender RPC calls forever instead of using `l1_provider.max_retries` or
+    /// `gateway_provider.max_retries`.
+    #[config(default_t = false)]
+    pub infinite_retries: bool,
+}
+
+impl L1SenderRpcRetryConfig {
+    pub(crate) fn overrides_default(self) -> bool {
+        self.retry_all_errors || self.infinite_retries
+    }
+}
+
 fn rate_limits_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
     let Some(&global) = limits.get("*") else {
         return true;
@@ -1170,6 +1195,10 @@ pub struct GatewaySenderConfig {
     /// Force transaction resubmission options.
     #[config(nest, default)]
     pub force_transaction_resubmission: ForceTransactionResubmissionConfig,
+
+    /// RPC retry overrides for the provider used by Gateway sender components.
+    #[config(nest, default)]
+    pub rpc_retry: L1SenderRpcRetryConfig,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     #[config(default_t = 16)]
@@ -2392,6 +2421,7 @@ mod tests {
                 max_priority_fee_per_gas: 1 * EtherUnit::Gwei,
                 max_fee_per_blob_gas: 2 * EtherUnit::Gwei,
                 force_transaction_resubmission: ForceTransactionResubmissionConfig::default(),
+                rpc_retry: L1SenderRpcRetryConfig::default(),
                 command_limit: 16,
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1056,9 +1056,9 @@ pub struct L1SenderConfig {
     #[config(nest, default)]
     pub force_transaction_resubmission: ForceTransactionResubmissionConfig,
 
-    /// RPC retry overrides for the provider used by L1 sender components.
-    #[config(nest, default)]
-    pub rpc_retry: L1SenderRpcRetryConfig,
+    /// Retry sender RPC calls on all errors forever.
+    #[config(default_t = true)]
+    pub rpc_retry_forever: bool,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     #[config(default_t = 16)]
@@ -1121,27 +1121,6 @@ pub struct ForceTransactionResubmissionConfig {
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
 }
 
-#[derive(Clone, Copy, Debug, Default, DescribeConfig, DeserializeConfig, ConfigValidate)]
-pub struct L1SenderRpcRetryConfig {
-    /// Retry every transport and JSON-RPC error returned to L1 sender components.
-    ///
-    /// This includes non-rate-limit JSON-RPC errors, so only enable it when the sender should keep
-    /// waiting for the RPC endpoint instead of surfacing any RPC failure.
-    #[config(default_t = false)]
-    pub retry_all_errors: bool,
-
-    /// Retry sender RPC calls forever instead of using `l1_provider.max_retries` or
-    /// `gateway_provider.max_retries`.
-    #[config(default_t = false)]
-    pub infinite_retries: bool,
-}
-
-impl L1SenderRpcRetryConfig {
-    pub(crate) fn overrides_default(self) -> bool {
-        self.retry_all_errors || self.infinite_retries
-    }
-}
-
 fn rate_limits_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
     let Some(&global) = limits.get("*") else {
         return true;
@@ -1196,9 +1175,9 @@ pub struct GatewaySenderConfig {
     #[config(nest, default)]
     pub force_transaction_resubmission: ForceTransactionResubmissionConfig,
 
-    /// RPC retry overrides for the provider used by Gateway sender components.
-    #[config(nest, default)]
-    pub rpc_retry: L1SenderRpcRetryConfig,
+    /// Retry sender RPC calls on all errors forever.
+    #[config(default_t = false)]
+    pub rpc_retry_forever: bool,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
     #[config(default_t = 16)]
@@ -2259,6 +2238,37 @@ mod tests {
             .unwrap()
     }
 
+    fn parse_l1_sender_config<const N: usize>(env_vars: [(&str, &str); N]) -> L1SenderConfig {
+        let schema = ConfigSchema::new(&L1SenderConfig::DESCRIPTION, "l1_sender");
+        let repo = ConfigRepository::new(&schema).with(Environment::from_iter("", env_vars));
+        repo.single::<L1SenderConfig>().unwrap().parse().unwrap()
+    }
+
+    fn parse_gateway_sender_config<const N: usize>(
+        env_vars: [(&str, &str); N],
+    ) -> GatewaySenderConfig {
+        let schema = ConfigSchema::new(&GatewaySenderConfig::DESCRIPTION, "gateway_sender");
+        let repo = ConfigRepository::new(&schema).with(Environment::from_iter("", env_vars));
+        repo.single::<GatewaySenderConfig>()
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn l1_sender_rpc_retry_forever_is_enabled_by_default() {
+        let config = parse_l1_sender_config([]);
+
+        assert!(config.rpc_retry_forever);
+    }
+
+    #[test]
+    fn gateway_sender_rpc_retry_forever_is_disabled_by_default() {
+        let config = parse_gateway_sender_config([]);
+
+        assert!(!config.rpc_retry_forever);
+    }
+
     #[test]
     fn replay_archive_config_defaults_to_noop() {
         let config = parse_replay_archive_config([]);
@@ -2421,7 +2431,7 @@ mod tests {
                 max_priority_fee_per_gas: 1 * EtherUnit::Gwei,
                 max_fee_per_blob_gas: 2 * EtherUnit::Gwei,
                 force_transaction_resubmission: ForceTransactionResubmissionConfig::default(),
-                rpc_retry: L1SenderRpcRetryConfig::default(),
+                rpc_retry_forever: true,
                 command_limit: 16,
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1407,13 +1407,13 @@ async fn build_l1_sender_provider(
     sl_provider: &NodeProvider,
     settles_on_gateway: bool,
 ) -> NodeProvider {
-    let rpc_retry_config = if settles_on_gateway {
-        config.gateway_sender_config.rpc_retry
+    let rpc_retry_forever = if settles_on_gateway {
+        config.gateway_sender_config.rpc_retry_forever
     } else {
-        config.l1_sender_config.rpc_retry
+        config.l1_sender_config.rpc_retry_forever
     };
 
-    if !rpc_retry_config.overrides_default() {
+    if !rpc_retry_forever {
         return sl_provider.clone();
     }
 
@@ -1430,10 +1430,7 @@ async fn build_l1_sender_provider(
     };
 
     tracing::info!(
-        "using dedicated {provider_kind:?} settlement provider with RPC retry overrides: \
-         retry_all_errors={}, infinite_retries={}",
-        rpc_retry_config.retry_all_errors,
-        rpc_retry_config.infinite_retries,
+        "using dedicated {provider_kind:?} settlement provider with RPC retry forever enabled"
     );
 
     build_node_provider(
@@ -1443,9 +1440,8 @@ async fn build_l1_sender_provider(
         0,
         provider_kind,
         Some(ProviderRetryConfig {
-            max_retries: (!rpc_retry_config.infinite_retries)
-                .then_some(provider_config.max_retries),
-            retry_all_errors: rpc_retry_config.retry_all_errors,
+            max_retries: None,
+            retry_all_errors: true,
             backoff: provider_config.retry_backoff,
         }),
     )

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -40,7 +40,7 @@ use crate::prover_api::prover_server;
 use crate::prover_api::snark_job_manager::{FakeSnarkProver, SnarkJobManager};
 use crate::prover_api::snark_proving_pipeline_step::SnarkProvingPipelineStep;
 use crate::prover_input_generator::ProverInputGenerator;
-use crate::provider::{ProviderKind, build_node_provider};
+use crate::provider::{ProviderKind, ProviderRetryConfig, build_node_provider};
 use crate::state_initializer::StateInitializer;
 use crate::tree_manager::TreeManager;
 use alloy::consensus::BlobTransactionSidecar;
@@ -198,6 +198,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         config.l1_watcher_config.finalized_poll_interval,
         config.l1_watcher_config.logs_cache_capacity,
         ProviderKind::L1,
+        None,
     )
     .await;
     let gateway_provider = if let Some(gw_config) = &config.gateway_provider_config {
@@ -208,6 +209,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 config.l1_watcher_config.finalized_poll_interval,
                 config.l1_watcher_config.logs_cache_capacity,
                 ProviderKind::Gateway,
+                None,
             )
             .await,
         )
@@ -1277,6 +1279,9 @@ async fn run_main_node_pipeline(
         );
     }
 
+    let l1_sender_provider =
+        build_l1_sender_provider(config, &sl_provider, settles_on_gateway).await;
+
     // Pick the L1Sender config based on whether the chain is currently settling on Gateway:
     // when it is, gateway_sender operator keys (funded on Gateway) and gateway_sender fee caps are used;
     // otherwise the L1-targeted l1_sender config is used.
@@ -1352,7 +1357,7 @@ async fn run_main_node_pipeline(
             ReplayArchiveGateComponent::new(replay_archiver, block_replay_storage.clone())
         }))
         .pipe(L1Sender::<CommitCommand> {
-            provider: sl_provider.clone(),
+            provider: l1_sender_provider.clone(),
             config: commit_sender_config,
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: settles_on_gateway,
@@ -1364,7 +1369,7 @@ async fn run_main_node_pipeline(
             node_state_on_startup.l1_state.last_executed_batch + 1,
         ))
         .pipe(L1Sender::<ProofCommand> {
-            provider: sl_provider.clone(),
+            provider: l1_sender_provider.clone(),
             config: prove_sender_config,
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: settles_on_gateway,
@@ -1381,7 +1386,7 @@ async fn run_main_node_pipeline(
             .unwrap(),
         )
         .pipe(L1Sender {
-            provider: sl_provider,
+            provider: l1_sender_provider,
             config: execute_sender_config,
             to_address: node_state_on_startup.l1_state.validator_timelock_sl,
             gateway: settles_on_gateway,
@@ -1395,6 +1400,56 @@ async fn run_main_node_pipeline(
     pipeline.spawn();
     let snapshot_rx = PipelineTracker::spawn(runtime, components);
     monitor.spawn(runtime, snapshot_rx)
+}
+
+async fn build_l1_sender_provider(
+    config: &Config,
+    sl_provider: &NodeProvider,
+    settles_on_gateway: bool,
+) -> NodeProvider {
+    let rpc_retry_config = if settles_on_gateway {
+        config.gateway_sender_config.rpc_retry
+    } else {
+        config.l1_sender_config.rpc_retry
+    };
+
+    if !rpc_retry_config.overrides_default() {
+        return sl_provider.clone();
+    }
+
+    let (provider_config, provider_kind) = if settles_on_gateway {
+        (
+            config
+                .gateway_provider_config
+                .as_ref()
+                .expect("gateway_provider config must be set when settling on Gateway"),
+            ProviderKind::GatewayCustomRetries,
+        )
+    } else {
+        (&config.l1_provider_config, ProviderKind::L1CustomRetries)
+    };
+
+    tracing::info!(
+        "using dedicated {provider_kind:?} settlement provider with RPC retry overrides: \
+         retry_all_errors={}, infinite_retries={}",
+        rpc_retry_config.retry_all_errors,
+        rpc_retry_config.infinite_retries,
+    );
+
+    build_node_provider(
+        provider_config,
+        config.l1_watcher_config.poll_interval,
+        config.l1_watcher_config.finalized_poll_interval,
+        0,
+        provider_kind,
+        Some(ProviderRetryConfig {
+            max_retries: (!rpc_retry_config.infinite_retries)
+                .then_some(provider_config.max_retries),
+            retry_all_errors: rpc_retry_config.retry_all_errors,
+            backoff: provider_config.retry_backoff,
+        }),
+    )
+    .await
 }
 
 /// Only for EN - we still populate channels destined for the batcher subsystem -

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -40,7 +40,7 @@ use crate::prover_api::prover_server;
 use crate::prover_api::snark_job_manager::{FakeSnarkProver, SnarkJobManager};
 use crate::prover_api::snark_proving_pipeline_step::SnarkProvingPipelineStep;
 use crate::prover_input_generator::ProverInputGenerator;
-use crate::provider::{ProviderKind, ProviderRetryConfig, build_node_provider};
+use crate::provider::{ProviderKind, build_node_provider};
 use crate::state_initializer::StateInitializer;
 use crate::tree_manager::TreeManager;
 use alloy::consensus::BlobTransactionSidecar;
@@ -198,7 +198,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         config.l1_watcher_config.finalized_poll_interval,
         config.l1_watcher_config.logs_cache_capacity,
         ProviderKind::L1,
-        None,
+        false,
     )
     .await;
     let gateway_provider = if let Some(gw_config) = &config.gateway_provider_config {
@@ -209,7 +209,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 config.l1_watcher_config.finalized_poll_interval,
                 config.l1_watcher_config.logs_cache_capacity,
                 ProviderKind::Gateway,
-                None,
+                false,
             )
             .await,
         )
@@ -1439,11 +1439,7 @@ async fn build_l1_sender_provider(
         config.l1_watcher_config.finalized_poll_interval,
         0,
         provider_kind,
-        Some(ProviderRetryConfig {
-            max_retries: None,
-            retry_all_errors: true,
-            backoff: provider_config.retry_backoff,
-        }),
+        true,
     )
     .await
 }

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -17,6 +17,25 @@ use zksync_os_provider::NodeProvider;
 pub(crate) enum ProviderKind {
     L1,
     Gateway,
+    L1CustomRetries,
+    GatewayCustomRetries,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProviderRetryConfig {
+    pub(crate) max_retries: Option<u32>,
+    pub(crate) retry_all_errors: bool,
+    pub(crate) backoff: Duration,
+}
+
+impl ProviderRetryConfig {
+    pub(crate) fn from_provider_config(config: &ProviderConfig) -> Self {
+        Self {
+            max_retries: Some(config.max_retries),
+            retry_all_errors: false,
+            backoff: config.retry_backoff,
+        }
+    }
 }
 
 pub(crate) async fn build_node_provider(
@@ -25,16 +44,18 @@ pub(crate) async fn build_node_provider(
     finalized_poll_interval: Duration,
     log_cache_capacity: usize,
     provider: ProviderKind,
+    retry_config: Option<ProviderRetryConfig>,
 ) -> NodeProvider {
-    let max_retries = config.max_retries;
-    let retry_backoff = config.retry_backoff;
+    let retry_config =
+        retry_config.unwrap_or_else(|| ProviderRetryConfig::from_provider_config(config));
     let provider_layers = ServiceBuilder::new()
         .layer_fn(move |inner| latency::LatencyService { inner, provider })
         .layer_fn(move |inner| retry::RetryService {
             inner,
             provider,
-            max_retries,
-            backoff: retry_backoff,
+            max_retries: retry_config.max_retries,
+            retry_all_errors: retry_config.retry_all_errors,
+            backoff: retry_config.backoff,
         });
 
     let client = RpcClient::builder()

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -21,41 +21,22 @@ pub(crate) enum ProviderKind {
     GatewayCustomRetries,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ProviderRetryConfig {
-    pub(crate) max_retries: Option<u32>,
-    pub(crate) retry_all_errors: bool,
-    pub(crate) backoff: Duration,
-}
-
-impl ProviderRetryConfig {
-    pub(crate) fn from_provider_config(config: &ProviderConfig) -> Self {
-        Self {
-            max_retries: Some(config.max_retries),
-            retry_all_errors: false,
-            backoff: config.retry_backoff,
-        }
-    }
-}
-
 pub(crate) async fn build_node_provider(
     config: &ProviderConfig,
     latest_poll_interval: Duration,
     finalized_poll_interval: Duration,
     log_cache_capacity: usize,
     provider: ProviderKind,
-    retry_config: Option<ProviderRetryConfig>,
+    infinite_retries: bool,
 ) -> NodeProvider {
-    let retry_config =
-        retry_config.unwrap_or_else(|| ProviderRetryConfig::from_provider_config(config));
     let provider_layers = ServiceBuilder::new()
         .layer_fn(move |inner| latency::LatencyService { inner, provider })
         .layer_fn(move |inner| retry::RetryService {
             inner,
             provider,
-            max_retries: retry_config.max_retries,
-            retry_all_errors: retry_config.retry_all_errors,
-            backoff: retry_config.backoff,
+            max_retries: config.max_retries,
+            infinite_retries,
+            backoff: config.retry_backoff,
         });
 
     let client = RpcClient::builder()

--- a/node/bin/src/provider/retry.rs
+++ b/node/bin/src/provider/retry.rs
@@ -13,14 +13,14 @@ use tower::Service;
 pub(super) struct RetryService<S> {
     pub(super) inner: S,
     pub(super) provider: ProviderKind,
-    pub(super) max_retries: Option<u32>,
-    pub(super) retry_all_errors: bool,
+    pub(super) max_retries: u32,
+    pub(super) infinite_retries: bool,
     pub(super) backoff: Duration,
 }
 
 impl<S> RetryService<S> {
-    fn should_retry(error: &TransportError, retry_all_errors: bool) -> bool {
-        if retry_all_errors {
+    fn should_retry(error: &TransportError, infinite_retries: bool) -> bool {
+        if infinite_retries {
             return true;
         }
         if RateLimitRetryPolicy::default().should_retry(error) {
@@ -71,7 +71,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, inner);
         let provider = self.provider;
         let max_retries = self.max_retries;
-        let retry_all_errors = self.retry_all_errors;
+        let infinite_retries = self.infinite_retries;
         let backoff = self.backoff;
         Box::pin(async move {
             let mut retry_number = 0;
@@ -90,9 +90,9 @@ where
                     Err(e) => err = e,
                 }
 
-                if Self::should_retry(&err, retry_all_errors) {
+                if Self::should_retry(&err, infinite_retries) {
                     retry_number += 1;
-                    if max_retries.is_some_and(|max_retries| retry_number > max_retries) {
+                    if !infinite_retries && retry_number > max_retries {
                         return Err(TransportErrorKind::custom_str(&format!(
                             "Max retries exceeded {err}"
                         )));
@@ -143,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    fn retry_all_errors_policy_retries_any_transport_error() {
+    fn infinite_retries_policy_retries_any_transport_error() {
         assert!(RetryService::<()>::should_retry(
             &error_response(-32001),
             true

--- a/node/bin/src/provider/retry.rs
+++ b/node/bin/src/provider/retry.rs
@@ -13,12 +13,16 @@ use tower::Service;
 pub(super) struct RetryService<S> {
     pub(super) inner: S,
     pub(super) provider: ProviderKind,
-    pub(super) max_retries: u32,
+    pub(super) max_retries: Option<u32>,
+    pub(super) retry_all_errors: bool,
     pub(super) backoff: Duration,
 }
 
 impl<S> RetryService<S> {
-    fn should_retry(error: &TransportError) -> bool {
+    fn should_retry(error: &TransportError, retry_all_errors: bool) -> bool {
+        if retry_all_errors {
+            return true;
+        }
         if RateLimitRetryPolicy::default().should_retry(error) {
             return true;
         }
@@ -67,6 +71,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, inner);
         let provider = self.provider;
         let max_retries = self.max_retries;
+        let retry_all_errors = self.retry_all_errors;
         let backoff = self.backoff;
         Box::pin(async move {
             let mut retry_number = 0;
@@ -85,9 +90,9 @@ where
                     Err(e) => err = e,
                 }
 
-                if Self::should_retry(&err) {
+                if Self::should_retry(&err, retry_all_errors) {
                     retry_number += 1;
-                    if retry_number > max_retries {
+                    if max_retries.is_some_and(|max_retries| retry_number > max_retries) {
                         return Err(TransportErrorKind::custom_str(&format!(
                             "Max retries exceeded {err}"
                         )));
@@ -100,5 +105,52 @@ where
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::rpc::json_rpc::ErrorPayload;
+    use std::borrow::Cow;
+
+    fn error_response(code: i64) -> TransportError {
+        TransportError::ErrorResp(ErrorPayload {
+            code,
+            message: Cow::Borrowed("rpc error"),
+            data: None,
+        })
+    }
+
+    #[test]
+    fn default_policy_retries_known_rpc_failures_only() {
+        assert!(RetryService::<()>::should_retry(
+            &TransportErrorKind::http_error(500, String::new()),
+            false
+        ));
+        assert!(RetryService::<()>::should_retry(
+            &error_response(-32603),
+            false
+        ));
+        assert!(!RetryService::<()>::should_retry(
+            &error_response(-32001),
+            false
+        ));
+        assert!(!RetryService::<()>::should_retry(
+            &TransportErrorKind::pubsub_unavailable(),
+            false
+        ));
+    }
+
+    #[test]
+    fn retry_all_errors_policy_retries_any_transport_error() {
+        assert!(RetryService::<()>::should_retry(
+            &error_response(-32001),
+            true
+        ));
+        assert!(RetryService::<()>::should_retry(
+            &TransportErrorKind::pubsub_unavailable(),
+            true
+        ));
     }
 }


### PR DESCRIPTION
## Summary

L1 sender should not crash the whole sequencer in case of any RPC issues. This PR adds config option that should allow to override the existing behaviour of l1 sender's RPC provider.

