### PR TITLE
refactor: init applied block with `None`

### DIFF
--- a/lib/sequencer/src/execution/block_applier.rs
+++ b/lib/sequencer/src/execution/block_applier.rs
@@ -2,6 +2,7 @@ use crate::config::SequencerConfig;
 use crate::execution::metrics::BlockApplierState;
 use crate::model::blocks::{AppliedBlock, BlockCommandType, BlockPayload};
 use alloy::consensus::Sealed;
+use alloy::primitives::BlockNumber;
 use async_trait::async_trait;
 use tokio::sync::{mpsc, watch};
 use zksync_os_observability::ComponentStateReporter;
@@ -20,7 +21,7 @@ where
     pub replay: Replay,
     pub repositories: Repo,
     pub config: SequencerConfig,
-    pub applied_block_number_sender: watch::Sender<u64>,
+    pub applied_block_number_sender: watch::Sender<Option<BlockNumber>>,
 }
 
 #[async_trait]
@@ -97,7 +98,8 @@ where
                 )
                 .await?;
 
-            self.applied_block_number_sender.send_replace(block_number);
+            self.applied_block_number_sender
+                .send_replace(Some(block_number));
 
             output.send_and_record(
                 AppliedBlock {

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -4,6 +4,7 @@ use crate::execution::execute_block_in_vm::execute_block_in_vm;
 use crate::execution::metrics::{EXECUTION_METRICS, SequencerState};
 use crate::execution::utils::save_dump;
 use crate::model::blocks::{BlockCommand, BlockCommandType, BlockPayload};
+use alloy::primitives::BlockNumber;
 use anyhow::Context;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ where
     /// before starting block `N + 1`. This works around an `OverlayBuffer` bug
     /// that reproduces during rebuilds when the runtime truncates base state.
     /// Once that bug is fixed, this wait can be removed.
-    pub applied_block_number_receiver: watch::Receiver<u64>,
+    pub applied_block_number_receiver: watch::Receiver<Option<BlockNumber>>,
 }
 
 #[async_trait]
@@ -79,7 +80,11 @@ where
             tracing::info!("Command {cmd} received by BlockExecutor");
             let cmd_type = cmd.command_type();
             state_reporter.enter_state(SequencerState::WaitingForApplier);
-            if let Some(last_block_number) = self.block_context_provider.last_block_number() {
+            // If we had a non-genesis block in the past, we need to wait for the block applier to
+            // catch up. Genesis is skipped because it never gets applied further down the pipeline.
+            if let Some(last_block_number) = self.block_context_provider.last_block_number()
+                && last_block_number > 0
+            {
                 wait_for_block_applier(&mut self.applied_block_number_receiver, last_block_number)
                     .await?;
             }
@@ -222,11 +227,11 @@ where
 }
 
 async fn wait_for_block_applier(
-    applied_block_number_receiver: &mut watch::Receiver<u64>,
-    required_block_number: u64,
+    applied_block_number_receiver: &mut watch::Receiver<Option<BlockNumber>>,
+    required_block_number: BlockNumber,
 ) -> anyhow::Result<()> {
     let applied_block_number = *applied_block_number_receiver.borrow_and_update();
-    if applied_block_number >= required_block_number {
+    if applied_block_number >= Some(required_block_number) {
         tracing::debug!(
             applied_block_number,
             required_block_number,
@@ -242,7 +247,7 @@ async fn wait_for_block_applier(
     );
 
     let reached_block_number = applied_block_number_receiver
-        .wait_for(|block_number| *block_number >= required_block_number)
+        .wait_for(|block_number| *block_number >= Some(required_block_number))
         .await
         .context("block applier progress watch closed while executor was waiting")?
         .to_owned();

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -867,7 +867,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
             node_startup_state,
             archiving_block_replay_storage,
             runtime,
-            starting_block,
             block_context_provider,
             state.clone(),
             tree_db,
@@ -987,8 +986,7 @@ async fn run_main_node_pipeline(
     let pipeline_gate = monitor.subscribe_gate();
 
     let (replays_to_execute_sender, replays_to_execute) = tokio::sync::mpsc::unbounded_channel();
-    let (applied_block_number_sender, applied_block_number_receiver) =
-        watch::channel(starting_block.saturating_sub(1));
+    let (applied_block_number_sender, applied_block_number_receiver) = watch::channel(None);
 
     let pipeline = Pipeline::new(runtime.clone())
         .pipe(ConsensusNodeCommandSource {
@@ -1227,7 +1225,6 @@ async fn run_en_pipeline(
     node_state_on_startup: NodeStateOnStartup,
     block_replay_storage: impl WriteReplay + Clone,
     runtime: &Runtime,
-    starting_block: u64,
     block_context_provider: BlockContextProvider<impl L2Subpool>,
     state: impl ReadStateHistory + WriteState + Clone,
     tree: MerkleTree<RocksDBWrapper>,
@@ -1245,8 +1242,7 @@ async fn run_en_pipeline(
             .rocks_db_path
             .join(INTERNAL_CONFIG_FILE_NAME),
     );
-    let (applied_block_number_sender, applied_block_number_receiver) =
-        watch::channel(starting_block.saturating_sub(1));
+    let (applied_block_number_sender, applied_block_number_receiver) = watch::channel(None);
 
     let monitor =
         BackpressureMonitor::new(config.build_backpressure_config(), stop_receiver.clone());

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -111,9 +111,7 @@ use zksync_os_storage_api::{
     FinalityStatus, ReadFinality, ReadReplay, ReadRepository, ReadStateHistory, ReplayRecord,
     WriteReplay, WriteRepository, WriteState,
 };
-use zksync_os_types::{
-    ExecutionVersion, ProtocolSemanticVersion, PubdataMode, TransactionAcceptanceState,
-};
+use zksync_os_types::{ExecutionVersion, PubdataMode, TransactionAcceptanceState};
 
 const BLOCK_REPLAY_WAL_DB_NAME: &str = "block_replay_wal";
 const RAFT_DB_NAME: &str = "raft";


### PR DESCRIPTION
## Summary

Initializes `applied_block_number_sender`/`applied_block_number_receiver` with `None` to reduce the usages of `starting_block`

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

