### PR TITLE
feat(rpc): add zks finality methods for blocks, transactions and batches

### DIFF
--- a/integration-tests/tests/rpc/finality.rs
+++ b/integration-tests/tests/rpc/finality.rs
@@ -1,0 +1,108 @@
+use alloy::eips::BlockNumberOrTag;
+use alloy::network::{ReceiptResponse, TransactionBuilder};
+use alloy::primitives::{Address, B256, U256};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use zksync_os_alloy_ext::provider::ZksyncApi;
+use zksync_os_integration_tests::assert_traits::ReceiptAssert;
+use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_rpc_api::finality::FinalityStage;
+
+/// Submits a transaction, waits for it to be executed on L1, and checks that every `zks` finality
+/// method reports a consistent view of the block / transaction / batch and the node-wide frontiers.
+#[test_multisetup([CURRENT_TO_L1])]
+async fn finality_progression(tester: Tester) -> anyhow::Result<()> {
+    // The `zks_*` finality methods live on the ZKsync-network provider; transactions go through the
+    // Ethereum-compatible one.
+    let zk = &tester.l2_zk_provider;
+
+    // 10x buffer on gas price so the tx doesn't get stuck while L1 catches up.
+    let gas_price = tester.l2_provider.get_gas_price().await? * 10;
+    let tx = TransactionRequest::default()
+        .with_to(Address::random())
+        .with_value(U256::from(100))
+        .with_gas_price(gas_price);
+    let receipt = tester
+        .l2_provider
+        .send_transaction(tx)
+        .await?
+        .expect_to_execute()
+        .await?;
+    let block_number = receipt.block_number().expect("receipt has a block number");
+    let tx_hash = receipt.transaction_hash();
+
+    // Node-wide snapshot: ordering invariant + liveness for the executed block.
+    let status = zk.get_finality_status().await?;
+    assert!(status.last_finalized_executed_block <= status.last_executed_block);
+    assert!(status.last_executed_block <= status.last_committed_block);
+    assert!(status.last_committed_block <= status.last_sealed_block);
+    assert!(status.last_finalized_executed_batch <= status.last_executed_batch);
+    assert!(status.last_executed_batch <= status.last_committed_batch);
+    assert!(status.last_executed_block >= block_number);
+
+    // Block finality: at least executed, with the containing batch resolved.
+    let block_finality = zk
+        .get_block_finality(BlockNumberOrTag::Number(block_number))
+        .await?
+        .expect("a known block has a finality status");
+    assert!(matches!(
+        block_finality.stage,
+        FinalityStage::Executed | FinalityStage::Finalized
+    ));
+    assert_eq!(block_finality.block_number, Some(block_number));
+    let batch_number = block_finality
+        .batch_number
+        .expect("an executed block belongs to a batch");
+
+    // Transaction finality matches its including block.
+    let tx_finality = zk
+        .get_transaction_finality(tx_hash)
+        .await?
+        .expect("a known transaction has a finality status");
+    assert!(matches!(
+        tx_finality.stage,
+        FinalityStage::Executed | FinalityStage::Finalized
+    ));
+    assert_eq!(tx_finality.block_number, Some(block_number));
+    assert_eq!(tx_finality.batch_number, Some(batch_number));
+
+    // Batch finality: the block's batch is at least executed.
+    let batch_finality = zk.get_batch_finality(batch_number).await?;
+    assert!(matches!(
+        batch_finality.stage,
+        FinalityStage::Executed | FinalityStage::Finalized
+    ));
+    assert_eq!(batch_finality.batch_number, Some(batch_number));
+
+    // Tag self-consistency: the `finalized` block is Finalized; the `safe` block is at least Committed.
+    let finalized = zk
+        .get_block_finality(BlockNumberOrTag::Finalized)
+        .await?
+        .expect("the finalized block has a finality status");
+    assert!(matches!(finalized.stage, FinalityStage::Finalized));
+    let safe = zk
+        .get_block_finality(BlockNumberOrTag::Safe)
+        .await?
+        .expect("the safe block has a finality status");
+    assert!(matches!(
+        safe.stage,
+        FinalityStage::Committed | FinalityStage::Executed | FinalityStage::Finalized
+    ));
+
+    // Unknown / future inputs.
+    let future_block = status.last_sealed_block + 1_000_000;
+    assert!(
+        zk.get_block_finality(BlockNumberOrTag::Number(future_block))
+            .await?
+            .is_none()
+    );
+    let future_batch = status.last_committed_batch + 1_000_000;
+    let future_batch_finality = zk.get_batch_finality(future_batch).await?;
+    assert!(matches!(
+        future_batch_finality.stage,
+        FinalityStage::Pending
+    ));
+    assert!(zk.get_transaction_finality(B256::random()).await?.is_none());
+
+    Ok(())
+}

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -4,6 +4,7 @@ mod debug;
 mod deployment_filter;
 mod fill_transaction;
 mod filter;
