### PR TITLE
fix(rpc): bound RPC metric label cardinality by method name

### DIFF
--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -3,6 +3,7 @@ mod call_fees;
 mod config;
 
 pub use config::{RateLimits, RpcConfig};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::watch;
 
@@ -158,9 +159,14 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     let limiter = LoggingLimiter::new(Limiter::new(config.rate_limits.clone().into_limits()));
     let rate_limit_logging = LoggingLimiter::run(limiter.clone());
     let method_filter = Arc::new(config.method_filter.clone());
+    // Snapshot the registered method names so monitoring can bound metric label cardinality:
+    // any other method name (e.g. junk sent to pollute metrics) is collapsed to a single label.
+    let known_methods = Arc::new(rpc.method_names().collect::<HashSet<&'static str>>());
     let rpc_middleware = RpcServiceBuilder::new()
         // Monitoring is outermost so rate-limited responses still appear in error metrics.
-        .layer_fn(move |service| Monitoring::new(service, max_response_size_bytes))
+        .layer_fn(move |service| {
+            Monitoring::new(service, max_response_size_bytes, known_methods.clone())
+        })
         .layer_fn(move |service| MethodFiltering::new(service, method_filter.clone()))
         .layer_fn(move |service| RateLimiting::new(service, limiter.clone()));
 

--- a/lib/rpc/src/monitoring_middleware.rs
+++ b/lib/rpc/src/monitoring_middleware.rs
@@ -5,8 +5,9 @@ use jsonrpsee::core::middleware::{Batch, BatchEntry, Notification};
 use jsonrpsee::server::middleware::rpc::{RpcService, RpcServiceT};
 use jsonrpsee::types::Request;
 use jsonrpsee::{BatchResponseBuilder, MethodResponse};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 use std::time::Instant;
 
 #[derive(Clone, Copy, Debug)]
@@ -15,25 +16,42 @@ pub enum CallKind {
     Notification,
 }
 
+/// Metric label for any method name that isn't registered on the server. Folding all such names
+/// into one label bounds metric cardinality, so a client can't spawn unbounded time series by
+/// sending requests for arbitrary nonexistent methods.
+const UNKNOWN_METHOD: &str = "<unknown>";
+
 #[derive(Clone)]
 pub struct Monitoring<S = RpcService> {
     inner: S,
     max_response_size_bytes: usize,
+    known_methods: Arc<HashSet<&'static str>>,
 }
 
 impl<S> Monitoring<S> {
-    pub fn new(inner: S, max_response_size_bytes: u32) -> Self {
+    pub fn new(
+        inner: S,
+        max_response_size_bytes: u32,
+        known_methods: Arc<HashSet<&'static str>>,
+    ) -> Self {
         Self {
             inner,
             max_response_size_bytes: max_response_size_bytes as usize,
+            known_methods,
         }
     }
+}
+
+/// Maps a method name to a bounded metric label: the registered name (a `'static` string, so no
+/// per-request allocation) or [`UNKNOWN_METHOD`].
+fn method_label(known_methods: &HashSet<&'static str>, method: &str) -> &'static str {
+    known_methods.get(method).copied().unwrap_or(UNKNOWN_METHOD)
 }
 
 /// Ensures latency is recorded even if the future is dropped mid-flight (client disconnected).
 struct CallGuard {
     kind: CallKind,
-    method: String,
+    method: &'static str,
     started: Instant,
     request_size: usize,
     /// `Some((output_size, error_code))` once the future has resolved.
@@ -42,7 +60,7 @@ struct CallGuard {
 }
 
 impl CallGuard {
-    fn new(kind: CallKind, method: String, request_size: usize) -> Self {
+    fn new(kind: CallKind, method: &'static str, request_size: usize) -> Self {
         Self {
             kind,
             method,
@@ -72,14 +90,14 @@ impl CallGuard {
 /// Ensures batch-level metrics are recorded even if the future is dropped mid-flight (client disconnected).
 struct BatchGuard {
     batch_input_size: usize,
-    request_counts: HashMap<String, u64>,
+    request_counts: HashMap<&'static str, u64>,
     started: Instant,
     /// `Some(response_size)` once the batch has resolved.
     completed: Option<usize>,
 }
 
 impl BatchGuard {
-    fn new(batch_input_size: usize, request_counts: HashMap<String, u64>) -> Self {
+    fn new(batch_input_size: usize, request_counts: HashMap<&'static str, u64>) -> Self {
         Self {
             batch_input_size,
             request_counts,
@@ -101,7 +119,7 @@ impl Drop for BatchGuard {
         API_METRICS.request_size["batch"].observe(self.batch_input_size);
         API_METRICS.response_size["batch"].observe(response_size);
         for (method, count) in &self.request_counts {
-            API_METRICS.requests_in_batch_count[method.as_str()].observe(*count);
+            API_METRICS.requests_in_batch_count[*method].observe(*count);
         }
         tracing::debug!(
             target: "rpc::monitoring::batch",
@@ -116,17 +134,17 @@ impl Drop for CallGuard {
         let elapsed = self.started.elapsed();
         let cancelled = self.completed.is_none();
         let (output_size, error_code) = self.completed.take().unwrap_or((0, None));
-        API_METRICS.response_time[&self.method].observe(elapsed);
-        API_METRICS.request_size[&self.method].observe(self.request_size);
-        API_METRICS.response_size[&self.method].observe(output_size);
+        API_METRICS.response_time[self.method].observe(elapsed);
+        API_METRICS.request_size[self.method].observe(self.request_size);
+        API_METRICS.response_size[self.method].observe(output_size);
         if let Some(code) = error_code {
-            API_METRICS.errors[&(self.method.clone(), code)].inc();
+            API_METRICS.errors[&(self.method.to_owned(), code)].inc();
         }
         if cancelled {
-            API_METRICS.cancelled[&self.method].inc();
+            API_METRICS.cancelled[self.method].inc();
         }
         if self.panicked {
-            API_METRICS.panicked[&self.method].inc();
+            API_METRICS.panicked[self.method].inc();
             match self.kind {
                 CallKind::Call => tracing::error!(method = %self.method, "RPC handler panicked"),
                 CallKind::Notification => {
@@ -146,7 +164,7 @@ impl Drop for CallGuard {
             };
         }
 
-        match self.method.as_str() {
+        match self.method {
             "eth_call" => log!("rpc::monitoring::eth::call"),
             "eth_sendRawTransaction" => log!("rpc::monitoring::eth::sendRawTransaction"),
             "debug_traceTransaction" => log!("rpc::monitoring::debug::traceTransaction"),
@@ -173,7 +191,7 @@ where
         &self,
         request: Request<'a>,
     ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
-        let method = request.method_name().to_owned();
+        let method = method_label(&self.known_methods, request.method_name());
         let request_size = request.params.as_ref().map_or(0, |p| p.get().len());
         let inner = self.inner.clone();
 
@@ -204,7 +222,7 @@ where
             .iter()
             .filter_map(|x| {
                 if let Ok(req) = x {
-                    Some(req.method_name().to_owned())
+                    Some(method_label(&self.known_methods, req.method_name()))
                 } else {
                     None
                 }
@@ -259,7 +277,7 @@ where
         n: Notification<'a>,
     ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
         let request_size = n.params.as_ref().map_or(0, |p| p.get().len());
-        let method = n.method_name().to_owned();
+        let method = method_label(&self.known_methods, n.method_name());
         let inner = self.inner.clone();
 
         async move {
@@ -268,5 +286,30 @@ where
                 .handle_result(handler, MethodResponse::notification)
                 .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UNKNOWN_METHOD, method_label};
+    use std::collections::HashSet;
+
+    #[test]
+    fn registered_methods_pass_through_unknown_methods_collapse() {
+        let known: HashSet<&'static str> = ["eth_call", "eth_getBlockByHash"].into_iter().collect();
+
+        // Registered methods are reported verbatim.
+        assert_eq!(method_label(&known, "eth_call"), "eth_call");
+        assert_eq!(
+            method_label(&known, "eth_getBlockByHash"),
+            "eth_getBlockByHash"
+        );
+
+        // Anything unregistered — including arbitrarily long junk used to pollute metrics —
+        // collapses to a single bounded label instead of minting a new time series.
+        assert_eq!(method_label(&known, "eth_does_not_exist"), UNKNOWN_METHOD);
+        assert_eq!(method_label(&known, ""), UNKNOWN_METHOD);
+        let junk = format!("eth_{}", "a".repeat(1_000_000));
+        assert_eq!(method_label(&known, &junk), UNKNOWN_METHOD);
     }
 }


### PR DESCRIPTION
## Summary

The monitoring middleware used the raw, client-supplied method name as a Prometheus label for every API metric. A client could mint unbounded time series (and force a large per-request allocation) by sending requests for arbitrary nonexistent method names.

Snapshot the set of registered methods and collapse any unregistered name to a single `<unknown>` label, done on the borrowed name so junk names are no longer allocated per request.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

