### PR TITLE
feat: added jsonwebtoken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ clap = "4.2.2"
 derive_more = "2.1.1"
 insta = "1.29.0"
 jsonrpsee = { version = "0.26.0", default-features = false }
+jsonwebtoken = { version = "10.3.0", features = ["use_pem", "rust_crypto"] }
 leb128 = "0.2.5"
 rayon = "1.11.0"
 once_cell = "1"

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -112,6 +112,7 @@ async-trait.workspace = true
 jsonrpsee = { workspace = true, default-features = false, features = [
     "client",
 ] }
+jsonwebtoken.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
 rustls = { workspace = true }


### PR DESCRIPTION
The server panics on startup when GCP KMS signing is configured:

```text
Could not automatically determine the process-level CryptoProvider from jsonwebtoken crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'rust_crypto' and 'aws_lc_rs' features is enabled.
```

This occurs in `jsonwebtoken` `10.3.0`, which introduced a process-global `CryptoProvider` abstraction, similar to `rustls` `0.23+`.

The provider must be selected either:

* at compile time via a feature flag, or
* at runtime via `CryptoProvider::install_default()`.

## Root Cause

`gcloud-sdk` depends on `jsonwebtoken` without enabling either the `rust_crypto` or `aws_lc_rs` feature.

As a result, `jsonwebtoken::CryptoProvider::from_crate_features()` has no provider to auto-detect and panics the first time a JWT is encoded.

In this case, the JWT is encoded during GCP KMS signer initialization in:

```rust
ConfigValidate::validate_async
```

## Fix

Add `jsonwebtoken` as a direct dependency of the server binary with the `rust_crypto` feature enabled.

Cargo’s feature unification will propagate the feature to the transitive `gcloud-sdk → jsonwebtoken` dependency, allowing `from_crate_features()` to auto-detect the provider without requiring any runtime code change.

This mirrors the existing pattern where:

```rust
rustls::crypto::ring::default_provider().install_default()
```

is called in `main()` to resolve the same class of problem for TLS.

## Note for Reviewers

The underlying issue is in `gcloud-sdk`: it should enable a crypto feature on its `jsonwebtoken` dependency.

This fix is a workaround until the issue is addressed upstream.
