### PR TITLE
fix(l1_watcher): tolerate migrationNumber reverts in start-block search

### DIFF
--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -12,6 +12,7 @@ use zksync_os_batch_types::{CommittedBatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IChainAssetHandler;
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
+use zksync_os_contract_interface::is_method_missing;
 use zksync_os_contract_interface::{Bridgehub, IExecutor, MessageRoot, ZkChain};
 use zksync_os_provider::NodeProvider;
 
@@ -59,11 +60,19 @@ pub async fn find_block_by_migration_number(
             if code.0.is_empty() {
                 return Ok(false);
             }
-            let res = instance
+            // At this block the address may have code but not yet be the ChainAssetHandler
+            // (e.g. a proxy upgraded to it only later), so `migrationNumber` reverts. Treat a
+            // revert as "not deployed yet" (false); real RPC errors still propagate.
+            let res = match instance
                 .migrationNumber(U256::from(chain_id))
                 .block(block.into())
                 .call()
-                .await?;
+                .await
+            {
+                Ok(res) => res,
+                Err(err) if is_method_missing(&err) => return Ok(false),
+                Err(err) => return Err(err.into()),
+            };
             Ok(res >= target)
         }
     })


### PR DESCRIPTION
## Summary

The gateway migration watcher panics on startup with `failed to resolve L1 watcher start block: ... execution reverted`, taking the node down — whenever the `ChainAssetHandler` lives behind a proxy that was upgraded into the handler only later (so older L1 blocks have unrelated code at that address).

Gated on protocol version `>= 0.31.0`, so it only surfaces once the v0.31 upgrade is active.

## Root cause

`find_block_by_migration_number` binary-searches historical L1 blocks, calling `migrationNumber` on the `ChainAssetHandler` address. The predicate only guards against the address having *no* code:

- When the address is a proxy that wasn't yet the `ChainAssetHandler` at that block, it **has** code but `migrationNumber` reverts.
- That revert was propagated as a fatal error, panicking the watcher — start-block resolution is `.expect()`-ed in `StartResolver::run`.

## Fix

Treat a contract revert / missing method from `migrationNumber` as "handler not deployed at this block yet" (predicate returns `false`), so the binary search stays monotonic and converges on the block where the handler became functional.

- Genuine transport / RPC errors still propagate.
- Reuses the existing `is_method_missing` helper to tell a revert apart from a real RPC failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)