### PR TITLE
fix: ignore tx limit for v31 upgrade block

### DIFF
--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -71,6 +71,17 @@ pub async fn execute_block_in_vm<V: ViewState>(
     let mut interop_roots_count = 0;
     let expect_sl_chain_id_tx_after_upgrade = command.expect_sl_chain_id_tx_after_upgrade;
 
+    if expect_sl_chain_id_tx_after_upgrade
+        && let SealPolicy::Decide(duration, tx_limit) = command.seal_policy
+        && tx_limit < 2
+    {
+        command.seal_policy = SealPolicy::Decide(duration, 2);
+        tracing::warn!(
+            "Upgrade v31 requires two txs (Upgrade and SetSLChainId) to be included in the first v31 block. \
+                `max_transactions_in_block` is ignored"
+        );
+    }
+
     /* ---------- main loop ------------------------------------------ */
     // seal_reason must only be used for observability - handling must remain generic
     let seal_reason = loop {


### PR DESCRIPTION
## Summary

v31 upgrade block should contain exactly 2 transactions, ignore tx_limit=1 if set

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

