### PR TITLE
feat(l1_consistency_checker): verify committed batches concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15589,14 +15589,12 @@ dependencies = [
 name = "zksync_os_l1_consistency_checker"
 version = "0.20.6"
 dependencies = [
- "alloy",
  "anyhow",
  "async-trait",
  "tokio",
  "tracing",
  "zksync_os_batch_types",
  "zksync_os_contract_interface",
- "zksync_os_merkle_tree_api",
  "zksync_os_observability",
  "zksync_os_pipeline",
  "zksync_os_storage_api",

--- a/lib/backpressure/src/config.rs
+++ b/lib/backpressure/src/config.rs
@@ -42,7 +42,7 @@ impl BackpressureConfig {
             ComponentId::BlockCanonizer
             | ComponentId::BlockApplier
             | ComponentId::RevmConsistencyChecker
-            | ComponentId::L1ConsistencyChecker
+            | ComponentId::LocalBatchDataCacher
             | ComponentId::TreeManager
             | ComponentId::ProverInputGenerator => PipelineCondition {
                 max_block_diff_to_upstream: Some(self.default_block_diff_limit),

--- a/lib/batch_types/src/batch_info.rs
+++ b/lib/batch_types/src/batch_info.rs
@@ -9,11 +9,118 @@ use zksync_os_contract_interface::models::{CommitBatchInfo, StoredBatchInfo};
 use zksync_os_merkle_tree_api::TreeBatchOutput;
 use zksync_os_mini_merkle_tree::MiniMerkleTree;
 use zksync_os_types::{
-    BlockOutput, L2_TO_L1_TREE_SIZE, L2ToL1Log, ProtocolSemanticVersion, PubdataMode, ZkEnvelope,
-    ZkTransaction,
+    BlockOutput, InteropRoot, L2_TO_L1_LOG_SERIALIZE_SIZE, L2_TO_L1_TREE_SIZE, L2ToL1Log,
+    ProtocolSemanticVersion, PubdataMode, ZkEnvelope, ZkTransaction,
 };
 
 const PUBDATA_SOURCE_CALLDATA: u8 = 0;
+
+/// Per-block inputs to a batch commitment, pre-folded from full block data.
+///
+/// Carries exactly what [`ExtendedCommitBatchInfo::build`] needs from each block, so callers
+/// that hold blocks for a while (the EN L1 consistency checker, the batch verification
+/// responder) can cache a few hundred bytes per block (plus pubdata) instead of the full
+/// `BlockOutput`/`ReplayRecord` pair. The bulky inputs — full transactions, tx results and
+/// the 8KB block-hashes ring — are reduced to hashes and counters at construction time.
+#[derive(Clone, Debug)]
+pub struct BlockCommitmentData {
+    pub block_number: u64,
+    pub timestamp: u64,
+    /// Onchain-data hashes of the block's L1 (priority) transactions, in execution order.
+    pub l1_tx_onchain_hashes: Vec<B256>,
+    pub num_l2_txs: u64,
+    pub interop_roots: Vec<InteropRoot>,
+    pub upgrade_tx_hash: Option<B256>,
+    /// Encoded L2->L1 logs emitted by the block, in emission order.
+    pub encoded_l2_l1_logs: Vec<[u8; L2_TO_L1_LOG_SERIALIZE_SIZE]>,
+    pub pubdata: Vec<u8>,
+    /// Blake2s over the previous 255 block hashes plus this block's own hash — the value
+    /// `new_state_commitment` needs if this block ends up last in its batch.
+    pub last_256_block_hashes_blake: B256,
+    pub tree_root_hash: B256,
+    pub tree_leaf_count: u64,
+    pub multichain_root: B256,
+    pub protocol_version: ProtocolSemanticVersion,
+}
+
+impl BlockCommitmentData {
+    pub fn new(
+        block_output: &BlockOutput,
+        transactions: &[ZkTransaction],
+        tree_output: &TreeBatchOutput,
+        last_256_block_hashes: &[U256; 256],
+        multichain_root: B256,
+        protocol_version: ProtocolSemanticVersion,
+    ) -> Self {
+        let mut l1_tx_onchain_hashes = Vec::new();
+        let mut num_l2_txs = 0;
+        let mut interop_roots = Vec::new();
+        let mut upgrade_tx_hash = None;
+        for tx in transactions {
+            match tx.envelope() {
+                ZkEnvelope::System(envelope) => {
+                    num_l2_txs += 1;
+                    if let Some(roots) = envelope.interop_roots() {
+                        interop_roots.extend(roots);
+                    }
+                }
+                ZkEnvelope::L2(_) => num_l2_txs += 1,
+                ZkEnvelope::L1(l1_tx) => l1_tx_onchain_hashes.push(*l1_tx.hash()),
+                ZkEnvelope::Upgrade(_) => {
+                    assert!(
+                        upgrade_tx_hash.is_none(),
+                        "more than one upgrade tx in a block: first {upgrade_tx_hash:?}, second {}",
+                        tx.hash()
+                    );
+                    upgrade_tx_hash = Some(*tx.hash());
+                }
+            }
+        }
+
+        let encoded_l2_l1_logs = block_output
+            .tx_results
+            .iter()
+            .flatten()
+            .flat_map(|tx_output| &tx_output.l2_to_l1_logs)
+            .map(|log_with_preimage| {
+                L2ToL1Log {
+                    l2_shard_id: log_with_preimage.log.l2_shard_id,
+                    is_service: log_with_preimage.log.is_service,
+                    tx_number_in_block: log_with_preimage.log.tx_number_in_block,
+                    sender: log_with_preimage.log.sender,
+                    key: log_with_preimage.log.key,
+                    value: log_with_preimage.log.value,
+                }
+                .encode()
+            })
+            .collect();
+
+        let last_256_block_hashes_blake = {
+            let mut blocks_hasher = Blake2s256::new();
+            for block_hash in &last_256_block_hashes[1..] {
+                blocks_hasher.update(block_hash.to_be_bytes::<32>());
+            }
+            blocks_hasher.update(block_output.header.hash());
+            B256::from_slice(&blocks_hasher.finalize())
+        };
+
+        Self {
+            block_number: block_output.header.number,
+            timestamp: block_output.header.timestamp,
+            l1_tx_onchain_hashes,
+            num_l2_txs,
+            interop_roots,
+            upgrade_tx_hash,
+            encoded_l2_l1_logs,
+            pubdata: block_output.pubdata.clone(),
+            last_256_block_hashes_blake,
+            tree_root_hash: tree_output.root_hash,
+            tree_leaf_count: tree_output.leaf_count,
+            multichain_root,
+            protocol_version,
+        }
+    }
+}
 
 /// Commitment information about a batch.
 /// Contains enough data to restore `StoredBatchInfo` that got applied on-chain.
@@ -30,98 +137,57 @@ pub struct ExtendedCommitBatchInfo {
 }
 
 impl ExtendedCommitBatchInfo {
-    #[allow(clippy::too_many_arguments)]
     pub fn build(
-        blocks: Vec<(&BlockOutput, &[ZkTransaction], &TreeBatchOutput)>,
+        blocks: &[BlockCommitmentData],
         chain_id: u64,
         batch_number: u64,
         pubdata_mode: PubdataMode,
         sl_chain_id: u64,
-        multichain_root: B256,
-        protocol_version: &ProtocolSemanticVersion,
-        last_256_block_hashes: &[U256; 256],
     ) -> (Self, Option<BlobTransactionSidecar>) {
+        let first_block = blocks.first().expect("batch cannot be empty");
+        let last_block = blocks.last().expect("batch cannot be empty");
+        // The protocol version (and the multichain root we compare against) is uniform within
+        // a batch — a batch is sealed whenever it changes — so the last block's values stand
+        // in for the whole batch.
+        let protocol_version = &last_block.protocol_version;
+
         let mut priority_operations_hash = keccak256([]);
         let mut number_of_layer1_txs = 0;
         let mut number_of_layer2_txs = 0;
         let mut total_pubdata = vec![];
         let mut encoded_l2_l1_logs = vec![];
-
-        let (first_block_output, _, _) = *blocks.first().unwrap();
-        let (last_block_output, _, last_block_tree) = *blocks.last().unwrap();
-
         let mut upgrade_tx_hash = None;
-
         let mut dependency_roots_rolling_hash = B256::ZERO;
 
-        for (block_output, transactions, _) in blocks {
-            total_pubdata.extend(block_output.pubdata.clone());
+        for block in blocks {
+            total_pubdata.extend_from_slice(&block.pubdata);
+            number_of_layer1_txs += block.l1_tx_onchain_hashes.len() as u64;
+            number_of_layer2_txs += block.num_l2_txs;
+            encoded_l2_l1_logs.extend(block.encoded_l2_l1_logs.iter().copied());
 
-            for tx in transactions {
-                match tx.envelope() {
-                    ZkEnvelope::System(envelope) => {
-                        number_of_layer2_txs += 1;
-
-                        if let Some(roots) = envelope.interop_roots() {
-                            for root in roots {
-                                dependency_roots_rolling_hash = keccak256(
-                                    (
-                                        dependency_roots_rolling_hash,
-                                        root.chainId,
-                                        root.blockOrBatchNumber,
-                                        root.sides,
-                                    )
-                                        .abi_encode_packed(),
-                                );
-                            }
-                        }
-                    }
-                    ZkEnvelope::L2(_) => {
-                        number_of_layer2_txs += 1;
-                    }
-                    ZkEnvelope::L1(l1_tx) => {
-                        let onchain_data_hash = l1_tx.hash();
-                        priority_operations_hash =
-                            keccak256([priority_operations_hash.0, onchain_data_hash.0].concat());
-                        number_of_layer1_txs += 1;
-                    }
-                    ZkEnvelope::Upgrade(_) => {
-                        assert!(
-                            upgrade_tx_hash.is_none(),
-                            "more than one upgrade tx in a batch: first {upgrade_tx_hash:?}, second {}",
-                            tx.hash()
-                        );
-                        upgrade_tx_hash = Some(*tx.hash());
-                    }
-                }
+            for onchain_data_hash in &block.l1_tx_onchain_hashes {
+                priority_operations_hash =
+                    keccak256([priority_operations_hash.0, onchain_data_hash.0].concat());
             }
-
-            for tx_output in block_output.tx_results.clone().into_iter().flatten() {
-                encoded_l2_l1_logs.extend(tx_output.l2_to_l1_logs.into_iter().map(
-                    |log_with_preimage| {
-                        let log = L2ToL1Log {
-                            l2_shard_id: log_with_preimage.log.l2_shard_id,
-                            is_service: log_with_preimage.log.is_service,
-                            tx_number_in_block: log_with_preimage.log.tx_number_in_block,
-                            sender: log_with_preimage.log.sender,
-                            key: log_with_preimage.log.key,
-                            value: log_with_preimage.log.value,
-                        };
-                        log.encode()
-                    },
-                ));
+            for root in &block.interop_roots {
+                dependency_roots_rolling_hash = keccak256(
+                    (
+                        dependency_roots_rolling_hash,
+                        root.chainId,
+                        root.blockOrBatchNumber,
+                        root.sides.clone(),
+                    )
+                        .abi_encode_packed(),
+                );
+            }
+            if let Some(hash) = block.upgrade_tx_hash {
+                assert!(
+                    upgrade_tx_hash.is_none(),
+                    "more than one upgrade tx in a batch: first {upgrade_tx_hash:?}, second {hash}"
+                );
+                upgrade_tx_hash = Some(hash);
             }
         }
-
-        let last_256_block_hashes_blake = {
-            let mut blocks_hasher = Blake2s256::new();
-            for block_hash in &last_256_block_hashes[1..] {
-                blocks_hasher.update(block_hash.to_be_bytes::<32>());
-            }
-            blocks_hasher.update(last_block_output.header.hash());
-
-            blocks_hasher.finalize()
-        };
 
         /* ---------- operator DA input ---------- */
         let da_fields = calculate_da_fields(&total_pubdata, pubdata_mode);
@@ -129,11 +195,11 @@ impl ExtendedCommitBatchInfo {
         /* ---------- new state commitment ---------- */
         // FIXME: extract to a type common batch types?
         let mut hasher = Blake2s256::new();
-        hasher.update(last_block_tree.root_hash.as_slice());
-        hasher.update(last_block_tree.leaf_count.to_be_bytes());
-        hasher.update(last_block_output.header.number.to_be_bytes());
-        hasher.update(last_256_block_hashes_blake);
-        hasher.update(last_block_output.header.timestamp.to_be_bytes());
+        hasher.update(last_block.tree_root_hash.as_slice());
+        hasher.update(last_block.tree_leaf_count.to_be_bytes());
+        hasher.update(last_block.block_number.to_be_bytes());
+        hasher.update(last_block.last_256_block_hashes_blake);
+        hasher.update(last_block.timestamp.to_be_bytes());
         let new_state_commitment = B256::from_slice(&hasher.finalize());
 
         /* ---------- root hash of l2->l1 logs ---------- */
@@ -145,7 +211,7 @@ impl ExtendedCommitBatchInfo {
 
         let l2_to_l1_logs_root_hash = if protocol_version.is_post_v31() {
             // The result should be Keccak(l2_l1_local_root, multichain_root).
-            keccak256([l2_l1_local_root.0, multichain_root.0].concat())
+            keccak256([l2_l1_local_root.0, last_block.multichain_root.0].concat())
         } else {
             // For older protocol versions, multichain root should be set to zero.
             keccak256([l2_l1_local_root.0, [0u8; 32]].concat())
@@ -161,10 +227,10 @@ impl ExtendedCommitBatchInfo {
             l2_to_l1_logs_root_hash,
             l2_da_commitment_scheme: pubdata_mode.da_commitment_scheme(),
             da_commitment: da_fields.da_commitment,
-            first_block_timestamp: first_block_output.header.timestamp,
-            first_block_number: Some(first_block_output.header.number),
-            last_block_timestamp: last_block_output.header.timestamp,
-            last_block_number: Some(last_block_output.header.number),
+            first_block_timestamp: first_block.timestamp,
+            first_block_number: Some(first_block.block_number),
+            last_block_timestamp: last_block.timestamp,
+            last_block_number: Some(last_block.block_number),
             chain_id,
             operator_da_input: da_fields.operator_da_input,
             sl_chain_id,

--- a/lib/batch_types/src/lib.rs
+++ b/lib/batch_types/src/lib.rs
@@ -9,4 +9,4 @@ pub use block_merkle_tree_data::BlockMerkleTreeData;
 mod batch_info;
 pub mod batcher_model;
 
-pub use batch_info::{DiscoveredCommittedBatch, ExtendedCommitBatchInfo};
+pub use batch_info::{BlockCommitmentData, DiscoveredCommittedBatch, ExtendedCommitBatchInfo};

--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -91,26 +91,12 @@ impl BatchVerificationResponder {
                 BatchVerificationError::MissingBlock(request.first_block_number)
             })?;
 
-        let last_block = blocks.last().unwrap();
-
         let (batch_info, _) = ExtendedCommitBatchInfo::build(
-            blocks
-                .iter()
-                .map(|block| {
-                    (
-                        &block.output,
-                        block.record.transactions.as_slice(),
-                        &block.tree_output,
-                    )
-                })
-                .collect(),
+            &blocks,
             self.chain_id,
             request.batch_number,
             request.pubdata_mode,
             self.l1_state.sl_chain_id,
-            last_block.multichain_root,
-            &blocks.first().unwrap().record.protocol_version,
-            &last_block.record.block_context.block_hashes.0,
         );
 
         let expected_commit_data = normalized_commit_data(
@@ -127,7 +113,7 @@ impl BatchVerificationResponder {
             self.diamond_proxy_sl,
             self.l1_state.sl_chain_id,
             self.l1_state.validator_timelock_sl,
-            &blocks.first().unwrap().record.protocol_version,
+            &blocks.first().unwrap().protocol_version,
             &self.signer,
         )
         .await;

--- a/lib/l1_consistency_checker/Cargo.toml
+++ b/lib/l1_consistency_checker/Cargo.toml
@@ -15,10 +15,8 @@ zksync_os_observability.workspace = true
 zksync_os_pipeline.workspace = true
 zksync_os_types.workspace = true
 zksync_os_batch_types.workspace = true
-zksync_os_merkle_tree_api.workspace = true
 
 anyhow.workspace = true
-alloy.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/lib/l1_consistency_checker/src/cache.rs
+++ b/lib/l1_consistency_checker/src/cache.rs
@@ -1,31 +1,19 @@
-use alloy::primitives::B256;
 use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::ops::RangeInclusive;
 use tokio::sync::watch;
-use zksync_os_merkle_tree_api::TreeBatchOutput;
-use zksync_os_storage_api::ReplayRecord;
-use zksync_os_types::BlockOutput;
+use zksync_os_batch_types::BlockCommitmentData;
 
 pub const DEFAULT_MAX_CACHED_TREE_BLOCKS: usize = 4096;
 
-/// Local data needed to reconstruct batch commitments from replayed blocks.
-#[derive(Clone, Debug)]
-pub struct LocalBatchBlockData {
-    pub output: BlockOutput,
-    pub record: ReplayRecord,
-    pub tree_output: TreeBatchOutput,
-    pub multichain_root: B256,
-}
-
-/// Ordered cache of per-block data keyed by block number.
+/// Ordered cache of per-block commitment data keyed by block number.
 ///
 /// Blocks must be inserted consecutively (each block number exactly one greater than the last).
 /// Eviction is the caller's responsibility; they decide when to call
 /// [`TreeBlockCache::remove_lower_or_equal_than`]
 #[derive(Debug)]
 pub struct TreeBlockCache {
-    data: VecDeque<LocalBatchBlockData>,
+    data: VecDeque<BlockCommitmentData>,
     first_block: Option<u64>,
     max_blocks: usize,
 }
@@ -51,7 +39,7 @@ impl TreeBlockCache {
 
     /// Insert a block into the cache. Blocks must arrive consecutively (each block number exactly
     /// one greater than the last).
-    pub fn insert(&mut self, block_number: u64, block: LocalBatchBlockData) -> anyhow::Result<()> {
+    pub fn insert(&mut self, block_number: u64, block: BlockCommitmentData) -> anyhow::Result<()> {
         if let Some((_, last_block)) = self.range() {
             if block_number != last_block + 1 {
                 anyhow::bail!("Out of order block received. This should never happen");
@@ -105,7 +93,7 @@ impl TreeBlockCache {
     pub fn get_range(
         &self,
         range: RangeInclusive<u64>,
-    ) -> anyhow::Result<Option<Vec<LocalBatchBlockData>>> {
+    ) -> anyhow::Result<Option<Vec<BlockCommitmentData>>> {
         let Some((first_block, last_block)) = self.range() else {
             return Ok(None);
         };
@@ -140,7 +128,7 @@ pub trait TreeBlockCacheReceiverExt {
     async fn wait_for_range(
         &self,
         range: RangeInclusive<u64>,
-    ) -> anyhow::Result<Vec<LocalBatchBlockData>>;
+    ) -> anyhow::Result<Vec<BlockCommitmentData>>;
 }
 
 #[async_trait]
@@ -148,7 +136,7 @@ impl TreeBlockCacheReceiverExt for watch::Receiver<TreeBlockCache> {
     async fn wait_for_range(
         &self,
         range: RangeInclusive<u64>,
-    ) -> anyhow::Result<Vec<LocalBatchBlockData>> {
+    ) -> anyhow::Result<Vec<BlockCommitmentData>> {
         let mut cache_rx = self.clone();
         loop {
             {

--- a/lib/l1_consistency_checker/src/cache.rs
+++ b/lib/l1_consistency_checker/src/cache.rs
@@ -1,20 +1,25 @@
 use async_trait::async_trait;
-use std::collections::VecDeque;
+use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 use tokio::sync::watch;
 use zksync_os_batch_types::BlockCommitmentData;
 
 pub const DEFAULT_MAX_CACHED_TREE_BLOCKS: usize = 4096;
 
-/// Ordered cache of per-block commitment data keyed by block number.
+/// Cache of per-block commitment data keyed by block number.
 ///
 /// Blocks must be inserted consecutively (each block number exactly one greater than the last).
-/// Eviction is the caller's responsibility; they decide when to call
-/// [`TreeBlockCache::remove_lower_or_equal_than`]
+/// Eviction is the caller's responsibility via [`TreeBlockCache::remove_range`]; because the
+/// L1 consistency checker verifies batches concurrently, batches can be verified — and their
+/// blocks evicted — out of order, leaving gaps in the otherwise consecutive key space. A
+/// [`BTreeMap`] (rather than a `VecDeque`) lets us represent those gaps.
 #[derive(Debug)]
 pub struct TreeBlockCache {
-    data: VecDeque<BlockCommitmentData>,
-    first_block: Option<u64>,
+    data: BTreeMap<u64, BlockCommitmentData>,
+    /// Block number expected on the next [`insert`](Self::insert). Monotonically increasing and
+    /// unaffected by eviction, so it doubles as the boundary between "was inserted (and possibly
+    /// already evicted)" and "not cached yet" when serving range reads.
+    next_expected_block: Option<u64>,
     max_blocks: usize,
 }
 
@@ -31,62 +36,43 @@ impl TreeBlockCache {
 
     pub fn with_max_blocks(max_blocks: usize) -> Self {
         Self {
-            data: VecDeque::new(),
-            first_block: None,
+            data: BTreeMap::new(),
+            next_expected_block: None,
             max_blocks,
         }
     }
 
     /// Insert a block into the cache. Blocks must arrive consecutively (each block number exactly
-    /// one greater than the last).
+    /// one greater than the last), regardless of any gaps left behind by eviction.
     pub fn insert(&mut self, block_number: u64, block: BlockCommitmentData) -> anyhow::Result<()> {
-        if let Some((_, last_block)) = self.range() {
-            if block_number != last_block + 1 {
-                anyhow::bail!("Out of order block received. This should never happen");
-            }
-        } else {
-            self.first_block = Some(block_number);
+        if let Some(expected) = self.next_expected_block
+            && block_number != expected
+        {
+            anyhow::bail!("Out of order block received. This should never happen");
         }
-        self.data.push_back(block);
+        self.data.insert(block_number, block);
+        self.next_expected_block = Some(block_number + 1);
         Ok(())
     }
 
     /// Whether the cache is still below its soft bound.
     ///
-    /// The bound is *soft*: the sole writer (the L1 consistency checker) is allowed to
-    /// overshoot it to finish caching the blocks an oversized pending batch needs. See
-    /// [`L1ConsistencyChecker::can_accept_tree_block`](crate::checker::L1ConsistencyChecker).
+    /// The bound counts blocks actually held, so gaps left by out-of-order eviction free up
+    /// capacity. It must comfortably exceed the combined block span of all batches verified
+    /// concurrently, otherwise intake stalls and the upstream pipeline channel eventually
+    /// overflows.
     pub fn has_capacity(&self) -> bool {
         self.data.len() < self.max_blocks
     }
 
-    /// Currently cached block-number range (inclusive bounds), or `None` if empty.
-    pub fn range(&self) -> Option<(u64, u64)> {
-        if self.data.is_empty() {
-            None
-        } else {
-            self.first_block
-                .map(|block| (block, block + self.data.len() as u64 - 1))
-        }
-    }
-
-    /// Removes all blocks lower than or equal to the given block number.
-    pub fn remove_lower_or_equal_than(&mut self, block_number: u64) {
-        if let Some((first_block, last_block)) = self.range() {
-            if block_number < first_block {
-                return;
-            }
-
-            let amount_to_remove = (block_number.min(last_block) - first_block + 1) as usize;
-            self.data.drain(0..amount_to_remove);
-
-            // Keep `first_block` aligned with the deque; an empty cache has no valid range.
-            if self.data.is_empty() {
-                self.first_block = None;
-            } else {
-                self.first_block = Some(first_block + amount_to_remove as u64);
-            }
-        }
+    /// Removes every block in the given (inclusive) range. Used to evict a single batch's blocks
+    /// once it has been verified; ranges of distinct batches never overlap.
+    pub fn remove_range(&mut self, range: RangeInclusive<u64>) {
+        // Split out the keys `>= start`, then split the remaining-to-keep keys `> end` back off,
+        // leaving only `[start, end]` to drop. Avoids an O(n) scan of the whole map.
+        let mut at_or_above_start = self.data.split_off(range.start());
+        let above_end = at_or_above_start.split_off(&(range.end() + 1));
+        self.data.extend(above_end);
     }
 
     /// Returns a complete cached block range, or `None` if it is not fully available yet.
@@ -94,31 +80,27 @@ impl TreeBlockCache {
         &self,
         range: RangeInclusive<u64>,
     ) -> anyhow::Result<Option<Vec<BlockCommitmentData>>> {
-        let Some((first_block, last_block)) = self.range() else {
+        let Some(next_expected_block) = self.next_expected_block else {
+            // Nothing has ever been inserted; the blocks are simply not cached yet.
             return Ok(None);
         };
-        if *range.start() < first_block {
-            anyhow::bail!(
-                "requested local batch data range {}..={} was already evicted; cached range is {}..={}",
-                range.start(),
-                range.end(),
-                first_block,
-                last_block
-            );
-        }
-        if *range.end() > last_block {
+        if *range.end() >= next_expected_block {
+            // The tail of the range hasn't been folded into the cache yet.
             return Ok(None);
         }
-        let start = (*range.start() - first_block) as usize;
 
-        Ok(Some(
-            self.data
-                .iter()
-                .skip(start)
-                .take(range.count())
-                .cloned()
-                .collect(),
-        ))
+        // Every block in the range was inserted at some point (its end is below `next_expected_block`),
+        // so a missing block means it was already evicted after its batch was verified.
+        let mut blocks = Vec::with_capacity(range.clone().count());
+        for block_number in range {
+            let Some(block) = self.data.get(&block_number) else {
+                anyhow::bail!(
+                    "requested local batch data block {block_number} was already evicted"
+                );
+            };
+            blocks.push(block.clone());
+        }
+        Ok(Some(blocks))
     }
 }
 

--- a/lib/l1_consistency_checker/src/cacher.rs
+++ b/lib/l1_consistency_checker/src/cacher.rs
@@ -1,0 +1,112 @@
+use crate::cache::TreeBlockCache;
+use async_trait::async_trait;
+use tokio::sync::{mpsc, watch};
+use zksync_os_batch_types::BlockCommitmentData;
+use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
+use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
+use zksync_os_storage_api::{ReadStateHistory, TreeBlock, read_multichain_root};
+
+/// Terminal EN pipeline component that folds replayed blocks into the shared
+/// [`TreeBlockCache`].
+///
+/// This is intentionally the *only* thing that runs on the pipeline task: it does no
+/// verification. The CPU-heavy L1 commit verification lives in a separate task
+/// ([`L1ConsistencyChecker`](crate::checker::L1ConsistencyChecker)) that evicts from the same
+/// cache as batches are confirmed. Keeping verification off this task is what prevents it from
+/// starving block intake — when the two shared a single `select!` loop, a burst of L1 commit
+/// events could stall intake long enough for the upstream pipeline channel to overflow
+/// ("consumer is catastrophically behind").
+pub struct LocalBatchDataCacher<ReadState> {
+    last_persisted_block_on_start: u64,
+    read_state: ReadState,
+    cache: watch::Sender<TreeBlockCache>,
+}
+
+impl<ReadState> LocalBatchDataCacher<ReadState> {
+    pub fn new(
+        last_persisted_block_on_start: u64,
+        read_state: ReadState,
+        cache: watch::Sender<TreeBlockCache>,
+    ) -> Self {
+        Self {
+            last_persisted_block_on_start,
+            read_state,
+            cache,
+        }
+    }
+}
+
+impl<ReadState: ReadStateHistory> LocalBatchDataCacher<ReadState> {
+    /// Inserts a block into the shared cache, pre-folded into its commitment ingredients so the
+    /// cache holds a few hundred bytes per block (plus pubdata) instead of full block data.
+    fn insert_tree_block(&self, tree_block: TreeBlock) -> anyhow::Result<()> {
+        let block_number = tree_block.record.block_context.block_number;
+        // Blocks already covered by a persisted batch were verified by a previous run; the
+        // verifier trusts them without rebuilding, so there is nothing to cache.
+        if block_number <= self.last_persisted_block_on_start {
+            return Ok(());
+        }
+        let state_view = self.read_state.state_view_at(block_number)?;
+        let multichain_root = read_multichain_root(state_view);
+        let data = BlockCommitmentData::new(
+            &tree_block.output,
+            &tree_block.record.transactions,
+            &tree_block.tree.output,
+            &tree_block.record.block_context.block_hashes.0,
+            multichain_root,
+            tree_block.record.protocol_version,
+        );
+
+        let mut result = Ok(());
+        self.cache
+            .send_if_modified(|cache| match cache.insert(block_number, data) {
+                Ok(()) => true,
+                Err(err) => {
+                    result = Err(err);
+                    false
+                }
+            });
+        result
+    }
+}
+
+#[async_trait]
+impl<ReadState: ReadStateHistory> PipelineComponent for LocalBatchDataCacher<ReadState> {
+    type Input = TreeBlock;
+    type Output = ();
+
+    const COMPONENT_ID: zksync_os_pipeline::ComponentId =
+        zksync_os_pipeline::ComponentId::LocalBatchDataCacher;
+
+    async fn run(
+        self,
+        mut input: PeekableReceiver<Self::Input>,
+        _output: mpsc::Sender<Self::Output>,
+        state_reporter: ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        tracing::info!("starting local batch data cacher");
+        // Watch the cache so we can wait for the verifier to evict once we hit the soft bound.
+        let mut cache_rx = self.cache.subscribe();
+        loop {
+            // Backpressure: stop pulling blocks once the cache is full and wait for the verifier
+            // to confirm and evict committed batches, freeing space. This bounds memory; it
+            // assumes the configured bound comfortably exceeds the gap between local replay and
+            // L1 commit availability (and any single batch's block span), otherwise intake stalls
+            // and the upstream pipeline channel eventually overflows.
+            while !cache_rx.borrow_and_update().has_capacity() {
+                state_reporter.enter_state(GenericComponentState::Idle);
+                cache_rx.changed().await?;
+            }
+
+            state_reporter.enter_state(GenericComponentState::Idle);
+            let Some(tree_block) = input.recv().await else {
+                return Ok(());
+            };
+            state_reporter.enter_state(GenericComponentState::Active);
+            let block_number = tree_block.record.block_context.block_number;
+            let block_timestamp = tree_block.record.block_context.timestamp;
+            self.insert_tree_block(tree_block)?;
+            state_reporter.record_processed(block_number, Some(block_timestamp), None);
+        }
+    }
+}

--- a/lib/l1_consistency_checker/src/checker.rs
+++ b/lib/l1_consistency_checker/src/checker.rs
@@ -1,8 +1,8 @@
-use crate::cache::{LocalBatchBlockData, TreeBlockCache};
+use crate::cache::TreeBlockCache;
 use async_trait::async_trait;
 use std::ops::RangeInclusive;
 use tokio::sync::{mpsc, watch};
-use zksync_os_batch_types::ExtendedCommitBatchInfo;
+use zksync_os_batch_types::{BlockCommitmentData, ExtendedCommitBatchInfo};
 use zksync_os_contract_interface::models::{DACommitmentScheme, StoredBatchInfo};
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
@@ -77,7 +77,8 @@ impl<ReadState: ReadStateHistory> L1ConsistencyChecker<ReadState> {
         }
     }
 
-    /// Inserts a block into the shared cache
+    /// Inserts a block into the shared cache, pre-folded into its commitment ingredients so the
+    /// cache holds a few hundred bytes per block (plus pubdata) instead of full block data.
     fn insert_tree_block(&self, tree_block: TreeBlock) -> anyhow::Result<()> {
         let block_number = tree_block.record.block_context.block_number;
         if block_number <= self.last_persisted_block_on_start {
@@ -85,12 +86,14 @@ impl<ReadState: ReadStateHistory> L1ConsistencyChecker<ReadState> {
         }
         let state_view = self.read_state.state_view_at(block_number)?;
         let multichain_root = read_multichain_root(state_view);
-        let data = LocalBatchBlockData {
-            output: tree_block.output,
-            record: tree_block.record,
-            tree_output: tree_block.tree.output,
+        let data = BlockCommitmentData::new(
+            &tree_block.output,
+            &tree_block.record.transactions,
+            &tree_block.tree.output,
+            &tree_block.record.block_context.block_hashes.0,
             multichain_root,
-        };
+            tree_block.record.protocol_version,
+        );
 
         let mut result = Ok(());
         self.cache
@@ -116,31 +119,12 @@ impl<ReadState: ReadStateHistory> L1ConsistencyChecker<ReadState> {
             return Ok(false);
         };
 
-        // The protocol version is uniform within a batch (a batch is sealed whenever it changes),
-        // so the last block carries everything we need: its protocol version, multichain root, and
-        // the trailing block hashes.
-        let last_block = blocks
-            .last()
-            .expect("L1 committed batch block range cannot be empty");
-
         let (local_batch_info, _) = ExtendedCommitBatchInfo::build(
-            blocks
-                .iter()
-                .map(|block| {
-                    (
-                        &block.output,
-                        block.record.transactions.as_slice(),
-                        &block.tree_output,
-                    )
-                })
-                .collect(),
+            &blocks,
             self.chain_id,
             commit.batch_number(),
             PubdataMode::from_da_commitment_scheme(commit.l2_da_commitment_scheme),
             self.sl_chain_id,
-            last_block.multichain_root,
-            &last_block.record.protocol_version,
-            &last_block.record.block_context.block_hashes.0,
         );
 
         let local_stored = local_batch_info.into_stored();

--- a/lib/l1_consistency_checker/src/checker.rs
+++ b/lib/l1_consistency_checker/src/checker.rs
@@ -1,6 +1,10 @@
 use crate::cache::{TreeBlockCache, TreeBlockCacheReceiverExt};
+use anyhow::Context;
+use std::collections::BTreeSet;
 use std::ops::RangeInclusive;
-use tokio::sync::{mpsc, watch};
+use std::sync::Arc;
+use tokio::sync::{Semaphore, mpsc, watch};
+use tokio::task::JoinSet;
 use zksync_os_batch_types::ExtendedCommitBatchInfo;
 use zksync_os_contract_interface::models::{DACommitmentScheme, StoredBatchInfo};
 use zksync_os_types::PubdataMode;
@@ -21,13 +25,22 @@ impl L1CommittedBatch {
     }
 }
 
+/// Outcome of verifying one committed batch, carried back to the run loop so it can evict the
+/// batch's blocks and advance the verified-batch watermark.
+struct VerifiedBatch {
+    batch_number: u64,
+    range: RangeInclusive<u64>,
+}
+
 /// Background task that checks L1-committed batches against locally replayed blocks.
 ///
 /// It runs off the pipeline (unlike the [`LocalBatchDataCacher`](crate::cacher::LocalBatchDataCacher)
 /// that fills the cache) so that its CPU-heavy commitment rebuild cannot starve block intake.
-/// It consumes committed batches in order, waits until the cacher has folded the batch's blocks
-/// into the shared cache, rebuilds the commitment locally, compares it against L1, then evicts the
-/// verified prefix and advances the latest-verified-batch watermark.
+/// Committed batches arrive in order, but each is verified in its own bounded-concurrency task so
+/// that one batch waiting for its blocks (or rebuilding its commitment) does not hold up batches
+/// behind it. As each batch is verified its blocks are evicted from the shared cache — restoring
+/// intake capacity — and the latest-verified-batch watermark is advanced (see [`Self::run`] for
+/// why the watermark only moves along the contiguous verified prefix).
 pub struct L1ConsistencyChecker {
     chain_id: u64,
     sl_chain_id: u64,
@@ -39,6 +52,8 @@ pub struct L1ConsistencyChecker {
     latest_verified_batch_tx: watch::Sender<u64>,
     /// Receives L1-committed batches to verify against locally replayed blocks.
     l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
+    /// Upper bound on batches verified concurrently (and thus on parallel commitment rebuilds).
+    verification_concurrency: usize,
 }
 
 impl L1ConsistencyChecker {
@@ -49,6 +64,7 @@ impl L1ConsistencyChecker {
         cache: watch::Sender<TreeBlockCache>,
         latest_verified_batch_tx: watch::Sender<u64>,
         l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
+        verification_concurrency: usize,
     ) -> Self {
         let cache_rx = cache.subscribe();
         Self {
@@ -59,77 +75,167 @@ impl L1ConsistencyChecker {
             cache_rx,
             latest_verified_batch_tx,
             l1_events_rx,
+            verification_concurrency,
         }
     }
 
     /// Verifies a single committed batch against locally replayed blocks, blocking until the
     /// cacher has the batch's blocks available. Batches already covered by a persisted batch were
     /// verified by a previous run and are trusted without rebuilding.
-    async fn verify_commit(&self, commit: &L1CommittedBatch) -> anyhow::Result<()> {
-        if commit.last_block_number() <= self.last_persisted_block_on_start {
-            return Ok(());
+    ///
+    /// Takes everything by value so it can run as an independent task; the CPU-heavy commitment
+    /// rebuild is offloaded to a blocking thread so it parallelizes across cores.
+    async fn verify_commit(
+        cache_rx: watch::Receiver<TreeBlockCache>,
+        chain_id: u64,
+        sl_chain_id: u64,
+        last_persisted_block_on_start: u64,
+        commit: L1CommittedBatch,
+    ) -> anyhow::Result<VerifiedBatch> {
+        let batch_number = commit.batch_number();
+        let range = commit.range.clone();
+
+        if commit.last_block_number() > last_persisted_block_on_start {
+            let blocks = cache_rx
+                .wait_for_range(range.clone())
+                .await
+                .context("while waiting for a committed batch's blocks to be cached")?;
+            let l2_da_commitment_scheme = commit.l2_da_commitment_scheme;
+            let l1_stored = commit.stored_batch_info;
+
+            tokio::task::spawn_blocking(move || {
+                let (local_batch_info, _) = ExtendedCommitBatchInfo::build(
+                    &blocks,
+                    chain_id,
+                    batch_number,
+                    PubdataMode::from_da_commitment_scheme(l2_da_commitment_scheme),
+                    sl_chain_id,
+                );
+
+                let local_stored = local_batch_info.into_stored();
+                if local_stored != l1_stored {
+                    tracing::error!(
+                        "L1 committed batch #{} is inconsistent with locally replayed blocks, expected: {:?}, received: {:?}",
+                        batch_number,
+                        local_stored,
+                        l1_stored,
+                    );
+                    anyhow::bail!(
+                        "L1 committed batch #{} is inconsistent with locally replayed blocks",
+                        batch_number
+                    );
+                }
+                Ok(())
+            })
+            .await
+            .context("while rebuilding a committed batch's commitment")??;
+
+            tracing::info!(
+                "verified L1 committed batch #{} against locally replayed blocks {:?}",
+                batch_number,
+                range,
+            );
         }
 
-        let blocks = self.cache_rx.wait_for_range(commit.range.clone()).await?;
-
-        let (local_batch_info, _) = ExtendedCommitBatchInfo::build(
-            &blocks,
-            self.chain_id,
-            commit.batch_number(),
-            PubdataMode::from_da_commitment_scheme(commit.l2_da_commitment_scheme),
-            self.sl_chain_id,
-        );
-
-        let local_stored = local_batch_info.into_stored();
-        let l1_stored = &commit.stored_batch_info;
-        if &local_stored != l1_stored {
-            tracing::error!(
-                "L1 committed batch #{} is inconsistent with locally replayed blocks, expected: {:?}, received: {:?}",
-                commit.batch_number(),
-                local_stored,
-                l1_stored,
-            );
-            anyhow::bail!(
-                "L1 committed batch #{} is inconsistent with locally replayed blocks",
-                commit.batch_number()
-            );
-        }
-
-        Ok(())
+        Ok(VerifiedBatch {
+            batch_number,
+            range,
+        })
     }
 
     pub async fn run(mut self) -> anyhow::Result<()> {
         tracing::info!("starting L1 consistency checker");
-        // Committed batches arrive in order; the channel itself provides backpressure on the
-        // L1 watcher, so we simply process them one at a time.
-        while let Some(commit) = self.l1_events_rx.recv().await {
-            tracing::debug!(
-                "received L1 committed batch {} for consistency checking in range {:?}",
-                commit.batch_number(),
-                commit.range,
-            );
-            self.verify_commit(&commit).await?;
-            tracing::info!(
-                "verified L1 committed batch #{} against locally replayed blocks {:?}",
-                commit.batch_number(),
-                commit.range,
-            );
 
-            // Drop the now-verified prefix from the cache, restoring intake capacity for the
-            // cacher, and publish the new watermark for the batch persist watcher.
-            let last_block_number = commit.last_block_number();
-            let batch_number = commit.batch_number();
-            self.cache
-                .send_modify(|cache| cache.remove_lower_or_equal_than(last_block_number));
-            self.latest_verified_batch_tx.send_if_modified(|latest| {
-                if batch_number > *latest {
-                    *latest = batch_number;
-                    true
-                } else {
-                    false
+        let semaphore = Arc::new(Semaphore::new(self.verification_concurrency));
+        let mut tasks: JoinSet<anyhow::Result<VerifiedBatch>> = JoinSet::new();
+
+        // Verifications complete out of order, but downstream (the persist batch watcher) must not
+        // see batch N marked verified before batch N-1 is. We therefore stage verified batch
+        // numbers and only advance the published watermark across the contiguous prefix that is
+        // fully verified. Eviction has no such constraint — a batch's blocks belong to it alone,
+        // so they are dropped as soon as that batch is verified, regardless of order.
+        let mut verified_ahead: BTreeSet<u64> = BTreeSet::new();
+        let mut next_batch_to_confirm = *self.latest_verified_batch_tx.borrow() + 1;
+
+        loop {
+            tokio::select! {
+                maybe_commit = self.l1_events_rx.recv() => {
+                    let Some(commit) = maybe_commit else {
+                        // Channel closed: stop accepting work and drain what is in flight.
+                        break;
+                    };
+                    tracing::debug!(
+                        "received L1 committed batch {} for consistency checking in range {:?}",
+                        commit.batch_number(),
+                        commit.range,
+                    );
+                    // Acquiring the permit here bounds in-flight verifications, providing
+                    // backpressure on intake of new commits.
+                    let permit = semaphore
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .expect("verification semaphore is never closed");
+                    let cache_rx = self.cache_rx.clone();
+                    let chain_id = self.chain_id;
+                    let sl_chain_id = self.sl_chain_id;
+                    let last_persisted_block_on_start = self.last_persisted_block_on_start;
+                    tasks.spawn(async move {
+                        let _permit = permit; // held until the verification finishes
+                        Self::verify_commit(
+                            cache_rx,
+                            chain_id,
+                            sl_chain_id,
+                            last_persisted_block_on_start,
+                            commit,
+                        )
+                        .await
+                    });
                 }
-            });
+                Some(joined) = tasks.join_next() => {
+                    let verified = joined.context("verification task panicked")??;
+                    self.handle_verified(verified, &mut verified_ahead, &mut next_batch_to_confirm);
+                }
+            }
+        }
+
+        // Finish the verifications that were still in flight when the channel closed.
+        while let Some(joined) = tasks.join_next().await {
+            let verified = joined.context("verification task panicked")??;
+            self.handle_verified(verified, &mut verified_ahead, &mut next_batch_to_confirm);
         }
         Ok(())
+    }
+
+    /// Applies one completed verification: evicts the batch's now-redundant blocks and advances the
+    /// verified-batch watermark across the contiguous prefix that is fully verified.
+    fn handle_verified(
+        &self,
+        verified: VerifiedBatch,
+        verified_ahead: &mut BTreeSet<u64>,
+        next_batch_to_confirm: &mut u64,
+    ) {
+        // Drop the now-verified blocks from the cache, restoring intake capacity for the cacher.
+        self.cache
+            .send_modify(|cache| cache.remove_range(verified.range));
+
+        // Batches at or below the current watermark were already verified on a previous run; only
+        // track the ones that can move it forward.
+        if verified.batch_number >= *next_batch_to_confirm {
+            verified_ahead.insert(verified.batch_number);
+        }
+        while verified_ahead.remove(next_batch_to_confirm) {
+            *next_batch_to_confirm += 1;
+        }
+
+        let confirmed = *next_batch_to_confirm - 1;
+        self.latest_verified_batch_tx.send_if_modified(|latest| {
+            if confirmed > *latest {
+                *latest = confirmed;
+                true
+            } else {
+                false
+            }
+        });
     }
 }

--- a/lib/l1_consistency_checker/src/checker.rs
+++ b/lib/l1_consistency_checker/src/checker.rs
@@ -1,12 +1,8 @@
-use crate::cache::TreeBlockCache;
-use async_trait::async_trait;
+use crate::cache::{TreeBlockCache, TreeBlockCacheReceiverExt};
 use std::ops::RangeInclusive;
 use tokio::sync::{mpsc, watch};
-use zksync_os_batch_types::{BlockCommitmentData, ExtendedCommitBatchInfo};
+use zksync_os_batch_types::ExtendedCommitBatchInfo;
 use zksync_os_contract_interface::models::{DACommitmentScheme, StoredBatchInfo};
-use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
-use zksync_os_pipeline::{PeekableReceiver, PipelineComponent};
-use zksync_os_storage_api::{ReadStateHistory, TreeBlock, read_multichain_root};
 use zksync_os_types::PubdataMode;
 
 pub struct L1CommittedBatch {
@@ -25,99 +21,56 @@ impl L1CommittedBatch {
     }
 }
 
-/// Terminal EN pipeline component that owns local batch data caching and L1 consistency checks.
-pub struct L1ConsistencyChecker<ReadState> {
+/// Background task that checks L1-committed batches against locally replayed blocks.
+///
+/// It runs off the pipeline (unlike the [`LocalBatchDataCacher`](crate::cacher::LocalBatchDataCacher)
+/// that fills the cache) so that its CPU-heavy commitment rebuild cannot starve block intake.
+/// It consumes committed batches in order, waits until the cacher has folded the batch's blocks
+/// into the shared cache, rebuilds the commitment locally, compares it against L1, then evicts the
+/// verified prefix and advances the latest-verified-batch watermark.
+pub struct L1ConsistencyChecker {
     chain_id: u64,
     sl_chain_id: u64,
     last_persisted_block_on_start: u64,
-    read_state: ReadState,
+    /// Shared with the cacher (which inserts) and the batch verification responder (which reads).
+    /// We hold the sender to evict verified blocks and a receiver to await freshly cached ones.
     cache: watch::Sender<TreeBlockCache>,
+    cache_rx: watch::Receiver<TreeBlockCache>,
     latest_verified_batch_tx: watch::Sender<u64>,
     /// Receives L1-committed batches to verify against locally replayed blocks.
     l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
 }
 
-impl<ReadState> L1ConsistencyChecker<ReadState> {
+impl L1ConsistencyChecker {
     pub fn new(
         chain_id: u64,
         sl_chain_id: u64,
         last_persisted_block_on_start: u64,
-        read_state: ReadState,
         cache: watch::Sender<TreeBlockCache>,
         latest_verified_batch_tx: watch::Sender<u64>,
         l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
     ) -> Self {
+        let cache_rx = cache.subscribe();
         Self {
             chain_id,
             sl_chain_id,
             last_persisted_block_on_start,
-            read_state,
             cache,
+            cache_rx,
             latest_verified_batch_tx,
             l1_events_rx,
         }
     }
-}
 
-impl<ReadState: ReadStateHistory> L1ConsistencyChecker<ReadState> {
-    /// Our backpressure signal: whether to pull another tree block from the input.
-    ///
-    /// We normally stop accepting once the cache reaches its soft bound. The one exception
-    /// is a pending batch larger than that bound: we must keep caching its blocks, otherwise
-    /// it could never be verified and evicted and the pipeline would deadlock. Once its full
-    /// range is cached it is verified and evicted at the top of the loop, restoring backpressure.
-    fn can_accept_tree_block(&self, pending: Option<&L1CommittedBatch>) -> bool {
-        let cache = self.cache.borrow();
-        if cache.has_capacity() {
-            return true;
-        }
-        match (pending, cache.range()) {
-            (Some(commit), Some((_, last_cached))) => last_cached < commit.last_block_number(),
-            _ => false,
-        }
-    }
-
-    /// Inserts a block into the shared cache, pre-folded into its commitment ingredients so the
-    /// cache holds a few hundred bytes per block (plus pubdata) instead of full block data.
-    fn insert_tree_block(&self, tree_block: TreeBlock) -> anyhow::Result<()> {
-        let block_number = tree_block.record.block_context.block_number;
-        if block_number <= self.last_persisted_block_on_start {
+    /// Verifies a single committed batch against locally replayed blocks, blocking until the
+    /// cacher has the batch's blocks available. Batches already covered by a persisted batch were
+    /// verified by a previous run and are trusted without rebuilding.
+    async fn verify_commit(&self, commit: &L1CommittedBatch) -> anyhow::Result<()> {
+        if commit.last_block_number() <= self.last_persisted_block_on_start {
             return Ok(());
         }
-        let state_view = self.read_state.state_view_at(block_number)?;
-        let multichain_root = read_multichain_root(state_view);
-        let data = BlockCommitmentData::new(
-            &tree_block.output,
-            &tree_block.record.transactions,
-            &tree_block.tree.output,
-            &tree_block.record.block_context.block_hashes.0,
-            multichain_root,
-            tree_block.record.protocol_version,
-        );
 
-        let mut result = Ok(());
-        self.cache
-            .send_if_modified(|cache| match cache.insert(block_number, data) {
-                Ok(()) => true,
-                Err(err) => {
-                    result = Err(err);
-                    false
-                }
-            });
-        result
-    }
-
-    /// Verifies whether data received from verification request is consistent with locally replayed data
-    fn verify_commit_if_available(&self, commit: &L1CommittedBatch) -> anyhow::Result<bool> {
-        // In case we received request for batch that was already persisted, we trust that it was verified previously
-        if commit.last_block_number() <= self.last_persisted_block_on_start {
-            return Ok(true);
-        }
-
-        let Some(blocks) = self.cache.borrow().get_range(commit.range.clone())? else {
-            // blocks required for consistency check are not available from cache yet
-            return Ok(false);
-        };
+        let blocks = self.cache_rx.wait_for_range(commit.range.clone()).await?;
 
         let (local_batch_info, _) = ExtendedCommitBatchInfo::build(
             &blocks,
@@ -142,81 +95,41 @@ impl<ReadState: ReadStateHistory> L1ConsistencyChecker<ReadState> {
             );
         }
 
-        Ok(true)
+        Ok(())
     }
-}
 
-#[async_trait]
-impl<ReadState: ReadStateHistory> PipelineComponent for L1ConsistencyChecker<ReadState> {
-    type Input = TreeBlock;
-    type Output = ();
-
-    const COMPONENT_ID: zksync_os_pipeline::ComponentId =
-        zksync_os_pipeline::ComponentId::L1ConsistencyChecker;
-
-    async fn run(
-        mut self,
-        mut input: PeekableReceiver<Self::Input>,
-        _output: mpsc::Sender<Self::Output>,
-        state_reporter: ComponentStateReporter,
-    ) -> anyhow::Result<()> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         tracing::info!("starting L1 consistency checker");
-        // At most one request is held outside the channel at a time; new requests stay queued
-        // in `l1_events_rx` (providing natural backpressure) until this slot is empty again.
-        let mut pending: Option<L1CommittedBatch> = None;
-        loop {
-            if let Some(commit) = &pending
-                && self.verify_commit_if_available(commit)?
-            {
-                tracing::info!(
-                    "verified L1 committed batch #{} against locally replayed blocks {:?}",
-                    commit.batch_number(),
-                    commit.range,
-                );
-                let last_block_number = commit.last_block_number();
-                let batch_number = commit.batch_number();
-                self.cache
-                    .send_modify(|cache| cache.remove_lower_or_equal_than(last_block_number));
-                self.latest_verified_batch_tx.send_if_modified(|latest| {
-                    if batch_number > *latest {
-                        *latest = batch_number;
-                        true
-                    } else {
-                        false
-                    }
-                });
-                pending = None;
-            }
+        // Committed batches arrive in order; the channel itself provides backpressure on the
+        // L1 watcher, so we simply process them one at a time.
+        while let Some(commit) = self.l1_events_rx.recv().await {
+            tracing::debug!(
+                "received L1 committed batch {} for consistency checking in range {:?}",
+                commit.batch_number(),
+                commit.range,
+            );
+            self.verify_commit(&commit).await?;
+            tracing::info!(
+                "verified L1 committed batch #{} against locally replayed blocks {:?}",
+                commit.batch_number(),
+                commit.range,
+            );
 
-            state_reporter.enter_state(GenericComponentState::Idle);
-            let can_accept_tree_block = self.can_accept_tree_block(pending.as_ref());
-            tokio::select! {
-                tree_block = input.recv(), if can_accept_tree_block => {
-                    let Some(tree_block) = tree_block else {
-                        if pending.is_some() {
-                            anyhow::bail!("tree block channel closed with pending L1 consistency check");
-                        }
-                        return Ok(());
-                    };
-                    state_reporter.enter_state(GenericComponentState::Active);
-                    let block_number = tree_block.record.block_context.block_number;
-                    let block_timestamp = tree_block.record.block_context.timestamp;
-                    self.insert_tree_block(tree_block)?;
-                    state_reporter.record_processed(block_number, Some(block_timestamp), None);
+            // Drop the now-verified prefix from the cache, restoring intake capacity for the
+            // cacher, and publish the new watermark for the batch persist watcher.
+            let last_block_number = commit.last_block_number();
+            let batch_number = commit.batch_number();
+            self.cache
+                .send_modify(|cache| cache.remove_lower_or_equal_than(last_block_number));
+            self.latest_verified_batch_tx.send_if_modified(|latest| {
+                if batch_number > *latest {
+                    *latest = batch_number;
+                    true
+                } else {
+                    false
                 }
-                commit = self.l1_events_rx.recv(), if pending.is_none() => {
-                    let Some(commit) = commit else {
-                        return Ok(());
-                    };
-                    state_reporter.enter_state(GenericComponentState::Active);
-                    tracing::debug!(
-                        "received L1 committed batch {} for consistency checking in range {:?}",
-                        commit.batch_number(),
-                        commit.range,
-                    );
-                    pending = Some(commit);
-                }
-            }
+            });
         }
+        Ok(())
     }
 }

--- a/lib/l1_consistency_checker/src/lib.rs
+++ b/lib/l1_consistency_checker/src/lib.rs
@@ -1,5 +1,7 @@
 mod cache;
+mod cacher;
 mod checker;
 
 pub use cache::{TreeBlockCache, TreeBlockCacheReceiverExt};
+pub use cacher::LocalBatchDataCacher;
 pub use checker::{L1CommittedBatch, L1ConsistencyChecker};

--- a/lib/l1_consistency_checker/src/lib.rs
+++ b/lib/l1_consistency_checker/src/lib.rs
@@ -1,5 +1,5 @@
 mod cache;
 mod checker;
 
-pub use cache::{LocalBatchBlockData, TreeBlockCache, TreeBlockCacheReceiverExt};
+pub use cache::{TreeBlockCache, TreeBlockCacheReceiverExt};
 pub use checker::{L1CommittedBatch, L1ConsistencyChecker};

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -1,6 +1,7 @@
 use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
 use crate::{BlockUpdates, L1WatcherConfig, LogsCache, SegmentSpec, SlAwareL1Watcher, util};
+use alloy::eips::BlockId;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::{Context, anyhow};
@@ -112,7 +113,21 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                     "first SL interval ({interval}) must start at or before first non-persisted batch ({})",
                     last_persisted_batch + 1
                 );
-                last_persisted_batch
+                // Nothing persisted yet: resolving the scan start from batch 1 lands exactly on
+                // the L1 block with the chain's first commit, skipping the dead span between
+                // contract deployment and the first commit. Fall back to batch 0 (deployment
+                // block) while the chain has no committed batches at all.
+                if last_persisted_batch == 0
+                    && zk_chain
+                        .get_total_batches_committed(BlockId::latest())
+                        .await
+                        .context("while attempting to read total committed batches")?
+                        >= 1
+                {
+                    1
+                } else {
+                    last_persisted_batch
+                }
             } else {
                 // First batch in the interval might not have been committed yet. We resolve the
                 // canonical start of the segment from the previous batch's import block.

--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -28,6 +28,11 @@ pub struct Pool<T> {
     interop_roots_subpool: InteropRootsSubpool,
     l1_subpool: L1Subpool,
     l2_subpool: T,
+    /// When `false`, replayed L1-originated transactions (priority, upgrade, interop,
+    /// SL-chain-id, interop-fee) are trusted as-is instead of being matched against locally
+    /// watched L1 events. False on external nodes, which don't run the L1 watchers feeding
+    /// these subpools and verify whole batches against L1 commitments instead.
+    verify_l1_origin_txs: bool,
 }
 
 impl<T: L2Subpool> Pool<T> {
@@ -38,6 +43,7 @@ impl<T: L2Subpool> Pool<T> {
         interop_roots_subpool: InteropRootsSubpool,
         l1_subpool: L1Subpool,
         l2_subpool: T,
+        verify_l1_origin_txs: bool,
     ) -> Self {
         Self {
             upgrade_subpool,
@@ -46,6 +52,7 @@ impl<T: L2Subpool> Pool<T> {
             interop_roots_subpool,
             l1_subpool,
             l2_subpool,
+            verify_l1_origin_txs,
         }
     }
 
@@ -228,25 +235,36 @@ impl<T: L2Subpool> Pool<T> {
                 }
             }
         }
-        self.upgrade_subpool
-            .on_canonical_state_change(&replay_record.protocol_version, upgrade_txs)
-            .await;
-        let last_interop_log_id = self
-            .interop_roots_subpool
-            .on_canonical_state_change(interop_txs)
-            .await;
-        let last_interop_fee_number = self
-            .interop_fee_subpool
-            .on_canonical_state_change(interop_fee_txs, strict_subpool_cleanup)
-            .await;
-        let sl_chain_id_outcome = self
-            .sl_chain_id_subpool
-            .on_canonical_state_change(sl_chain_id_txs)
-            .await;
-        let last_l1_priority_id = self
-            .l1_subpool
-            .on_canonical_state_change(l1_transactions)
-            .await;
+        // With verification disabled there is nothing to match the replayed transactions
+        // against (the L1 watchers feeding these subpools are off). The cursors the subpools
+        // would produce only matter for block production, which never happens in that mode,
+        // so they are simply left unset.
+        let (
+            last_interop_log_id,
+            last_interop_fee_number,
+            sl_chain_id_outcome,
+            last_l1_priority_id,
+        ) = if self.verify_l1_origin_txs {
+            self.upgrade_subpool
+                .on_canonical_state_change(&replay_record.protocol_version, upgrade_txs)
+                .await;
+            (
+                self.interop_roots_subpool
+                    .on_canonical_state_change(interop_txs)
+                    .await,
+                self.interop_fee_subpool
+                    .on_canonical_state_change(interop_fee_txs, strict_subpool_cleanup)
+                    .await,
+                self.sl_chain_id_subpool
+                    .on_canonical_state_change(sl_chain_id_txs)
+                    .await,
+                self.l1_subpool
+                    .on_canonical_state_change(l1_transactions)
+                    .await,
+            )
+        } else {
+            (None, None, None, None)
+        };
 
         let (header, hash) = header.into_parts();
         let body = BlockBody::default();

--- a/lib/pipeline/src/component_id.rs
+++ b/lib/pipeline/src/component_id.rs
@@ -27,7 +27,7 @@ pub enum ComponentId {
     PriorityTree,
     L1SenderExecute,
     RevmConsistencyChecker,
-    L1ConsistencyChecker,
+    LocalBatchDataCacher,
     MigrationGate,
     ReplayArchiveGate,
 }
@@ -58,7 +58,7 @@ impl ComponentId {
             Self::PriorityTree => "priority_tree",
             Self::L1SenderExecute => "l1_sender_execute",
             Self::RevmConsistencyChecker => "revm_consistency_checker",
-            Self::L1ConsistencyChecker => "l1_consistency_checker",
+            Self::LocalBatchDataCacher => "local_batch_data_cacher",
             Self::MigrationGate => "migration_gate",
             Self::ReplayArchiveGate => "replay_archive_gate",
         }

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -10,7 +10,7 @@ mod block;
 pub use block::BlockExt;
 
 mod log;
-pub use log::{L2_TO_L1_TREE_SIZE, L2ToL1Log};
+pub use log::{L2_TO_L1_LOG_SERIALIZE_SIZE, L2_TO_L1_TREE_SIZE, L2ToL1Log};
 
 mod receipt;
 pub use receipt::{ZkReceipt, ZkReceiptEnvelope};

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -1,8 +1,8 @@
 use alloy::primitives::Address;
-use zksync_os_batch_types::ExtendedCommitBatchInfo;
 use zksync_os_batch_types::batcher_model::{
     BatchEnvelope, BatchForSigning, BatchMetadata, ProverInput,
 };
+use zksync_os_batch_types::{BlockCommitmentData, ExtendedCommitBatchInfo};
 use zksync_os_batcher_metrics::BatchExecutionStage;
 use zksync_os_contract_interface::models::{L2Log, StoredBatchInfo};
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord, read_multichain_root};
@@ -29,24 +29,28 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
     let block_number_to = blocks.last().unwrap().1.block_context.block_number;
     let last_block_hash = blocks.last().unwrap().0.header.hash();
     let protocol_version = blocks.first().unwrap().1.protocol_version.clone();
-    let (_, last_replay_record, _, _) = blocks.last().unwrap();
 
     let state_view = read_state.state_view_at(block_number_to)?;
     let multichain_root = read_multichain_root(state_view);
+    let commitment_blocks: Vec<BlockCommitmentData> = blocks
+        .iter()
+        .map(|(block_output, replay_record, tree, _)| {
+            BlockCommitmentData::new(
+                block_output,
+                &replay_record.transactions,
+                tree,
+                &replay_record.block_context.block_hashes.0,
+                multichain_root,
+                replay_record.protocol_version.clone(),
+            )
+        })
+        .collect();
     let (batch_info, blob_sidecar) = ExtendedCommitBatchInfo::build(
-        blocks
-            .iter()
-            .map(|(block_output, replay_record, tree, _)| {
-                (block_output, replay_record.transactions.as_slice(), tree)
-            })
-            .collect(),
+        &commitment_blocks,
         chain_id,
         batch_number,
         pubdata_mode,
         sl_chain_id,
-        multichain_root,
-        &protocol_version,
-        &last_replay_record.block_context.block_hashes.0,
     );
 
     let mut logs = Vec::new();

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -504,6 +504,15 @@ pub struct GeneralConfig {
     #[config(default_t = 512)]
     pub blocks_to_retain_in_memory: usize,
 
+    /// [external node] Max number of blocks whose commitment data the L1 consistency checker
+    /// may hold while waiting for the corresponding L1 commit events. Bounds the gap between
+    /// local replay and L1 verification: once full, the checker stops consuming and the
+    /// pipeline fails fast ("consumer is catastrophically behind"), so it must comfortably
+    /// cover the L1 watcher's lag during a fresh sync. Entries are small (~0.3KB plus the
+    /// block's pubdata), so large values are affordable.
+    #[config(default_t = 100_000)]
+    pub consistency_checker_max_cached_blocks: usize,
+
     /// **IMPORTANT: It must be set for an external node. However, setting this DOES NOT make the node into an external node.
     /// [`GeneralConfig::node_role`] is the source of truth for node type. **
     #[config(default_t = None)]

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -513,6 +513,14 @@ pub struct GeneralConfig {
     #[config(default_t = 100_000)]
     pub consistency_checker_max_cached_blocks: usize,
 
+    /// [external node] Upper bound on how many L1-committed batches the consistency checker
+    /// verifies concurrently (and thus on parallel commitment rebuilds, each offloaded to a
+    /// blocking thread). Note that `consistency_checker_max_cached_blocks` must comfortably
+    /// exceed the combined block span of this many batches, otherwise intake stalls waiting for
+    /// eviction.
+    #[config(default_t = 16)]
+    pub consistency_checker_verification_concurrency: usize,
+
     /// **IMPORTANT: It must be set for an external node. However, setting this DOES NOT make the node into an external node.
     /// [`GeneralConfig::node_role`] is the source of truth for node type. **
     #[config(default_t = None)]

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1646,12 +1646,12 @@ async fn run_en_pipeline(
             local_batch_data_cache,
             latest_verified_batch_tx,
             l1_consistency_event_rx,
+            config
+                .general_config
+                .consistency_checker_verification_concurrency,
         );
         async move {
-            checker
-                .run()
-                .await
-                .expect("L1 consistency checker failed");
+            checker.run().await.expect("L1 consistency checker failed");
         }
     });
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -68,7 +68,9 @@ use zksync_os_gas_adjuster::GasAdjuster;
 use zksync_os_genesis::{FileGenesisInputSource, Genesis, GenesisInputSource};
 use zksync_os_internal_config::InternalConfigManager;
 use zksync_os_interop_fee_updater::{InteropFeeUpdater, InteropFeeUpdaterConfig};
-use zksync_os_l1_consistency_checker::{L1CommittedBatch, L1ConsistencyChecker, TreeBlockCache};
+use zksync_os_l1_consistency_checker::{
+    L1CommittedBatch, L1ConsistencyChecker, LocalBatchDataCacher, TreeBlockCache,
+};
 use zksync_os_l1_sender::commands::commit::CommitCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
@@ -1627,15 +1629,31 @@ async fn run_en_pipeline(
                 }),
         )
         .pipe(TreeManager { tree: tree.clone() })
-        .pipe(L1ConsistencyChecker::new(
+        // Block intake (folding replayed blocks into the shared cache) stays on the pipeline;
+        // the CPU-heavy L1 commit verification runs in the separate task spawned below so it
+        // cannot starve intake and overflow the upstream channel.
+        .pipe(LocalBatchDataCacher::new(
+            last_persisted_block_on_start,
+            state.clone(),
+            local_batch_data_cache.clone(),
+        ));
+
+    runtime.spawn_critical_task("l1 consistency checker", {
+        let checker = L1ConsistencyChecker::new(
             chain_id,
             node_state_on_startup.l1_state.sl_chain_id,
             last_persisted_block_on_start,
-            state.clone(),
             local_batch_data_cache,
             latest_verified_batch_tx,
             l1_consistency_event_rx,
-        ));
+        );
+        async move {
+            checker
+                .run()
+                .await
+                .expect("L1 consistency checker failed");
+        }
+    });
 
     let components = pipeline.components();
     pipeline.spawn();

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -995,7 +995,9 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         state.clone(),
         tree_for_rpc,
     );
-    let (local_batch_data_cache, _) = watch::channel(TreeBlockCache::new());
+    let (local_batch_data_cache, _) = watch::channel(TreeBlockCache::with_max_blocks(
+        config.general_config.consistency_checker_max_cached_blocks,
+    ));
     let (l1_consistency_event_tx, l1_consistency_event_rx) =
         tokio::sync::mpsc::channel::<L1CommittedBatch>(4096);
     let (latest_verified_batch_tx, latest_verified_batch_rx) =

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -728,25 +728,39 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let (migration_triggered_sender, migration_triggered_receiver) =
         watch::channel::<Option<u64>>(None);
 
-    if current_protocol_version >= &ProtocolSemanticVersion::new(0, 31, 0) {
-        runtime.spawn_critical_task(
-            "gateway migration watcher",
-            GatewayMigrationWatcher::create_watcher(
-                node_startup_state.l1_state.diamond_proxy_l1.clone(),
-                node_startup_state.l1_state.bridgehub_l1.clone(),
-                chain_id,
-                node_startup_state.l1_state.l1_chain_id,
-                config.general_config.gateway_chain_id,
-                next_cursors.migration_number,
-                config.l1_watcher_config.clone().into(),
-                sl_chain_id_subpool.clone(),
-                l1_block_updates.clone(),
-                l1_logs_cache.clone(),
-            )
-            .await
-            .expect("failed to start gateway migration watcher")
-            .run(),
+    // The watchers that feed L1-originated transactions into the mempool (priority txs,
+    // protocol upgrades, interop roots, gateway migrations) only run on the main node, which
+    // sources produced blocks from them. External nodes don't produce blocks, and they don't
+    // verify replayed transactions one-by-one against L1 events either — they verify whole
+    // batches against L1 commitments in the L1 consistency checker instead.
+    let l1_watchers_enabled = node_role.is_main();
+    if !l1_watchers_enabled {
+        tracing::info!(
+            "L1 transaction watchers are not started on an external node; replayed blocks are verified against L1 batch commitments instead"
         );
+    }
+
+    if current_protocol_version >= &ProtocolSemanticVersion::new(0, 31, 0) {
+        if l1_watchers_enabled {
+            runtime.spawn_critical_task(
+                "gateway migration watcher",
+                GatewayMigrationWatcher::create_watcher(
+                    node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                    node_startup_state.l1_state.bridgehub_l1.clone(),
+                    chain_id,
+                    node_startup_state.l1_state.l1_chain_id,
+                    config.general_config.gateway_chain_id,
+                    next_cursors.migration_number,
+                    config.l1_watcher_config.clone().into(),
+                    sl_chain_id_subpool.clone(),
+                    l1_block_updates.clone(),
+                    l1_logs_cache.clone(),
+                )
+                .await
+                .expect("failed to start gateway migration watcher")
+                .run(),
+            );
+        }
 
         // Initializes `last_finalized_migration` from the SL's `migrationNumber(chainId)` and,
         // if the current SL interval migration has not yet finalized, spawns a watcher to track
@@ -782,41 +796,44 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             .run(),
         );
 
-        if let Some(interop_watcher) = InteropWatcher::create_watcher(
-            node_startup_state
-                .l1_state
-                .settlement_layer_intervals
-                .clone(),
-            config.l1_watcher_config.clone().into(),
-            chain_id,
-            next_cursors.interop_root_id,
-            interop_roots_subpool.clone(),
-            gateway_block_updates.clone(),
-            gateway_logs_cache.clone(),
-        )
-        .await
-        .expect("failed to start L1 interop roots watcher")
+        if l1_watchers_enabled
+            && let Some(interop_watcher) = InteropWatcher::create_watcher(
+                node_startup_state
+                    .l1_state
+                    .settlement_layer_intervals
+                    .clone(),
+                config.l1_watcher_config.clone().into(),
+                chain_id,
+                next_cursors.interop_root_id,
+                interop_roots_subpool.clone(),
+                gateway_block_updates.clone(),
+                gateway_logs_cache.clone(),
+            )
+            .await
+            .expect("failed to start L1 interop roots watcher")
         {
             runtime.spawn_critical_task("interop roots watcher", interop_watcher.run());
         }
     }
 
     let l1_subpool = L1Subpool::new(10);
-    runtime.spawn_critical_task(
-        "L1 transaction watcher",
-        L1TxWatcher::create_watcher(
-            config.l1_watcher_config.clone().into(),
-            node_startup_state.l1_state.diamond_proxy_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_sl.clone(),
-            l1_subpool.clone(),
-            next_cursors.l1_priority_id,
-            l1_block_updates.clone(),
-            l1_logs_cache.clone(),
-        )
-        .await
-        .expect("failed to start L1 transaction watcher")
-        .run(),
-    );
+    if l1_watchers_enabled {
+        runtime.spawn_critical_task(
+            "L1 transaction watcher",
+            L1TxWatcher::create_watcher(
+                config.l1_watcher_config.clone().into(),
+                node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_sl.clone(),
+                l1_subpool.clone(),
+                next_cursors.l1_priority_id,
+                l1_block_updates.clone(),
+                l1_logs_cache.clone(),
+            )
+            .await
+            .expect("failed to start L1 transaction watcher")
+            .run(),
+        );
+    }
 
     // Transaction acceptance state - tracks whether we're accepting new transactions
     // Main nodes: accepts, but may switch to reject when `sequencer_max_blocks_to_produce` blocks are produced
@@ -921,6 +938,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         interop_roots_subpool,
         l1_subpool,
         l2_subpool.clone(),
+        l1_watchers_enabled,
     );
     let block_context_provider = BlockContextProvider::new(
         next_cursors,
@@ -946,24 +964,26 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     // ========== Start L1 Upgrade Watcher ===========
 
-    runtime.spawn_critical_task(
-        "l1 upgrade transaction watcher",
-        L1UpgradeTxWatcher::create_watcher(
-            config.l1_watcher_config.clone().into(),
-            chain_id,
-            node_startup_state.l1_state.bridgehub_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_sl.clone(),
-            bytecode_supplier_address,
-            current_protocol_version.clone(),
-            upgrade_subpool,
-            l1_block_updates.clone(),
-            l1_logs_cache.clone(),
-        )
-        .await
-        .expect("failed to start L1 upgrade transaction watcher")
-        .run(),
-    );
+    if l1_watchers_enabled {
+        runtime.spawn_critical_task(
+            "l1 upgrade transaction watcher",
+            L1UpgradeTxWatcher::create_watcher(
+                config.l1_watcher_config.clone().into(),
+                chain_id,
+                node_startup_state.l1_state.bridgehub_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_sl.clone(),
+                bytecode_supplier_address,
+                current_protocol_version.clone(),
+                upgrade_subpool,
+                l1_block_updates.clone(),
+                l1_logs_cache.clone(),
+            )
+            .await
+            .expect("failed to start L1 upgrade transaction watcher")
+            .run(),
+        );
+    }
 
     // ========== Start L1 Persist Batch Watcher ===========
 


### PR DESCRIPTION
## What

Stacked on top of `afo/verify-l1-consistency-2`. The headline change makes the EN L1 consistency checker verify committed batches **concurrently** instead of one at a time; the rest of the branch is the supporting cache/intake refinement it builds on.

### Concurrent verification (main change)

Previously the checker processed L1-committed batches strictly sequentially: it awaited each batch's blocks, rebuilt and compared the commitment, then evicted and bumped the watermark before touching the next batch. Under a burst of commits this serialized both **cache eviction** (intake capacity wasn't reclaimed until each batch finished) and the **latest-verified-batch watermark** the persist watcher depends on — with the CPU-heavy commitment rebuild as the bottleneck.

Now each batch is verified in its own task, bounded by a semaphore (`consistency_checker_verification_concurrency`, default 16), with the rebuild offloaded to a blocking thread so rebuilds parallelize across cores. The async wait for a batch's blocks stays inside the task, so a batch whose blocks aren't cached yet no longer head-of-line-blocks ready ones.

Out-of-order completion required two supporting changes:

- **`TreeBlockCache`: `VecDeque` → `BTreeMap`.** Out-of-order eviction leaves gaps in the otherwise-consecutive key space, which a deque can't represent. Each batch's blocks are evicted as soon as that batch is verified, regardless of order (`remove_range`). `next_expected_block` tracks consecutive insertion and doubles as the boundary that distinguishes "already evicted" from "not cached yet" when serving range reads.
- **Watermark advances only along the contiguous verified prefix.** If batch N+1 finishes before N, the published watermark must not move to N+1 — otherwise the persist watcher could persist N before it's been verified. Verified batch numbers are staged and the watermark advances across the fully-verified prefix only. Eviction has no such constraint, since a batch's blocks belong to it alone.

## Config

New `consistency_checker_verification_concurrency` (default 16) bounds the semaphore. Note: `consistency_checker_max_cached_blocks` must now comfortably exceed the combined block span of *this many* concurrently-verified batches, not just one — documented on both fields.

## Testing

`cargo fmt`, `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -D warnings`, and a full-binary `cargo check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)