### PR TITLE
feat(network): treat boot nodes as trusted peers to keep ENs synced

### DIFF
--- a/lib/network/src/config.rs
+++ b/lib/network/src/config.rs
@@ -13,6 +13,7 @@ pub struct NetworkConfig {
     /// Port 0 is resolved to a concrete TCP+UDP port by `NetworkService::new`.
     pub port: u16,
     /// All boot nodes to start network discovery with. Expected format is
-    /// `enode://<node ID>@<IP address-or-DNS host>:<port>`.
+    /// `enode://<node ID>@<IP address-or-DNS host>:<port>`. Boot nodes are also treated as trusted
+    /// peers: always kept connected and admitted to the zks subprotocol regardless of the cap.
     pub boot_nodes: Vec<TrustedPeer>,
 }

--- a/lib/network/src/protocol/connection.rs
+++ b/lib/network/src/protocol/connection.rs
@@ -10,14 +10,14 @@ use tokio::sync::{OwnedSemaphorePermit, mpsc};
 /// Wraps an mpsc receiver fed by a background Tokio task (`run_mn_connection()` or
 /// `run_en_connection()`) that owns the actual protocol logic. Dropping this struct aborts the
 /// background task, unregisters the peer, emits `ProtocolEvent::Closed`, and releases the
-/// connection permit.
+/// connection permit (if any; trusted peers hold none).
 pub struct ZksConnection {
     pub(crate) outbound_rx: mpsc::Receiver<BytesMut>,
     pub(crate) task: tokio::task::JoinHandle<()>,
     pub(crate) events_sender: mpsc::UnboundedSender<ProtocolEvent>,
     pub(crate) peer_id: PeerId,
     pub(crate) connection_registry: ConnectionRegistry,
-    pub(crate) _permit: OwnedSemaphorePermit,
+    pub(crate) _permit: Option<OwnedSemaphorePermit>,
 }
 
 impl Drop for ZksConnection {

--- a/lib/network/src/protocol/handler.rs
+++ b/lib/network/src/protocol/handler.rs
@@ -48,8 +48,8 @@ pub struct ZksProtocolConnectionHandler<P: ZksProtocolVersionSpec, Replay: Clone
     state: HandlerSharedState,
     connection_registry: ConnectionRegistry,
     remote_addr: SocketAddr,
-    /// Owned permit that corresponds to a taken active connection slot.
-    permit: OwnedSemaphorePermit,
+    /// Owned permit for a taken active connection slot, or `None` for a trusted peer that bypasses the cap.
+    permit: Option<OwnedSemaphorePermit>,
     _phantom: PhantomData<P>,
 }
 
