### PR TITLE
refactor(batcher): split pending/committed batch info

### DIFF
--- a/lib/batch_types/src/batch_info.rs
+++ b/lib/batch_types/src/batch_info.rs
@@ -15,12 +15,12 @@ use zksync_os_types::{
 
 const PUBDATA_SOURCE_CALLDATA: u8 = 0;
 
-/// Commitment information about a batch.
+/// Information about a batch produced by the batcher and driven through the pipeline before it is
+/// committed on-chain.
 /// Contains enough data to restore `StoredBatchInfo` that got applied on-chain.
-/// Contains enough data to construct public input hash.
-/// todo: these fields should be a part of `CommitBatchInfo` but needs to be changed on L1 contracts' side first
+/// Contains enough data to construct public input hash (the batch commitment).
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct ExtendedCommitBatchInfo {
+pub struct PendingBatchInfo {
     #[serde(flatten)]
     pub commit_info: CommitBatchInfo,
     /// L1 protocol upgrade transaction that was finalized in this batch. Missing for the vast
@@ -29,7 +29,7 @@ pub struct ExtendedCommitBatchInfo {
     pub protocol_version: ProtocolSemanticVersion,
 }
 
-impl ExtendedCommitBatchInfo {
+impl PendingBatchInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn build(
         blocks: Vec<(&BlockOutput, &[ZkTransaction], &TreeBatchOutput)>,
@@ -179,8 +179,8 @@ impl ExtendedCommitBatchInfo {
         )
     }
 
-    /// Calculate keccak256 hash of BatchOutput part of public input
-    pub fn public_input_hash(&self) -> B256 {
+    /// Calculate keccak256 hash of BatchOutput part of public input (the batch commitment).
+    fn public_input_hash(&self) -> B256 {
         let commit_info = &self.commit_info;
         let upgrade_tx_hash = self.upgrade_tx_hash.unwrap_or(B256::ZERO);
         match self.protocol_version.minor {
@@ -222,8 +222,46 @@ impl ExtendedCommitBatchInfo {
         }
     }
 
-    pub fn into_stored(self) -> StoredBatchInfo {
+    /// Computes the batch commitment and turns this into its committed form.
+    pub fn into_committed(self) -> CommittedBatchInfo {
         let commitment = self.public_input_hash();
+        CommittedBatchInfo {
+            commit_info: self.commit_info,
+            commitment,
+        }
+    }
+
+    pub fn into_stored(self) -> StoredBatchInfo {
+        self.into_committed().into_stored()
+    }
+}
+
+impl Deref for PendingBatchInfo {
+    type Target = CommitBatchInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.commit_info
+    }
+}
+
+impl DerefMut for PendingBatchInfo {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.commit_info
+    }
+}
+
+/// Information about a batch that has already been committed on-chain, as discovered from L1.
+/// Carries the batch `commitment` directly (e.g. read from the `BlockCommit` event) instead of
+/// the data required to recompute it.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct CommittedBatchInfo {
+    #[serde(flatten)]
+    pub commit_info: CommitBatchInfo,
+    pub commitment: B256,
+}
+
+impl CommittedBatchInfo {
+    pub fn into_stored(self) -> StoredBatchInfo {
         let commit_info = self.commit_info;
         StoredBatchInfo {
             batch_number: commit_info.batch_number,
@@ -232,24 +270,10 @@ impl ExtendedCommitBatchInfo {
             priority_operations_hash: commit_info.priority_operations_hash,
             dependency_roots_rolling_hash: commit_info.dependency_roots_rolling_hash,
             l2_to_l1_logs_root_hash: commit_info.l2_to_l1_logs_root_hash,
-            commitment,
+            commitment: self.commitment,
             // unused
             last_block_timestamp: Some(0),
         }
-    }
-}
-
-impl Deref for ExtendedCommitBatchInfo {
-    type Target = CommitBatchInfo;
-
-    fn deref(&self) -> &Self::Target {
-        &self.commit_info
-    }
-}
-
-impl DerefMut for ExtendedCommitBatchInfo {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.commit_info
     }
 }
 

--- a/lib/batch_types/src/batcher_model.rs
+++ b/lib/batch_types/src/batcher_model.rs
@@ -1,4 +1,4 @@
-use crate::{BatchSignatureSet, ExtendedCommitBatchInfo};
+use crate::{BatchSignatureSet, PendingBatchInfo};
 use alloy::consensus::BlobTransactionSidecar;
 use alloy::primitives::{Address, B256, Bytes};
 use anyhow::Context as _;
@@ -12,8 +12,6 @@ use zksync_os_contract_interface::models::{L2Log, StoredBatchInfo};
 use zksync_os_observability::LatencyDistributionTracker;
 use zksync_os_pipeline::HasBlockRangeEnd;
 use zksync_os_types::{ProvingVersion, PubdataMode};
-// todo: these models are used throughout the batcher subsystem - not only l1 sender
-//       we will move them to `types` or `batcher_types` when an analogous crate is created in `zksync-os`
 
 /// Information about a batch that is enough for all L1 operations.
 /// Used throughout the batcher subsystem
@@ -30,7 +28,7 @@ pub struct BatchMetadata {
     // This is not purely commitment information, but we keep old serialization name for
     // backwards-compatibility.
     #[serde(rename = "commit_batch_info")]
-    pub batch_info: ExtendedCommitBatchInfo,
+    pub batch_info: PendingBatchInfo,
     pub chain_address: Address,
     pub blob_sidecar: Option<BlobTransactionSidecar>,
     pub first_block_number: u64,

--- a/lib/batch_types/src/lib.rs
+++ b/lib/batch_types/src/lib.rs
@@ -9,4 +9,4 @@ pub use block_merkle_tree_data::BlockMerkleTreeData;
 mod batch_info;
 pub mod batcher_model;
 
-pub use batch_info::{DiscoveredCommittedBatch, ExtendedCommitBatchInfo};
+pub use batch_info::{CommittedBatchInfo, DiscoveredCommittedBatch, PendingBatchInfo};

--- a/lib/batch_verification/src/tests/mod.rs
+++ b/lib/batch_verification/src/tests/mod.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::{Address, B256};
 /// This module is for sharing various testing utilities and helpers.
 use tokio::sync::watch;
-use zksync_os_batch_types::ExtendedCommitBatchInfo;
+use zksync_os_batch_types::PendingBatchInfo;
 use zksync_os_batch_types::batcher_model::{BatchEnvelope, BatchMetadata, MissingSignature};
 use zksync_os_contract_interface::models::{CommitBatchInfo, DACommitmentScheme, StoredBatchInfo};
 use zksync_os_storage_api::{FinalityStatus, ReadFinality};
@@ -72,7 +72,7 @@ pub fn dummy_batch_metadata(batch_number: u64, from: u64, to: u64) -> BatchMetad
             // unused
             last_block_timestamp: Some(0),
         },
-        batch_info: ExtendedCommitBatchInfo {
+        batch_info: PendingBatchInfo {
             commit_info: dummy_commit_batch_info(batch_number, from, to),
             protocol_version: ProtocolSemanticVersion::legacy_genesis_version(),
             upgrade_tx_hash: None,

--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -7,7 +7,7 @@ use block_cache::BlockCache;
 use secrecy::{ExposeSecret, SecretString};
 use std::str::FromStr;
 use tokio::sync::{broadcast, mpsc};
-use zksync_os_batch_types::{BatchSignature, ExtendedCommitBatchInfo};
+use zksync_os_batch_types::{BatchSignature, PendingBatchInfo};
 use zksync_os_contract_interface::l1_discovery::{BatchVerificationSL, L1State};
 use zksync_os_network::{
     PeerVerifyBatch, PeerVerifyBatchResult, VerifyBatch, VerifyBatchOutcome, VerifyBatchResult,
@@ -110,7 +110,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory>
         let multichain_root = read_multichain_root(state_view);
         let (_, last_replay_record, _) = blocks.last().unwrap();
 
-        let (batch_info, _) = ExtendedCommitBatchInfo::build(
+        let (batch_info, _) = PendingBatchInfo::build(
             blocks
                 .iter()
                 .map(|(block_output, replay_record, tree)| {

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -14,7 +14,7 @@ use crate::IZKChain::IZKChainInstance;
 use alloy::contract::SolCallBuilder;
 use alloy::eips::BlockId;
 use alloy::network::Ethereum;
-use alloy::primitives::{Address, B256, TxHash, U256};
+use alloy::primitives::{Address, B256, U256};
 use alloy::providers::Provider;
 use zksync_os_provider::NodeProvider;
 
@@ -286,8 +286,6 @@ alloy::sol! {
         function getAdmin() external view returns (address);
         function getChainTypeManager() external view returns (address);
         function getProtocolVersion() external view returns (uint256);
-        function getL2SystemContractsUpgradeTxHash() external view returns (bytes32);
-        function getL2SystemContractsUpgradeBatchNumber() external view returns (uint256);
         function baseTokenGasPriceMultiplierNominator() external view returns (uint128);
         function baseTokenGasPriceMultiplierDenominator() external view returns (uint128);
         function getBaseToken() external view returns (address);
@@ -882,27 +880,6 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("getProtocolVersion", Some(block_id))
-    }
-
-    /// Returns current upgrade transaction waiting to be executed. Zeroed out if not present.
-    pub async fn get_upgrade_tx_hash(&self, block_id: BlockId) -> Result<TxHash> {
-        self.instance
-            .getL2SystemContractsUpgradeTxHash()
-            .block(block_id)
-            .call()
-            .await
-            .enrich("getL2SystemContractsUpgradeTxHash", Some(block_id))
-    }
-
-    /// Returns batch number that contains current upgrade transaction. Returns `0` if not present.
-    pub async fn get_upgrade_batch_number(&self, block_id: BlockId) -> Result<u64> {
-        self.instance
-            .getL2SystemContractsUpgradeBatchNumber()
-            .block(block_id)
-            .call()
-            .await
-            .map(|n| n.saturating_to())
-            .enrich("getL2SystemContractsUpgradeBatchNumber", Some(block_id))
     }
 
     /// Returns base token address.

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -123,9 +123,10 @@ impl<Finality: WriteFinality> ProcessL1Event for L1CommitWatcher<Finality> {
             let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
             let l1_block_number = log.block_number.expect("indexed log without block number");
             let zk_chain = ZkChain::new(log.address(), provider.clone());
-            let batch_info = util::fetch_committed_batch_data(&zk_chain, tx_hash, l1_block_number)
-                .await?
-                .into_stored();
+            let batch_info =
+                util::fetch_committed_batch_data(&zk_chain, tx_hash, l1_block_number, batch_number)
+                    .await?
+                    .into_stored();
             let committed_batch = DiscoveredCommittedBatch {
                 batch_info,
                 block_range: report.firstBlockNumber..=report.lastBlockNumber,

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -161,9 +161,14 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
         let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
         let l1_block_number = log.block_number.expect("indexed log without block number");
         let zk_chain = ZkChain::new(log.address(), provider.clone());
-        let batch_info = util::fetch_committed_batch_data(&zk_chain, tx_hash, l1_block_number)
-            .await?
-            .into_stored();
+        let batch_info = util::fetch_committed_batch_data(
+            &zk_chain,
+            tx_hash,
+            l1_block_number,
+            report.batchNumber,
+        )
+        .await?
+        .into_stored();
 
         Ok(DiscoveredCommittedBatch {
             batch_info,

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -384,7 +384,7 @@ pub async fn fetch_stored_batch_data(
     }) else {
         return Ok(None);
     };
-    let batch_info = fetch_committed_batch_data(zk_chain, tx_hash, l1_block_number)
+    let batch_info = fetch_committed_batch_data(zk_chain, tx_hash, l1_block_number, batch_number)
         .await?
         .into_stored();
 
@@ -400,64 +400,90 @@ pub async fn fetch_committed_batch_data(
     zk_chain: &ZkChain<NodeProvider>,
     tx_hash: TxHash,
     l1_block_number: BlockNumber,
+    batch_number: u64,
 ) -> Result<CommittedBatchInfo, L1WatcherError> {
-    let tx = (|| async {
-        let tx = zk_chain
-            .provider()
-            .get_transaction_by_hash(tx_hash)
-            .await
-            .map_err(|e| L1WatcherError::Other(e.into()))?
-            .ok_or_else(|| {
-                L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
-            })?;
-        tx.block_number.ok_or_else(|| {
-            L1WatcherError::Other(anyhow::anyhow!(
-                "commit tx {tx_hash} has no block number (still pending)"
-            ))
-        })?;
-        Ok::<_, L1WatcherError>(tx)
-    })
-    .retry(
+    // The commit transaction (which carries the `CommitBatchInfo` calldata) and the `BlockCommit`
+    // event (which carries the commitment) are independent given the batch number, so we fetch
+    // them concurrently. Both can transiently lag right after the commit is observed when hitting
+    // a load-balanced RPC, so each is retried.
+    let retry_policy = || {
         ConstantBuilder::default()
             .with_delay(Duration::from_millis(200))
-            .with_max_times(50),
-    )
-    .await?;
+            .with_max_times(50)
+    };
+
+    let tx_fut = async {
+        (|| async {
+            let tx = zk_chain
+                .provider()
+                .get_transaction_by_hash(tx_hash)
+                .await
+                .map_err(|e| L1WatcherError::Other(e.into()))?
+                .ok_or_else(|| {
+                    L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
+                })?;
+            tx.block_number.ok_or_else(|| {
+                L1WatcherError::Other(anyhow::anyhow!(
+                    "commit tx {tx_hash} has no block number (still pending)"
+                ))
+            })?;
+            Ok::<_, L1WatcherError>(tx)
+        })
+        .retry(retry_policy())
+        .await
+    };
+
+    // The batch commitment is emitted in the `BlockCommit` event (indexed by batch number) of the
+    // commit transaction. Reading it from L1 directly is safe and accurate, unlike deriving it from
+    // the current protocol version / upgrade transaction hash, which reflect the latest chain state
+    // rather than the state at the moment this batch was committed. Filtering on the indexed
+    // `batchNumber` topic isolates this batch's event directly (a single commit tx covers a range
+    // of L2 blocks, and an L1 block may contain commits for several batches).
+    let log_fut = async {
+        (|| async {
+            zk_chain
+                .provider()
+                .get_logs(
+                    &Filter::new()
+                        .address(*zk_chain.address())
+                        .event_signature(IExecutor::BlockCommit::SIGNATURE_HASH)
+                        .topic1(U256::from(batch_number))
+                        .from_block(l1_block_number)
+                        .to_block(l1_block_number),
+                )
+                .await
+                .map_err(|e| L1WatcherError::Other(e.into()))?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    L1WatcherError::Other(anyhow::anyhow!(
+                        "`BlockCommit` event for batch {batch_number} not found in L1 block {l1_block_number}"
+                    ))
+                })
+        })
+        .retry(retry_policy())
+        .await
+    };
+
+    let (tx, log) = tokio::try_join!(tx_fut, log_fut)?;
 
     let CommitCalldata {
         commit_batch_info, ..
     } = CommitCalldata::decode(tx.input()).map_err(L1WatcherError::Other)?;
+    if commit_batch_info.batch_number != batch_number {
+        return Err(L1WatcherError::Other(anyhow::anyhow!(
+            "commit tx {tx_hash} encodes batch {} but batch {batch_number} was expected",
+            commit_batch_info.batch_number
+        )));
+    }
 
-    // The batch commitment is emitted in the `BlockCommit` event (indexed by batch number) of
-    // the commit transaction. Reading it from L1 directly is safe and accurate, unlike deriving
-    // it from the current protocol version / upgrade transaction hash, which reflect the latest
-    // chain state rather than the state at the moment this batch was committed.
-    let logs = zk_chain
-        .provider()
-        .get_logs(
-            &Filter::new()
-                .address(*zk_chain.address())
-                .event_signature(IExecutor::BlockCommit::SIGNATURE_HASH)
-                .from_block(l1_block_number)
-                .to_block(l1_block_number),
-        )
-        .await
-        .map_err(|e| L1WatcherError::Other(e.into()))?;
-    // A single commit transaction may commit a range of batches, so there can be multiple
-    // `BlockCommit` logs in this L1 block - pick the one matching our batch number.
-    let commitment = logs
-        .into_iter()
-        .find_map(|log| {
-            let event = IExecutor::BlockCommit::decode_log(&log.inner).ok()?;
-            (event.batchNumber == U256::from(commit_batch_info.batch_number))
-                .then_some(event.commitment)
-        })
-        .ok_or_else(|| {
+    let commitment = IExecutor::BlockCommit::decode_log(&log.inner)
+        .map_err(|e| {
             L1WatcherError::Other(anyhow::anyhow!(
-                "`BlockCommit` event for batch {} not found in L1 block {l1_block_number}",
-                commit_batch_info.batch_number
+                "failed to decode `BlockCommit` event for batch {batch_number}: {e}"
             ))
-        })?;
+        })?
+        .commitment;
 
     Ok(CommittedBatchInfo {
         commit_info: commit_batch_info,

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -1,22 +1,19 @@
 use crate::watcher::L1WatcherError;
 use alloy::consensus::Transaction;
-use alloy::eips::BlockId;
 use alloy::primitives::{Address, BlockNumber, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
-use anyhow::Context;
 use backon::{ConstantBuilder, Retryable};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
-use zksync_os_batch_types::{DiscoveredCommittedBatch, ExtendedCommitBatchInfo};
+use zksync_os_batch_types::{CommittedBatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IChainAssetHandler;
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
 use zksync_os_contract_interface::{Bridgehub, IExecutor, MessageRoot, ZkChain};
 use zksync_os_provider::NodeProvider;
-use zksync_os_types::ProtocolSemanticVersion;
 
 /// Finds the first block where `IChainAssetHandler::migrationNumber(chain_id) >= migration_number`
 /// using binary search. Returns latest block if migration number is not reached yet.
@@ -403,79 +400,67 @@ pub async fn fetch_committed_batch_data(
     zk_chain: &ZkChain<NodeProvider>,
     tx_hash: TxHash,
     l1_block_number: BlockNumber,
-) -> Result<ExtendedCommitBatchInfo, L1WatcherError> {
-    // L1 block where this batch got committed.
-    let l1_block_id = BlockId::number(l1_block_number);
-    let tx_fut = async {
-        (|| async {
-            let tx = zk_chain
-                .provider()
-                .get_transaction_by_hash(tx_hash)
-                .await
-                .map_err(|e| L1WatcherError::Other(e.into()))?
-                .ok_or_else(|| {
-                    L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
-                })?;
-            tx.block_number.ok_or_else(|| {
-                L1WatcherError::Other(anyhow::anyhow!(
-                    "commit tx {tx_hash} has no block number (still pending)"
-                ))
+) -> Result<CommittedBatchInfo, L1WatcherError> {
+    let tx = (|| async {
+        let tx = zk_chain
+            .provider()
+            .get_transaction_by_hash(tx_hash)
+            .await
+            .map_err(|e| L1WatcherError::Other(e.into()))?
+            .ok_or_else(|| {
+                L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
             })?;
-            Ok::<_, L1WatcherError>(tx)
-        })
-        .retry(
-            ConstantBuilder::default()
-                .with_delay(Duration::from_millis(200))
-                .with_max_times(50),
-        )
-        .await
-    };
-    let upgrade_fut = async {
-        zk_chain
-            .get_upgrade_batch_number(l1_block_id)
-            .await
-            .map_err(|e| L1WatcherError::Other(e.into()))
-    };
-    // Fetch active protocol version at the moment the batch got committed. This should work
-    // for the vast majority of cases except when upgrade gets applied in the same L1 block
-    // but after batch was committed.
-    let packed_protocol_version_fut = async {
-        zk_chain
-            .get_raw_protocol_version(l1_block_id)
-            .await
-            .map_err(|e| L1WatcherError::Other(e.into()))
-    };
-    let (tx, upgrade_batch_number, packed_protocol_version) =
-        tokio::try_join!(tx_fut, upgrade_fut, packed_protocol_version_fut,)?;
+        tx.block_number.ok_or_else(|| {
+            L1WatcherError::Other(anyhow::anyhow!(
+                "commit tx {tx_hash} has no block number (still pending)"
+            ))
+        })?;
+        Ok::<_, L1WatcherError>(tx)
+    })
+    .retry(
+        ConstantBuilder::default()
+            .with_delay(Duration::from_millis(200))
+            .with_max_times(50),
+    )
+    .await?;
 
     let CommitCalldata {
         commit_batch_info, ..
     } = CommitCalldata::decode(tx.input()).map_err(L1WatcherError::Other)?;
 
-    // To recreate batch's commitment (and hence it's `StoredBatchInfo` form) we need to
-    // know any potential upgrade transaction hash that was applied in this batch.
-    //
-    // Unfortunately, this information is not passed in `CommitBatchInfo` so we must derive
-    // it through other means. Querying `getL2SystemContractsUpgradeTxHash()` and
-    // `getL2SystemContractsUpgradeBatchNumber()` should work for the vast majority of cases
-    // except when the batch got committed and executed in the same L1 block (which should
-    // never happen in current implementation as commit->prove->execute operations are submitted
-    // sequentially after at least 1 block confirmation).
-    let upgrade_tx_hash = if upgrade_batch_number == commit_batch_info.batch_number {
-        // If the latest upgrade transaction belongs to this batch then current upgrade tx
-        // hash must also be present on L1. Thus, we fetch it.
-        Some(zk_chain.get_upgrade_tx_hash(l1_block_id).await?)
-    } else {
-        // Either latest in-progress upgrade transaction belongs to a different batch or
-        // there is none. If none, `upgrade_batch_number` would be `0` and thus never equal
-        // to the currently inspected batch as genesis does not get committed via this flow.
-        None
-    };
-    Ok(ExtendedCommitBatchInfo {
+    // The batch commitment is emitted in the `BlockCommit` event (indexed by batch number) of
+    // the commit transaction. Reading it from L1 directly is safe and accurate, unlike deriving
+    // it from the current protocol version / upgrade transaction hash, which reflect the latest
+    // chain state rather than the state at the moment this batch was committed.
+    let logs = zk_chain
+        .provider()
+        .get_logs(
+            &Filter::new()
+                .address(*zk_chain.address())
+                .event_signature(IExecutor::BlockCommit::SIGNATURE_HASH)
+                .from_block(l1_block_number)
+                .to_block(l1_block_number),
+        )
+        .await
+        .map_err(|e| L1WatcherError::Other(e.into()))?;
+    // A single commit transaction may commit a range of batches, so there can be multiple
+    // `BlockCommit` logs in this L1 block - pick the one matching our batch number.
+    let commitment = logs
+        .into_iter()
+        .find_map(|log| {
+            let event = IExecutor::BlockCommit::decode_log(&log.inner).ok()?;
+            (event.batchNumber == U256::from(commit_batch_info.batch_number))
+                .then_some(event.commitment)
+        })
+        .ok_or_else(|| {
+            L1WatcherError::Other(anyhow::anyhow!(
+                "`BlockCommit` event for batch {} not found in L1 block {l1_block_number}",
+                commit_batch_info.batch_number
+            ))
+        })?;
+
+    Ok(CommittedBatchInfo {
         commit_info: commit_batch_info,
-        upgrade_tx_hash,
-        protocol_version: ProtocolSemanticVersion::try_from(packed_protocol_version)
-            .context("invalid protocol version fetched from L1")
-            .map_err(L1WatcherError::Other)?,
+        commitment,
     })
 }

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::Address;
-use zksync_os_batch_types::ExtendedCommitBatchInfo;
+use zksync_os_batch_types::PendingBatchInfo;
 use zksync_os_batch_types::batcher_model::{
     BatchEnvelope, BatchForSigning, BatchMetadata, ProverInput,
 };
@@ -33,7 +33,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
 
     let state_view = read_state.state_view_at(block_number_to)?;
     let multichain_root = read_multichain_root(state_view);
-    let (batch_info, blob_sidecar) = ExtendedCommitBatchInfo::build(
+    let (batch_info, blob_sidecar) = PendingBatchInfo::build(
         blocks
             .iter()
             .map(|(block_output, replay_record, tree, _)| {

--- a/node/bin/src/prover_api/prover_job_map/map.rs
+++ b/node/bin/src/prover_api/prover_job_map/map.rs
@@ -466,7 +466,7 @@ mod tests {
     use crate::prover_api::metrics::ProverStage;
     use alloy::primitives::{Address, B256};
     use std::time::Duration;
-    use zksync_os_batch_types::ExtendedCommitBatchInfo;
+    use zksync_os_batch_types::PendingBatchInfo;
     use zksync_os_batch_types::batcher_model::{BatchForSigning, BatchMetadata};
     use zksync_os_contract_interface::models::{
         CommitBatchInfo, DACommitmentScheme, StoredBatchInfo,
@@ -486,7 +486,7 @@ mod tests {
                 // unused
                 last_block_timestamp: Some(0),
             },
-            batch_info: ExtendedCommitBatchInfo {
+            batch_info: PendingBatchInfo {
                 commit_info: CommitBatchInfo {
                     batch_number,
                     new_state_commitment: B256::ZERO,


### PR DESCRIPTION
## Summary

  Splits the dual-purpose `ExtendedCommitBatchInfo` into two purpose-built types and lets the L1 watcher read a batch's `commitment` directly from the `BlockCommit` event instead of deriving it from unreliable L1 state calls.                                                                          
                                                                                                                                                                                                                                                                                                           
  - **`PendingBatchInfo`** (renamed from `ExtendedCommitBatchInfo`) — the batcher's working type, driven through the pipeline. Keeps `commit_info` + `upgrade_tx_hash` + `protocol_version`; computes the commitment lazily.                                                                               
  - **`CommittedBatchInfo`** (new, slim) — `commit_info` + `commitment`, used for batches discovered already-committed on L1.

Main reasoning is removing old assumptions that can break in extreme circumstances. Which can lead to very hard-to-debug issues down the line