### PR TITLE
fix(sequencer): ensure l1 revert is completed

### DIFF
--- a/lib/l1_watcher/src/revert_watcher.rs
+++ b/lib/l1_watcher/src/revert_watcher.rs
@@ -14,11 +14,12 @@ pub struct L1RevertWatcher {
 }
 
 impl L1RevertWatcher {
-    pub fn create_watcher(
+    pub async fn create_watcher(
         config: L1WatcherConfig,
         zk_chain: ZkChain<NodeProvider>,
         startup_sl_block: u64,
-    ) -> L1Watcher<L1RevertWatcher> {
+        l1_chain_id: u64,
+    ) -> anyhow::Result<L1Watcher<L1RevertWatcher>> {
         tracing::info!(
             startup_sl_block,
             zk_chain_address = ?zk_chain.address(),
@@ -26,14 +27,16 @@ impl L1RevertWatcher {
         );
         let this = Self { startup_sl_block };
         // Process forward from the startup SL block; reverts in earlier blocks are already accounted for.
-        L1Watcher::new_finalized(
+        L1Watcher::new_confirmed(
             config,
             zk_chain.provider().clone(),
             (*zk_chain.address()).into(),
             startup_sl_block + 1,
             None,
+            l1_chain_id,
             this,
         )
+        .await
     }
 }
 

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -17,6 +17,20 @@ enum BlockBoundary {
 type ResolveStartFn<S, P> =
     Box<dyn FnOnce(S) -> BoxFuture<'static, anyhow::Result<(BlockNumber, P)>> + Send + Sync>;
 
+/// Resolves the confirmation depth for a confirmed-boundary watcher: the configured depth when the
+/// watcher tails L1, or zero on the Gateway.
+async fn resolve_confirmations(
+    provider: &NodeProvider,
+    l1_chain_id: u64,
+    config: &L1WatcherConfig,
+) -> anyhow::Result<BlockNumber> {
+    Ok(if provider.get_chain_id().await? != l1_chain_id {
+        0
+    } else {
+        config.confirmations
+    })
+}
+
 /// Deferred constructor for an [`L1Watcher`]: holds the watcher's static dependencies and turns
 /// a starting point `S` into a ready-to-run watcher once that starting point is finally known.
 ///
@@ -48,12 +62,7 @@ impl<S, P: ProcessRawEvents> StartResolver<S, P> {
     where
         Fut: Future<Output = anyhow::Result<(BlockNumber, P)>> + Send + 'static,
     {
-        let confirmations = if provider.get_chain_id().await? != l1_chain_id {
-            // Gateway case, zero out confirmations.
-            0
-        } else {
-            config.confirmations
-        };
+        let confirmations = resolve_confirmations(&provider, l1_chain_id, &config).await?;
 
         Ok(Self {
             provider,
@@ -162,6 +171,30 @@ impl<P: ProcessRawEvents> L1Watcher<P> {
             block_boundary: BlockBoundary::Finalized,
             processor,
         }
+    }
+
+    /// Builds a watcher for a single pre-resolved segment, tailing the confirmed boundary
+    /// (`latest - confirmations`). Unlike [`new_finalized`](Self::new_finalized), it reacts to an
+    /// event within `confirmations` blocks instead of waiting out finality.
+    pub(crate) async fn new_confirmed(
+        config: L1WatcherConfig,
+        provider: NodeProvider,
+        address: ValueOrArray<Address>,
+        next_block: BlockNumber,
+        end_block: Option<BlockNumber>,
+        l1_chain_id: u64,
+        processor: P,
+    ) -> anyhow::Result<Self> {
+        let confirmations = resolve_confirmations(&provider, l1_chain_id, &config).await?;
+        Ok(Self {
+            provider,
+            address,
+            next_block,
+            end_block,
+            max_blocks_to_process: config.max_blocks_to_process,
+            block_boundary: BlockBoundary::Confirmed { confirmations },
+            processor,
+        })
     }
 
     /// Polls for new events.

--- a/node/bin/src/l1_revert.rs
+++ b/node/bin/src/l1_revert.rs
@@ -1,7 +1,10 @@
+use alloy::eips::BlockId;
 use alloy::primitives::U256;
 use anyhow::Context as _;
-use zksync_os_contract_interface::IValidatorTimelock;
+use backon::{ConstantBuilder, Retryable};
+use std::time::Duration;
 use zksync_os_contract_interface::l1_discovery::L1State;
+use zksync_os_contract_interface::{IValidatorTimelock, ZkChain};
 use zksync_os_l1_watcher::{fetch_batch, fetch_batch_commit_tx_hash};
 use zksync_os_operator_signer::SignerConfig;
 use zksync_os_provider::{EthWalletProvider, NodeProvider};
@@ -158,6 +161,61 @@ async fn perform_l1_revert(
         "startup L1 revert completed"
     );
 
+    // Ensure L1 node returns the proper last committed batch number after the revert.
+    // This is a sanity check for the L1 node's RPC: a lagging or load-balanced
+    ensure_revert(&l1_state.diamond_proxy_sl, plan.last_l1_batch_to_keep).await?;
+
+    Ok(())
+}
+
+/// Waits until the settlement layer reports a committed-batch count consistent with the revert.
+async fn ensure_revert(
+    diamond_proxy_sl: &ZkChain<NodeProvider>,
+    last_l1_batch_to_keep: u64,
+) -> anyhow::Result<()> {
+    const RETRY_BUILDER: ConstantBuilder = ConstantBuilder::new()
+        .with_delay(Duration::from_secs(2))
+        .with_max_times(30);
+
+    let observed = match (|| async {
+        let committed = diamond_proxy_sl
+            .get_total_batches_committed(BlockId::latest())
+            .await
+            .context("failed to read totalBatchesCommitted")?;
+        anyhow::ensure!(
+            committed == last_l1_batch_to_keep,
+            "last committed batch is {committed}, expected == {last_l1_batch_to_keep}"
+        );
+        anyhow::Ok(committed)
+    })
+    .retry(RETRY_BUILDER)
+    .notify(|err, _| {
+        tracing::warn!(
+            error = %err,
+            last_l1_batch_to_keep,
+            "L1 revert not yet observable at the latest block; retrying"
+        );
+    })
+    .await
+    {
+        Ok(committed) => committed,
+        Err(err) => {
+            tracing::error!(
+                error = %err,
+                last_l1_batch_to_keep,
+                "L1 revert did not become observable within the retry timeout; the SL \
+                 RPC kept reporting a committed batch different from the kept batch"
+            );
+            return Err(err)
+                .context("L1 revert not observable at the latest block within the retry timeout");
+        }
+    };
+
+    tracing::info!(
+        last_committed_batch = observed,
+        last_l1_batch_to_keep,
+        "L1 revert observable: settlement-layer committed batch decreased to the expected value"
+    );
     Ok(())
 }
 

--- a/node/bin/src/l1_revert.rs
+++ b/node/bin/src/l1_revert.rs
@@ -162,7 +162,6 @@ async fn perform_l1_revert(
     );
 
     // Ensure L1 node returns the proper last committed batch number after the revert.
-    // This is a sanity check for the L1 node's RPC: a lagging or load-balanced
     ensure_revert(&l1_state.diamond_proxy_sl, plan.last_l1_batch_to_keep).await?;
 
     Ok(())

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -630,7 +630,10 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
                 config.l1_watcher_config.clone().into(),
                 node_startup_state.l1_state.diamond_proxy_sl.clone(),
                 node_startup_state.l1_state.sl_block_number,
+                node_startup_state.l1_state.l1_chain_id,
             )
+            .await
+            .expect("failed to start L1 revert watcher")
             .run(),
         );
     }


### PR DESCRIPTION
## Summary

Make the external node reliably detect and recover from an L1 batch revert.

## Changes

- **`fix(sequencer): ensure l1 revert`**: after performing a startup L1 revert, poll the settlement layer until `totalBatchesCommitted` reflects it (retry up to 30×2s):
<img width="1038" height="309" alt="Screenshot 2026-06-29 at 16 30 11" src="https://github.com/user-attachments/assets/9dddabf5-9685-4649-85fb-e7e6b1aee47d" />

- **`fix: switch l1 revert watcher to watch confirmed blocks`**: the EN's `L1RevertWatcher` now uses the confirmed boundary instead of finalized, so it reacts to a revert within `confirmations` blocks rather than waiting out finality.