@@ -85,7 +85,7 @@ impl<P: ZksProtocolVersionSpec, Replay: Clone> ZksProtocolHandler<P, Replay> {
     fn establish_connection(
         &self,
         remote_addr: SocketAddr,
-        permit: OwnedSemaphorePermit,
+        permit: Option<OwnedSemaphorePermit>,
     ) -> ZksProtocolConnectionHandler<P, Replay> {
         ZksProtocolConnectionHandler {
             role: self.role.clone(),
@@ -102,8 +102,15 @@ impl<P: ZksProtocolVersionSpec, Replay: Clone> ZksProtocolHandler<P, Replay> {
         socket_addr: SocketAddr,
         peer_id: Option<PeerId>,
     ) -> Option<ZksProtocolConnectionHandler<P, Replay>> {
+        // Trusted peers (identified on outgoing dials) bypass the cap, so a pinned serving node is
+        // never locked out by other peers already filling the pool.
+        if let Some(peer_id) = peer_id
+            && self.state.is_trusted(&peer_id)
+        {
+            return Some(self.establish_connection(socket_addr, None));
+        }
         match self.state.try_acquire_connection_slot() {
-            Ok(permit) => Some(self.establish_connection(socket_addr, permit)),
+            Ok(permit) => Some(self.establish_connection(socket_addr, Some(permit))),
             Err(_) => {
                 match peer_id {
                     Some(peer_id) => tracing::warn!(

--- a/lib/network/src/protocol/handler_shared_state.rs
+++ b/lib/network/src/protocol/handler_shared_state.rs
@@ -1,4 +1,6 @@
 use super::events::ProtocolEvent;
+use reth_network_peers::PeerId;
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError, mpsc};
 
@@ -9,6 +11,9 @@ pub struct HandlerSharedState {
     /// The maximum number of active connections.
     max_active_connections: usize,
     active_connections_semaphore: Arc<Semaphore>,
+    /// Peers that bypass the connection cap, so a pinned serving node is never locked out by other
+    /// peers filling the pool.
+    trusted_peers: Arc<HashSet<PeerId>>,
 }
 
 impl HandlerSharedState {
@@ -16,17 +21,24 @@ impl HandlerSharedState {
     pub fn new(
         events_sender: mpsc::UnboundedSender<ProtocolEvent>,
         max_active_connections: usize,
+        trusted_peers: HashSet<PeerId>,
     ) -> Self {
         Self {
             events_sender,
             max_active_connections,
             active_connections_semaphore: Arc::new(Semaphore::new(max_active_connections)),
+            trusted_peers: Arc::new(trusted_peers),
         }
     }
 
     /// Returns the current number of active connections.
     pub fn active_connections(&self) -> u64 {
         (self.max_active_connections - self.active_connections_semaphore.available_permits()) as u64
+    }
+
+    /// Whether `peer_id` is a trusted peer that bypasses the connection cap.
+    pub(crate) fn is_trusted(&self, peer_id: &PeerId) -> bool {
+        self.trusted_peers.contains(peer_id)
     }
 
     pub(crate) fn try_acquire_connection_slot(

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -24,7 +24,7 @@ use reth_network_peers::PeerId;
 use reth_network_peers::{NodeRecord, TrustedPeer};
 use reth_provider::BlockNumReader;
 use reth_tasks::Runtime;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::io;
 use std::net::{
@@ -400,7 +400,10 @@ impl NetworkService {
                     })
                     // Peers' fork id must match, otherwise we could discover peers from other
                     // chains.
-                    .with_enforce_enr_fork_id(true),
+                    .with_enforce_enr_fork_id(true)
+                    // Treat boot nodes as trusted peers: always keep and redial them (e.g. an EN
+                    // pinning the main node) so replay sync never gets stranded on non-serving peers.
+                    .with_trusted_nodes(config.boot_nodes.clone()),
             )
             .discovery_addr(rlpx_address)
             // Disable transaction gossip as it is unsupported by ZKsync OS
@@ -412,6 +415,9 @@ impl NetworkService {
             // Use genesis as chain head
             .set_head(genesis);
         let connection_registry: ConnectionRegistry = Arc::new(RwLock::new(HashMap::new()));
+        // Boot nodes double as trusted peers, exempt from the connection cap on outgoing dials.
+        let trusted_peer_ids: HashSet<PeerId> =
+            config.boot_nodes.iter().map(|peer| peer.id).collect();
         let mut cfg_builder = match protocol_config {
             ZksProtocolConfig::MainNode(protocol) => Self::register_main_node_rlpx_sub_protocols(
                 cfg_builder,
@@ -419,6 +425,7 @@ impl NetworkService {
                 replay,
                 protocol_tx,
                 connection_registry.clone(),
+                trusted_peer_ids,
             ),
             ZksProtocolConfig::ExternalNode(protocol) => {
                 Self::register_external_node_rlpx_sub_protocols(
@@ -427,6 +434,7 @@ impl NetworkService {
                     replay,
                     protocol_tx,
                     connection_registry.clone(),
+                    trusted_peer_ids,
                 )
             }
         };
@@ -468,8 +476,9 @@ impl NetworkService {
         replay: impl ReadReplay + Clone,
         protocol_tx: mpsc::UnboundedSender<ProtocolEvent>,
         connection_registry: ConnectionRegistry,
+        trusted_peers: HashSet<PeerId>,
     ) -> NetworkConfigBuilder {
-        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS);
+        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
         builder
             // Support for v1 must be dropped before upgrade to protocol version v31.0. Otherwise,
             // we might send invalid record to ENs that are still using v1 protocol (`starting_migration_number`
@@ -506,8 +515,9 @@ impl NetworkService {
         replay: impl ReadReplay + Clone,
         protocol_tx: mpsc::UnboundedSender<ProtocolEvent>,
         connection_registry: ConnectionRegistry,
+        trusted_peers: HashSet<PeerId>,
     ) -> NetworkConfigBuilder {
-        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS);
+        let state = HandlerSharedState::new(protocol_tx, MAX_ACTIVE_CONNECTIONS, trusted_peers);
         builder
             .add_rlpx_sub_protocol(ZksProtocolHandler::<ZksProtocolV1, _>::for_external_node(
                 replay.clone(),

--- a/lib/network/tests/e2e.rs
+++ b/lib/network/tests/e2e.rs
@@ -3,10 +3,11 @@ use alloy::signers::local::PrivateKeySigner;
 use assert_matches::assert_matches;
 use reth_network::test_utils::Peer;
 use reth_network::{Peers, test_utils::Testnet};
+use reth_network_peers::PeerId;
 use reth_provider::test_utils::MockEthProvider;
 use reth_provider::{BlockReader, HeaderProvider};
 use secrecy::{ExposeSecret, SecretString};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use test_casing::test_casing;
@@ -127,6 +128,7 @@ trait PeerExt {
         replays: impl IntoIterator<Item = (BlockNumber, ReplayRecord)>,
         max_active_connections: usize,
         verifier_signing_key: Option<SecretString>,
+        trusted_peers: HashSet<PeerId>,
     ) -> TestPeerProtocolHandles;
 }
 
@@ -155,6 +157,7 @@ where
             replays,
             max_active_connections,
             verifier_enabled.then(default_verifier_signing_key),
+            HashSet::new(),
         );
         (protocol_rx, replay_rx)
     }
@@ -166,6 +169,7 @@ where
         replays: impl IntoIterator<Item = (BlockNumber, ReplayRecord)>,
         max_active_connections: usize,
         verifier_signing_key: Option<SecretString>,
+        trusted_peers: HashSet<PeerId>,
     ) -> TestPeerProtocolHandles {
         let (protocol_tx, protocol_rx) = mpsc::unbounded_channel();
         let (replay_tx, replay_rx) = mpsc::channel(8);
@@ -184,7 +188,7 @@ where
             } else {
                 (None, None)
             };
-        let state = HandlerSharedState::new(protocol_tx, max_active_connections);
+        let state = HandlerSharedState::new(protocol_tx, max_active_connections, trusted_peers);
         let connection_registry = Arc::new(RwLock::new(HashMap::new()));
         let (handler, verify_result_rx) = if node_role.is_main() {
             let (verify_result_tx, verify_result_rx) = mpsc::channel(8);
@@ -552,6 +556,7 @@ async fn emits_verifier_unauthorized_before_replay() {
         [(1, record1.clone())],
         100,
         None,
+        HashSet::new(),
     );
     let mut external = net.peers_mut()[1].add_zks_sub_protocol_with_test_handles::<ZksProtocolV3>(
         NodeRole::ExternalNode,
@@ -559,6 +564,7 @@ async fn emits_verifier_unauthorized_before_replay() {
         [(1, record1.clone())],
         100,
         Some(alternate_verifier_signing_key()),
+        HashSet::new(),
     );
 
     let handle = net.spawn();
@@ -627,6 +633,7 @@ async fn forwards_verify_batch_result_to_main_node() {
         [(1, record1.clone())],
         100,
         None,
+        HashSet::new(),
     );
     let mut external = net.peers_mut()[1].add_zks_sub_protocol_with_test_handles::<ZksProtocolV3>(
         NodeRole::ExternalNode,
@@ -634,6 +641,7 @@ async fn forwards_verify_batch_result_to_main_node() {
         [(1, record1.clone())],
         100,
         Some(default_verifier_signing_key()),
+        HashSet::new(),
     );
 
     let handle = net.spawn();
@@ -820,4 +828,38 @@ async fn max_active_connections() {
             other => panic!("unexpected protocol event: {other:?}"),
         }
     }
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn trusted_peer_bypasses_max_active_connections() {
+    // peer0 (main node) allows zero active connections, so only a trusted peer can connect. Its
+    // outgoing dial to trusted peer1 is admitted regardless of the cap.
+    let mut net = Testnet::create_with(2, MockEthProvider::default()).await;
+    let peer1_id = net.peers_mut()[1].peer_id();
+
+    let mut from_peer0 = net.peers_mut()[0]
+        .add_zks_sub_protocol_with_test_handles::<ZksProtocolV1>(
+            NodeRole::MainNode,
+            1,
+            [],
+            0,
+            None,
+            HashSet::from([peer1_id]),
+        )
+        .protocol_rx;
+    let peer1_addr = net.peers_mut()[1].local_addr();
+    net.peers_mut()[1].add_zks_sub_protocol::<ZksProtocolV1>(
+        NodeRole::ExternalNode,
+        1,
+        [],
+        100,
+        false,
+    );
+
+    let handle = net.spawn();
+    handle.peers()[0].network().add_peer(peer1_id, peer1_addr);
+
+    assert_matches!(from_peer0.recv().await, Some(ProtocolEvent::Established { peer_id, .. }) => {
+        assert_eq!(peer_id, peer1_id);
+    });
 }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -607,6 +607,10 @@ pub struct NetworkConfig {
     /// `enode://<node ID>@<IP address>:<port>` or `enode://<node ID>@<DNS name>:<port>`
     /// delimited by commas (`,`). DNS names are resolved by the networking stack. For example:
     /// `enode://dbd18888f17bad7df7fa958b57f4993f47312ba5364508fd0d9027e62ea17a037ca6985d6b0969c4341f1d4f8763a802785961989d07b1fb5373ced9d43969f6@127.0.0.1:3060`
+    ///
+    /// Boot nodes are also treated as trusted peers: always kept connected and admitted to the zks
+    /// subprotocol regardless of the active-connection cap. On an external node, listing the main
+    /// node here keeps replay sync from getting stranded on non-serving peers.
     #[config(
         default,
         with = Delimited::repeat(Serde![str], ",")


### PR DESCRIPTION
## Problem

External nodes sync replays over p2p, but **only the main node serves them** — an EN ignores other peers' `GetBlockReplays`. Discovery (discv5) filters by fork-id but does **not** signal node role, so an EN cannot tell which discovered peers will actually serve blocks. With a mix of one MN and many ENs, an EN can fill its connection slots with other (non-serving) ENs and silently stop receiving blocks until it is restarted and happens to reconnect to the main node. This matches the recurring "EN falls behind, recovers after a restart" reports.

## Fix

Register `boot_nodes` as reth **trusted peers** (`with_trusted_nodes`) so they are always dialed and kept, and exempt them from the zks active-connection cap on **outgoing** dials. An EN that lists the main node in `boot_nodes` — as our deployments already do — now pins that connection and can no longer be stranded on non-serving peers.

Boot nodes are already a small, curated per-deployment set (each node lists its siblings), so reusing them avoids introducing a second config knob. No config changes are required for existing deployments.

## Notes / behavior change

- **Every boot node is now pinned and cap-exempt.** Fine for our curated mesh; worth keeping in mind if a deployment ever lists a large or public bootstrap set there.
- The cap-bypass only applies to outgoing dials (where the peer id is known at accept time); inbound connections are unaffected. reth actively dials trusted peers, so the pinned connection is established outbound.
- This does **not** change the 25-connection serve cap or add EN→EN fan-out; it fixes peer selection, not serve capacity.

## Testing

- New `trusted_peer_bypasses_max_active_connections` e2e test: with the cap set to 0, only a trusted peer connects.
- Existing `max_active_connections` test still passes (non-trusted peers remain capped).
- `cargo fmt`, `cargo clippy -D warnings`, full network test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)