+mod finality;
 mod policy_client;
 mod pubsub;
 mod simulate;

--- a/lib/alloy_ext/src/provider.rs
+++ b/lib/alloy_ext/src/provider.rs
@@ -1,10 +1,12 @@
 use crate::network::Zksync;
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, BlockNumber, StorageKey, TxHash};
 use alloy::providers::Provider;
 use alloy::transports::TransportResult;
 use serde::Deserialize;
 use std::time::Duration;
 use zksync_os_contract_interface::models::StoredBatchInfo;
+use zksync_os_rpc_api::finality::{FinalityResponse, NodeFinalityStatus};
 use zksync_os_rpc_api::types::{BatchStorageProof, L2ToL1LogProof, LogProofTarget};
 
 /// RPC interface that gives access to methods specific to ZKsync OS.
@@ -61,6 +63,34 @@ pub trait ZksyncApi: Provider<Zksync> {
             .await?;
         tracing::debug!(block_number, ?batch_info, "got batch info for block");
         Ok(batch_info.batch_number)
+    }
+
+    async fn get_block_finality(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> TransportResult<Option<FinalityResponse>> {
+        self.client()
+            .request("zks_getBlockFinality", (block,))
+            .await
+    }
+
+    async fn get_transaction_finality(
+        &self,
+        tx_hash: TxHash,
+    ) -> TransportResult<Option<FinalityResponse>> {
+        self.client()
+            .request("zks_getTransactionFinality", (tx_hash,))
+            .await
+    }
+
+    async fn get_batch_finality(&self, batch_number: u64) -> TransportResult<FinalityResponse> {
+        self.client()
+            .request("zks_getBatchFinality", (batch_number,))
+            .await
+    }
+
+    async fn get_finality_status(&self) -> TransportResult<NodeFinalityStatus> {
+        self.client().request("zks_getFinalityStatus", ()).await
     }
 
     async fn wait_batch_number_by_block_number(

--- a/lib/rpc/src/finality_impl.rs
+++ b/lib/rpc/src/finality_impl.rs
@@ -1,0 +1,134 @@
+use crate::ReadRpcStorage;
+use crate::result::ToRpcResult;
+use alloy::eips::{BlockId, BlockNumberOrTag};
+use alloy::primitives::TxHash;
+use jsonrpsee::core::RpcResult;
+use zksync_os_rpc_api::finality::{
+    FinalityResponse, FinalityStage, NodeFinalityStatus, ZksFinalityApiServer,
+};
+use zksync_os_storage_api::RepositoryError;
+
+pub struct FinalityNamespace<RpcStorage> {
+    storage: RpcStorage,
+}
+
+impl<RpcStorage> FinalityNamespace<RpcStorage> {
+    pub fn new(storage: RpcStorage) -> Self {
+        Self { storage }
+    }
+}
+
+/// Classifies a block or batch number against the committed, executed and finalized frontiers.
+fn finality_stage(number: u64, committed: u64, executed: u64, finalized: u64) -> FinalityStage {
+    if number <= finalized {
+        FinalityStage::Finalized
+    } else if number <= executed {
+        FinalityStage::Executed
+    } else if number <= committed {
+        FinalityStage::Committed
+    } else {
+        FinalityStage::Pending
+    }
+}
+
+impl<RpcStorage: ReadRpcStorage> FinalityNamespace<RpcStorage> {
+    /// Builds a [`FinalityResponse`] for a block known to exist, enriching it with the containing
+    /// batch number once that batch is executed.
+    fn block_finality(&self, block_number: u64) -> FinalityResult<FinalityResponse> {
+        let finality = self.storage.finality().get_finality_status();
+        let batch = self
+            .storage
+            .batch()
+            .get_batch_by_block_number(block_number)?;
+        Ok(FinalityResponse {
+            stage: finality_stage(
+                block_number,
+                finality.last_committed_block,
+                finality.last_executed_block,
+                finality.last_finalized_executed_block,
+            ),
+            block_number: Some(block_number),
+            batch_number: batch.map(|b| b.number()),
+        })
+    }
+
+    fn get_block_finality_impl(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> FinalityResult<Option<FinalityResponse>> {
+        let Some(block_number) = self.storage.resolve_block_number(BlockId::Number(block))? else {
+            return Ok(None);
+        };
+        // `resolve_block_number` does not check existence for an explicit number, so bound it by the
+        // latest sealed block; tags always resolve to an existing block.
+        if block_number > self.storage.repository().get_latest_block() {
+            return Ok(None);
+        }
+        Ok(Some(self.block_finality(block_number)?))
+    }
+
+    fn get_transaction_finality_impl(
+        &self,
+        tx_hash: TxHash,
+    ) -> FinalityResult<Option<FinalityResponse>> {
+        let Some(meta) = self.storage.repository().get_transaction_meta(tx_hash)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.block_finality(meta.block_number)?))
+    }
+
+    fn get_batch_finality_impl(&self, batch_number: u64) -> FinalityResult<FinalityResponse> {
+        let finality = self.storage.finality().get_finality_status();
+        // The block range is only persisted once the batch is executed.
+        let batch = self.storage.batch().get_batch_by_number(batch_number)?;
+        Ok(FinalityResponse {
+            stage: finality_stage(
+                batch_number,
+                finality.last_committed_batch,
+                finality.last_executed_batch,
+                finality.last_finalized_executed_batch,
+            ),
+            block_number: batch.map(|b| b.last_block_number()),
+            batch_number: Some(batch_number),
+        })
+    }
+}
+
+impl<RpcStorage: ReadRpcStorage> ZksFinalityApiServer for FinalityNamespace<RpcStorage> {
+    fn get_block_finality(&self, block: BlockNumberOrTag) -> RpcResult<Option<FinalityResponse>> {
+        self.get_block_finality_impl(block).to_rpc_result()
+    }
+
+    fn get_transaction_finality(&self, tx_hash: TxHash) -> RpcResult<Option<FinalityResponse>> {
+        self.get_transaction_finality_impl(tx_hash).to_rpc_result()
+    }
+
+    fn get_batch_finality(&self, batch_number: u64) -> RpcResult<FinalityResponse> {
+        self.get_batch_finality_impl(batch_number).to_rpc_result()
+    }
+
+    fn get_finality_status(&self) -> RpcResult<NodeFinalityStatus> {
+        let finality = self.storage.finality().get_finality_status();
+        Ok(NodeFinalityStatus {
+            last_sealed_block: self.storage.repository().get_latest_block(),
+            last_committed_block: finality.last_committed_block,
+            last_committed_batch: finality.last_committed_batch,
+            last_executed_block: finality.last_executed_block,
+            last_executed_batch: finality.last_executed_batch,
+            last_finalized_executed_block: finality.last_finalized_executed_block,
+            last_finalized_executed_batch: finality.last_finalized_executed_batch,
+        })
+    }
+}
+
+/// `zks` finality methods result type.
+pub type FinalityResult<Ok> = Result<Ok, FinalityError>;
+
+/// General `zks` finality errors.
+#[derive(Debug, thiserror::Error)]
+pub enum FinalityError {
+    #[error(transparent)]
+    Batch(#[from] anyhow::Error),
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
+}

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -12,6 +12,7 @@ mod eth_fill_transaction_handler;
 mod eth_filter;
 mod eth_impl;
 mod eth_pubsub_impl;
+mod finality_impl;
 mod metrics;
 mod ots_impl;
 mod result;
@@ -38,6 +39,7 @@ use crate::debug_impl::DebugNamespace;
 use crate::eth_filter::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
+use crate::finality_impl::FinalityNamespace;
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
@@ -61,6 +63,7 @@ use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_rpc_api::debug::DebugApiServer;
 use zksync_os_rpc_api::eth::EthApiServer;
 use zksync_os_rpc_api::filter::EthFilterApiServer;
+use zksync_os_rpc_api::finality::ZksFinalityApiServer;
 use zksync_os_rpc_api::net::NetApiServer;
 use zksync_os_rpc_api::ots::OtsApiServer;
 use zksync_os_rpc_api::pubsub::EthPubSubApiServer;
@@ -130,6 +133,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
         )
         .into_rpc(),
     )?;
