### PR TITLE
feat(network): move 2FA logic to its own subprotocol

### DIFF
--- a/lib/network/src/lib.rs
+++ b/lib/network/src/lib.rs
@@ -4,12 +4,17 @@ pub mod protocol;
 pub mod raft;
 pub mod service;
 pub mod session;
+pub mod twofa;
 pub mod version;
 mod wire;
 
 // todo: temporary re-export while we have record overrides, otherwise `wire` module should be
 //       entirely internal
 pub use service::{NetworkPorts, PeerVerifyBatch, PeerVerifyBatchResult};
+pub use twofa::{
+    ExternalNode2faConfig, MainNode2faConfig, ZKS_2FA_PROTOCOL, Zks2faMessage,
+    Zks2faProtocolHandler,
+};
 pub use wire::replays::RecordOverride;
 pub use wire::verification::{VerifyBatch, VerifyBatchOutcome, VerifyBatchResult};
 

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -5,10 +5,15 @@ use crate::protocol::{
 };
 use crate::raft::protocol::RaftProtocolHandler;
 use crate::session::PeerSessionStore;
-use crate::version::{ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4};
+use crate::twofa::wire::Zks2faMessage;
+use crate::twofa::{
+    ExternalNode2faConfig, MainNode2faConfig, Zks2faConnectionRegistry, Zks2faProtocolHandler,
+};
+use crate::version::{ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4, ZksProtocolV5};
 use crate::wire::message::ZksMessage;
 use crate::{VerifyBatch, VerifyBatchResult};
 use alloy::eips::eip2124::Head;
+use alloy::primitives::bytes::BytesMut;
 use backon::{ConstantBuilder, Retryable};
 use futures::future::join_all;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
@@ -217,7 +222,11 @@ pub struct NetworkService {
     network_manager: NetworkManager,
     protocol_rx: mpsc::UnboundedReceiver<ProtocolEvent>,
     peer_sessions: Arc<RwLock<PeerSessionStore>>,
+    /// Registry of live `zks` (replay) connections. Retained for dispatching `VerifyBatch` to
+    /// pre-split peers that still carry verifier traffic over `zks/3`/`zks/4`.
     connection_registry: ConnectionRegistry,
+    /// Registry of live `zks_2fa` connections used to dispatch `VerifyBatch` to verifier peers.
+    zks_2fa_registry: Zks2faConnectionRegistry,
 }
 
 #[derive(Debug, Clone)]
@@ -421,6 +430,7 @@ impl NetworkService {
         // Boot nodes double as trusted peers, exempt from the connection cap on outgoing dials.
         let trusted_peer_ids: HashSet<PeerId> =
             config.boot_nodes.iter().map(|peer| peer.id).collect();
+        let zks_2fa_registry: Zks2faConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
         let mut cfg_builder = match protocol_config {
             ZksProtocolConfig::MainNode(protocol) => Self::register_main_node_rlpx_sub_protocols(
                 cfg_builder,
@@ -428,6 +438,7 @@ impl NetworkService {
                 replay,
                 protocol_tx,
                 connection_registry.clone(),
+                zks_2fa_registry.clone(),
                 trusted_peer_ids,
             ),
             ZksProtocolConfig::ExternalNode(protocol) => {
@@ -437,6 +448,7 @@ impl NetworkService {
                     replay,
                     protocol_tx,
                     connection_registry.clone(),
+                    zks_2fa_registry.clone(),
                     trusted_peer_ids,
                 )
             }
@@ -465,6 +477,7 @@ impl NetworkService {
                 protocol_rx,
                 peer_sessions: Arc::new(RwLock::new(PeerSessionStore::default())),
                 connection_registry,
+                zks_2fa_registry,
             },
             NetworkPorts {
                 tcp: bound_tcp_port,
@@ -479,9 +492,20 @@ impl NetworkService {
         replay: impl ReadReplay + Clone,
         protocol_tx: mpsc::UnboundedSender<ProtocolEvent>,
         connection_registry: ConnectionRegistry,
+        zks_2fa_registry: Zks2faConnectionRegistry,
         trusted_peers: HashSet<PeerId>,
     ) -> NetworkConfigBuilder {
-        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
+        let state = HandlerSharedState::new(
+            protocol_tx.clone(),
+            MAX_ACTIVE_CONNECTIONS,
+            trusted_peers.clone(),
+        );
+        let twofa_config = MainNode2faConfig {
+            accepted_verifier_signers: protocol.accepted_verifier_signers.clone(),
+            verify_result_tx: protocol.verify_result_tx.clone(),
+        };
+        let twofa_state =
+            HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
         builder
             // Support for v1 must be dropped before upgrade to protocol version v31.0. Otherwise,
             // we might send invalid record to ENs that are still using v1 protocol (`starting_migration_number`
@@ -505,10 +529,22 @@ impl NetworkService {
                 connection_registry.clone(),
             ))
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV4, _>::for_main_node(
+                replay.clone(),
+                protocol.clone(),
+                state.clone(),
+                connection_registry.clone(),
+            ))
+            // Replay-only version: verifier traffic is carried by `zks_2fa` instead.
+            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV5, _>::for_main_node(
                 replay,
                 protocol,
                 state,
                 connection_registry,
+            ))
+            .add_rlpx_sub_protocol(Zks2faProtocolHandler::for_main_node(
+                twofa_config,
+                twofa_state,
+                zks_2fa_registry,
             ))
     }
 
@@ -518,10 +554,24 @@ impl NetworkService {
         replay: impl ReadReplay + Clone,
         protocol_tx: mpsc::UnboundedSender<ProtocolEvent>,
         connection_registry: ConnectionRegistry,
+        zks_2fa_registry: Zks2faConnectionRegistry,
         trusted_peers: HashSet<PeerId>,
     ) -> NetworkConfigBuilder {
-        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
-        builder
+        let state = HandlerSharedState::new(
+            protocol_tx.clone(),
+            MAX_ACTIVE_CONNECTIONS,
+            trusted_peers.clone(),
+        );
+        // Only verifier ENs advertise `zks_2fa`; replay-only ENs leave `verification` unset.
+        let twofa_config = protocol
+            .verification
+            .clone()
+            .map(|verifier| ExternalNode2faConfig {
+                signing_key: verifier.signing_key,
+                verify_batch_tx: verifier.verify_batch_tx,
+                outgoing_verify_results: verifier.outgoing_verify_results,
+            });
+        let builder = builder
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV1, _>::for_external_node(
                 replay.clone(),
                 protocol.clone(),
@@ -541,11 +591,30 @@ impl NetworkService {
                 connection_registry.clone(),
             ))
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV4, _>::for_external_node(
+                replay.clone(),
+                protocol.clone(),
+                state.clone(),
+                connection_registry.clone(),
+            ))
+            // Replay-only version: verifier traffic is carried by `zks_2fa` instead.
+            .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV5, _>::for_external_node(
                 replay,
                 protocol,
                 state,
                 connection_registry,
-            ))
+            ));
+        match twofa_config {
+            Some(twofa_config) => {
+                let twofa_state =
+                    HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
+                builder.add_rlpx_sub_protocol(Zks2faProtocolHandler::for_external_node(
+                    twofa_config,
+                    twofa_state,
+                    zks_2fa_registry,
+                ))
+            }
+            None => builder,
+        }
     }
 
     /// Consume the service by registering it as the set of long-running tasks that drive p2p
