### PR TITLE
fix(l1-watcher): handle pre-v31 CAH interface

### DIFF
--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -34,11 +34,18 @@ pub async fn find_block_by_migration_number(
     ));
     let target = U256::from(migration_number);
     let latest = instance.provider().get_block_number().await?;
-    let latest_migration_number = instance
+    let latest_migration_number = match instance
         .migrationNumber(U256::from(chain_id))
         .block(latest.into())
         .call()
-        .await?;
+        .await
+    {
+        Ok(n) => n,
+        // Pre-V31 `ChainAssetHandler` does not expose `migrationNumber`. No Gateway migrations can
+        // exist in that era, so there is nothing to scan for — start from the latest block.
+        Err(err) if is_method_missing(&err) => return Ok(latest),
+        Err(err) => return Err(err.into()),
+    };
     // If this migration has not been reached yet, return the latest block.
     if latest_migration_number < migration_number {
         return Ok(latest);


### PR DESCRIPTION
## Summary

After the migrationNumber was advanced on L1 past the node's cursor, the binary search done by the l1_watcher started failing because `migrationNumber` function did not exist pre-v31 in ChainAssetHandler. 

This PR properly handles the scenario where the method is missing.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