+    rpc.merge(FinalityNamespace::new(storage.clone()).into_rpc())?;
     rpc.merge(OtsNamespace::new(storage.clone()).into_rpc())?;
     rpc.merge(DebugNamespace::new(storage.clone(), eth_call_handler).into_rpc())?;
     rpc.merge(TxpoolNamespace::new(mempool.clone()).into_rpc())?;

--- a/lib/rpc/src/result.rs
+++ b/lib/rpc/src/result.rs
@@ -8,6 +8,7 @@ use crate::debug_impl::DebugError;
 use crate::eth_call_handler::EthCallError;
 use crate::eth_filter::EthFilterError;
 use crate::eth_impl::EthError;
+use crate::finality_impl::FinalityError;
 use crate::rpc_storage::RpcStorageError;
 use crate::tx_forwarder::TxForwardError;
 use crate::tx_handler::{EthSendRawTransactionError, EthSendRawTransactionSyncError};
@@ -44,6 +45,7 @@ macro_rules! impl_to_rpc_result {
 
 impl_to_rpc_result!(ZksError);
 impl_to_rpc_result!(UnstableError);
+impl_to_rpc_result!(FinalityError);
 
 impl<Ok> ToRpcResult<Ok, EthError> for Result<Ok, EthError> {
     fn to_rpc_result(self) -> RpcResult<Ok> {

--- a/lib/rpc_api/src/finality.rs
+++ b/lib/rpc_api/src/finality.rs
@@ -1,0 +1,84 @@
+//! `zks` finality methods: report how far a block / transaction / batch has progressed through the
+//! L1 finality pipeline (pending → committed → executed → finalized), plus a single-call snapshot of
+//! all finality frontiers.
+
+use alloy::eips::BlockNumberOrTag;
+use alloy::primitives::TxHash;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use serde::{Deserialize, Serialize};
+
+/// Stage reached in the L1 finality pipeline.
+///
+/// Progression, from least to most final: `Pending` → `Committed` → `Executed` → `Finalized`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinalityStage {
+    /// Produced by the sequencer but not yet committed to L1; matches the `latest` block tag.
+    Pending,
+    /// Committed to L1; matches the `safe` block tag.
+    Committed,
+    /// Executed on L1 — the execute transaction is mined, but its L1 block may not be finalized yet.
+    Executed,
+    /// Executed, and the L1 execute transaction is itself finalized (irreversible); matches the
+    /// `finalized` block tag.
+    Finalized,
+}
+
+/// Finality status of a single block, transaction, or batch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinalityResponse {
+    /// Highest finality stage reached.
+    pub stage: FinalityStage,
+    /// L2 block this status refers to: the queried block, the transaction's block, or the batch's
+    /// last block. `None` when it cannot be resolved.
+    pub block_number: Option<u64>,
+    /// L1 batch number, when known. Populated once the batch is executed — the batch↔block mapping
+    /// is only persisted for executed batches.
+    pub batch_number: Option<u64>,
+}
+
+/// Snapshot of every finality frontier the node tracks, in a single call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeFinalityStatus {
+    /// Latest block sealed by the sequencer; matches `latest`.
+    pub last_sealed_block: u64,
+    /// Last L2 block committed to L1; matches `safe`.
+    pub last_committed_block: u64,
+    /// Last batch committed to L1.
+    pub last_committed_batch: u64,
+    /// Last L2 block whose batch was executed on L1.
+    pub last_executed_block: u64,
+    /// Last batch executed on L1.
+    pub last_executed_batch: u64,
+    /// Last executed L2 block whose L1 execute transaction is finalized; matches `finalized`.
+    pub last_finalized_executed_block: u64,
+    /// Last executed batch whose L1 execute transaction is finalized.
+    pub last_finalized_executed_batch: u64,
+}
+
+#[cfg_attr(not(feature = "server"), rpc(client, namespace = "zks"))]
+#[cfg_attr(feature = "server", rpc(server, client, namespace = "zks"))]
+pub trait ZksFinalityApi {
+    /// Returns the finality status of a block (by number or tag), or `null` if the block does not
+    /// exist on this node.
+    #[method(name = "getBlockFinality")]
+    fn get_block_finality(&self, block: BlockNumberOrTag) -> RpcResult<Option<FinalityResponse>>;
+
+    /// Returns the finality status of a transaction (by hash), or `null` if it is unknown to this
+    /// node.
+    #[method(name = "getTransactionFinality")]
+    fn get_transaction_finality(&self, tx_hash: TxHash) -> RpcResult<Option<FinalityResponse>>;
+
+    /// Returns the finality status of an L1 batch (by number). Batches above the committed frontier
+    /// report [`FinalityStage::Pending`].
+    #[method(name = "getBatchFinality")]
+    fn get_batch_finality(&self, batch_number: u64) -> RpcResult<FinalityResponse>;
+
+    /// Returns every finality frontier the node tracks (sealed / committed / executed / finalized)
+    /// in a single call.
+    #[method(name = "getFinalityStatus")]
+    fn get_finality_status(&self) -> RpcResult<NodeFinalityStatus>;
+}