@@ -561,10 +630,17 @@ impl NetworkService {
     ) {
         let peer_sessions = Arc::clone(&self.peer_sessions);
         let connection_registry = Arc::clone(&self.connection_registry);
+        let zks_2fa_registry = Arc::clone(&self.zks_2fa_registry);
         if let Some(mut verify_request_rx) = verify_request_rx {
             runtime.spawn_critical_task("p2p verify dispatcher", async move {
                 while let Some(request) = verify_request_rx.recv().await {
-                    dispatch_verify_batch(&peer_sessions, &connection_registry, request).await;
+                    dispatch_verify_batch(
+                        &peer_sessions,
+                        &connection_registry,
+                        &zks_2fa_registry,
+                        request,
+                    )
+                    .await;
                 }
             });
         }
@@ -674,6 +750,7 @@ impl NetworkService {
 async fn dispatch_verify_batch(
     peer_sessions: &Arc<RwLock<PeerSessionStore>>,
     connection_registry: &ConnectionRegistry,
+    zks_2fa_registry: &Zks2faConnectionRegistry,
     request: VerifyBatch,
 ) {
     let required_block = request.last_block_number;
@@ -694,36 +771,49 @@ async fn dispatch_verify_batch(
         return;
     }
 
+    // Resolve each eligible peer to a concrete send target. New peers carry verifier traffic over
+    // `zks_2fa`; pre-split peers still use the in-`zks` verifier path on zks/3+.
+    enum Target {
+        Zks2fa(mpsc::Sender<BytesMut>),
+        LegacyZks(mpsc::Sender<BytesMut>),
+    }
     let dispatch_targets: Vec<_> = {
+        let zks_2fa_registry = zks_2fa_registry.read().unwrap();
         let connection_registry = connection_registry.read().unwrap();
         eligible_peers
             .into_iter()
-            .map(|peer_id| (peer_id, connection_registry.get(&peer_id).cloned()))
+            .map(|peer_id| {
+                let target = if let Some(handle) = zks_2fa_registry.get(&peer_id) {
+                    Some(Target::Zks2fa(handle.outbound_tx.clone()))
+                } else {
+                    connection_registry.get(&peer_id).and_then(|connection| {
+                        (connection.version >= crate::version::ZksVersion::Zks3)
+                            .then(|| Target::LegacyZks(connection.outbound_tx.clone()))
+                    })
+                };
+                (peer_id, target)
+            })
             .collect()
     };
     let mut sent = 0usize;
-    for (peer_id, connection) in dispatch_targets {
-        let Some(connection) = connection else {
-            tracing::warn!(
-                peer_id = %peer_id,
-                request_id = request.request_id,
-                batch_number = request.batch_number,
-                "skipping verify request: missing active connection"
-            );
-            continue;
+    for (peer_id, target) in dispatch_targets {
+        let (outbound_tx, encoded) = match target {
+            Some(Target::Zks2fa(tx)) => (tx, Zks2faMessage::VerifyBatch(request.clone()).encoded()),
+            Some(Target::LegacyZks(tx)) => (
+                tx,
+                ZksMessage::<ZksProtocolV3>::VerifyBatch(request.clone()).encoded(),
+            ),
+            None => {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    request_id = request.request_id,
+                    batch_number = request.batch_number,
+                    "skipping verify request: no eligible active connection"
+                );
+                continue;
+            }
         };
-        if connection.version < crate::version::ZksVersion::Zks3 {
-            tracing::warn!(
-                peer_id = %peer_id,
-                request_id = request.request_id,
-                batch_number = request.batch_number,
-                version = ?connection.version,
-                "skipping verify request: peer is not on zks/3"
-            );
-            continue;
-        }
-        let encoded = ZksMessage::<ZksProtocolV3>::VerifyBatch(request.clone()).encoded();
-        if connection.outbound_tx.send(encoded).await.is_err() {
+        if outbound_tx.send(encoded).await.is_err() {
             tracing::warn!(
                 peer_id = %peer_id,
                 request_id = request.request_id,
@@ -763,6 +853,8 @@ mod tests {
     use crate::VerifyBatch;
     use crate::protocol::PeerConnectionHandle;
     use crate::session::PeerSessionStore;
+    use crate::twofa::wire::Zks2faMessage;
+    use crate::twofa::{Zks2faConnectionRegistry, Zks2faPeerHandle};
     use crate::version::{ZksProtocolV3, ZksVersion};
     use crate::wire::message::ZksMessage;
     use alloy::primitives::{Address, B512, Bytes};
@@ -1034,6 +1126,7 @@ mod tests {
 
         let peer_sessions = Arc::new(RwLock::new(store));
         let connection_registry: ConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let zks_2fa_registry: Zks2faConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
 
         let (eligible_tx, mut eligible_rx) = mpsc::channel(1);
         let (lagging_tx, mut lagging_rx) = mpsc::channel(1);
@@ -1073,7 +1166,13 @@ mod tests {
         }
 
         let request = verify_request();
-        dispatch_verify_batch(&peer_sessions, &connection_registry, request.clone()).await;
+        dispatch_verify_batch(
+            &peer_sessions,
+            &connection_registry,
+            &zks_2fa_registry,
+            request.clone(),
+        )
+        .await;
 
         let encoded =
             tokio::time::timeout(std::time::Duration::from_millis(250), eligible_rx.recv())
@@ -1111,12 +1210,76 @@ mod tests {
     async fn dispatch_verify_batch_returns_when_no_eligible_peers_exist() {
         let peer_sessions = Arc::new(RwLock::new(PeerSessionStore::default()));
         let connection_registry: ConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let zks_2fa_registry: Zks2faConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
 
         tokio::time::timeout(
             std::time::Duration::from_millis(250),
-            dispatch_verify_batch(&peer_sessions, &connection_registry, verify_request()),
+            dispatch_verify_batch(
+                &peer_sessions,
+                &connection_registry,
+                &zks_2fa_registry,
+                verify_request(),
+            ),
         )
         .await
         .expect("dispatch should return immediately when there are no eligible peers");
+    }
+
+    #[test_log::test(tokio::test(flavor = "current_thread"))]
+    async fn dispatch_verify_batch_prefers_zks_2fa_for_new_peers() {
+        // A peer present in the `zks_2fa` registry receives the request over `zks_2fa`, even if it
+        // also has a (replay-only) `zks` connection.
+        let zks_2fa_peer = peer_id(0x11);
+        let signer = Address::repeat_byte(0xAA);
+
+        let mut store = PeerSessionStore::default();
+        add_authorized_peer(&mut store, zks_2fa_peer, 120, signer);
+
+        let peer_sessions = Arc::new(RwLock::new(store));
+        let connection_registry: ConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        let zks_2fa_registry: Zks2faConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
+
+        let (twofa_tx, mut twofa_rx) = mpsc::channel(1);
+        // A replay-only `zks/5` connection coexists for the same peer; it must NOT receive the
+        // verify request because `zks_2fa` takes precedence.
+        let (zks_tx, mut zks_rx) = mpsc::channel(1);
+        zks_2fa_registry.write().unwrap().insert(
+            zks_2fa_peer,
+            Zks2faPeerHandle {
+                outbound_tx: twofa_tx,
+            },
+        );
+        connection_registry.write().unwrap().insert(
+            zks_2fa_peer,
+            PeerConnectionHandle {
+                version: ZksVersion::Zks5,
+                outbound_tx: zks_tx,
+            },
+        );
+
+        let request = verify_request();
+        dispatch_verify_batch(
+            &peer_sessions,
+            &connection_registry,
+            &zks_2fa_registry,
+            request.clone(),
+        )
+        .await;
+
+        let encoded = tokio::time::timeout(std::time::Duration::from_millis(250), twofa_rx.recv())
+            .await
+            .expect("zks_2fa peer should receive verify request")
+            .expect("zks_2fa peer channel closed");
+        let mut slice = encoded.as_ref();
+        match Zks2faMessage::decode_message(&mut slice).unwrap() {
+            Zks2faMessage::VerifyBatch(actual) => assert_eq!(actual, request),
+            other => panic!("unexpected zks_2fa message dispatched: {other:?}"),
+        }
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), zks_rx.recv())
+                .await
+                .is_err(),
+            "replay-only zks/5 connection must not receive the verify request"
+        );
     }
 }

--- a/lib/network/src/twofa/config.rs
+++ b/lib/network/src/twofa/config.rs
@@ -1,0 +1,20 @@
+use crate::service::{PeerVerifyBatch, PeerVerifyBatchResult};
+use alloy::primitives::Address;
+use tokio::sync::{broadcast, mpsc};
+
+/// Dependencies required to run the main-node side of the `zks_2fa` subprotocol.
+#[derive(Debug, Clone)]
+pub struct MainNode2faConfig {
+    /// Accepted verifier signers for this main node.
+    pub accepted_verifier_signers: Vec<Address>,
+    /// Channel used to forward batch verification results back into the node.
+    pub verify_result_tx: mpsc::Sender<PeerVerifyBatchResult>,
+}
+
+/// Verifier identity and transport used by an external node participating in `zks_2fa`.
+#[derive(Debug, Clone)]
+pub struct ExternalNode2faConfig {
+    pub signing_key: secrecy::SecretString,
+    pub verify_batch_tx: mpsc::Sender<PeerVerifyBatch>,
+    pub outgoing_verify_results: broadcast::Sender<PeerVerifyBatchResult>,
+}

--- a/lib/network/src/twofa/en.rs
+++ b/lib/network/src/twofa/en.rs
@@ -1,0 +1,150 @@
+use super::config::ExternalNode2faConfig;
+use super::wire::Zks2faMessage;
+use crate::service::{PeerVerifyBatch, PeerVerifyBatchResult};
+use crate::wire::auth::{VerifierAuth, verifier_auth_prehash};
+use alloy::primitives::bytes::BytesMut;
+use alloy::signers::{SignerSync, local::PrivateKeySigner};
+use futures::{Stream, StreamExt};
+use reth_network_peers::PeerId;
+use secrecy::ExposeSecret;
+use std::str::FromStr;
+use tokio::sync::{broadcast, mpsc};
+
+/// Background task that drives the external-node side of a `zks_2fa` connection.
+///
+/// Performs the verifier handshake immediately, then forwards each received `VerifyBatch` request
+/// into the local verifier via `verify_batch_tx` and relays signed `VerifyBatchResult`s back to the
+/// requesting main node.
+pub(super) async fn run_2fa_en_connection(
+    mut conn: impl Stream<Item = Zks2faMessage> + Unpin,
+    outbound_tx: mpsc::Sender<BytesMut>,
+    peer_id: PeerId,
+    config: ExternalNode2faConfig,
+) {
+    // Subscribe before the handshake so a result broadcast right after authentication is not
+    // missed (a `broadcast::Receiver` only observes messages sent after it subscribed).
+    let outgoing_verify_results = config.outgoing_verify_results.subscribe();
+    if perform_verifier_handshake(&mut conn, &outbound_tx, &config)
+        .await
+        .is_err()
+    {
+        return;
+    }
+    receive_verification(conn, outbound_tx, peer_id, config, outgoing_verify_results).await;
+}
+
+async fn perform_verifier_handshake(
+    conn: &mut (impl Stream<Item = Zks2faMessage> + Unpin),
+    outbound_tx: &mpsc::Sender<BytesMut>,
+    config: &ExternalNode2faConfig,
+) -> Result<(), ()> {
+    if outbound_tx
+        .send(Zks2faMessage::verifier_role_request().encoded())
+        .await
+        .is_err()
+    {
+        return Err(());
+    }
+
+    let signer = match PrivateKeySigner::from_str(config.signing_key.expose_secret()) {
+        Ok(signer) => signer,
+        Err(error) => {
+            tracing::info!(%error, "invalid verifier signing key; terminating");
+            return Err(());
+        }
+    };
+
+    let challenge = match conn.next().await {
+        Some(Zks2faMessage::VerifierChallenge(challenge)) => challenge,
+        Some(other) => {
+            tracing::info!(
+                ?other,
+                "received unexpected message while waiting for verifier challenge; terminating"
+            );
+            return Err(());
+        }
+        None => return Err(()),
+    };
+
+    let signature = match signer.sign_hash_sync(&verifier_auth_prehash(challenge.nonce)) {
+        Ok(signature) => signature,
+        Err(error) => {
+            tracing::info!(%error, "failed to sign verifier challenge; terminating");
+            return Err(());
+        }
+    };
+
+    let msg = Zks2faMessage::VerifierAuth(VerifierAuth {
+        signature: signature.as_bytes().to_vec().into(),
+    });
+    if outbound_tx.send(msg.encoded()).await.is_err() {
+        return Err(());
+    }
+    Ok(())
+}
+
+async fn receive_verification(
+    mut conn: impl Stream<Item = Zks2faMessage> + Unpin,
+    outbound_tx: mpsc::Sender<BytesMut>,
+    peer_id: PeerId,
+    config: ExternalNode2faConfig,
+    mut outgoing_verify_results: broadcast::Receiver<PeerVerifyBatchResult>,
+) {
+    loop {
+        tokio::select! {
+            msg = conn.next() => {
+                let Some(msg) = msg else {
+                    break;
+                };
+                match msg {
+                    Zks2faMessage::VerifyBatch(request) => {
+                        if config
+                            .verify_batch_tx
+                            .send(PeerVerifyBatch {
+                                peer_id,
+                                message: request,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::info!("verify batch channel is closed; terminating");
+                            break;
+                        }
+                    }
+                    other => {
+                        tracing::info!(?other, "ignoring unexpected zks_2fa message");
+                    }
+                }
+            }
+            result = recv_outgoing_verify_result(&mut outgoing_verify_results) => {
+                let Some(result) = result else {
+                    break;
+                };
+                if result.peer_id != peer_id {
+                    continue;
+                }
+                if outbound_tx
+                    .send(Zks2faMessage::VerifyBatchResult(result.message).encoded())
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn recv_outgoing_verify_result(
+    receiver: &mut broadcast::Receiver<PeerVerifyBatchResult>,
+) -> Option<PeerVerifyBatchResult> {
+    loop {
+        match receiver.recv().await {
+            Ok(result) => return Some(result),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                tracing::warn!(skipped, "lagged on outgoing verify results broadcast");
+            }
+            Err(broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}

--- a/lib/network/src/twofa/mn.rs
+++ b/lib/network/src/twofa/mn.rs
@@ -1,0 +1,103 @@
+use super::config::MainNode2faConfig;
+use super::wire::Zks2faMessage;
+use crate::protocol::ProtocolEvent;
+use crate::service::PeerVerifyBatchResult;
+use crate::wire::auth::recover_verifier_signer;
+use alloy::primitives::B256;
+use alloy::primitives::bytes::BytesMut;
+use futures::{Stream, StreamExt};
+use reth_network_peers::PeerId;
+use tokio::sync::mpsc;
+
+/// Background task that drives the main-node side of a `zks_2fa` connection.
+///
+/// Authenticates a verifier external node (role request -> challenge -> auth), then forwards any
+/// [`VerifyBatchResult`](crate::wire::verification::VerifyBatchResult) the peer returns into the
+/// node via `verify_result_tx`. Outbound `VerifyBatch` requests are pushed onto this connection by
+/// the verify dispatcher via the connection registry, not from this task.
+pub(super) async fn run_2fa_mn_connection(
+    mut conn: impl Stream<Item = Zks2faMessage> + Unpin,
+    outbound_tx: mpsc::Sender<BytesMut>,
+    events_sender: mpsc::UnboundedSender<ProtocolEvent>,
+    peer_id: PeerId,
+    config: MainNode2faConfig,
+) {
+    let MainNode2faConfig {
+        accepted_verifier_signers,
+        verify_result_tx,
+    } = config;
+    let mut pending_verifier_nonce: Option<B256> = None;
+    loop {
+        match conn.next().await {
+            Some(Zks2faMessage::VerifierRoleRequest(_)) => {
+                events_sender
+                    .send(ProtocolEvent::VerifierRoleRequested { peer_id })
+                    .ok();
+                let nonce = B256::random();
+                if outbound_tx
+                    .send(Zks2faMessage::verifier_challenge(nonce).encoded())
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                pending_verifier_nonce = Some(nonce);
+                events_sender
+                    .send(ProtocolEvent::VerifierChallengeSent { peer_id, nonce })
+                    .ok();
+            }
+            Some(Zks2faMessage::VerifierAuth(auth)) => {
+                let Some(nonce) = pending_verifier_nonce.take() else {
+                    tracing::info!("received verifier auth without pending challenge; terminating");
+                    return;
+                };
+                match recover_verifier_signer(nonce, auth.signature.as_ref()) {
+                    Ok(signer) if accepted_verifier_signers.contains(&signer) => {
+                        events_sender
+                            .send(ProtocolEvent::VerifierAuthorized { peer_id, signer })
+                            .ok();
+                    }
+                    Ok(signer) => {
+                        tracing::warn!(%peer_id, %signer, "peer failed verifier authorization");
+                        events_sender
+                            .send(ProtocolEvent::VerifierUnauthorized {
+                                peer_id,
+                                signer: Some(signer),
+                            })
+                            .ok();
+                    }
+                    Err(error) => {
+                        tracing::warn!(%peer_id, %error, "failed to recover verifier signer");
+                        events_sender
+                            .send(ProtocolEvent::VerifierUnauthorized {
+                                peer_id,
+                                signer: None,
+                            })
+                            .ok();
+                    }
+                }
+            }
+            Some(Zks2faMessage::VerifyBatchResult(result)) => {
+                if verify_result_tx
+                    .send(PeerVerifyBatchResult {
+                        peer_id,
+                        message: result,
+                    })
+                    .await
+                    .is_err()
+                {
+                    tracing::info!("verify result channel is closed; terminating");
+                    return;
+                }
+            }
+            Some(msg) => {
+                tracing::info!(
+                    ?msg,
+                    "received unexpected zks_2fa message from peer; terminating"
+                );
+                return;
+            }
+            None => return,
+        }
+    }
+}

--- a/lib/network/src/twofa/mod.rs
+++ b/lib/network/src/twofa/mod.rs
@@ -1,0 +1,15 @@
+//! The `zks_2fa` RLPx subprotocol: verifier authentication and batch verification.
+//!
+//! Split out of the `zks` subprotocol so that replay streaming (`zks`) and verifier / batch
+//! verification (`zks_2fa`) can evolve independently. Both subprotocols are multiplexed over the
+//! same RLPx connection, so a verifier peer is correlated across them by its `PeerId`.
+
+pub mod config;
+mod en;
+mod mn;
+pub mod protocol;
+pub mod wire;
+
+pub use config::{ExternalNode2faConfig, MainNode2faConfig};
+pub use protocol::{Zks2faConnectionRegistry, Zks2faPeerHandle, Zks2faProtocolHandler};
+pub use wire::{ZKS_2FA_PROTOCOL, Zks2faMessage};

--- a/lib/network/src/twofa/protocol.rs
+++ b/lib/network/src/twofa/protocol.rs
@@ -1,0 +1,244 @@
+use super::config::{ExternalNode2faConfig, MainNode2faConfig};
+use super::en::run_2fa_en_connection;
+use super::mn::run_2fa_mn_connection;
+use super::wire::Zks2faMessage;
+use crate::protocol::HandlerSharedState;
+use alloy::primitives::bytes::BytesMut;
+use futures::{Stream, StreamExt};
+use reth_eth_wire::capability::SharedCapabilities;
+use reth_eth_wire::multiplex::ProtocolConnection;
+use reth_eth_wire::protocol::Protocol;
+use reth_network::Direction;
+use reth_network::protocol::{ConnectionHandler, OnNotSupported, ProtocolHandler};
+use reth_network_peers::PeerId;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use tokio::sync::{OwnedSemaphorePermit, mpsc};
+use tracing::Instrument;
+
+/// Channel capacity for outbound `zks_2fa` protocol messages.
+const OUTBOUND_CHANNEL_CAPACITY: usize = 32;
+
+/// Handle for sending messages to a peer over its live `zks_2fa` connection.
+#[derive(Debug, Clone)]
+pub struct Zks2faPeerHandle {
+    /// Channel used to queue encoded protocol frames to the peer.
+    pub outbound_tx: mpsc::Sender<BytesMut>,
+}
+
+/// Registry of currently connected `zks_2fa` peers and their live outbound send handles.
+pub type Zks2faConnectionRegistry = Arc<RwLock<HashMap<PeerId, Zks2faPeerHandle>>>;
+
+#[derive(Debug, Clone)]
+enum Twofa2Role {
+    MainNode(MainNode2faConfig),
+    ExternalNode(ExternalNode2faConfig),
+}
+
+#[derive(Debug, Clone)]
+pub struct Zks2faProtocolHandler {
+    role: Twofa2Role,
+    state: HandlerSharedState,
+    connection_registry: Zks2faConnectionRegistry,
+}
+
+pub struct Zks2faConnectionHandler {
+    role: Twofa2Role,
+    state: HandlerSharedState,
+    connection_registry: Zks2faConnectionRegistry,
+    /// Owned permit that corresponds to a taken active connection slot.
+    permit: OwnedSemaphorePermit,
+}
+
+impl Zks2faProtocolHandler {
+    pub fn for_main_node(
+        config: MainNode2faConfig,
+        state: HandlerSharedState,
+        connection_registry: Zks2faConnectionRegistry,
+    ) -> Self {
+        Self {
+            role: Twofa2Role::MainNode(config),
+            state,
+            connection_registry,
+        }
+    }
+
+    pub fn for_external_node(
+        config: ExternalNode2faConfig,
+        state: HandlerSharedState,
+        connection_registry: Zks2faConnectionRegistry,
+    ) -> Self {
+        Self {
+            role: Twofa2Role::ExternalNode(config),
+            state,
+            connection_registry,
+        }
+    }
+
+    fn try_establish_connection(
+        &self,
+        socket_addr: SocketAddr,
+        peer_id: Option<PeerId>,
+    ) -> Option<Zks2faConnectionHandler> {
+        match self.state.try_acquire_connection_slot() {
+            Ok(permit) => Some(Zks2faConnectionHandler {
+                role: self.role.clone(),
+                state: self.state.clone(),
+                connection_registry: self.connection_registry.clone(),
+                permit,
+            }),
+            Err(_) => {
+                match peer_id {
+                    Some(peer_id) => tracing::warn!(
+                        max_connections = self.state.max_active_connections(),
+                        %socket_addr,
+                        %peer_id,
+                        "ignoring outgoing zks_2fa connection, max active reached"
+                    ),
+                    None => tracing::warn!(
+                        max_connections = self.state.max_active_connections(),
+                        %socket_addr,
+                        "ignoring incoming zks_2fa connection, max active reached"
+                    ),
+                }
+                self.state.emit_max_active_connections_exceeded();
+                None
+            }
+        }
+    }
+}
+
+impl ProtocolHandler for Zks2faProtocolHandler {
+    type ConnectionHandler = Zks2faConnectionHandler;
+
+    fn on_incoming(&self, socket_addr: SocketAddr) -> Option<Self::ConnectionHandler> {
+        self.try_establish_connection(socket_addr, None)
+    }
+
+    fn on_outgoing(
+        &self,
+        socket_addr: SocketAddr,
+        peer_id: PeerId,
+    ) -> Option<Self::ConnectionHandler> {
+        self.try_establish_connection(socket_addr, Some(peer_id))
+    }
+}
+
+impl ConnectionHandler for Zks2faConnectionHandler {
+    type Connection = Zks2faConnection;
+
+    fn protocol(&self) -> Protocol {
+        Zks2faMessage::protocol()
+    }
+
+    fn on_unsupported_by_peer(
+        self,
+        _supported: &SharedCapabilities,
+        _direction: Direction,
+        _peer_id: PeerId,
+    ) -> OnNotSupported {
+        // `zks_2fa` is an optional sub-protocol; replay-only peers must stay connected.
+        OnNotSupported::KeepAlive
+    }
+
+    fn into_connection(
+        self,
+        _direction: Direction,
+        peer_id: PeerId,
+        conn: ProtocolConnection,
+    ) -> Self::Connection {
+        // Note: session lifecycle (`Established`/`Closed`) is intentionally owned by the `zks`
+        // replay connection, which every verifier peer also has. Emitting those events here too
+        // would double-count peers in `PeerSessionStore`. We only emit verifier-specific events.
+        let events_sender = self.state.events_sender();
+        let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
+        self.connection_registry
+            .write()
+            .expect("zks_2fa connection registry lock poisoned")
+            .insert(
+                peer_id,
+                Zks2faPeerHandle {
+                    outbound_tx: outbound_tx.clone(),
+                },
+            );
+        let conn = into_message_stream(conn);
+        let connection_registry = self.connection_registry.clone();
+
+        let task = match self.role {
+            Twofa2Role::MainNode(config) => tokio::spawn(
+                run_2fa_mn_connection(conn, outbound_tx, events_sender, peer_id, config)
+                    .instrument(tracing::info_span!("zks_2fa_mn_connection", %peer_id)),
+            ),
+            Twofa2Role::ExternalNode(config) => tokio::spawn(
+                run_2fa_en_connection(conn, outbound_tx, peer_id, config)
+                    .instrument(tracing::info_span!("zks_2fa_en_connection", %peer_id)),
+            ),
+        };
+
+        Zks2faConnection {
+            outbound_rx,
+            task,
+            peer_id,
+            connection_registry,
+            _permit: self.permit,
+        }
+    }
+}
+
+/// The outbound side of a `zks_2fa` protocol connection.
+///
+/// Wraps an mpsc receiver fed by a background Tokio task (`run_2fa_mn_connection` or
+/// `run_2fa_en_connection`). Dropping this struct unregisters the peer from the connection registry
+/// and aborts the background task.
+pub struct Zks2faConnection {
+    outbound_rx: mpsc::Receiver<BytesMut>,
+    task: tokio::task::JoinHandle<()>,
+    peer_id: PeerId,
+    connection_registry: Zks2faConnectionRegistry,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Drop for Zks2faConnection {
+    fn drop(&mut self) {
+        self.connection_registry
+            .write()
+            .expect("zks_2fa connection registry lock poisoned")
+            .remove(&self.peer_id);
+        self.task.abort();
+    }
+}
+
+impl Stream for Zks2faConnection {
+    type Item = BytesMut;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.outbound_rx.poll_recv(cx)
+    }
+}
+
+/// Wraps a raw `ProtocolConnection` into a typed `Zks2faMessage` stream.
+///
+/// Decode errors are logged and terminate the stream (by returning `None`), matching the behaviour
+/// of a closed connection.
+fn into_message_stream(
+    conn: ProtocolConnection,
+) -> impl Stream<Item = Zks2faMessage> + Unpin + Send + 'static {
+    Box::pin(conn.scan((), |_, raw| {
+        let result = Zks2faMessage::decode_message(&mut &raw[..]);
+        async move {
+            match result {
+                Ok(msg) => {
+                    tracing::trace!(?msg, "processing peer zks_2fa message");
+                    Some(msg)
+                }
+                Err(error) => {
+                    tracing::info!(%error, "error decoding peer zks_2fa message; terminating");
+                    None
+                }
+            }
+        }
+    }))
+}

--- a/lib/network/src/twofa/wire.rs
+++ b/lib/network/src/twofa/wire.rs
@@ -1,0 +1,225 @@
+//! Definitions for `zks_2fa` wire-protocol messages and encode / decode helpers.
+//!
+//! The `zks_2fa` subprotocol carries verifier authentication and batch-verification request /
+//! response traffic that previously lived inside `zks/3` and `zks/4`. It reuses the same message
+//! payload types (see [`crate::wire::auth`] and [`crate::wire::verification`]) but renumbers the
+//! message ids starting from `0x00` because it is a fresh, single-version protocol.
+
+use crate::wire::auth::{VerifierAuth, VerifierChallenge, VerifierRoleRequest};
+use crate::wire::verification::{VerifyBatch, VerifyBatchResult};
+use alloy::primitives::{
+    B256,
+    bytes::{Buf, BufMut, BytesMut},
+};
+use alloy_rlp::{Decodable, Encodable, Error as RlpError};
+use reth_eth_wire::protocol::Protocol;
+use reth_network::types::Capability;
+
+pub const ZKS_2FA_PROTOCOL: &str = "zks_2fa";
+pub(crate) const ZKS_2FA_PROTOCOL_VERSION: usize = 1;
+pub(crate) const ZKS_2FA_MESSAGE_COUNT: u8 = 5;
+
+/// A `zks_2fa` wire-protocol message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Zks2faMessage {
+    /// External node requests verifier role for the current session.
+    VerifierRoleRequest(VerifierRoleRequest),
+    /// Main-node provides verifier challenge.
+    VerifierChallenge(VerifierChallenge),
+    /// External node authentication response proving control of the verifier signing key.
+    VerifierAuth(VerifierAuth),
+    /// Main node requests an external-node verifier to validate and sign a batch.
+    VerifyBatch(VerifyBatch),
+    /// External-node verifier responds to a [`VerifyBatch`] request with approval or refusal.
+    VerifyBatchResult(VerifyBatchResult),
+}
+
+impl Zks2faMessage {
+    /// Returns the capability for the `zks_2fa` protocol.
+    pub const fn capability() -> Capability {
+        Capability::new_static(ZKS_2FA_PROTOCOL, ZKS_2FA_PROTOCOL_VERSION)
+    }
+
+    /// Returns the protocol for the `zks_2fa` protocol.
+    pub const fn protocol() -> Protocol {
+        Protocol::new(Self::capability(), ZKS_2FA_MESSAGE_COUNT)
+    }
+
+    /// Returns the message's ID.
+    pub const fn message_id(&self) -> Zks2faMessageId {
+        match self {
+            Zks2faMessage::VerifierRoleRequest(_) => Zks2faMessageId::VerifierRoleRequest,
+            Zks2faMessage::VerifierChallenge(_) => Zks2faMessageId::VerifierChallenge,
+            Zks2faMessage::VerifierAuth(_) => Zks2faMessageId::VerifierAuth,
+            Zks2faMessage::VerifyBatch(_) => Zks2faMessageId::VerifyBatch,
+            Zks2faMessage::VerifyBatchResult(_) => Zks2faMessageId::VerifyBatchResult,
+        }
+    }
+
+    pub fn verifier_role_request() -> Self {
+        Self::VerifierRoleRequest(VerifierRoleRequest {})
+    }
+
+    pub fn verifier_challenge(nonce: B256) -> Self {
+        Self::VerifierChallenge(VerifierChallenge { nonce })
+    }
+
+    /// Return RLP encoded message.
+    pub fn encoded(&self) -> BytesMut {
+        let mut buf = BytesMut::with_capacity(self.length());
+        self.encode(&mut buf);
+        buf
+    }
+
+    /// Decodes a `Zks2faMessage` from the given message buffer.
+    pub fn decode_message(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let message_type = Zks2faMessageId::decode(buf)?;
+        Ok(match message_type {
+            Zks2faMessageId::VerifierRoleRequest => {
+                Self::VerifierRoleRequest(VerifierRoleRequest::decode(buf)?)
+            }
+            Zks2faMessageId::VerifierChallenge => {
+                Self::VerifierChallenge(VerifierChallenge::decode(buf)?)
+            }
+            Zks2faMessageId::VerifierAuth => Self::VerifierAuth(VerifierAuth::decode(buf)?),
+            Zks2faMessageId::VerifyBatch => Self::VerifyBatch(VerifyBatch::decode(buf)?),
+            Zks2faMessageId::VerifyBatchResult => {
+                Self::VerifyBatchResult(VerifyBatchResult::decode(buf)?)
+            }
+        })
+    }
+}
+
+impl Encodable for Zks2faMessage {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.message_id().encode(out);
+        match self {
+            Zks2faMessage::VerifierRoleRequest(message) => message.encode(out),
+            Zks2faMessage::VerifierChallenge(message) => message.encode(out),
+            Zks2faMessage::VerifierAuth(message) => message.encode(out),
+            Zks2faMessage::VerifyBatch(message) => message.encode(out),
+            Zks2faMessage::VerifyBatchResult(message) => message.encode(out),
+        }
+    }
+
+    fn length(&self) -> usize {
+        self.message_id().length()
+            + match self {
+                Zks2faMessage::VerifierRoleRequest(message) => message.length(),
+                Zks2faMessage::VerifierChallenge(message) => message.length(),
+                Zks2faMessage::VerifierAuth(message) => message.length(),
+                Zks2faMessage::VerifyBatch(message) => message.length(),
+                Zks2faMessage::VerifyBatchResult(message) => message.length(),
+            }
+    }
+}
+
+/// Represents message IDs for `zks_2fa` protocol messages.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Zks2faMessageId {
+    /// Request verifier role.
+    VerifierRoleRequest = 0x00,
+    /// Verifier challenge message.
+    VerifierChallenge = 0x01,
+    /// Verifier auth message.
+    VerifierAuth = 0x02,
+    /// Batch verification request.
+    VerifyBatch = 0x03,
+    /// Batch verification response.
+    VerifyBatchResult = 0x04,
+}
+
+impl Zks2faMessageId {
+    /// Returns the corresponding `u8` value for a `Zks2faMessageId`.
+    pub const fn as_u8(&self) -> u8 {
+        *self as u8
+    }
+}
+
+impl Encodable for Zks2faMessageId {
+    fn encode(&self, out: &mut dyn BufMut) {
+        out.put_u8(self.as_u8());
+    }
+    fn length(&self) -> usize {
+        1
+    }
+}
+
+impl Decodable for Zks2faMessageId {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        let byte = buf.first().ok_or(alloy_rlp::Error::InputTooShort)?;
+        let id = Zks2faMessageId::try_from(*byte).map_err(RlpError::Custom)?;
+        buf.advance(1);
+        Ok(id)
+    }
+}
+
+impl TryFrom<u8> for Zks2faMessageId {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::VerifierRoleRequest),
+            0x01 => Ok(Self::VerifierChallenge),
+            0x02 => Ok(Self::VerifierAuth),
+            0x03 => Ok(Self::VerifyBatch),
+            0x04 => Ok(Self::VerifyBatchResult),
+            _ => Err("unrecognized zks_2fa message id"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Zks2faMessage;
+    use crate::wire::auth::{VerifierAuth, VerifierChallenge, VerifierRoleRequest};
+    use crate::wire::verification::{VerifyBatch, VerifyBatchOutcome, VerifyBatchResult};
+    use alloy::primitives::{B256, Bytes};
+
+    #[test]
+    fn round_trips_all_messages() {
+        let messages = [
+            Zks2faMessage::VerifierRoleRequest(VerifierRoleRequest {}),
+            Zks2faMessage::VerifierChallenge(VerifierChallenge {
+                nonce: B256::repeat_byte(0x11),
+            }),
+            Zks2faMessage::VerifierAuth(VerifierAuth {
+                signature: Bytes::from(vec![7u8; 65]),
+            }),
+            Zks2faMessage::VerifyBatch(VerifyBatch {
+                request_id: 41,
+                batch_number: 7,
+                first_block_number: 100,
+                last_block_number: 120,
+                pubdata_mode: 0,
+                commit_data: Bytes::from_static(b"commit"),
+                prev_commit_data: Bytes::from_static(b"prev"),
+                execution_protocol_version: 31,
+            }),
+            Zks2faMessage::VerifyBatchResult(VerifyBatchResult {
+                request_id: 41,
+                batch_number: 7,
+                result: VerifyBatchOutcome::Approved(Bytes::from(vec![9u8; 65])),
+            }),
+        ];
+
+        for message in messages {
+            let encoded = message.encoded();
+            let mut slice = encoded.as_ref();
+            let decoded = Zks2faMessage::decode_message(&mut slice).unwrap();
+            assert_eq!(decoded, message);
+            assert_eq!(decoded.encoded(), encoded);
+            assert!(slice.is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_message_id() {
+        let err = Zks2faMessage::decode_message(&mut [0x05u8].as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            alloy_rlp::Error::Custom("unrecognized zks_2fa message id")
+        );
+    }
+}

--- a/lib/network/src/version.rs
+++ b/lib/network/src/version.rs
@@ -68,6 +68,18 @@ impl ZksProtocolVersionSpec for ZksProtocolV4 {
     const VERSION: ZksVersion = ZksVersion::Zks4;
 }
 
+/// Protocol version 5 keeps the v3 replay record encoding from v4 but drops all verifier-related
+/// messages. The verifier handshake and batch verification now live in the standalone `zks_2fa`
+/// subprotocol, leaving `zks` purely responsible for replay streaming.
+#[derive(Debug, Clone)]
+pub struct ZksProtocolV5;
+
+impl ZksProtocolVersionSpec for ZksProtocolV5 {
+    type Record = v3::ReplayRecord;
+
+    const VERSION: ZksVersion = ZksVersion::Zks5;
+}
+
 /// Error thrown when failed to parse a valid [`ZksVersion`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("Unknown zks protocol version: {0}")]
@@ -87,15 +99,23 @@ pub enum ZksVersion {
     Zks3 = 3,
     /// The `zks` protocol version 4.
     Zks4 = 4,
+    /// The `zks` protocol version 5. Replay-only; verifier messages moved to `zks_2fa`.
+    Zks5 = 5,
 }
 
 impl ZksVersion {
     /// The latest known zks version
-    pub const LATEST: Self = Self::Zks4;
+    pub const LATEST: Self = Self::Zks5;
 
     /// All known zks versions
-    pub const ALL_VERSIONS: &'static [Self] =
-        &[Self::Zks0, Self::Zks1, Self::Zks2, Self::Zks3, Self::Zks4];
+    pub const ALL_VERSIONS: &'static [Self] = &[
+        Self::Zks0,
+        Self::Zks1,
+        Self::Zks2,
+        Self::Zks3,
+        Self::Zks4,
+        Self::Zks5,
+    ];
 
     /// Returns the max message id for the given version.
     const fn max_message_id(&self) -> u8 {
@@ -105,6 +125,8 @@ impl ZksVersion {
             ZksVersion::Zks2 => ZksMessageId::BlockReplays as u8,
             ZksVersion::Zks3 => ZksMessageId::VerifyBatchResult as u8,
             ZksVersion::Zks4 => ZksMessageId::VerifyBatchResult as u8,
+            // Replay-only: verifier messages live in the `zks_2fa` subprotocol.
+            ZksVersion::Zks5 => ZksMessageId::BlockReplays as u8,
         }
     }
 
@@ -158,6 +180,8 @@ impl TryFrom<u8> for ZksVersion {
             1 => Ok(Self::Zks1),
             2 => Ok(Self::Zks2),
             3 => Ok(Self::Zks3),
+            4 => Ok(Self::Zks4),
+            5 => Ok(Self::Zks5),
             _ => Err(ParseVersionError(u.to_string())),
         }
     }
@@ -179,6 +203,7 @@ impl From<ZksVersion> for &'static str {
             ZksVersion::Zks2 => "2",
             ZksVersion::Zks3 => "3",
             ZksVersion::Zks4 => "4",
+            ZksVersion::Zks5 => "5",
         }
     }
 }
@@ -211,7 +236,9 @@ mod tests {
             (1_u8, Ok(ZksVersion::Zks1)),
             (2_u8, Ok(ZksVersion::Zks2)),
             (3_u8, Ok(ZksVersion::Zks3)),
-            (4_u8, Err(RlpError::Custom("invalid zks version"))),
+            (4_u8, Ok(ZksVersion::Zks4)),
+            (5_u8, Ok(ZksVersion::Zks5)),
+            (6_u8, Err(RlpError::Custom("invalid zks version"))),
         ];
 
         for (input, expected) in test_cases {
@@ -231,6 +258,8 @@ mod tests {
             (ZksVersion::Zks1, 2),
             (ZksVersion::Zks2, 2),
             (ZksVersion::Zks3, 7),
+            (ZksVersion::Zks4, 7),
+            (ZksVersion::Zks5, 2),
         ];
 
         for (version, expected_count) in test_cases {
@@ -249,7 +278,12 @@ mod tests {
             ZksMessageId::VerifyBatchResult,
         ];
 
-        for version in [ZksVersion::Zks0, ZksVersion::Zks1, ZksVersion::Zks2] {
+        for version in [
+            ZksVersion::Zks0,
+            ZksVersion::Zks1,
+            ZksVersion::Zks2,
+            ZksVersion::Zks5,
+        ] {
             for message in old_messages {
                 assert!(version.supports_message(message));
             }
@@ -260,6 +294,7 @@ mod tests {
 
         for message in old_messages.into_iter().chain(new_messages) {
             assert!(ZksVersion::Zks3.supports_message(message));
+            assert!(ZksVersion::Zks4.supports_message(message));
         }
     }
 }

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -17,8 +17,9 @@ use zksync_os_network::protocol::{
     ExternalNodeProtocolConfig, ExternalNodeVerifierConfig, HandlerSharedState,
     MainNodeProtocolConfig, ProtocolEvent, ZksProtocolHandler,
 };
+use zksync_os_network::twofa::{ExternalNode2faConfig, MainNode2faConfig, Zks2faProtocolHandler};
 use zksync_os_network::version::{
-    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4,
+    ZksProtocolV0, ZksProtocolV1, ZksProtocolV2, ZksProtocolV3, ZksProtocolV4, ZksProtocolV5,
     ZksProtocolVersionSpec, ZksVersion,
 };
 use zksync_os_network::{PeerVerifyBatchResult, VerifyBatchOutcome, VerifyBatchResult};
@@ -130,6 +131,18 @@ trait PeerExt {
         verifier_signing_key: Option<SecretString>,
         trusted_peers: HashSet<PeerId>,
     ) -> TestPeerProtocolHandles;
+
+    /// Registers a replay-only `zks/5` handler plus a `zks_2fa` handler on the same peer, sharing a
+    /// single `ProtocolEvent` stream — mirroring how a post-split verifier peer is wired. Pass
+    /// `verifier_signing_key` only for external nodes.
+    fn add_zks_2fa_sub_protocol(
+        &mut self,
+        node_role: NodeRole,
+        starting_block: BlockNumber,
+        replays: impl IntoIterator<Item = (BlockNumber, ReplayRecord)>,
+        max_active_connections: usize,
+        verifier_signing_key: Option<SecretString>,
+    ) -> TestPeerProtocolHandles;
 }
 
 impl<C> PeerExt for Peer<C>
@@ -229,9 +242,86 @@ where
             outgoing_verify_results_tx,
         }
     }
+
+    fn add_zks_2fa_sub_protocol(
+        &mut self,
+        node_role: NodeRole,
+        starting_block: BlockNumber,
+        replays: impl IntoIterator<Item = (BlockNumber, ReplayRecord)>,
+        max_active_connections: usize,
+        verifier_signing_key: Option<SecretString>,
+    ) -> TestPeerProtocolHandles {
+        let (protocol_tx, protocol_rx) = mpsc::unbounded_channel();
+        let (replay_tx, replay_rx) = mpsc::channel(8);
+        // Both subprotocols share one event stream, exactly as in production.
+        let zks_state =
+            HandlerSharedState::new(protocol_tx.clone(), max_active_connections, HashSet::new());
+        let twofa_state =
+            HandlerSharedState::new(protocol_tx, max_active_connections, HashSet::new());
+        let connection_registry = Arc::new(RwLock::new(HashMap::new()));
+        let zks_2fa_registry = Arc::new(RwLock::new(HashMap::new()));
+        let replays = InMemReplay(HashMap::from_iter(replays));
+
+        let (verify_result_rx, outgoing_verify_results_tx) = if node_role.is_main() {
+            let (verify_result_tx, verify_result_rx) = mpsc::channel(8);
+            // Replay-only zks/5 handler. Its verifier fields are unused on this version.
+            self.add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV5, _>::for_main_node(
+                replays,
+                MainNodeProtocolConfig {
+                    accepted_verifier_signers: accepted_verifier_signers(),
+                    verify_result_tx: verify_result_tx.clone(),
+                },
+                zks_state,
+                connection_registry,
+            ));
+            self.add_rlpx_sub_protocol(Zks2faProtocolHandler::for_main_node(
+                MainNode2faConfig {
+                    accepted_verifier_signers: accepted_verifier_signers(),
+                    verify_result_tx,
+                },
+                twofa_state,
+                zks_2fa_registry,
+            ));
+            (Some(verify_result_rx), None)
+        } else {
+            let signing_key =
+                verifier_signing_key.expect("external verifier node requires a signing key");
+            let (verify_batch_tx, _verify_batch_rx) = mpsc::channel(8);
+            let (outgoing_verify_results, _outgoing_verify_results_rx) = broadcast::channel(8);
+            self.add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV5, _>::for_external_node(
+                replays,
+                ExternalNodeProtocolConfig {
+                    starting_block: Arc::new(RwLock::new(starting_block)),
+                    record_overrides: vec![],
+                    max_blocks_per_message: 64,
+                    replay_sender: replay_tx,
+                    verification: None,
+                },
+                zks_state,
+                connection_registry,
+            ));
+            self.add_rlpx_sub_protocol(Zks2faProtocolHandler::for_external_node(
+                ExternalNode2faConfig {
+                    signing_key,
+                    verify_batch_tx,
+                    outgoing_verify_results: outgoing_verify_results.clone(),
+                },
+                twofa_state,
+                zks_2fa_registry,
+            ));
+            (None, Some(outgoing_verify_results))
+        };
+
+        TestPeerProtocolHandles {
+            protocol_rx,
+            replay_rx,
+            verify_result_rx,
+            outgoing_verify_results_tx,
+        }
+    }
 }
 
-#[test_casing(3, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3])]
+#[test_casing(4, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3, ZksVersion::Zks5])]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn send_replay_record_matching_version(version: ZksVersion) {
     // Run two peers that both communicate on exactly one matching zks protocol and successfully
@@ -276,6 +366,7 @@ async fn send_replay_record_matching_version(version: ZksVersion) {
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
         ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
         ZksVersion::Zks4 => test_inner::<ZksProtocolV4>().await,
+        ZksVersion::Zks5 => test_inner::<ZksProtocolV5>().await,
     }
 }
 
@@ -708,7 +799,7 @@ async fn forwards_verify_batch_result_to_main_node() {
     assert_eq!(forwarded.message, result);
 }
 
-#[test_casing(3, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3])]
+#[test_casing(4, [ZksVersion::Zks1, ZksVersion::Zks2, ZksVersion::Zks3, ZksVersion::Zks5])]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn send_replay_record_different_versions(version: ZksVersion) {
     // Run two peers where peer0 can communicate on zks protocol v0 AND v1, while peer1 can only
@@ -770,6 +861,7 @@ async fn send_replay_record_different_versions(version: ZksVersion) {
         ZksVersion::Zks2 => test_inner::<ZksProtocolV2>().await,
         ZksVersion::Zks3 => test_inner::<ZksProtocolV3>().await,
         ZksVersion::Zks4 => test_inner::<ZksProtocolV4>().await,
+        ZksVersion::Zks5 => test_inner::<ZksProtocolV5>().await,
     }
 }
 
@@ -862,4 +954,137 @@ async fn trusted_peer_bypasses_max_active_connections() {
     assert_matches!(from_peer0.recv().await, Some(ProtocolEvent::Established { peer_id, .. }) => {
         assert_eq!(peer_id, peer1_id);
     });
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn zks_2fa_authorizes_verifier_and_replays() {
+    // A post-split pair: replay flows over `zks/5` while the verifier handshake flows over
+    // `zks_2fa`. The main node must authorize the verifier and the replay record must transfer.
+    let mut net = Testnet::create_with(2, MockEthProvider::default()).await;
+    let record1 = dummy_record::<ZksProtocolV5>(1);
+    let expected_signer = PrivateKeySigner::from_str(
+        "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110",
+    )
+    .unwrap()
+    .address();
+
+    let mut main = net.peers_mut()[0].add_zks_2fa_sub_protocol(
+        NodeRole::MainNode,
+        0,
+        [(1, record1.clone())],
+        100,
+        None,
+    );
+    let mut external = net.peers_mut()[1].add_zks_2fa_sub_protocol(
+        NodeRole::ExternalNode,
+        1,
+        [(1, record1.clone())],
+        100,
+        Some(default_verifier_signing_key()),
+    );
+
+    let handle = net.spawn();
+    handle.connect_peers().await;
+
+    let peer1_id = *handle.peers()[1].peer_id();
+    let mut saw_verifier_authorized = false;
+    let mut saw_replay_requested = false;
+
+    while !(saw_verifier_authorized && saw_replay_requested) {
+        match main.protocol_rx.recv().await {
+            Some(ProtocolEvent::VerifierAuthorized { peer_id, signer }) => {
+                assert_eq!(peer_id, peer1_id);
+                assert_eq!(signer, expected_signer);
+                saw_verifier_authorized = true;
+            }
+            Some(ProtocolEvent::ReplayRequested {
+                peer_id,
+                starting_block,
+            }) => {
+                assert_eq!(peer_id, peer1_id);
+                assert_eq!(starting_block, 1);
+                saw_replay_requested = true;
+            }
+            Some(ProtocolEvent::VerifierUnauthorized { signer, .. }) => {
+                panic!("unexpected verifier unauthorized event: {signer:?}")
+            }
+            Some(
+                ProtocolEvent::Established { .. }
+                | ProtocolEvent::Closed { .. }
+                | ProtocolEvent::ReplayBlockSent { .. }
+                | ProtocolEvent::VerifierRoleRequested { .. }
+                | ProtocolEvent::VerifierChallengeSent { .. },
+            ) => {}
+            Some(ProtocolEvent::MaxActiveConnectionsExceeded { .. }) => {
+                panic!("unexpected max active connections event")
+            }
+            None => panic!("event stream closed before verifier auth + replay were observed"),
+        }
+    }
+
+    let received_replay_record = external.replay_rx.recv().await.unwrap();
+    assert_eq!(received_replay_record, record1);
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn zks_2fa_forwards_verify_batch_result_to_main_node() {
+    let mut net = Testnet::create_with(2, MockEthProvider::default()).await;
+    let record1 = dummy_record::<ZksProtocolV5>(1);
+
+    let mut main = net.peers_mut()[0].add_zks_2fa_sub_protocol(
+        NodeRole::MainNode,
+        0,
+        [(1, record1.clone())],
+        100,
+        None,
+    );
+    let external = net.peers_mut()[1].add_zks_2fa_sub_protocol(
+        NodeRole::ExternalNode,
+        1,
+        [(1, record1.clone())],
+        100,
+        Some(default_verifier_signing_key()),
+    );
+
+    let handle = net.spawn();
+    handle.connect_peers().await;
+
+    let main_peer_id = *handle.peers()[0].peer_id();
+    let external_peer_id = *handle.peers()[1].peer_id();
+
+    // Wait until the verifier is authorized so the `zks_2fa` connection is fully established.
+    loop {
+        match main.protocol_rx.recv().await {
+            Some(ProtocolEvent::VerifierAuthorized { peer_id, .. }) => {
+                assert_eq!(peer_id, external_peer_id);
+                break;
+            }
+            Some(ProtocolEvent::VerifierUnauthorized { signer, .. }) => {
+                panic!("unexpected verifier unauthorized event: {signer:?}")
+            }
+            Some(_) => {}
+            None => panic!("event stream closed before verifier was authorized"),
+        }
+    }
+
+    let result = dummy_verify_batch_result();
+    external
+        .outgoing_verify_results_tx
+        .as_ref()
+        .unwrap()
+        .send(PeerVerifyBatchResult {
+            peer_id: main_peer_id,
+            message: result.clone(),
+        })
+        .unwrap();
+
+    let forwarded = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        main.verify_result_rx.as_mut().unwrap().recv(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(forwarded.peer_id, external_peer_id);
+    assert_eq!(forwarded.message, result);
 }


### PR DESCRIPTION
## Summary

Splits 2FA / verifier networking out of the `zks` RLPx subprotocol into its own standalone `zks_2fa` subprotocol.

  Previously `zks` multiplexed two unrelated concerns: replay streaming (`GetBlockReplays`/`BlockReplays`) and verifier traffic (verifier handshake + `VerifyBatch`/`VerifyBatchResult`, only on `zks/3` and `zks/4`). This separates them so they can evolve independently, following the existing
  `zks_raft` precedent.

Existing `zks` versions are unaffected, but `zks/5` is introduced that drops support for legacy 2FA messages. Hence, this PR is not breaking yet, pre-5 versions of `zks` will be dropped in the next breaking release (i.e. `v0.21.0`).

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

