### PR TITLE
feat(l1_consistency_checker): verify committed batches from events instead of commit calldata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15937,6 +15937,7 @@ dependencies = [
 name = "zksync_os_l1_consistency_checker"
 version = "0.20.6"
 dependencies = [
+ "alloy",
  "anyhow",
  "async-trait",
  "tokio",

--- a/lib/l1_consistency_checker/Cargo.toml
+++ b/lib/l1_consistency_checker/Cargo.toml
@@ -16,6 +16,7 @@ zksync_os_pipeline.workspace = true
 zksync_os_types.workspace = true
 zksync_os_batch_types.workspace = true
 
+alloy.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true

--- a/lib/l1_consistency_checker/src/cache.rs
+++ b/lib/l1_consistency_checker/src/cache.rs
@@ -120,6 +120,33 @@ impl TreeBlockCache {
     }
 }
 
+#[async_trait]
+pub trait TreeBlockCacheReceiverExt {
+    /// Waits until a complete block range is available in the cache.
+    async fn wait_for_range(
+        &self,
+        range: RangeInclusive<u64>,
+    ) -> anyhow::Result<Vec<BlockCommitmentData>>;
+}
+
+#[async_trait]
+impl TreeBlockCacheReceiverExt for watch::Receiver<TreeBlockCache> {
+    async fn wait_for_range(
+        &self,
+        range: RangeInclusive<u64>,
+    ) -> anyhow::Result<Vec<BlockCommitmentData>> {
+        let mut cache_rx = self.clone();
+        loop {
+            {
+                if let Some(blocks) = cache_rx.borrow_and_update().get_range(range.clone())? {
+                    return Ok(blocks);
+                }
+            }
+            cache_rx.changed().await?;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,32 +184,5 @@ mod tests {
         cache.remove_range(1..=1);
         assert!(cache.has_capacity());
         assert_eq!(cache.cached_bytes, 0);
-    }
-}
-
-#[async_trait]
-pub trait TreeBlockCacheReceiverExt {
-    /// Waits until a complete block range is available in the cache.
-    async fn wait_for_range(
-        &self,
-        range: RangeInclusive<u64>,
-    ) -> anyhow::Result<Vec<BlockCommitmentData>>;
-}
-
-#[async_trait]
-impl TreeBlockCacheReceiverExt for watch::Receiver<TreeBlockCache> {
-    async fn wait_for_range(
-        &self,
-        range: RangeInclusive<u64>,
-    ) -> anyhow::Result<Vec<BlockCommitmentData>> {
-        let mut cache_rx = self.clone();
-        loop {
-            {
-                if let Some(blocks) = cache_rx.borrow_and_update().get_range(range.clone())? {
-                    return Ok(blocks);
-                }
-            }
-            cache_rx.changed().await?;
-        }
     }
 }

--- a/lib/l1_consistency_checker/src/checker.rs
+++ b/lib/l1_consistency_checker/src/checker.rs
@@ -1,23 +1,27 @@
 use crate::cache::{TreeBlockCache, TreeBlockCacheReceiverExt};
+use alloy::primitives::B256;
 use anyhow::Context;
-use std::collections::BTreeSet;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 use tokio::sync::{Semaphore, mpsc, watch};
 use tokio::task::JoinSet;
-use zksync_os_batch_types::ExtendedCommitBatchInfo;
-use zksync_os_contract_interface::models::{DACommitmentScheme, StoredBatchInfo};
+use zksync_os_batch_types::{DiscoveredCommittedBatch, ExtendedCommitBatchInfo};
 use zksync_os_types::PubdataMode;
 
+/// An L1-committed batch to check, built purely from `BlockCommit` + `ReportCommittedBatchRange`
+/// events — no commit calldata. The two hashes are all we need to validate a local rebuild:
+/// `commitment` (the batch output hash) binds every other `StoredBatchInfo` field, and
+/// `state_commitment` is the post-batch state root.
 pub struct L1CommittedBatch {
-    pub stored_batch_info: StoredBatchInfo,
-    pub l2_da_commitment_scheme: DACommitmentScheme,
+    pub batch_number: u64,
+    pub state_commitment: B256,
+    pub commitment: B256,
     pub range: RangeInclusive<u64>,
 }
 
 impl L1CommittedBatch {
     pub fn batch_number(&self) -> u64 {
-        self.stored_batch_info.batch_number
+        self.batch_number
     }
 
     pub fn last_block_number(&self) -> u64 {
@@ -25,16 +29,15 @@ impl L1CommittedBatch {
     }
 }
 
-/// Verified batch returned by a worker task.
-struct VerifiedBatch {
-    batch_number: u64,
-    range: RangeInclusive<u64>,
-}
-
-/// Checks L1-committed batches against locally replayed blocks.
+/// Checks L1-committed batches against locally replayed blocks by rebuilding each batch's
+/// commitment from the local block cache and matching it against the on-chain event hashes.
 ///
-/// Verification is concurrent, but the published watermark advances only across the contiguous
-/// verified prefix.
+/// The rebuilt [`StoredBatchInfo`](zksync_os_contract_interface::models::StoredBatchInfo) — which,
+/// once matched, is provably identical to what L1 committed — is sent back to the persist batch
+/// watcher so it can be persisted without ever fetching commit calldata.
+///
+/// Verification is concurrent; verified batches are emitted as soon as they complete (the persist
+/// watcher orders them via execute events).
 pub struct L1ConsistencyChecker {
     chain_id: u64,
     sl_chain_id: u64,
@@ -42,18 +45,25 @@ pub struct L1ConsistencyChecker {
     /// Shared with the cacher and batch verification responder.
     cache: watch::Sender<TreeBlockCache>,
     cache_rx: watch::Receiver<TreeBlockCache>,
-    latest_verified_batch_tx: watch::Sender<u64>,
+    /// Pubdata-mode candidates to try when rebuilding, cheapest first. More than one only when the
+    /// DA scheme can't be derived from settlement config alone (L1 + Rollup: Calldata vs Blobs);
+    /// the candidate whose rebuilt `commitment` matches the event identifies the scheme.
+    da_candidates: Arc<Vec<PubdataMode>>,
+    /// Verified batches, sent back to the persist batch watcher for persistence.
+    verified_batch_tx: mpsc::Sender<DiscoveredCommittedBatch>,
     l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
     verification_concurrency: usize,
 }
 
 impl L1ConsistencyChecker {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain_id: u64,
         sl_chain_id: u64,
         last_persisted_block_on_start: u64,
         cache: watch::Sender<TreeBlockCache>,
-        latest_verified_batch_tx: watch::Sender<u64>,
+        da_candidates: Vec<PubdataMode>,
+        verified_batch_tx: mpsc::Sender<DiscoveredCommittedBatch>,
         l1_events_rx: mpsc::Receiver<L1CommittedBatch>,
         verification_concurrency: usize,
     ) -> Self {
@@ -64,68 +74,70 @@ impl L1ConsistencyChecker {
             last_persisted_block_on_start,
             cache,
             cache_rx,
-            latest_verified_batch_tx,
+            da_candidates: Arc::new(da_candidates),
+            verified_batch_tx,
             l1_events_rx,
             verification_concurrency,
         }
     }
 
-    /// Verifies one committed batch once its local blocks are cached.
+    /// Rebuilds one committed batch from its cached blocks and matches it against the event hashes,
+    /// returning the verified local [`StoredBatchInfo`](zksync_os_contract_interface::models::StoredBatchInfo).
     async fn verify_commit(
         cache_rx: watch::Receiver<TreeBlockCache>,
         chain_id: u64,
         sl_chain_id: u64,
-        last_persisted_block_on_start: u64,
+        da_candidates: Arc<Vec<PubdataMode>>,
         commit: L1CommittedBatch,
-    ) -> anyhow::Result<VerifiedBatch> {
-        let batch_number = commit.batch_number();
+    ) -> anyhow::Result<DiscoveredCommittedBatch> {
+        let batch_number = commit.batch_number;
         let range = commit.range.clone();
+        let blocks = cache_rx
+            .wait_for_range(range.clone())
+            .await
+            .context("while waiting for a committed batch's blocks to be cached")?;
+        let state_commitment = commit.state_commitment;
+        let commitment = commit.commitment;
 
-        if commit.last_block_number() > last_persisted_block_on_start {
-            let blocks = cache_rx
-                .wait_for_range(range.clone())
-                .await
-                .context("while waiting for a committed batch's blocks to be cached")?;
-            let l2_da_commitment_scheme = commit.l2_da_commitment_scheme;
-            let l1_stored = commit.stored_batch_info;
-
-            tokio::task::spawn_blocking(move || {
+        let batch_info = tokio::task::spawn_blocking(move || {
+            // Try each DA-scheme candidate; a `commitment` match both verifies the batch and
+            // identifies the scheme it was committed under.
+            for &pubdata_mode in da_candidates.iter() {
                 let (local_batch_info, _) = ExtendedCommitBatchInfo::build(
                     &blocks,
                     chain_id,
                     batch_number,
-                    PubdataMode::from_da_commitment_scheme(l2_da_commitment_scheme),
+                    pubdata_mode,
                     sl_chain_id,
                 );
-
                 let local_stored = local_batch_info.into_stored();
-                if local_stored != l1_stored {
-                    tracing::error!(
-                        "L1 committed batch #{} is inconsistent with locally replayed blocks, expected: {:?}, received: {:?}",
-                        batch_number,
-                        local_stored,
-                        l1_stored,
-                    );
-                    anyhow::bail!(
-                        "L1 committed batch #{} is inconsistent with locally replayed blocks",
-                        batch_number
-                    );
+                if local_stored.state_commitment == state_commitment
+                    && local_stored.commitment == commitment
+                {
+                    return Ok(local_stored);
                 }
-                Ok(())
-            })
-            .await
-            .context("while rebuilding a committed batch's commitment")??;
-
-            tracing::info!(
-                "verified L1 committed batch #{} against locally replayed blocks {:?}",
+            }
+            tracing::error!(
                 batch_number,
-                range,
+                ?state_commitment,
+                ?commitment,
+                "L1 committed batch is inconsistent with locally replayed blocks (no DA-scheme candidate matched)",
             );
-        }
+            anyhow::bail!(
+                "L1 committed batch #{batch_number} is inconsistent with locally replayed blocks"
+            )
+        })
+        .await
+        .context("while rebuilding a committed batch's commitment")??;
 
-        Ok(VerifiedBatch {
+        tracing::info!(
+            "verified L1 committed batch #{} against locally replayed blocks {:?}",
             batch_number,
             range,
+        );
+        Ok(DiscoveredCommittedBatch {
+            batch_info,
+            block_range: range,
         })
     }
 
@@ -133,11 +145,7 @@ impl L1ConsistencyChecker {
         tracing::info!("starting L1 consistency checker");
 
         let semaphore = Arc::new(Semaphore::new(self.verification_concurrency));
-        let mut tasks: JoinSet<anyhow::Result<VerifiedBatch>> = JoinSet::new();
-
-        // Stage out-of-order completions; publish only the contiguous verified prefix.
-        let mut verified_ahead: BTreeSet<u64> = BTreeSet::new();
-        let mut next_batch_to_confirm = *self.latest_verified_batch_tx.borrow() + 1;
+        let mut tasks: JoinSet<anyhow::Result<DiscoveredCommittedBatch>> = JoinSet::new();
 
         loop {
             tokio::select! {
@@ -145,6 +153,11 @@ impl L1ConsistencyChecker {
                     let Some(commit) = maybe_commit else {
                         break;
                     };
+                    // Batches already persisted before startup were verified by a previous run;
+                    // their blocks are not cached, so don't wait for them.
+                    if commit.last_block_number() <= self.last_persisted_block_on_start {
+                        continue;
+                    }
                     tracing::debug!(
                         "received L1 committed batch {} for consistency checking in range {:?}",
                         commit.batch_number(),
@@ -159,58 +172,36 @@ impl L1ConsistencyChecker {
                     let cache_rx = self.cache_rx.clone();
                     let chain_id = self.chain_id;
                     let sl_chain_id = self.sl_chain_id;
-                    let last_persisted_block_on_start = self.last_persisted_block_on_start;
+                    let da_candidates = self.da_candidates.clone();
                     tasks.spawn(async move {
                         let _permit = permit; // held until the verification finishes
-                        Self::verify_commit(
-                            cache_rx,
-                            chain_id,
-                            sl_chain_id,
-                            last_persisted_block_on_start,
-                            commit,
-                        )
-                        .await
+                        Self::verify_commit(cache_rx, chain_id, sl_chain_id, da_candidates, commit)
+                            .await
                     });
                 }
                 Some(joined) = tasks.join_next() => {
                     let verified = joined.context("verification task panicked")??;
-                    self.handle_verified(verified, &mut verified_ahead, &mut next_batch_to_confirm);
+                    self.handle_verified(verified).await?;
                 }
             }
         }
 
         while let Some(joined) = tasks.join_next().await {
             let verified = joined.context("verification task panicked")??;
-            self.handle_verified(verified, &mut verified_ahead, &mut next_batch_to_confirm);
+            self.handle_verified(verified).await?;
         }
         Ok(())
     }
 
-    /// Evicts verified blocks and advances the contiguous verified-batch watermark.
-    fn handle_verified(
-        &self,
-        verified: VerifiedBatch,
-        verified_ahead: &mut BTreeSet<u64>,
-        next_batch_to_confirm: &mut u64,
-    ) {
+    /// Evicts the verified batch's blocks from the cache and hands the rebuilt batch back to the
+    /// persist watcher.
+    async fn handle_verified(&self, verified: DiscoveredCommittedBatch) -> anyhow::Result<()> {
         self.cache
-            .send_modify(|cache| cache.remove_range(verified.range));
-
-        if verified.batch_number >= *next_batch_to_confirm {
-            verified_ahead.insert(verified.batch_number);
-        }
-        while verified_ahead.remove(next_batch_to_confirm) {
-            *next_batch_to_confirm += 1;
-        }
-
-        let confirmed = *next_batch_to_confirm - 1;
-        self.latest_verified_batch_tx.send_if_modified(|latest| {
-            if confirmed > *latest {
-                *latest = confirmed;
-                true
-            } else {
-                false
-            }
-        });
+            .send_modify(|cache| cache.remove_range(verified.block_range.clone()));
+        self.verified_batch_tx
+            .send(verified)
+            .await
+            .context("persist batch watcher closed the verified-batch channel")?;
+        Ok(())
     }
 }

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -3,13 +3,17 @@ use crate::traits::ProcessRawEvents;
 use crate::watcher::L1WatcherError;
 use crate::{L1WatcherConfig, SegmentSpec, util};
 use alloy::eips::BlockId;
+use alloy::primitives::B256;
 use alloy::rpc::types::{Log, Topic};
 use alloy::sol_types::SolEvent;
 use anyhow::{Context, anyhow};
 use std::collections::HashMap;
-use tokio::sync::{mpsc, watch};
+use std::ops::RangeInclusive;
+use tokio::sync::mpsc;
 use zksync_os_batch_types::{DiscoveredCommittedBatch, ExtendedCommitBatchInfo};
-use zksync_os_contract_interface::IExecutor::{BlockExecution, ReportCommittedBatchRangeZKsyncOS};
+use zksync_os_contract_interface::IExecutor::{
+    BlockCommit, BlockExecution, ReportCommittedBatchRangeZKsyncOS,
+};
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::settlement_layer_intervals::SettlementLayerIntervals;
 use zksync_os_l1_consistency_checker::L1CommittedBatch;
@@ -31,8 +35,19 @@ use zksync_os_storage_api::{PersistedBatch, WriteBatch};
 ///   proof-related requests;
 pub struct L1PersistBatchWatcher<BatchStorage> {
     batch_storage: BatchStorage,
+    /// EN-only. When set, the watcher dispatches committed batches to the L1 consistency checker
+    /// (built from `BlockCommit` + `ReportCommittedBatchRange` events, no commit calldata) and
+    /// persists the locally-rebuilt batch the checker returns via `verified_batch_rx`. When unset
+    /// (main node), the watcher rebuilds the batch from commit calldata instead.
     consistency_checker_tx: Option<mpsc::Sender<L1CommittedBatch>>,
-    latest_verified_batch_rx: Option<watch::Receiver<u64>>,
+    /// EN-only. Verified, locally-rebuilt batches returned by the consistency checker, keyed into
+    /// `committed_batches` as they arrive (out of order) and consumed at execute time.
+    verified_batch_rx: Option<mpsc::Receiver<DiscoveredCommittedBatch>>,
+    /// EN-only buffers for pairing the two commit events by batch number, since their emission
+    /// order within the commit tx is not guaranteed: `(state_commitment, commitment)` from
+    /// `BlockCommit`, and the block range from `ReportCommittedBatchRange`.
+    pending_commit_hashes: HashMap<u64, (B256, B256)>,
+    pending_commit_ranges: HashMap<u64, RangeInclusive<u64>>,
     committed_batches: HashMap<u64, DiscoveredCommittedBatch>,
     last_processed_commit_batch: u64,
     last_persisted_batch_on_start: u64,
@@ -53,12 +68,12 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
         intervals: SettlementLayerIntervals,
         batch_storage: BatchStorage,
         consistency_checker_tx: Option<mpsc::Sender<L1CommittedBatch>>,
-        latest_verified_batch_rx: Option<watch::Receiver<u64>>,
+        verified_batch_rx: Option<mpsc::Receiver<DiscoveredCommittedBatch>>,
     ) -> SegmentResolver<(), Self> {
         assert_eq!(
             consistency_checker_tx.is_some(),
-            latest_verified_batch_rx.is_some(),
-            "L1 consistency checker sender and latest verified batch receiver must be configured together"
+            verified_batch_rx.is_some(),
+            "L1 consistency checker sender and verified-batch receiver must be configured together"
         );
         tracing::info!(
             num_intervals = intervals.intervals().len(),
@@ -167,7 +182,9 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
             let processor = Self {
                 batch_storage,
                 consistency_checker_tx,
-                latest_verified_batch_rx,
+                verified_batch_rx,
+                pending_commit_hashes: HashMap::new(),
+                pending_commit_ranges: HashMap::new(),
                 committed_batches: HashMap::new(),
                 last_processed_commit_batch: last_persisted_batch,
                 last_persisted_batch_on_start: last_persisted_batch,
@@ -258,44 +275,100 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 );
             }
             tracing::debug!(batch_number, "discovered committed batch");
-            let (batch_info, committed_batch) =
-                self.parse_committed_batch(provider, report, &log).await?;
 
-            // EN-only consistency checker input.
-            if let Some(tx) = &self.consistency_checker_tx {
-                let l1_commit = L1CommittedBatch {
-                    stored_batch_info: committed_batch.batch_info.clone(),
-                    l2_da_commitment_scheme: batch_info.l2_da_commitment_scheme,
-                    range: committed_batch.block_range.clone(),
-                };
-
-                tx.send(l1_commit).await.map_err(|_| {
-                    L1WatcherError::Other(anyhow::anyhow!(
-                        "L1 consistency checker event channel closed"
-                    ))
-                })?;
+            match &self.consistency_checker_tx {
+                // EN: dispatch to the consistency checker, pairing this report's block range with
+                // the `BlockCommit` hashes. The rebuilt batch comes back via `verified_batch_rx`
+                // and is persisted at execute time — no commit calldata is fetched.
+                Some(_) => {
+                    self.pending_commit_ranges.insert(
+                        batch_number,
+                        report.firstBlockNumber..=report.lastBlockNumber,
+                    );
+                    self.try_dispatch_commit(batch_number).await?;
+                }
+                // Main node: rebuild the batch from commit calldata and buffer it for persistence.
+                None => {
+                    let (_, committed_batch) =
+                        self.parse_committed_batch(provider, report, &log).await?;
+                    self.committed_batches.insert(batch_number, committed_batch);
+                }
             }
 
-            self.committed_batches.insert(batch_number, committed_batch);
             self.last_processed_commit_batch = batch_number;
         }
         Ok(())
     }
 
-    async fn wait_until_batch_verified(&mut self, batch_number: u64) -> Result<(), L1WatcherError> {
-        let Some(latest_verified_batch_rx) = self.latest_verified_batch_rx.as_mut() else {
+    /// Records a `BlockCommit` event's hashes and tries to pair them with an already-seen report.
+    /// EN-only.
+    async fn record_block_commit(&mut self, log: &Log) -> Result<(), L1WatcherError> {
+        let event = BlockCommit::decode_log(&log.inner)?.data;
+        let batch_number = event.batchNumber.to::<u64>();
+        // `batchHash` carries the post-batch state commitment for ZKsync OS batches.
+        self.pending_commit_hashes
+            .insert(batch_number, (event.batchHash, event.commitment));
+        self.try_dispatch_commit(batch_number).await
+    }
+
+    /// Dispatches a committed batch to the consistency checker once both of its commit events
+    /// (`BlockCommit` hashes and `ReportCommittedBatchRange` block range) have been seen. No-op
+    /// until then. EN-only.
+    async fn try_dispatch_commit(&mut self, batch_number: u64) -> Result<(), L1WatcherError> {
+        let (Some(&(state_commitment, commitment)), Some(range)) = (
+            self.pending_commit_hashes.get(&batch_number),
+            self.pending_commit_ranges.get(&batch_number),
+        ) else {
             return Ok(());
         };
+        let range = range.clone();
+        self.pending_commit_hashes.remove(&batch_number);
+        self.pending_commit_ranges.remove(&batch_number);
 
+        let Some(tx) = &self.consistency_checker_tx else {
+            return Ok(());
+        };
+        tx.send(L1CommittedBatch {
+            batch_number,
+            state_commitment,
+            commitment,
+            range,
+        })
+        .await
+        .map_err(|_| {
+            L1WatcherError::Other(anyhow::anyhow!(
+                "L1 consistency checker event channel closed"
+            ))
+        })
+    }
+
+    /// Waits for the consistency checker to return the verified, locally-rebuilt batch, buffering
+    /// any earlier-arriving batches into `committed_batches`. EN-only; the main node never calls
+    /// this (it rebuilds from calldata and buffers directly).
+    async fn wait_for_verified_batch(
+        &mut self,
+        batch_number: u64,
+    ) -> Result<DiscoveredCommittedBatch, L1WatcherError> {
+        if let Some(committed_batch) = self.committed_batches.remove(&batch_number) {
+            return Ok(committed_batch);
+        }
         loop {
-            if *latest_verified_batch_rx.borrow_and_update() >= batch_number {
-                return Ok(());
+            let verified = self
+                .verified_batch_rx
+                .as_mut()
+                .expect("verified-batch receiver is configured on the external node")
+                .recv()
+                .await
+                .ok_or_else(|| {
+                    L1WatcherError::Other(anyhow::anyhow!(
+                        "L1 consistency checker stopped before verifying batch #{batch_number}"
+                    ))
+                })?;
+            let verified_number = verified.batch_info.batch_number;
+            if verified_number == batch_number {
+                return Ok(verified);
             }
-            latest_verified_batch_rx.changed().await.map_err(|_| {
-                L1WatcherError::Other(anyhow::anyhow!(
-                    "L1 consistency checker stopped before verifying batch #{batch_number}"
-                ))
-            })?;
+            self.committed_batches.insert(verified_number, verified);
         }
     }
 }
@@ -307,9 +380,16 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
     }
 
     fn event_signatures(&self) -> Topic {
-        Topic::default()
+        let topic = Topic::default()
             .extend(ReportCommittedBatchRangeZKsyncOS::SIGNATURE_HASH)
-            .extend(BlockExecution::SIGNATURE_HASH)
+            .extend(BlockExecution::SIGNATURE_HASH);
+        // On the EN the batch is rebuilt locally and matched against the `BlockCommit` hashes
+        // (commitment + state commitment), avoiding the commit calldata fetch.
+        if self.consistency_checker_tx.is_some() {
+            topic.extend(BlockCommit::SIGNATURE_HASH)
+        } else {
+            topic
+        }
     }
 
     fn filter_events(&self, logs: Vec<Log>) -> Vec<Log> {
@@ -327,20 +407,34 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
                 let report = ReportCommittedBatchRangeZKsyncOS::decode_log(&log.inner)?.data;
                 self.process_commit(provider, report, log).await?;
             }
+            s if s == BlockCommit::SIGNATURE_HASH => {
+                self.record_block_commit(&log).await?;
+            }
             s if s == BlockExecution::SIGNATURE_HASH => {
                 let execute = BlockExecution::decode_log(&log.inner)?.data;
                 let batch_number = execute.batchNumber.to::<u64>();
                 if batch_number > self.last_persisted_batch_on_start {
                     let batch_hash = execute.batchHash;
-                    if let Some(committed_batch) = self.committed_batches.remove(&batch_number) {
+                    // Legacy batches (older testnet chains) never produced a
+                    // `ReportCommittedBatchRangeZKsyncOS`, so no commit was ever processed.
+                    let is_legacy =
+                        self.last_processed_commit_batch == self.last_persisted_batch_on_start;
+                    // Obtain the batch to persist: the consistency checker's locally-rebuilt batch
+                    // on the EN, or the calldata-rebuilt buffer on the main node.
+                    let committed_batch = if is_legacy {
+                        None
+                    } else if self.consistency_checker_tx.is_some() {
                         tracing::debug!(
                             batch_number,
                             ?batch_hash,
                             "discovered executed batch, waiting for consistency check"
                         );
+                        Some(self.wait_for_verified_batch(batch_number).await?)
+                    } else {
+                        self.committed_batches.remove(&batch_number)
+                    };
 
-                        self.wait_until_batch_verified(batch_number).await?;
-
+                    if let Some(committed_batch) = committed_batch {
                         if execute.commitment != committed_batch.batch_info.commitment {
                             return Err(L1WatcherError::Other(anyhow!(
                                 "Commitment is not matching for batch #{}, commit: {:?}, execute: {:?}",
@@ -369,8 +463,7 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
                                 log.block_number.expect("Missing block number in log"),
                             ),
                         });
-                    } else if self.last_processed_commit_batch == self.last_persisted_batch_on_start
-                    {
+                    } else if is_legacy {
                         // No `ReportCommittedBatchRangeZKsyncOS` event was processed yet, it is very likely that the batch is legacy
                         // i.e. block range was not reported for it. Skip this batch.
                         tracing::info!("assuming batch #{batch_number} is legacy and skipping it");

--- a/lib/mempool/src/pool.rs
+++ b/lib/mempool/src/pool.rs
@@ -28,6 +28,11 @@ pub struct Pool<T> {
     interop_roots_subpool: InteropRootsSubpool,
     l1_subpool: L1Subpool,
     l2_subpool: T,
+    /// When `false`, replayed L1-originated transactions (priority, upgrade, interop,
+    /// SL-chain-id, interop-fee) are trusted as-is instead of being matched against locally
+    /// watched L1 events. False on external nodes, which don't run the L1 watchers feeding
+    /// these subpools and verify whole batches against L1 commitments instead.
+    verify_l1_origin_txs: bool,
 }
 
 impl<T: L2Subpool> Pool<T> {
@@ -38,6 +43,7 @@ impl<T: L2Subpool> Pool<T> {
         interop_roots_subpool: InteropRootsSubpool,
         l1_subpool: L1Subpool,
         l2_subpool: T,
+        verify_l1_origin_txs: bool,
     ) -> Self {
         Self {
             upgrade_subpool,
@@ -46,6 +52,7 @@ impl<T: L2Subpool> Pool<T> {
             interop_roots_subpool,
             l1_subpool,
             l2_subpool,
+            verify_l1_origin_txs,
         }
     }
 
@@ -228,25 +235,36 @@ impl<T: L2Subpool> Pool<T> {
                 }
             }
         }
-        self.upgrade_subpool
-            .on_canonical_state_change(&replay_record.protocol_version, upgrade_txs)
-            .await;
-        let last_interop_log_id = self
-            .interop_roots_subpool
-            .on_canonical_state_change(interop_txs)
-            .await;
-        let last_interop_fee_number = self
-            .interop_fee_subpool
-            .on_canonical_state_change(interop_fee_txs, strict_subpool_cleanup)
-            .await;
-        let sl_chain_id_outcome = self
-            .sl_chain_id_subpool
-            .on_canonical_state_change(sl_chain_id_txs)
-            .await;
-        let last_l1_priority_id = self
-            .l1_subpool
-            .on_canonical_state_change(l1_transactions)
-            .await;
+        // With verification disabled there is nothing to match the replayed transactions
+        // against (the L1 watchers feeding these subpools are off). The cursors the subpools
+        // would produce only matter for block production, which never happens in that mode,
+        // so they are simply left unset.
+        let (
+            last_interop_log_id,
+            last_interop_fee_number,
+            sl_chain_id_outcome,
+            last_l1_priority_id,
+        ) = if self.verify_l1_origin_txs {
+            self.upgrade_subpool
+                .on_canonical_state_change(&replay_record.protocol_version, upgrade_txs)
+                .await;
+            (
+                self.interop_roots_subpool
+                    .on_canonical_state_change(interop_txs)
+                    .await,
+                self.interop_fee_subpool
+                    .on_canonical_state_change(interop_fee_txs, strict_subpool_cleanup)
+                    .await,
+                self.sl_chain_id_subpool
+                    .on_canonical_state_change(sl_chain_id_txs)
+                    .await,
+                self.l1_subpool
+                    .on_canonical_state_change(l1_transactions)
+                    .await,
+            )
+        } else {
+            (None, None, None, None)
+        };
 
         let (header, hash) = header.into_parts();
         let body = BlockBody::default();

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -57,6 +57,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use zksync_os_backpressure::{BackpressureMonitor, PipelineTracker};
 use zksync_os_base_token_adjuster::BaseTokenPriceUpdater;
+use zksync_os_batch_types::DiscoveredCommittedBatch;
 use zksync_os_batch_verification::{
     BatchVerificationConfig as BatchVerificationPolicyConfig, BatchVerificationPipelineStep,
     BatchVerificationResponder, effective_verification_policy,
@@ -907,10 +908,11 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     ));
     let (l1_consistency_event_tx, l1_consistency_event_rx) =
         tokio::sync::mpsc::channel::<L1CommittedBatch>(4096);
-    let (latest_verified_batch_tx, latest_verified_batch_rx) =
-        tokio::sync::watch::channel(persistent_batch_storage.latest_batch());
+    // The consistency checker returns the locally-rebuilt batch for the persist watcher to write.
+    let (verified_batch_tx, verified_batch_rx) =
+        tokio::sync::mpsc::channel::<DiscoveredCommittedBatch>(4096);
     let l1_consistency_event_tx = (!node_role.is_main()).then_some(l1_consistency_event_tx);
-    let latest_verified_batch_rx = (!node_role.is_main()).then_some(latest_verified_batch_rx);
+    let verified_batch_rx = (!node_role.is_main()).then_some(verified_batch_rx);
     runtime.spawn_critical_task("l1 batch persist watcher", {
         let config = config.l1_watcher_config.clone();
         let settlement_layer_intervals = node_startup_state
@@ -919,14 +921,13 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             .clone();
         let persistent_batch_storage = persistent_batch_storage.clone();
         let l1_consistency_event_tx = l1_consistency_event_tx.clone();
-        let latest_verified_batch_rx = latest_verified_batch_rx.clone();
         async move {
             L1PersistBatchWatcher::create_watcher(
                 config.into(),
                 settlement_layer_intervals,
                 persistent_batch_storage,
                 l1_consistency_event_tx,
-                latest_verified_batch_rx,
+                verified_batch_rx,
             )
             .run(())
             .await
@@ -1079,7 +1080,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             chain_id,
             last_persisted_block_on_start,
             local_batch_data_cache,
-            latest_verified_batch_tx,
+            verified_batch_tx,
             l1_consistency_event_rx,
             verify_batch_rx,
             outgoing_verify_results.clone(),
@@ -1447,7 +1448,7 @@ async fn run_en_pipeline(
     chain_id: u64,
     last_persisted_block_on_start: u64,
     local_batch_data_cache: watch::Sender<TreeBlockCache>,
-    latest_verified_batch_tx: watch::Sender<u64>,
+    verified_batch_tx: tokio::sync::mpsc::Sender<DiscoveredCommittedBatch>,
     l1_consistency_event_rx: tokio::sync::mpsc::Receiver<L1CommittedBatch>,
     verify_batch_rx: tokio::sync::mpsc::Receiver<PeerVerifyBatch>,
     outgoing_verify_results: tokio::sync::broadcast::Sender<PeerVerifyBatchResult>,
@@ -1531,13 +1532,28 @@ async fn run_en_pipeline(
             local_batch_data_cache.clone(),
         ));
 
+    // Pubdata-mode candidates the checker rebuilds under. The DA scheme is fully determined by the
+    // settlement layer except for L1+Rollup, where Calldata vs Blobs is the operator's choice — so
+    // we try both (cheapest first) and let the matching commitment identify it.
+    let da_candidates = if node_state_on_startup.l1_state.settles_on_gateway() {
+        match node_state_on_startup.l1_state.da_input_mode {
+            BatchDaInputMode::Rollup => vec![PubdataMode::RelayedL2Calldata],
+            BatchDaInputMode::Validium => vec![PubdataMode::Validium],
+        }
+    } else {
+        match node_state_on_startup.l1_state.da_input_mode {
+            BatchDaInputMode::Rollup => vec![PubdataMode::Calldata, PubdataMode::Blobs],
+            BatchDaInputMode::Validium => vec![PubdataMode::Validium],
+        }
+    };
     runtime.spawn_critical_task("l1 consistency checker", {
         let checker = L1ConsistencyChecker::new(
             chain_id,
             node_state_on_startup.l1_state.sl_chain_id,
             last_persisted_block_on_start,
             local_batch_data_cache,
-            latest_verified_batch_tx,
+            da_candidates,
+            verified_batch_tx,
             l1_consistency_event_rx,
             config
                 .general_config

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -697,22 +697,36 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     let (migration_triggered_sender, migration_triggered_receiver) =
         watch::channel::<Option<u64>>(None);
 
-    if current_protocol_version >= &ProtocolSemanticVersion::new(0, 31, 0) {
-        runtime.spawn_critical_task(
-            "gateway migration watcher",
-            GatewayMigrationWatcher::create_watcher(
-                node_startup_state.l1_state.diamond_proxy_l1.clone(),
-                node_startup_state.l1_state.bridgehub_l1.clone(),
-                chain_id,
-                node_startup_state.l1_state.l1_chain_id,
-                config.general_config.gateway_chain_id,
-                config.l1_watcher_config.clone().into(),
-                sl_chain_id_subpool.clone(),
-            )
-            .await
-            .expect("failed to start gateway migration watcher")
-            .run(next_cursors.migration_number),
+    // The watchers that feed L1-originated transactions into the mempool (priority txs,
+    // protocol upgrades, interop roots, gateway migrations) only run on the main node, which
+    // sources produced blocks from them. External nodes don't produce blocks, and they don't
+    // verify replayed transactions one-by-one against L1 events either — they verify whole
+    // batches against L1 commitments in the L1 consistency checker instead.
+    let l1_watchers_enabled = node_role.is_main();
+    if !l1_watchers_enabled {
+        tracing::info!(
+            "L1 transaction watchers are not started on an external node; replayed blocks are verified against L1 batch commitments instead"
         );
+    }
+
+    if current_protocol_version >= &ProtocolSemanticVersion::new(0, 31, 0) {
+        if l1_watchers_enabled {
+            runtime.spawn_critical_task(
+                "gateway migration watcher",
+                GatewayMigrationWatcher::create_watcher(
+                    node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                    node_startup_state.l1_state.bridgehub_l1.clone(),
+                    chain_id,
+                    node_startup_state.l1_state.l1_chain_id,
+                    config.general_config.gateway_chain_id,
+                    config.l1_watcher_config.clone().into(),
+                    sl_chain_id_subpool.clone(),
+                )
+                .await
+                .expect("failed to start gateway migration watcher")
+                .run(next_cursors.migration_number),
+            );
+        }
 
         // Initializes `last_finalized_migration` from the SL's `migrationNumber(chainId)` and,
         // if the current SL interval migration has not yet finalized, spawns a watcher to track
@@ -746,16 +760,17 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             .run(),
         );
 
-        if let Some(interop_watcher) = InteropWatcher::create_watcher(
-            node_startup_state
-                .l1_state
-                .settlement_layer_intervals
-                .clone(),
-            config.l1_watcher_config.clone().into(),
-            chain_id,
-            interop_roots_subpool.clone(),
-        )
-        .expect("failed to start L1 interop roots watcher")
+        if l1_watchers_enabled
+            && let Some(interop_watcher) = InteropWatcher::create_watcher(
+                node_startup_state
+                    .l1_state
+                    .settlement_layer_intervals
+                    .clone(),
+                config.l1_watcher_config.clone().into(),
+                chain_id,
+                interop_roots_subpool.clone(),
+            )
+            .expect("failed to start L1 interop roots watcher")
         {
             runtime.spawn_critical_task(
                 "interop roots watcher",
@@ -765,18 +780,20 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     }
 
     let l1_subpool = L1Subpool::new(10);
-    runtime.spawn_critical_task(
-        "L1 transaction watcher",
-        L1TxWatcher::create_watcher(
-            config.l1_watcher_config.clone().into(),
-            node_startup_state.l1_state.diamond_proxy_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_sl.clone(),
-            l1_subpool.clone(),
-        )
-        .await
-        .expect("failed to start L1 transaction watcher")
-        .run(next_cursors.l1_priority_id),
-    );
+    if l1_watchers_enabled {
+        runtime.spawn_critical_task(
+            "L1 transaction watcher",
+            L1TxWatcher::create_watcher(
+                config.l1_watcher_config.clone().into(),
+                node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_sl.clone(),
+                l1_subpool.clone(),
+            )
+            .await
+            .expect("failed to start L1 transaction watcher")
+            .run(next_cursors.l1_priority_id),
+        );
+    }
 
     // Transaction acceptance state - tracks whether we're accepting new transactions
     // Main nodes: accepts, but may switch to reject when `sequencer_max_blocks_to_produce` blocks are produced
@@ -854,6 +871,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         interop_roots_subpool,
         l1_subpool,
         l2_subpool.clone(),
+        l1_watchers_enabled,
     );
     let block_context_provider = BlockContextProvider::new(
         fee_provider,
@@ -876,21 +894,23 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
 
     // ========== Start L1 Upgrade Watcher ===========
 
-    runtime.spawn_critical_task(
-        "l1 upgrade transaction watcher",
-        L1UpgradeTxWatcher::create_watcher(
-            config.l1_watcher_config.clone().into(),
-            chain_id,
-            node_startup_state.l1_state.bridgehub_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_l1.clone(),
-            node_startup_state.l1_state.diamond_proxy_sl.clone(),
-            bytecode_supplier_address,
-            upgrade_subpool,
-        )
-        .await
-        .expect("failed to start L1 upgrade transaction watcher")
-        .run(current_protocol_version.clone()),
-    );
+    if l1_watchers_enabled {
+        runtime.spawn_critical_task(
+            "l1 upgrade transaction watcher",
+            L1UpgradeTxWatcher::create_watcher(
+                config.l1_watcher_config.clone().into(),
+                chain_id,
+                node_startup_state.l1_state.bridgehub_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_l1.clone(),
+                node_startup_state.l1_state.diamond_proxy_sl.clone(),
+                bytecode_supplier_address,
+                upgrade_subpool,
+            )
+            .await
+            .expect("failed to start L1 upgrade transaction watcher")
+            .run(current_protocol_version.clone()),
+        );
+    }
 
     // ========== Start L1 Persist Batch Watcher ===========
 


### PR DESCRIPTION
Stacked on `afo/verify-l1-consistency-2`. Two changes.

## 1. Verify committed batches from events, drop the commit calldata fetch

On the external-node sync path, L1-committed batches are now validated purely from the `BlockCommit` + `ReportCommittedBatchRange` events plus a local rebuild, instead of fetching and decoding each batch's commit transaction calldata.

**Why it's sound:** `BlockCommit.commitment` (the batch output hash = `public_input_hash`) binds every other `StoredBatchInfo` field, and `batchHash` is the post-batch state commitment. So matching a locally-rebuilt batch's `commitment` + `state_commitment` against the event is equivalent to matching the full on-chain `StoredBatchInfo.hash()` — no weaker integrity guarantee (only keccak collision-resistance, which the protocol already assumes).

**What's eliminated per batch on the EN steady-state path** — the previous `fetch_committed_batch_data` made, for every committed batch:
- `eth_getTransactionByHash` (with a retry loop) + decode of the `commitBatchesSharedBridge` calldata;
- `getL2SystemContractsUpgradeBatchNumber()`;
- `getProtocolVersion()`;
- conditionally `getL2SystemContractsUpgradeTxHash()`.

All four are gone — every input to the commitment hash (tx counts, priority-ops hash, L2→L1 logs root, dep-roots, **protocol version**, **upgrade tx hash**) is already in the locally-replayed block data; the EN executed those blocks. The one input not in the blocks — the **pubdata/DA commitment scheme** — is resolved by **trial-match**: the checker rebuilds under candidate schemes (deterministic from the settlement layer except L1+Rollup, which tries Calldata then Blobs) and the candidate whose rebuilt `commitment` matches the event identifies it. A wrong locally-derived value simply fails the match, so dropping those calls doesn't weaken the check.

Mechanics:
- `L1CommittedBatch` slimmed to `{ batch_number, state_commitment, commitment, range }` (built from events).
- The checker rebuilds the batch from its cache, trial-matches, and returns the verified, locally-rebuilt `StoredBatchInfo` to the persist watcher over an mpsc (replacing the `latest_verified_batch` watermark watch) — so the persisted record is the local rebuild, never reconstructed from calldata.
- The persist watcher subscribes to `BlockCommit` (EN only) and pairs it with `ReportCommittedBatchRange` by batch number (bidirectional buffering, since their emission order within the commit tx isn't guaranteed). It keeps its existing execute-time `commitment`/`batchHash` cross-check as a final guard.
- Main node is unchanged (rebuilds from calldata); the EN resume re-validation of already-persisted batches keeps the calldata fallback. Legacy batches without a range report are still skipped.

## 2. Don't run L1 tx watchers on external nodes

Restores the mempool change reverted in `6f22816`, re-applied onto the current (since-refactored) watcher APIs. The watchers feeding L1-originated transactions into the mempool (priority, upgrade, interop roots, gateway migration) only run on the main node now; ENs verify whole batches against L1 commitments instead, so `Pool` is told to trust replayed L1-origin txs (`verify_l1_origin_txs = false`) rather than match them against L1 events it doesn't watch.

## Testing

`cargo check` (full binary), `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -D warnings`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)