--- a/lib/rpc_api/src/lib.rs
+++ b/lib/rpc_api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod debug;
 pub mod eth;
 pub mod filter;
+pub mod finality;
 pub mod net;
 pub mod ots;
 #[cfg(feature = "server")]


### PR DESCRIPTION
## What

Adds four `zks` JSON-RPC methods that report L1 finality:

| Method | Returns |
|---|---|
| `zks_getBlockFinality(block)` | finality of a block (number or tag), or `null` |
| `zks_getTransactionFinality(txHash)` | finality of a transaction, or `null` |
| `zks_getBatchFinality(batchNumber)` | finality of an L1 batch |
| `zks_getFinalityStatus()` | all finality frontiers in one call |

Each block/tx/batch response carries a `stage` — `pending → committed → executed → finalized` —
mapping onto the existing `FinalityStatus` frontiers (`safe` = committed,
`finalized` = finalized-executed), plus the resolved block and containing batch number.

## Why

Finality is currently only indirectly observable via the `safe`/`finalized` block tags, at block
granularity only. These methods expose it explicitly for blocks, transactions and batches — and
in a single snapshot call — which bridges, indexers and external nodes need (an EN has no finality
RPC or metric today).

## Implementation notes

- New trait `ZksFinalityApi` sharing the `zks` namespace, registered alongside the other
  namespaces. No existing types, methods or wire formats are touched.
- Reads only data the node already tracks (`FinalityStatus` + the executed-batch store); batch
  lookups are local RocksDB point reads.
- No `proven` stage: the node does not track a proven frontier (see the `FinalityStatus` doc
  comment), so only the four tracked stages are emitted.

## Testing

- `integration-tests/tests/rpc/finality.rs` drives a real commit→execute→finalize cycle and
  asserts every method, the ordering invariant, tag self-consistency, and the unknown/future
  cases.
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`,
  and the integration test all pass locally.

Closes #1376 
