### PR TITLE
fix(deps): bump anyhow to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aquamarine"


### PR DESCRIPTION
## What

Bumps `anyhow` from 1.0.99 to 1.0.103 in `Cargo.lock`.

## Why

`cargo audit` / `cargo deny` flags [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190): an unsoundness in `anyhow::Error::downcast_mut()`. Affected versions violate borrow rules, resulting in undefined behavior when context is added to an error via `Error::context` and `Error::downcast_mut` is later called on the returned `Error`. Fixed in 1.0.103.

## Changes

- `Cargo.lock`: `anyhow` 1.0.99 → 1.0.103. The workspace constraint (`anyhow = "1"`) already allows this, so no manifest changes were needed.

## Testing

- `cargo check --workspace --exclude zksync_os_integration_tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)