### PR TITLE
chore(deps): ignore unfixable quick-xml DoS advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,15 @@ ignore = [
     # which is a significant effort (alloy 1.x → 2.x migration).
     "RUSTSEC-2026-0118",
     "RUSTSEC-2026-0119",
+    # quick-xml < 0.41 DoS advisories. Pulled in transitively via `inferno`
+    # (flamegraph generation, from the zksync-airbender git dependency) and
+    # `plist` -> `os_info` -> `sentry-contexts` (local OS metadata for Sentry
+    # error context). Neither path parses untrusted/remote XML. No released
+    # version of `inferno` or `plist` depends on quick-xml >=0.41 yet (latest
+    # `inferno` 0.12.6 and `plist` 1.9.0 both still require `^0.39`), so a
+    # `cargo update` cannot resolve this. Revisit once upstream bumps land.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary
- `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` flag `quick-xml` versions pulled in transitively via `inferno` (flamegraph generation, from the zksync-airbender git dependency) and `plist` -> `os_info` -> `sentry-contexts` (local OS metadata for Sentry error context).
- Neither path parses untrusted/remote XML, so these advisories aren't exploitable here.
- No released version of `inferno` or `plist` depends on a patched `quick-xml (>=0.41)` yet — the latest releases (`inferno` 0.12.6, `plist` 1.9.0) still require `quick-xml ^0.39` — so `cargo update` cannot resolve this today. Ignored in `deny.toml` with a rationale comment, following the existing pattern for other currently-unfixable advisories, to be revisited once upstream bumps land.

## Test plan
- [x] `cargo deny check advisories` no longer reports `RUSTSEC-2026-0194` / `RUSTSEC-2026-0195`