### PR TITLE
feat(rpc): configurable rate limits via RateLimits enum

### DIFF
--- a/lib/rpc/src/config.rs
+++ b/lib/rpc/src/config.rs
@@ -10,8 +10,37 @@ pub enum RateLimits {
     /// No rate limiting.
     #[default]
     None,
-    /// One global cap, an `m_rps` bucket shared by `m_methods`, and per-method overrides
-    /// in `custom_methods`.
+    /// One global cap, plus per-method buckets: `m_rps` applied to each entry in
+    /// `m_methods`, and the explicit RPS in `custom_methods` for each entry there.
+    ///
+    /// Production example:
+    ///
+    /// ```yaml
+    /// rpc:
+    ///   rate_limits:
+    ///     type: Tiered
+    ///     global_rps: 1000
+    ///     m_rps: 200
+    ///     m_methods:
+    ///       - eth_call
+    ///       - eth_estimateGas
+    ///       - eth_getBlockReceipts
+    ///       - eth_fillTransaction
+    ///       - zks_getProof
+    ///       - ots_getBlockTransactions
+    ///       - txpool_inspect
+    ///     custom_methods:
+    ///       eth_getLogs: 200
+    ///       eth_simulateV1: 1
+    ///       debug_traceTransaction: 10
+    ///       debug_traceCall: 10
+    ///       debug_traceBlockByHash: 10
+    ///       debug_traceBlockByNumber: 10
+    ///       zks_getL2ToL1LogProof: 10
+    ///       ots_searchTransactionsBefore: 10
+    ///       ots_searchTransactionsAfter: 10
+    ///       txpool_content: 10
+    /// ```
     Tiered {
         global_rps: NonZeroU32,
         m_rps: NonZeroU32,

--- a/lib/rpc/src/config.rs
+++ b/lib/rpc/src/config.rs
@@ -1,22 +1,42 @@
+use crate::limits::Limits;
 use alloy::primitives::Address;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroU32;
 use std::time::Duration;
 
-/// A per-method rate limit entry.
-#[derive(Clone, Debug)]
-pub struct RpcRateLimit {
-    /// Exact RPC method name, e.g. `"eth_call"`.
-    pub method: String,
-    /// Maximum number of requests per second across all callers combined.
-    pub requests_per_second: NonZeroU32,
+/// Rate-limit configuration.
+#[derive(Clone, Debug, Default)]
+pub enum RateLimits {
+    /// No rate limiting.
+    #[default]
+    None,
+    /// One global cap, an `m_rps` bucket shared by `m_methods`, and per-method overrides
+    /// in `custom_methods`.
+    Tiered {
+        global_rps: NonZeroU32,
+        m_rps: NonZeroU32,
+        m_methods: HashSet<String>,
+        custom_methods: HashMap<String, NonZeroU32>,
+    },
 }
 
-impl From<(String, NonZeroU32)> for RpcRateLimit {
-    fn from((method, requests_per_second): (String, NonZeroU32)) -> Self {
-        Self {
-            method,
-            requests_per_second,
+impl RateLimits {
+    pub(crate) fn into_limits(self) -> Limits {
+        match self {
+            Self::None => Limits::default(),
+            Self::Tiered {
+                global_rps,
+                m_rps,
+                m_methods,
+                custom_methods,
+            } => Limits {
+                global_rps: Some(global_rps),
+                methods: m_methods
+                    .into_iter()
+                    .map(|name| (name, m_rps))
+                    .chain(custom_methods)
+                    .collect(),
+            },
         }
     }
 }
@@ -74,9 +94,8 @@ pub struct RpcConfig {
     /// because pubdata price increase in-between estimation and sequencing.
     pub estimate_gas_pubdata_price_factor: f64,
 
-    /// Per-method rate limits.  Use `"*"` as the method name for a global limit applied before
-    /// per-method limits.  Empty means no rate limiting.
-    pub rate_limits: Vec<RpcRateLimit>,
+    /// Rate limits for incoming requests.
+    pub rate_limits: RateLimits,
 }
 
 impl RpcConfig {

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -2,7 +2,7 @@ mod call_fees;
 
 mod config;
 
-pub use config::{RpcConfig, RpcRateLimit};
+pub use config::{RateLimits, RpcConfig};
 use std::sync::Arc;
 use tokio::sync::watch;
 
@@ -20,6 +20,7 @@ mod simulate;
 pub use rpc_storage::{ReadRpcStorage, RpcStorage};
 mod debug_impl;
 pub mod js_tracer;
+mod limits;
 mod log_proof_utils;
 mod monitoring_middleware;
 mod net_impl;
@@ -39,10 +40,11 @@ use crate::debug_impl::DebugNamespace;
 use crate::eth_filter::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
+use crate::limits::Limiter;
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
-use crate::rate_limit_middleware::{RateLimiting, build_limiters};
+use crate::rate_limit_middleware::RateLimiting;
 use crate::txpool_impl::TxpoolNamespace;
 use crate::unstable_impl::UnstableNamespace;
 use crate::web3_impl::Web3Namespace;
@@ -151,12 +153,11 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     let middleware = tower::ServiceBuilder::new().layer(cors);
 
     let max_response_size_bytes = config.max_response_size_bytes();
-    // Build once so all connections share the same token-bucket state.
-    let limiters = build_limiters(&config.rate_limits);
+    let limiter = Limiter::new(config.rate_limits.clone().into_limits());
     let rpc_middleware = RpcServiceBuilder::new()
         // Monitoring is outermost so rate-limited responses still appear in error metrics.
         .layer_fn(move |service| Monitoring::new(service, max_response_size_bytes))
-        .layer_fn(move |service| RateLimiting::new(service, limiters.clone()));
+        .layer_fn(move |service| RateLimiting::new(service, limiter.clone()));
 
     let server_config = ServerConfigBuilder::default()
         .max_connections(config.max_connections)

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -40,7 +40,7 @@ use crate::debug_impl::DebugNamespace;
 use crate::eth_filter::EthFilterNamespace;
 use crate::eth_impl::EthNamespace;
 use crate::eth_pubsub_impl::EthPubsubNamespace;
-use crate::limits::Limiter;
+use crate::limits::{Limiter, LoggingLimiter};
 use crate::monitoring_middleware::Monitoring;
 use crate::net_impl::NetNamespace;
 use crate::ots_impl::OtsNamespace;
@@ -153,7 +153,8 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     let middleware = tower::ServiceBuilder::new().layer(cors);
 
     let max_response_size_bytes = config.max_response_size_bytes();
-    let limiter = Limiter::new(config.rate_limits.clone().into_limits());
+    let limiter = LoggingLimiter::new(Limiter::new(config.rate_limits.clone().into_limits()));
+    let rate_limit_logging = LoggingLimiter::run(limiter.clone());
     let rpc_middleware = RpcServiceBuilder::new()
         // Monitoring is outermost so rate-limited responses still appear in error metrics.
         .layer_fn(move |service| Monitoring::new(service, max_response_size_bytes))
@@ -197,6 +198,9 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
             // The stale-filter cleanup loop exited unexpectedly; this task also ends in that case.
             _ = eth_filter.watch_and_clear_stale_filters() => {
                 unreachable!("eth_filter.watch_and_clear_stale_filters() is an infinite loop")
+            }
+            _ = rate_limit_logging => {
+                unreachable!("LoggingLimiter::run is an infinite loop")
             }
             // Graceful shutdown was requested; stop accepting RPC traffic and wait for the server to exit.
             _guard = &mut shutdown => {

--- a/lib/rpc/src/limits.rs
+++ b/lib/rpc/src/limits.rs
@@ -1,0 +1,57 @@
+use governor::clock::{Clock, DefaultClock, QuantaInstant};
+use governor::{DefaultDirectRateLimiter, NotUntil, Quota};
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+/// Rate-limit spec consumed by [`Limiter`] at construction.
+#[derive(Clone, Debug, Default)]
+pub struct Limits {
+    pub global_rps: Option<NonZeroU32>,
+    pub methods: HashMap<String, NonZeroU32>,
+}
+
+fn bucket(rps: NonZeroU32) -> DefaultDirectRateLimiter {
+    governor::RateLimiter::direct(Quota::per_second(rps))
+}
+
+fn retry_after(not_until: NotUntil<QuantaInstant>) -> u64 {
+    let now = DefaultClock::default().now();
+    not_until
+        .wait_time_from(now)
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+/// Stateful enforcer for a [`Limits`] spec. Owns the token buckets; middleware calls `check`
+/// per request to gate it.
+pub struct Limiter {
+    global: Option<DefaultDirectRateLimiter>,
+    per_method: HashMap<String, DefaultDirectRateLimiter>,
+}
+
+impl Limiter {
+    pub fn new(limits: Limits) -> Arc<Self> {
+        let global = limits.global_rps.map(bucket);
+        let per_method = limits
+            .methods
+            .into_iter()
+            .map(|(name, rps)| (name, bucket(rps)))
+            .collect();
+        Arc::new(Self { global, per_method })
+    }
+
+    fn check_global(&self) -> Option<u64> {
+        self.global.as_ref()?.check().err().map(retry_after)
+    }
+
+    fn check_per_method(&self, name: &str) -> Option<u64> {
+        self.per_method.get(name)?.check().err().map(retry_after)
+    }
+
+    pub fn check(&self, method: &str) -> Option<u64> {
+        self.check_global()
+            .or_else(|| self.check_per_method(method))
+    }
+}

--- a/lib/rpc/src/limits.rs
+++ b/lib/rpc/src/limits.rs
@@ -1,8 +1,12 @@
 use governor::clock::{Clock, DefaultClock, QuantaInstant};
-use governor::{DefaultDirectRateLimiter, NotUntil, Quota};
+use governor::{DefaultDirectRateLimiter, NotUntil, Quota, RateLimiter};
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::time::interval;
 
 /// Rate-limit spec consumed by [`Limiter`] at construction.
 #[derive(Clone, Debug, Default)]
@@ -12,7 +16,7 @@ pub struct Limits {
 }
 
 fn bucket(rps: NonZeroU32) -> DefaultDirectRateLimiter {
-    governor::RateLimiter::direct(Quota::per_second(rps))
+    RateLimiter::direct(Quota::per_second(rps))
 }
 
 fn retry_after(not_until: NotUntil<QuantaInstant>) -> u64 {
@@ -32,14 +36,14 @@ pub struct Limiter {
 }
 
 impl Limiter {
-    pub fn new(limits: Limits) -> Arc<Self> {
+    pub fn new(limits: Limits) -> Self {
         let global = limits.global_rps.map(bucket);
         let per_method = limits
             .methods
             .into_iter()
             .map(|(name, rps)| (name, bucket(rps)))
             .collect();
-        Arc::new(Self { global, per_method })
+        Self { global, per_method }
     }
 
     fn check_global(&self) -> Option<u64> {
@@ -53,5 +57,37 @@ impl Limiter {
     pub fn check(&self, method: &str) -> Option<u64> {
         self.check_global()
             .or_else(|| self.check_per_method(method))
+    }
+}
+
+/// Wraps a [`Limiter`] with a rolling rejection counter, drained into a 1/s log line.
+pub struct LoggingLimiter {
+    inner: Limiter,
+    rejections: AtomicU64,
+}
+
+impl LoggingLimiter {
+    pub fn new(inner: Limiter) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            rejections: AtomicU64::new(0),
+        })
+    }
+
+    pub(crate) fn check(&self, method: &str) -> Option<u64> {
+        self.inner.check(method).inspect(|_| {
+            self.rejections.fetch_add(1, Ordering::Relaxed);
+        })
+    }
+
+    pub async fn run(this: Arc<Self>) -> Infallible {
+        let mut ticker = interval(Duration::from_secs(1));
+        loop {
+            ticker.tick().await;
+            let count = this.rejections.swap(0, Ordering::Relaxed);
+            if count > 0 {
+                tracing::warn!(count, "rpc requests rate-limited in last 1s");
+            }
+        }
     }
 }

--- a/lib/rpc/src/rate_limit_middleware.rs
+++ b/lib/rpc/src/rate_limit_middleware.rs
@@ -1,4 +1,4 @@
-use crate::limits::Limiter;
+use crate::limits::LoggingLimiter;
 use jsonrpsee::MethodResponse;
 use jsonrpsee::core::middleware::{Batch, Notification};
 use jsonrpsee::core::to_json_raw_value;
@@ -22,20 +22,15 @@ fn rate_limited_err(retry_after_ms: u64) -> ErrorObject<'static> {
     ErrorObject::owned(RATE_LIMIT_ERROR_CODE, "Too many requests", Some(data))
 }
 
-/// JSON-RPC middleware that enforces per-method request rate limits globally across all connections.
-///
-/// Build the rate limiter once with [`Limiter::new`] and share it across connections via `Arc`.
-/// Sit this layer inside `Monitoring` so rate-limited responses are counted in error metrics.
-/// `Monitoring` decomposes batch requests by calling `call()` per entry, so batch items are
-/// rate-limited automatically.
+/// JSON-RPC middleware that enforces per-method rate limits.
 #[derive(Clone)]
 pub(crate) struct RateLimiting<S = RpcService> {
     inner: S,
-    limiter: Arc<Limiter>,
+    limiter: Arc<LoggingLimiter>,
 }
 
 impl<S> RateLimiting<S> {
-    pub(crate) fn new(inner: S, limiter: Arc<Limiter>) -> Self {
+    pub(crate) fn new(inner: S, limiter: Arc<LoggingLimiter>) -> Self {
         Self { inner, limiter }
     }
 }

--- a/lib/rpc/src/rate_limit_middleware.rs
+++ b/lib/rpc/src/rate_limit_middleware.rs
@@ -1,6 +1,4 @@
-use crate::config::RpcRateLimit;
-use governor::clock::{Clock, DefaultClock};
-use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+use crate::limits::Limiter;
 use jsonrpsee::MethodResponse;
 use jsonrpsee::core::middleware::{Batch, Notification};
 use jsonrpsee::core::to_json_raw_value;
@@ -8,29 +6,10 @@ use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
 use jsonrpsee::types::Request;
 use jsonrpsee::types::error::ErrorObject;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// EIP-1474 "Limit exceeded" — the de facto Ethereum rate-limit error code used by Infura, Alchemy, etc.
 const RATE_LIMIT_ERROR_CODE: i32 = -32005;
-
-/// Pre-builds the shared limiter map from config.  Pass the returned `Arc` to every
-/// `RateLimiting::new` call so all connections share the same token-bucket state.
-pub(crate) fn build_limiters(
-    limits: &[RpcRateLimit],
-) -> Arc<HashMap<String, DefaultDirectRateLimiter>> {
-    Arc::new(
-        limits
-            .iter()
-            .map(|l| {
-                (
-                    l.method.clone(),
-                    RateLimiter::direct(Quota::per_second(l.requests_per_second)),
-                )
-            })
-            .collect(),
-    )
-}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -45,19 +24,19 @@ fn rate_limited_err(retry_after_ms: u64) -> ErrorObject<'static> {
 
 /// JSON-RPC middleware that enforces per-method request rate limits globally across all connections.
 ///
-/// Build the limiter map once with [`build_limiters`] and share it across connections via `Arc`.
+/// Build the rate limiter once with [`Limiter::new`] and share it across connections via `Arc`.
 /// Sit this layer inside `Monitoring` so rate-limited responses are counted in error metrics.
 /// `Monitoring` decomposes batch requests by calling `call()` per entry, so batch items are
-/// rate-limited automatically.  Any method absent from the map is unrestricted.
+/// rate-limited automatically.
 #[derive(Clone)]
 pub(crate) struct RateLimiting<S = RpcService> {
     inner: S,
-    limiters: Arc<HashMap<String, DefaultDirectRateLimiter>>,
+    limiter: Arc<Limiter>,
 }
 
 impl<S> RateLimiting<S> {
-    pub(crate) fn new(inner: S, limiters: Arc<HashMap<String, DefaultDirectRateLimiter>>) -> Self {
-        Self { inner, limiters }
+    pub(crate) fn new(inner: S, limiter: Arc<Limiter>) -> Self {
+        Self { inner, limiter }
     }
 }
 
@@ -79,31 +58,12 @@ where
         &self,
         request: Request<'a>,
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
-        // Check synchronously before the async block to avoid holding a borrow across an await.
-        // Global limit ("*") is checked first; if it fires the per-method limiter is not touched.
-        let now = DefaultClock::default().now();
-        let not_until_global = self.limiters.get("*").and_then(|l| l.check().err());
-        let not_until_method = if not_until_global.is_none() {
-            self.limiters
-                .get(request.method_name())
-                .and_then(|l| l.check().err())
-        } else {
-            None
-        };
-        let retry_after_ms = not_until_global.or(not_until_method).map(|not_until| {
-            not_until
-                .wait_time_from(now)
-                .as_millis()
-                .try_into()
-                .unwrap_or(u64::MAX)
-        });
+        let retry_after_ms = self.limiter.check(request.method_name());
         let inner = self.inner.clone();
         async move {
             if let Some(ms) = retry_after_ms {
-                return MethodResponse::error(
-                    request.id.clone().into_owned(),
-                    rate_limited_err(ms),
-                );
+                let id = request.id.clone().into_owned();
+                return MethodResponse::error(id, rate_limited_err(ms));
             }
             inner.call(request).await
         }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1008,17 +1008,47 @@ pub struct RpcConfig {
     #[config(default_t = 2.0)]
     pub estimate_gas_pubdata_price_factor: f64,
 
-    /// Per-method rate limits: map from RPC method name to max requests per second (across all
-    /// callers).  Use `"*"` for a global limit applied before per-method limits.  Methods absent
-    /// from the map are unrestricted.
-    ///
-    /// Accepts a JSON object or a comma-separated `method=rps` string, e.g.
-    /// `*=500,eth_call=100,debug_traceTransaction=5`.
-    #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="), validate(
-        rate_limits_within_global,
-        "each per-method limit must not exceed the global `*` limit"
-    ))]
-    pub rate_limits: HashMap<String, NonZeroU32>,
+    /// Rate limits for incoming JSON-RPC requests.
+    #[config(nest)]
+    pub rate_limits: RpcRateLimitsConfig,
+}
+
+/// Rate-limit configuration for the JSON-RPC server.
+#[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
+#[config(tag = "type", derive(Default))]
+pub enum RpcRateLimitsConfig {
+    /// No rate limiting.
+    #[config(default)]
+    None,
+    /// One global cap, an `m_rps` bucket shared by `m_methods`, and per-method overrides
+    /// in `custom_methods`.
+    Tiered {
+        global_rps: NonZeroU32,
+        m_rps: NonZeroU32,
+        #[config(default, with = Delimited::new(","))]
+        m_methods: HashSet<String>,
+        #[config(default, with = Entries::WELL_KNOWN.delimited(",", "="))]
+        custom_methods: HashMap<String, NonZeroU32>,
+    },
+}
+
+impl From<RpcRateLimitsConfig> for zksync_os_rpc::RateLimits {
+    fn from(c: RpcRateLimitsConfig) -> Self {
+        match c {
+            RpcRateLimitsConfig::None => Self::None,
+            RpcRateLimitsConfig::Tiered {
+                global_rps,
+                m_rps,
+                m_methods,
+                custom_methods,
+            } => Self::Tiered {
+                global_rps,
+                m_rps,
+                m_methods,
+                custom_methods,
+            },
+        }
+    }
 }
 
 /// L1 sender configuration. The signing key fields are only required on the Main Node;
@@ -1124,16 +1154,6 @@ pub struct ForceTransactionResubmissionConfig {
     /// Multiplier applied to `max_fee_per_blob_gas` when force transaction resubmission is enabled.
     #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
-}
-
-fn rate_limits_within_global(limits: &HashMap<String, NonZeroU32>) -> bool {
-    let Some(&global) = limits.get("*") else {
-        return true;
-    };
-    limits
-        .iter()
-        .filter(|(k, _)| k.as_str() != "*")
-        .all(|(_, &v)| v <= global)
 }
 
 fn is_positive_f64(&val: &f64) -> bool {
@@ -1846,7 +1866,7 @@ impl From<RpcConfig> for zksync_os_rpc::RpcConfig {
             send_raw_transaction_sync_timeout: c.send_raw_transaction_sync_timeout,
             gas_price_scale_factor: c.gas_price_scale_factor,
             estimate_gas_pubdata_price_factor: c.estimate_gas_pubdata_price_factor,
-            rate_limits: c.rate_limits.into_iter().map(Into::into).collect(),
+            rate_limits: c.rate_limits.into(),
         }
     }
 }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1020,8 +1020,8 @@ pub enum RpcRateLimitsConfig {
     /// No rate limiting.
     #[config(default)]
     None,
-    /// One global cap, an `m_rps` bucket shared by `m_methods`, and per-method overrides
-    /// in `custom_methods`.
+    /// One global cap, plus per-method buckets: `m_rps` applied to each entry in
+    /// `m_methods`, and the explicit RPS in `custom_methods` for each entry there.
     Tiered {
         global_rps: NonZeroU32,
         m_rps: NonZeroU32,


### PR DESCRIPTION
## Summary

Implements the rate-limit knobs from the [iRaaS Downside Protection doc](https://app.notion.com/p/matterlabs/iRaas-Downside-Protection-366a48363f23806a9c9bcdee3b212db2). The doc's tiered shape (global cap, M-bucket shared across listed methods, per-method overrides) maps directly onto a typed enum on `RpcConfig`:

```rust
pub enum RateLimits {
    None,
    Tiered { global_rps, m_rps, m_methods, custom_methods },
}
```

Operators set every value via YAML or env vars; default `None` is a no-op deploy.

- Bin uses smart-config's tagged enum (`#[config(tag = "type")]`), so env vars flatten:
  ```
  RPC_RATE_LIMITS_TYPE=Tiered
  RPC_RATE_LIMITS_GLOBAL_RPS=1000
  RPC_RATE_LIMITS_M_RPS=200
  RPC_RATE_LIMITS_M_METHODS=eth_call,eth_estimateGas,...
  RPC_RATE_LIMITS_CUSTOM_METHODS=eth_getLogs=200,eth_simulateV1=1,...
  ```
- Internal: middleware switches from `Arc<HashMap<String, RateLimiter>>` to a typed `Limiter` built from a `Limits` spec. `RateLimits::into_limits` resolves the enum.
- Drops `RpcRateLimit`, `build_limiters`, and the `rate_limits_within_global` validator.