### PR TITLE
feat(replay_archive): GCP KMS encryption for archive records

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -40,7 +40,10 @@ jobs:
           # `inferno` (flamegraph generation) and `plist` -> `os_info` -> `sentry-contexts` (local OS metadata for
           # Sentry). Neither path parses untrusted/remote XML. No released version of `inferno` or `plist` depends
           # on quick-xml >=0.41 yet, so this cannot be resolved by updating. Revisit once upstream bumps land.
-          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0118,RUSTSEC-2026-0119,RUSTSEC-2026-0194,RUSTSEC-2026-0195'
+          # 'RUSTSEC-2023-0071': Marvin timing sidechannel in `rsa` private-key operations. Production code only
+          # performs public-key RSA-OAEP encryption (wrapping the age file key to the GCP KMS public key);
+          # private-key decryption happens inside GCP KMS, never locally. No patched version exists yet.
+          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0118,RUSTSEC-2026-0119,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2023-0071'
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5913,15 +5913,21 @@ dependencies = [
  "base64 0.21.7",
  "google-cloud-metadata",
  "google-cloud-token",
+ "hex",
+ "hmac 0.12.1",
  "home",
  "jsonwebtoken 9.3.1",
+ "path-clean",
+ "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
+ "url",
  "urlencoding",
 ]
 
@@ -8635,6 +8641,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "path-tree"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16438,6 +16438,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber 0.3.22",
  "vise",
  "zksync_os_interface",
  "zksync_os_l1_sender",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,7 +3925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -5598,7 +5598,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -7424,6 +7424,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128"
@@ -8083,6 +8086,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -8756,6 +8775,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -11652,6 +11682,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12875,6 +12925,12 @@ dependencies = [
  "rand 0.8.5",
  "sha1 0.10.6",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin"
@@ -16344,19 +16400,27 @@ name = "zksync_os_replay_archive"
 version = "0.20.9"
 dependencies = [
  "age",
+ "age-core",
  "alloy",
  "anyhow",
  "async-trait",
  "aws-config",
  "aws-runtime",
  "aws-sdk-s3",
+ "base64 0.22.1",
  "clap",
  "futures",
  "google-cloud-auth",
  "google-cloud-storage",
+ "google-cloud-token",
  "http 1.3.1",
+ "rand_core 0.6.4",
+ "reqwest 0.12.28",
  "reth-tasks",
+ "rsa",
+ "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ aws-sdk-s3 = { version = "1.133.0", default-features = false, features = [
 ] }
 google-cloud-auth = "0.16.0"
 google-cloud-storage = "0.20.0"
+google-cloud-token = "0.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"
 serde_json = "1"
@@ -255,6 +256,9 @@ quote = "1"
 syn = "2"
 proc-macro2 = "1"
 age = "0.11.2"
+age-core = "0.11.0"
+rsa = "0.9"
+rand_core06 = { package = "rand_core", version = "0.6", features = ["getrandom"] }
 
 tracing-opentelemetry = "0.32.0"
 opentelemetry = "0.31.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ aws-sdk-s3 = { version = "1.133.0", default-features = false, features = [
     "rt-tokio",
     "default-https-client",
 ] }
-google-cloud-auth = "0.16.0"
+google-cloud-auth = { version = "0.16.0", features = ["external-account"] }
 google-cloud-storage = "0.20.0"
 google-cloud-token = "0.1.2"
 serde = { version = "1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,13 @@ ignore = [
     # `cargo update` cannot resolve this. Revisit once upstream bumps land.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # Marvin timing sidechannel in `rsa` private-key operations. We use `rsa`
+    # directly in `replay_archive` for KMS envelope encryption, but production
+    # code only performs public-key RSA-OAEP encryption (wrapping the age file
+    # key to the KMS public key); private-key decryption happens inside GCP KMS,
+    # never locally. Local `RsaPrivateKey` usage is test-only. No patched
+    # version exists yet (tracked in RustCrypto/RSA#19).
+    "RUSTSEC-2023-0071",
 ]
 
 [bans]

--- a/integration-tests/tests/node/replay_archive.rs
+++ b/integration-tests/tests/node/replay_archive.rs
@@ -9,7 +9,8 @@ use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, ReceiptAssert}
 use zksync_os_integration_tests::provider::ZksyncTestingProvider;
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, test_multisetup};
 use zksync_os_replay_archive::{
-    FileSystemReplayArchiveReader, download_all_replay_archive_objects, read_age_x25519_identity,
+    ArchiveIdentity, DEFAULT_DECRYPT_CONCURRENCY, FileSystemReplayArchiveReader,
+    download_all_replay_archive_objects, read_age_x25519_identity,
     recover_replay_records_to_rocksdb_with_optional_decryption,
 };
 use zksync_os_server::config::{ReplayArchiveConfig, ReplayArchiveEncryptionConfig};
@@ -147,7 +148,8 @@ async fn recover_replay_storage_from_archive(
         &rocks_db_path.join("block_replay_wal"),
         latest_block_number,
         latest_block_hash,
-        Some(identity),
+        Some(ArchiveIdentity::X25519(identity)),
+        DEFAULT_DECRYPT_CONCURRENCY,
     )
     .await?;
     assert_eq!(

--- a/lib/replay_archive/Cargo.toml
+++ b/lib/replay_archive/Cargo.toml
@@ -40,9 +40,10 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
 tokio-stream.workspace = true
 tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 vise.workspace = true
 
 [dev-dependencies]

--- a/lib/replay_archive/Cargo.toml
+++ b/lib/replay_archive/Cargo.toml
@@ -18,19 +18,27 @@ zksync_os_pipeline.workspace = true
 zksync_os_observability.workspace = true
 
 age.workspace = true
+age-core.workspace = true
 alloy = { workspace = true, default-features = false }
 anyhow.workspace = true
 async-trait.workspace = true
 aws-config.workspace = true
 aws-runtime.workspace = true
 aws-sdk-s3.workspace = true
+base64.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 futures.workspace = true
 google-cloud-auth.workspace = true
 google-cloud-storage.workspace = true
+google-cloud-token.workspace = true
 http.workspace = true
+rand_core06.workspace = true
+reqwest.workspace = true
 reth-tasks.workspace = true
+rsa.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread", "sync"] }
 tokio-stream.workspace = true

--- a/lib/replay_archive/README.md
+++ b/lib/replay_archive/README.md
@@ -62,7 +62,8 @@ Current archive implementations:
 - `S3ReplayArchiveStorage`: append-only object storage in S3 or an S3-compatible service.
 - `GcsReplayArchiveStorage`: append-only object storage in Google Cloud Storage.
 - `AgeEncryptedReplayArchiver`: wrapper that JSON-encodes replay records and encrypts them with
-  age X25519 before storing them in any `ReplayArchiveStorage`.
+  age before storing them in any `ReplayArchiveStorage`. Supports X25519 recipients and GCP KMS
+  asymmetric keys.
 
 Current reader implementation:
 
@@ -77,9 +78,9 @@ Other storage backends should implement:
 
 ## Encryption
 
-Encrypted archives use age X25519.
+Encrypted archives use the age format with one of two recipient types.
 
-The node needs only the public recipient key:
+With age X25519, the node needs only the public recipient key:
 
 ```text
 age1...
@@ -90,6 +91,21 @@ The private identity should be stored separately and used only during recovery:
 ```text
 AGE-SECRET-KEY-...
 ```
+
+With GCP KMS, the node is configured with the resource name of an `ASYMMETRIC_DECRYPT` key version
+using an `RSA_DECRYPT_OAEP_*_SHA256` algorithm:
+
+```text
+projects/../locations/../keyRings/../cryptoKeys/../cryptoKeyVersions/..
+```
+
+The node fetches the public key once at startup (requiring only
+`cloudkms.cryptoKeyVersions.viewPublicKey`) and wraps the per-record age file key locally with
+RSA-OAEP; no private key material exists outside KMS. During recovery, unwrapping the file key of
+every record takes one KMS `AsymmetricDecrypt` call (requiring
+`cloudkms.cryptoKeyVersions.useToDecrypt`), so key access can be revoked and audited per record.
+Note that KMS-encrypted objects use a custom age stanza and can only be decrypted by the recovery
+tool, not by the stock `age` CLI.
 
 Encryption is randomized, so archive presence checks verify object existence only. They do not
 re-encrypt a replay record and compare bytes.
@@ -111,7 +127,9 @@ anchor = (latest_block_number, latest_block_hash)
 ```
 
 If the archive was encrypted, recovery decrypts downloaded objects in memory when an age identity
-file is provided. Decrypted replay records are not written to disk.
+file (`--identity-file` / `--age-secret-key`) or a GCP KMS key version (`--kms-key-version`, with
+optional `--kms-credential-file-path`) is provided. Decrypted replay records are not written to
+disk.
 
 The recovery logic starts from the anchor, reads the replay record for that block, extracts the
 previous block hash from the replay record, and walks backward until block `0`. It then writes the

--- a/lib/replay_archive/src/age_encrypted.rs
+++ b/lib/replay_archive/src/age_encrypted.rs
@@ -1,23 +1,45 @@
+use crate::kms::GcpKmsRecipient;
 use crate::metrics::REPLAY_ARCHIVE_METRICS;
 use crate::replay_record::encode_replay_record;
 use crate::{ReplayArchiveStorage, ReplayArchiver};
+use age_core::format::{FileKey, Stanza};
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
 use async_trait::async_trait;
+use std::collections::HashSet;
 use std::time::Instant;
 use zksync_os_storage_api::ReplayRecord;
 
 const BYTES_PER_MEGABYTE: f64 = 1024.0 * 1024.0;
 
-/// Replay archiver that stores age/X25519-encrypted JSON replay records.
+/// age recipient used for replay archive record encryption.
+#[derive(Debug, Clone)]
+pub enum ArchiveRecipient {
+    X25519(age::x25519::Recipient),
+    GcpKms(GcpKmsRecipient),
+}
+
+impl age::Recipient for ArchiveRecipient {
+    fn wrap_file_key(
+        &self,
+        file_key: &FileKey,
+    ) -> Result<(Vec<Stanza>, HashSet<String>), age::EncryptError> {
+        match self {
+            Self::X25519(recipient) => recipient.wrap_file_key(file_key),
+            Self::GcpKms(recipient) => recipient.wrap_file_key(file_key),
+        }
+    }
+}
+
+/// Replay archiver that stores age-encrypted JSON replay records.
 #[derive(Debug, Clone)]
 pub struct AgeEncryptedReplayArchiver<Storage> {
     storage: Storage,
-    recipient: age::x25519::Recipient,
+    recipient: ArchiveRecipient,
 }
 
 impl<Storage> AgeEncryptedReplayArchiver<Storage> {
-    pub fn new(storage: Storage, recipient: age::x25519::Recipient) -> Self {
+    pub fn new(storage: Storage, recipient: ArchiveRecipient) -> Self {
         Self { storage, recipient }
     }
 
@@ -25,7 +47,7 @@ impl<Storage> AgeEncryptedReplayArchiver<Storage> {
         let recipient = recipient
             .parse()
             .map_err(|err| anyhow::anyhow!("failed to parse age X25519 recipient: {err}"))?;
-        Ok(Self::new(storage, recipient))
+        Ok(Self::new(storage, ArchiveRecipient::X25519(recipient)))
     }
 
     pub(crate) fn encrypt_replay_record(
@@ -38,7 +60,7 @@ impl<Storage> AgeEncryptedReplayArchiver<Storage> {
 
         let started_at = Instant::now();
         let encrypted = age::encrypt(&self.recipient, encoded.as_slice())
-            .context("failed to encrypt replay record with age X25519")?;
+            .context("failed to encrypt replay record with age")?;
         let elapsed = started_at.elapsed();
         REPLAY_ARCHIVE_METRICS.encryption_time.observe(elapsed);
         if encoded_len > 0 {

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -97,6 +97,10 @@ enum Command {
         /// when absent.
         #[arg(long, requires = "kms_key_version")]
         kms_credential_file_path: Option<PathBuf>,
+        /// Number of replay records decoded concurrently. With KMS decryption every record takes
+        /// one KMS call, so this bounds in-flight KMS requests.
+        #[arg(long, default_value_t = zksync_os_replay_archive::DEFAULT_DECRYPT_CONCURRENCY)]
+        decrypt_concurrency: usize,
     },
 }
 
@@ -159,6 +163,7 @@ async fn main() -> anyhow::Result<()> {
             age_secret_key,
             kms_key_version,
             kms_credential_file_path,
+            decrypt_concurrency,
         } => {
             let identity = if let Some(key_version) = kms_key_version {
                 let auth_mode = match kms_credential_file_path {
@@ -188,6 +193,7 @@ async fn main() -> anyhow::Result<()> {
                 anchor_block_number,
                 anchor_block_hash,
                 identity,
+                decrypt_concurrency,
             )
             .await?;
             println!("Recovered {recovered} replay records to RocksDB");

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -1,8 +1,9 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use zksync_os_replay_archive::{
-    FileSystemReplayArchiveReader, GcsReplayArchiveAuthMode, GcsReplayArchiveConfig,
-    GcsReplayArchiveReader, S3ReplayArchiveAuthMode, S3ReplayArchiveConfig, S3ReplayArchiveReader,
+    ArchiveIdentity, FileSystemReplayArchiveReader, GcpKmsClient, GcpKmsConfig, GcpKmsIdentity,
+    GcsReplayArchiveAuthMode, GcsReplayArchiveConfig, GcsReplayArchiveReader,
+    S3ReplayArchiveAuthMode, S3ReplayArchiveConfig, S3ReplayArchiveReader,
     download_all_replay_archive_objects, parse_age_x25519_identity, read_age_x25519_identity,
     recover_replay_records_to_rocksdb_with_optional_decryption,
 };
@@ -76,16 +77,26 @@ enum Command {
         #[arg(long)]
         anchor_block_hash: alloy::primitives::BlockHash,
         /// age identity file containing AGE-SECRET-KEY. If provided, records are decrypted in memory.
-        #[arg(long, conflicts_with = "age_secret_key")]
+        #[arg(long, conflicts_with_all = ["age_secret_key", "kms_key_version"])]
         identity_file: Option<PathBuf>,
         /// age AGE-SECRET-KEY value. If provided, records are decrypted in memory.
         #[arg(
             long,
             env = "REPLAY_ARCHIVE_AGE_SECRET_KEY",
             hide_env_values = true,
-            conflicts_with = "identity_file"
+            conflicts_with_all = ["identity_file", "kms_key_version"]
         )]
         age_secret_key: Option<String>,
+        /// GCP KMS key version resource name
+        /// (`projects/../locations/../keyRings/../cryptoKeys/../cryptoKeyVersions/..`).
+        /// If provided, records are decrypted in memory, unwrapping the encryption key of every
+        /// record with one KMS asymmetric decrypt call.
+        #[arg(long, conflicts_with_all = ["identity_file", "age_secret_key"])]
+        kms_key_version: Option<String>,
+        /// Path to the GCP credentials file for KMS access. Ambient authentication is used
+        /// when absent.
+        #[arg(long, requires = "kms_key_version")]
+        kms_credential_file_path: Option<PathBuf>,
     },
 }
 
@@ -146,11 +157,24 @@ async fn main() -> anyhow::Result<()> {
             anchor_block_hash,
             identity_file,
             age_secret_key,
+            kms_key_version,
+            kms_credential_file_path,
         } => {
-            let identity = if let Some(age_secret_key) = age_secret_key {
-                Some(parse_age_x25519_identity(&age_secret_key)?)
+            let identity = if let Some(key_version) = kms_key_version {
+                let client = GcpKmsClient::new(&GcpKmsConfig {
+                    key_version,
+                    credentials_file: kms_credential_file_path,
+                })
+                .await?;
+                Some(ArchiveIdentity::GcpKms(GcpKmsIdentity::new(client)))
+            } else if let Some(age_secret_key) = age_secret_key {
+                Some(ArchiveIdentity::X25519(parse_age_x25519_identity(
+                    &age_secret_key,
+                )?))
             } else if let Some(identity_file) = identity_file {
-                Some(read_age_x25519_identity(&identity_file).await?)
+                Some(ArchiveIdentity::X25519(
+                    read_age_x25519_identity(&identity_file).await?,
+                ))
             } else {
                 None
             };

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -1,8 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use zksync_os_replay_archive::{
-    ArchiveIdentity, FileSystemReplayArchiveReader, GcpKmsClient, GcpKmsConfig, GcpKmsIdentity,
-    GcsReplayArchiveAuthMode, GcsReplayArchiveConfig, GcsReplayArchiveReader,
+    ArchiveIdentity, FileSystemReplayArchiveReader, GcpKmsAuthMode, GcpKmsClient, GcpKmsConfig,
+    GcpKmsIdentity, GcsReplayArchiveAuthMode, GcsReplayArchiveConfig, GcsReplayArchiveReader,
     S3ReplayArchiveAuthMode, S3ReplayArchiveConfig, S3ReplayArchiveReader,
     download_all_replay_archive_objects, parse_age_x25519_identity, read_age_x25519_identity,
     recover_replay_records_to_rocksdb_with_optional_decryption,
@@ -161,9 +161,13 @@ async fn main() -> anyhow::Result<()> {
             kms_credential_file_path,
         } => {
             let identity = if let Some(key_version) = kms_key_version {
+                let auth_mode = match kms_credential_file_path {
+                    Some(path) => GcpKmsAuthMode::AuthenticatedWithCredentialFile(path),
+                    None => GcpKmsAuthMode::Authenticated,
+                };
                 let client = GcpKmsClient::new(&GcpKmsConfig {
                     key_version,
-                    credentials_file: kms_credential_file_path,
+                    auth_mode,
                 })
                 .await?;
                 Some(ArchiveIdentity::GcpKms(GcpKmsIdentity::new(client)))

--- a/lib/replay_archive/src/bin/replay_archive_recovery.rs
+++ b/lib/replay_archive/src/bin/replay_archive_recovery.rs
@@ -106,6 +106,13 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let cli = Cli::parse();
 
     match cli.command {

--- a/lib/replay_archive/src/filesystem/reader.rs
+++ b/lib/replay_archive/src/filesystem/reader.rs
@@ -1,17 +1,12 @@
 use crate::{
-    ReplayArchiveKey, ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveSession,
-    ReplayArchiveStorageReader,
+    ReplayArchiveKey, ReplayArchiveKeyPage, ReplayArchiveSession, ReplayArchiveStorageReader,
+    format_block_hash,
 };
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures::StreamExt as _;
 use std::path::{Path, PathBuf};
 use std::str::FromStr as _;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-
-const LIST_OBJECTS_CHANNEL_SIZE: usize = 128;
 
 /// File-system implementation of [`ReplayArchiveStorageReader`].
 #[derive(Debug, Clone)]
@@ -27,74 +22,68 @@ impl FileSystemReplayArchiveReader {
     pub fn root_path(&self) -> &Path {
         &self.root_path
     }
+
+    fn object_path(&self, key: &ReplayArchiveKey) -> PathBuf {
+        self.root_path
+            .join(key.session.folder_name())
+            .join(key.block_number.to_string())
+            .join(format_block_hash(key.block_hash))
+    }
 }
 
 #[async_trait]
 impl ReplayArchiveStorageReader for FileSystemReplayArchiveReader {
-    async fn list_objects(&self) -> ReplayArchiveObjectStream {
-        let root_path = self.root_path.clone();
-        let (sender, receiver) = mpsc::channel(LIST_OBJECTS_CHANNEL_SIZE);
-        tokio::spawn(async move {
-            if let Err(err) = list_objects(root_path, sender.clone()).await {
-                let _ = sender.send(Err(err)).await;
-            }
-        });
-        ReceiverStream::new(receiver).boxed()
-    }
-}
+    // The local filesystem backend does not paginate: the first page contains every key.
+    async fn list_keys_page(
+        &self,
+        page_token: Option<String>,
+    ) -> anyhow::Result<ReplayArchiveKeyPage> {
+        anyhow::ensure!(
+            page_token.is_none(),
+            "filesystem replay archive reader returns a single page"
+        );
+        let mut keys = Vec::new();
+        let mut session_entries =
+            tokio::fs::read_dir(&self.root_path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to read replay archive root {}",
+                        self.root_path.display()
+                    )
+                })?;
 
-async fn list_objects(
-    root_path: PathBuf,
-    sender: mpsc::Sender<anyhow::Result<ReplayArchiveObject>>,
-) -> anyhow::Result<()> {
-    let mut session_entries = tokio::fs::read_dir(&root_path)
-        .await
-        .with_context(|| format!("failed to read replay archive root {}", root_path.display()))?;
-
-    while let Some(session_entry) = session_entries.next_entry().await.with_context(|| {
-        format!(
-            "failed to read replay archive root entry {}",
-            root_path.display()
-        )
-    })? {
-        let session_metadata = session_entry.metadata().await.with_context(|| {
+        while let Some(session_entry) = session_entries.next_entry().await.with_context(|| {
             format!(
-                "failed to read replay archive session metadata {}",
-                session_entry.path().display()
-            )
-        })?;
-        if !session_metadata.is_dir() {
-            continue;
-        }
-
-        let session = parse_session_entry(&session_entry)?;
-        let mut block_entries = tokio::fs::read_dir(session_entry.path())
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to read replay archive session {}",
-                    session_entry.path().display()
-                )
-            })?;
-        while let Some(block_entry) = block_entries.next_entry().await.with_context(|| {
-            format!(
-                "failed to read replay archive session entry {}",
-                session_entry.path().display()
+                "failed to read replay archive root entry {}",
+                self.root_path.display()
             )
         })? {
-            let block_metadata = block_entry.metadata().await.with_context(|| {
-                format!(
-                    "failed to read replay archive block directory metadata {}",
-                    block_entry.path().display()
-                )
-            })?;
-            if !block_metadata.is_dir() {
+            if !session_entry.file_type().await?.is_dir() {
                 continue;
             }
+            let session = parse_session_entry(&session_entry)?;
 
-            let block_number = parse_block_number_entry(&block_entry)?;
-            let mut object_entries =
-                tokio::fs::read_dir(block_entry.path())
+            let mut block_entries = tokio::fs::read_dir(session_entry.path())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to read replay archive session {}",
+                        session_entry.path().display()
+                    )
+                })?;
+            while let Some(block_entry) = block_entries.next_entry().await.with_context(|| {
+                format!(
+                    "failed to read replay archive session entry {}",
+                    session_entry.path().display()
+                )
+            })? {
+                if !block_entry.file_type().await?.is_dir() {
+                    continue;
+                }
+                let block_number = parse_block_number_entry(&block_entry)?;
+
+                let mut object_entries = tokio::fs::read_dir(block_entry.path())
                     .await
                     .with_context(|| {
                         format!(
@@ -102,44 +91,39 @@ async fn list_objects(
                             block_entry.path().display()
                         )
                     })?;
-            while let Some(object_entry) = object_entries.next_entry().await.with_context(|| {
-                format!(
-                    "failed to read replay archive object entry {}",
-                    block_entry.path().display()
-                )
-            })? {
-                let object_metadata = object_entry.metadata().await.with_context(|| {
-                    format!(
-                        "failed to read replay archive object metadata {}",
-                        object_entry.path().display()
-                    )
-                })?;
-                if !object_metadata.is_file() {
-                    continue;
-                }
-
-                let block_hash = parse_block_hash_entry(&object_entry)?;
-                let key = ReplayArchiveKey::new(session.clone(), block_number, block_hash);
-                let bytes = tokio::fs::read(object_entry.path())
-                    .await
-                    .with_context(|| {
+                while let Some(object_entry) =
+                    object_entries.next_entry().await.with_context(|| {
                         format!(
-                            "failed to read replay archive object {}",
-                            object_entry.path().display()
+                            "failed to read replay archive object entry {}",
+                            block_entry.path().display()
                         )
-                    })?;
-                if sender
-                    .send(Ok(ReplayArchiveObject { key, bytes }))
-                    .await
-                    .is_err()
+                    })?
                 {
-                    return Ok(());
+                    if !object_entry.file_type().await?.is_file() {
+                        continue;
+                    }
+                    let block_hash = parse_block_hash_entry(&object_entry)?;
+                    keys.push(ReplayArchiveKey::new(
+                        session.clone(),
+                        block_number,
+                        block_hash,
+                    ));
                 }
             }
         }
+
+        Ok(ReplayArchiveKeyPage {
+            keys,
+            next_page_token: None,
+        })
     }
 
-    Ok(())
+    async fn fetch_object(&self, key: &ReplayArchiveKey) -> anyhow::Result<Vec<u8>> {
+        let path = self.object_path(key);
+        tokio::fs::read(&path)
+            .await
+            .with_context(|| format!("failed to read replay archive object {}", path.display()))
+    }
 }
 
 fn parse_session_entry(entry: &tokio::fs::DirEntry) -> anyhow::Result<ReplayArchiveSession> {
@@ -175,8 +159,7 @@ fn parse_block_hash_entry(entry: &tokio::fs::DirEntry) -> anyhow::Result<BlockHa
     let file_name = file_name
         .to_str()
         .context("replay archive block hash path is not valid UTF-8")?;
-    let block_hash = file_name.strip_prefix("0x").unwrap_or(file_name);
-    BlockHash::from_str(block_hash).with_context(|| {
+    BlockHash::from_str(file_name).with_context(|| {
         format!(
             "failed to parse replay archive block hash {}",
             entry.path().display()

--- a/lib/replay_archive/src/gcs.rs
+++ b/lib/replay_archive/src/gcs.rs
@@ -1,11 +1,10 @@
 use crate::{
-    ReplayArchiveKey, ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveSession,
-    ReplayArchiveStorage, ReplayArchiveStorageReader,
+    ReplayArchiveKey, ReplayArchiveKeyPage, ReplayArchiveSession, ReplayArchiveStorage,
+    ReplayArchiveStorageReader,
 };
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
 use async_trait::async_trait;
-use futures::StreamExt as _;
 use google_cloud_auth::credentials::CredentialsFile;
 use google_cloud_storage::client::{Client, ClientConfig};
 use google_cloud_storage::http::objects::download::Range;
@@ -14,9 +13,12 @@ use google_cloud_storage::http::objects::list::ListObjectsRequest;
 use google_cloud_storage::http::objects::upload::{Media, UploadObjectRequest, UploadType};
 use http::StatusCode;
 use std::fmt;
+use std::future::Future;
 use std::path::PathBuf;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
+use std::time::Duration;
+
+const DOWNLOAD_RETRY_ATTEMPTS: u32 = 4;
+const DOWNLOAD_RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
 
 /// Authentication mode for GCS replay archive access.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +213,46 @@ fn is_not_found(err: &google_cloud_storage::http::Error) -> bool {
     }
 }
 
+/// Follows the GCS retry guidance: HTTP 408/429/5xx and transport-level failures are
+/// transient; other client errors are permanent.
+fn is_transient(err: &google_cloud_storage::http::Error) -> bool {
+    match err {
+        google_cloud_storage::http::Error::Response(response) => response.is_retriable(),
+        google_cloud_storage::http::Error::HttpClient(err) => err
+            .status()
+            .is_none_or(|status| matches!(status.as_u16(), 408 | 429 | 500..=599)),
+        _ => true,
+    }
+}
+
+/// Retries a GCS call on transient failures with exponential backoff.
+async fn with_download_retries<T, Fut>(
+    description: &str,
+    operation: impl Fn() -> Fut,
+) -> Result<T, google_cloud_storage::http::Error>
+where
+    Fut: Future<Output = Result<T, google_cloud_storage::http::Error>>,
+{
+    let mut attempt = 1;
+    loop {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt < DOWNLOAD_RETRY_ATTEMPTS && is_transient(&err) => {
+                let delay = DOWNLOAD_RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                tracing::warn!(
+                    attempt,
+                    delay_ms = delay.as_millis() as u64,
+                    error = %err,
+                    "transient GCS error while {description}; retrying"
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 /// GCS implementation of [`ReplayArchiveStorageReader`].
 #[derive(Clone)]
 pub struct GcsReplayArchiveReader {
@@ -240,77 +282,58 @@ impl GcsReplayArchiveReader {
 
 #[async_trait]
 impl ReplayArchiveStorageReader for GcsReplayArchiveReader {
-    async fn list_objects(&self) -> ReplayArchiveObjectStream {
-        let config = self.config.clone();
-        let client = self.client.clone();
-        let (sender, receiver) = mpsc::channel(crate::REPLAY_ARCHIVE_OBJECT_LIST_CHANNEL_SIZE);
-        tokio::spawn(async move {
-            if let Err(err) = list_objects(config, client, sender.clone()).await {
-                let _ = sender.send(Err(err)).await;
-            }
-        });
-        ReceiverStream::new(receiver).boxed()
-    }
-}
-
-async fn list_objects(
-    config: GcsReplayArchiveConfig,
-    client: Client,
-    sender: mpsc::Sender<anyhow::Result<ReplayArchiveObject>>,
-) -> anyhow::Result<()> {
-    let mut page_token = None;
-
-    loop {
+    async fn list_keys_page(
+        &self,
+        page_token: Option<String>,
+    ) -> anyhow::Result<ReplayArchiveKeyPage> {
         let request = ListObjectsRequest {
-            bucket: config.bucket_base_url.clone(),
-            page_token: page_token.clone(),
+            bucket: self.config.bucket_base_url.clone(),
+            page_token,
             ..Default::default()
         };
-
-        let response = client.list_objects(&request).await.with_context(|| {
+        let response = with_download_retries("listing replay archive objects", || {
+            self.client.list_objects(&request)
+        })
+        .await
+        .with_context(|| {
             format!(
                 "failed to list replay archive GCS objects in gs://{}",
-                config.bucket_base_url
+                self.config.bucket_base_url
             )
         })?;
 
+        let mut keys = Vec::new();
         for object in response.items.into_iter().flatten() {
-            let object_key = object.name;
-            let Some(key) = crate::parse_archive_object_key(&object_key)? else {
-                continue;
-            };
-
-            let get_request = GetObjectRequest {
-                bucket: config.bucket_base_url.clone(),
-                object: object_key.clone(),
-                ..Default::default()
-            };
-            let bytes = client
-                .download_object(&get_request, &Range::default())
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to read replay archive GCS object gs://{}/{}",
-                        config.bucket_base_url, object_key
-                    )
-                })?;
-
-            if sender
-                .send(Ok(ReplayArchiveObject { key, bytes }))
-                .await
-                .is_err()
-            {
-                return Ok(());
+            if let Some(key) = crate::parse_archive_object_key(&object.name)? {
+                keys.push(key);
             }
         }
-
-        let Some(next_token) = response.next_page_token else {
-            break;
-        };
-        page_token = Some(next_token);
+        Ok(ReplayArchiveKeyPage {
+            keys,
+            next_page_token: response.next_page_token,
+        })
     }
 
-    Ok(())
+    async fn fetch_object(&self, key: &ReplayArchiveKey) -> anyhow::Result<Vec<u8>> {
+        let object_key = key.object_path();
+        let get_request = GetObjectRequest {
+            bucket: self.config.bucket_base_url.clone(),
+            object: object_key.clone(),
+            ..Default::default()
+        };
+        let range = Range::default();
+        with_download_retries(
+            &format!("downloading replay archive object {object_key}"),
+            || self.client.download_object(&get_request, &range),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to read replay archive GCS object gs://{}/{}",
+                self.config.bucket_base_url, object_key
+            )
+        })
+    }
 }
 
 #[cfg(test)]

--- a/lib/replay_archive/src/init.rs
+++ b/lib/replay_archive/src/init.rs
@@ -6,10 +6,10 @@ use anyhow::Context as _;
 use reth_tasks::Runtime;
 
 use crate::{
-    AgeEncryptedReplayArchiver, FileSystemReplayArchiveStorage, GcsReplayArchiveConfig,
-    GcsReplayArchiveStorage, ReplayArchiveComponent, ReplayArchiveSender, ReplayArchiveSession,
-    ReplayArchiveStorage, ReplayArchiver, ReplayRecordArchiver, S3ReplayArchiveConfig,
-    S3ReplayArchiveStorage,
+    AgeEncryptedReplayArchiver, ArchiveRecipient, FileSystemReplayArchiveStorage, GcpKmsClient,
+    GcpKmsConfig, GcpKmsRecipient, GcsReplayArchiveConfig, GcsReplayArchiveStorage,
+    ReplayArchiveComponent, ReplayArchiveSender, ReplayArchiveSession, ReplayArchiveStorage,
+    ReplayArchiver, ReplayRecordArchiver, S3ReplayArchiveConfig, S3ReplayArchiveStorage,
 };
 
 #[derive(Debug, Clone)]
@@ -33,6 +33,7 @@ pub enum ReplayArchiveConfig {
 pub enum ReplayArchiveEncryptionConfig {
     Noop,
     AgeX25519 { recipient: String },
+    GcpKms { config: GcpKmsConfig },
 }
 
 pub type InitializedReplayArchive = (ReplayArchiveSender, Arc<dyn ReplayArchiver>);
@@ -59,21 +60,21 @@ pub async fn init_replay_archive(
                 .await
                 .with_context(|| format!("failed to create replay archive session {session}"))
                 .expect("failed to initialize replay archive");
-            archive_for_storage(storage, encryption)
+            archive_for_storage(storage, encryption).await
         }
         ReplayArchiveConfig::S3 { config, encryption } => {
             let storage = S3ReplayArchiveStorage::init(config.clone(), session.clone())
                 .await
                 .with_context(|| format!("failed to create replay archive S3 session {session}"))
                 .expect("failed to initialize S3 replay archive");
-            archive_for_storage(storage, encryption)
+            archive_for_storage(storage, encryption).await
         }
         ReplayArchiveConfig::Gcs { config, encryption } => {
             let storage = GcsReplayArchiveStorage::init(config.clone(), session.clone())
                 .await
                 .with_context(|| format!("failed to create replay archive GCS session {session}"))
                 .expect("failed to initialize GCS replay archive");
-            archive_for_storage(storage, encryption)
+            archive_for_storage(storage, encryption).await
         }
     };
     let (sender, component) = ReplayArchiveComponent::new(archive.clone());
@@ -87,7 +88,7 @@ pub async fn init_replay_archive(
     Some((sender, archive))
 }
 
-fn archive_for_storage<Storage>(
+async fn archive_for_storage<Storage>(
     storage: Storage,
     encryption: &ReplayArchiveEncryptionConfig,
 ) -> Arc<dyn ReplayArchiver>
@@ -100,6 +101,18 @@ where
             AgeEncryptedReplayArchiver::from_recipient_str(storage, recipient)
                 .expect("failed to initialize age X25519 replay archive encryption"),
         ),
+        ReplayArchiveEncryptionConfig::GcpKms { config } => {
+            let client = GcpKmsClient::new(config)
+                .await
+                .expect("failed to initialize GCP KMS client for replay archive encryption");
+            let recipient = GcpKmsRecipient::fetch(&client)
+                .await
+                .expect("failed to fetch GCP KMS public key for replay archive encryption");
+            Arc::new(AgeEncryptedReplayArchiver::new(
+                storage,
+                ArchiveRecipient::GcpKms(recipient),
+            ))
+        }
     }
 }
 

--- a/lib/replay_archive/src/kms.rs
+++ b/lib/replay_archive/src/kms.rs
@@ -29,6 +29,17 @@ const KMS_ENDPOINT: &str = "https://cloudkms.googleapis.com/v1";
 /// age header stanza tag for file keys wrapped with a GCP KMS RSA-OAEP key.
 const GCP_KMS_STANZA_TAG: &str = "gcp-kms-rsa-oaep";
 
+/// Authentication mode for GCP KMS access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GcpKmsAuthMode {
+    /// Ambient authentication (works if the binary runs on Google Cloud, e.g. via workload
+    /// identity). This is the primary mode this backend is built for.
+    Authenticated,
+    /// Authentication via a credentials file at the specified path.
+    AuthenticatedWithCredentialFile(PathBuf),
+}
+
 /// GCP KMS key configuration for replay archive encryption.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GcpKmsConfig {
@@ -37,9 +48,7 @@ pub struct GcpKmsConfig {
     /// The key must have purpose `ASYMMETRIC_DECRYPT` and an `RSA_DECRYPT_OAEP_*_SHA256`
     /// algorithm.
     pub key_version: String,
-    /// Path to a GCP credentials file. Ambient authentication (e.g. workload identity) is used
-    /// when absent.
-    pub credentials_file: Option<PathBuf>,
+    pub auth_mode: GcpKmsAuthMode,
 }
 
 /// Minimal GCP KMS REST client covering the two methods the replay archive needs.
@@ -69,8 +78,8 @@ impl GcpKmsClient {
             scopes: Some(&[KMS_SCOPE]),
             sub: None,
         };
-        let provider = match &config.credentials_file {
-            Some(path) => {
+        let provider = match &config.auth_mode {
+            GcpKmsAuthMode::AuthenticatedWithCredentialFile(path) => {
                 let path = path
                     .to_str()
                     .with_context(|| {
@@ -83,7 +92,7 @@ impl GcpKmsClient {
                 DefaultTokenSourceProvider::new_with_credentials(auth_config, Box::new(credentials))
                     .await
             }
-            None => DefaultTokenSourceProvider::new(auth_config).await,
+            GcpKmsAuthMode::Authenticated => DefaultTokenSourceProvider::new(auth_config).await,
         }
         .context("failed to initialize GCP KMS token source")?;
         Ok(Self {

--- a/lib/replay_archive/src/kms.rs
+++ b/lib/replay_archive/src/kms.rs
@@ -1,0 +1,341 @@
+//! age recipient/identity backed by a GCP KMS asymmetric key.
+//!
+//! Encryption wraps the per-file age file key with the RSA-OAEP-SHA256 public key of a KMS
+//! `ASYMMETRIC_DECRYPT` key version and is fully local: the node only needs the public key,
+//! fetched once at startup. Decryption unwraps the file key with one KMS `AsymmetricDecrypt`
+//! call per object; the private key never leaves KMS.
+
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use age_core::format::{FILE_KEY_BYTES, FileKey, Stanza};
+use age_core::secrecy::ExposeSecret as _;
+use anyhow::Context as _;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use google_cloud_auth::credentials::CredentialsFile;
+use google_cloud_auth::project::Config as AuthConfig;
+use google_cloud_auth::token::DefaultTokenSourceProvider;
+use google_cloud_token::{TokenSource, TokenSourceProvider as _};
+use rsa::pkcs8::DecodePublicKey as _;
+use rsa::{Oaep, RsaPublicKey};
+use serde::Deserialize;
+use sha2::Sha256;
+
+const KMS_SCOPE: &str = "https://www.googleapis.com/auth/cloudkms";
+const KMS_ENDPOINT: &str = "https://cloudkms.googleapis.com/v1";
+/// age header stanza tag for file keys wrapped with a GCP KMS RSA-OAEP key.
+const GCP_KMS_STANZA_TAG: &str = "gcp-kms-rsa-oaep";
+
+/// GCP KMS key configuration for replay archive encryption.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcpKmsConfig {
+    /// Full key version resource name:
+    /// `projects/../locations/../keyRings/../cryptoKeys/../cryptoKeyVersions/..`.
+    /// The key must have purpose `ASYMMETRIC_DECRYPT` and an `RSA_DECRYPT_OAEP_*_SHA256`
+    /// algorithm.
+    pub key_version: String,
+    /// Path to a GCP credentials file. Ambient authentication (e.g. workload identity) is used
+    /// when absent.
+    pub credentials_file: Option<PathBuf>,
+}
+
+/// Minimal GCP KMS REST client covering the two methods the replay archive needs.
+#[derive(Clone, Debug)]
+pub struct GcpKmsClient {
+    http: reqwest::Client,
+    token_source: Arc<dyn TokenSource>,
+    key_version: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PublicKeyResponse {
+    pem: String,
+    algorithm: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AsymmetricDecryptResponse {
+    plaintext: String,
+}
+
+impl GcpKmsClient {
+    pub async fn new(config: &GcpKmsConfig) -> anyhow::Result<Self> {
+        let auth_config = AuthConfig {
+            audience: None,
+            scopes: Some(&[KMS_SCOPE]),
+            sub: None,
+        };
+        let provider = match &config.credentials_file {
+            Some(path) => {
+                let path = path
+                    .to_str()
+                    .with_context(|| {
+                        format!("credentials file path {} is not UTF-8", path.display())
+                    })?
+                    .to_owned();
+                let credentials = CredentialsFile::new_from_file(path)
+                    .await
+                    .context("failed to read GCP KMS credentials file")?;
+                DefaultTokenSourceProvider::new_with_credentials(auth_config, Box::new(credentials))
+                    .await
+            }
+            None => DefaultTokenSourceProvider::new(auth_config).await,
+        }
+        .context("failed to initialize GCP KMS token source")?;
+        Ok(Self {
+            http: reqwest::Client::new(),
+            token_source: provider.token_source(),
+            key_version: config.key_version.clone(),
+        })
+    }
+
+    pub fn key_version(&self) -> &str {
+        &self.key_version
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        url: String,
+        body: Option<String>,
+    ) -> anyhow::Result<String> {
+        let token = self
+            .token_source
+            .token()
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to obtain GCP access token: {err}"))?;
+        let mut request = self
+            .http
+            .request(method, &url)
+            .header("authorization", token);
+        if let Some(body) = body {
+            request = request
+                .header("content-type", "application/json")
+                .body(body);
+        }
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("GCP KMS request to {url} failed"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .with_context(|| format!("failed to read GCP KMS response from {url}"))?;
+        anyhow::ensure!(
+            status.is_success(),
+            "GCP KMS request to {url} returned {status}: {body}"
+        );
+        Ok(body)
+    }
+
+    /// Fetches the public key of the key version, returning `(pem, algorithm)`.
+    pub async fn get_public_key(&self) -> anyhow::Result<(String, String)> {
+        let url = format!("{KMS_ENDPOINT}/{}/publicKey", self.key_version);
+        let body = self.request(reqwest::Method::GET, url, None).await?;
+        let response: PublicKeyResponse =
+            serde_json::from_str(&body).context("failed to decode GCP KMS public key response")?;
+        Ok((response.pem, response.algorithm))
+    }
+
+    /// Decrypts data encrypted with the public key of the key version.
+    pub async fn asymmetric_decrypt(&self, ciphertext: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let url = format!("{KMS_ENDPOINT}/{}:asymmetricDecrypt", self.key_version);
+        let request = serde_json::json!({ "ciphertext": BASE64.encode(ciphertext) }).to_string();
+        let body = self
+            .request(reqwest::Method::POST, url, Some(request))
+            .await?;
+        let response: AsymmetricDecryptResponse = serde_json::from_str(&body)
+            .context("failed to decode GCP KMS asymmetric decrypt response")?;
+        BASE64
+            .decode(response.plaintext)
+            .context("failed to decode GCP KMS asymmetric decrypt plaintext")
+    }
+}
+
+/// age recipient that wraps file keys with the RSA-OAEP-SHA256 public key of a GCP KMS
+/// `ASYMMETRIC_DECRYPT` key version. Wrapping is fully local.
+#[derive(Debug, Clone)]
+pub struct GcpKmsRecipient {
+    public_key: RsaPublicKey,
+    key_version: String,
+}
+
+impl GcpKmsRecipient {
+    pub fn from_public_key_pem(
+        pem: &str,
+        algorithm: &str,
+        key_version: String,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            algorithm.starts_with("RSA_DECRYPT_OAEP_") && algorithm.ends_with("_SHA256"),
+            "unsupported GCP KMS key algorithm {algorithm}; \
+             the key version must use an RSA_DECRYPT_OAEP_*_SHA256 algorithm"
+        );
+        let public_key = RsaPublicKey::from_public_key_pem(pem)
+            .context("failed to parse GCP KMS public key PEM")?;
+        Ok(Self {
+            public_key,
+            key_version,
+        })
+    }
+
+    /// Fetches the public key of the client's key version from KMS.
+    pub async fn fetch(client: &GcpKmsClient) -> anyhow::Result<Self> {
+        let (pem, algorithm) = client.get_public_key().await?;
+        Self::from_public_key_pem(&pem, &algorithm, client.key_version().to_owned())
+    }
+}
+
+impl age::Recipient for GcpKmsRecipient {
+    fn wrap_file_key(
+        &self,
+        file_key: &FileKey,
+    ) -> Result<(Vec<Stanza>, HashSet<String>), age::EncryptError> {
+        let body = self
+            .public_key
+            .encrypt(
+                &mut rand_core06::OsRng,
+                Oaep::new::<Sha256>(),
+                file_key.expose_secret(),
+            )
+            .map_err(|err| {
+                age::EncryptError::Io(io::Error::other(format!(
+                    "RSA-OAEP wrapping of age file key failed: {err}"
+                )))
+            })?;
+        Ok((
+            vec![Stanza {
+                tag: GCP_KMS_STANZA_TAG.to_owned(),
+                args: vec![self.key_version.clone()],
+                body,
+            }],
+            HashSet::new(),
+        ))
+    }
+}
+
+/// age identity that unwraps file keys via GCP KMS `AsymmetricDecrypt`, one call per age file.
+#[derive(Clone, Debug)]
+pub struct GcpKmsIdentity {
+    client: GcpKmsClient,
+    runtime: tokio::runtime::Handle,
+}
+
+impl GcpKmsIdentity {
+    /// Must be called inside a multi-threaded tokio runtime: unwrapping a stanza issues a
+    /// blocking KMS call via `block_in_place`.
+    pub fn new(client: GcpKmsClient) -> Self {
+        Self {
+            client,
+            runtime: tokio::runtime::Handle::current(),
+        }
+    }
+
+    pub fn key_version(&self) -> &str {
+        self.client.key_version()
+    }
+}
+
+impl age::Identity for GcpKmsIdentity {
+    fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, age::DecryptError>> {
+        if stanza.tag != GCP_KMS_STANZA_TAG || stanza.args != [self.client.key_version()] {
+            return None;
+        }
+        let plaintext = tokio::task::block_in_place(|| {
+            self.runtime
+                .block_on(self.client.asymmetric_decrypt(&stanza.body))
+        });
+        let plaintext = match plaintext {
+            Ok(plaintext) => plaintext,
+            Err(err) => {
+                return Some(Err(age::DecryptError::Io(io::Error::other(format!(
+                    "GCP KMS asymmetric decrypt failed: {err:#}"
+                )))));
+            }
+        };
+        match <[u8; FILE_KEY_BYTES]>::try_from(plaintext.as_slice()) {
+            Ok(bytes) => Some(Ok(FileKey::new(Box::new(bytes)))),
+            Err(_) => Some(Err(age::DecryptError::KeyDecryptionFailed)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::EncodePublicKey as _;
+
+    const TEST_KEY_VERSION: &str =
+        "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1";
+
+    /// Test identity mirroring what GCP KMS `AsymmetricDecrypt` does server-side.
+    struct LocalRsaOaepIdentity {
+        private_key: RsaPrivateKey,
+        key_version: String,
+    }
+
+    impl age::Identity for LocalRsaOaepIdentity {
+        fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, age::DecryptError>> {
+            if stanza.tag != GCP_KMS_STANZA_TAG || stanza.args != [self.key_version.as_str()] {
+                return None;
+            }
+            let plaintext = self
+                .private_key
+                .decrypt(Oaep::new::<Sha256>(), &stanza.body)
+                .expect("RSA-OAEP unwrap failed");
+            let bytes = <[u8; FILE_KEY_BYTES]>::try_from(plaintext.as_slice()).unwrap();
+            Some(Ok(FileKey::new(Box::new(bytes))))
+        }
+    }
+
+    #[test]
+    fn kms_recipient_roundtrips_through_rsa_oaep_stanza() {
+        let private_key = RsaPrivateKey::new(&mut rand_core06::OsRng, 2048).unwrap();
+        let pem = private_key
+            .to_public_key()
+            .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
+            .unwrap();
+        let recipient = GcpKmsRecipient::from_public_key_pem(
+            &pem,
+            "RSA_DECRYPT_OAEP_2048_SHA256",
+            TEST_KEY_VERSION.to_owned(),
+        )
+        .unwrap();
+
+        let encrypted = age::encrypt(&recipient, b"replay record").unwrap();
+
+        let identity = LocalRsaOaepIdentity {
+            private_key: private_key.clone(),
+            key_version: TEST_KEY_VERSION.to_owned(),
+        };
+        let decrypted = age::decrypt(&identity, encrypted.as_slice()).unwrap();
+        assert_eq!(decrypted, b"replay record");
+
+        let other_version_identity = LocalRsaOaepIdentity {
+            private_key,
+            key_version: format!("{TEST_KEY_VERSION}0"),
+        };
+        let err = age::decrypt(&other_version_identity, encrypted.as_slice()).unwrap_err();
+        assert!(matches!(err, age::DecryptError::NoMatchingKeys));
+    }
+
+    #[test]
+    fn kms_recipient_rejects_non_oaep_sha256_algorithms() {
+        let err = GcpKmsRecipient::from_public_key_pem(
+            "irrelevant",
+            "RSA_DECRYPT_OAEP_4096_SHA512",
+            TEST_KEY_VERSION.to_owned(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported GCP KMS key algorithm")
+        );
+    }
+}

--- a/lib/replay_archive/src/kms.rs
+++ b/lib/replay_archive/src/kms.rs
@@ -24,7 +24,13 @@ use rsa::{Oaep, RsaPublicKey};
 use serde::Deserialize;
 use sha2::Sha256;
 
-const KMS_SCOPE: &str = "https://www.googleapis.com/auth/cloudkms";
+/// `cloud-platform` must come along with the KMS scope: under workload identity federation
+/// the federated STS token itself calls `iamcredentials.generateAccessToken`, which rejects
+/// tokens that only carry service-specific scopes.
+const KMS_SCOPES: [&str; 2] = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/cloudkms",
+];
 const KMS_ENDPOINT: &str = "https://cloudkms.googleapis.com/v1";
 /// age header stanza tag for file keys wrapped with a GCP KMS RSA-OAEP key.
 const GCP_KMS_STANZA_TAG: &str = "gcp-kms-rsa-oaep";
@@ -75,7 +81,7 @@ impl GcpKmsClient {
     pub async fn new(config: &GcpKmsConfig) -> anyhow::Result<Self> {
         let auth_config = AuthConfig {
             audience: None,
-            scopes: Some(&[KMS_SCOPE]),
+            scopes: Some(&KMS_SCOPES),
             sub: None,
         };
         let provider = match &config.auth_mode {

--- a/lib/replay_archive/src/kms.rs
+++ b/lib/replay_archive/src/kms.rs
@@ -236,8 +236,9 @@ pub struct GcpKmsIdentity {
 }
 
 impl GcpKmsIdentity {
-    /// Must be called inside a multi-threaded tokio runtime: unwrapping a stanza issues a
-    /// blocking KMS call via `block_in_place`.
+    /// Must be called inside a tokio runtime. Unwrapping a stanza blocks on the KMS call, so
+    /// decryption must run on a blocking thread (e.g. via `spawn_blocking`), never directly on
+    /// an async worker thread.
     pub fn new(client: GcpKmsClient) -> Self {
         Self {
             client,
@@ -255,10 +256,9 @@ impl age::Identity for GcpKmsIdentity {
         if stanza.tag != GCP_KMS_STANZA_TAG || stanza.args != [self.client.key_version()] {
             return None;
         }
-        let plaintext = tokio::task::block_in_place(|| {
-            self.runtime
-                .block_on(self.client.asymmetric_decrypt(&stanza.body))
-        });
+        let plaintext = self
+            .runtime
+            .block_on(self.client.asymmetric_decrypt(&stanza.body));
         let plaintext = match plaintext {
             Ok(plaintext) => plaintext,
             Err(err) => {

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -34,7 +34,7 @@ pub use init::{
     InitializedReplayArchive, ReplayArchiveConfig, ReplayArchiveEncryptionConfig,
     init_replay_archive,
 };
-pub use kms::{GcpKmsClient, GcpKmsConfig, GcpKmsIdentity, GcpKmsRecipient};
+pub use kms::{GcpKmsAuthMode, GcpKmsClient, GcpKmsConfig, GcpKmsIdentity, GcpKmsRecipient};
 pub use reader::{ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveStorageReader};
 pub use recovery::{
     ArchiveIdentity, download_all_replay_archive_objects, parse_age_x25519_identity,

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -12,6 +12,7 @@ mod filesystem;
 mod gate_component;
 mod gcs;
 mod init;
+mod kms;
 mod metrics;
 mod reader;
 mod recovery;
@@ -19,7 +20,7 @@ mod replay_record;
 mod s3;
 mod write_replay;
 
-pub use age_encrypted::AgeEncryptedReplayArchiver;
+pub use age_encrypted::{AgeEncryptedReplayArchiver, ArchiveRecipient};
 pub use component::{ReplayArchiveComponent, ReplayArchiveRecord, ReplayArchiveSender};
 pub use filesystem::{
     FileSystemReplayArchiveReader, FileSystemReplayArchiveStorage, FileSystemReplayArchiver,
@@ -33,10 +34,12 @@ pub use init::{
     InitializedReplayArchive, ReplayArchiveConfig, ReplayArchiveEncryptionConfig,
     init_replay_archive,
 };
+pub use kms::{GcpKmsClient, GcpKmsConfig, GcpKmsIdentity, GcpKmsRecipient};
 pub use reader::{ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveStorageReader};
 pub use recovery::{
-    download_all_replay_archive_objects, parse_age_x25519_identity, read_age_x25519_identity,
-    recover_replay_records_to_rocksdb, recover_replay_records_to_rocksdb_with_optional_decryption,
+    ArchiveIdentity, download_all_replay_archive_objects, parse_age_x25519_identity,
+    read_age_x25519_identity, recover_replay_records_to_rocksdb,
+    recover_replay_records_to_rocksdb_with_optional_decryption,
 };
 pub use replay_record::ReplayRecordArchiver;
 pub use s3::{
@@ -393,7 +396,7 @@ mod tests {
     fn age_encrypted_archive_encrypts_replay_record_for_recipient() {
         let identity = age::x25519::Identity::generate();
         let recipient = identity.to_public();
-        let archive = AgeEncryptedReplayArchiver::new((), recipient);
+        let archive = AgeEncryptedReplayArchiver::new((), ArchiveRecipient::X25519(recipient));
         let replay_record = test_replay_record(7);
 
         let encrypted = archive.encrypt_replay_record(&replay_record).unwrap();

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -37,8 +37,8 @@ pub use init::{
 pub use kms::{GcpKmsAuthMode, GcpKmsClient, GcpKmsConfig, GcpKmsIdentity, GcpKmsRecipient};
 pub use reader::{ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveStorageReader};
 pub use recovery::{
-    ArchiveIdentity, download_all_replay_archive_objects, parse_age_x25519_identity,
-    read_age_x25519_identity, recover_replay_records_to_rocksdb,
+    ArchiveIdentity, DEFAULT_DECRYPT_CONCURRENCY, download_all_replay_archive_objects,
+    parse_age_x25519_identity, read_age_x25519_identity, recover_replay_records_to_rocksdb,
     recover_replay_records_to_rocksdb_with_optional_decryption,
 };
 pub use replay_record::ReplayRecordArchiver;

--- a/lib/replay_archive/src/lib.rs
+++ b/lib/replay_archive/src/lib.rs
@@ -35,7 +35,7 @@ pub use init::{
     init_replay_archive,
 };
 pub use kms::{GcpKmsAuthMode, GcpKmsClient, GcpKmsConfig, GcpKmsIdentity, GcpKmsRecipient};
-pub use reader::{ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveStorageReader};
+pub use reader::{ReplayArchiveKeyPage, ReplayArchiveStorageReader};
 pub use recovery::{
     ArchiveIdentity, DEFAULT_DECRYPT_CONCURRENCY, download_all_replay_archive_objects,
     parse_age_x25519_identity, read_age_x25519_identity, recover_replay_records_to_rocksdb,
@@ -171,9 +171,6 @@ fn validate_node_id(node_id: &str) -> Result<(), InvalidReplayArchiveSession> {
 fn format_block_hash(block_hash: BlockHash) -> String {
     alloy::hex::encode_prefixed(block_hash.0)
 }
-
-/// Channel size used by object-store backends to stream listed objects to callers.
-pub(crate) const REPLAY_ARCHIVE_OBJECT_LIST_CHANNEL_SIZE: usize = 128;
 
 /// Marker object name written under `<session>/` to mark a session as created.
 pub(crate) const SESSION_MARKER_FILE_NAME: &str = ".session";

--- a/lib/replay_archive/src/reader.rs
+++ b/lib/replay_archive/src/reader.rs
@@ -1,20 +1,29 @@
 use crate::ReplayArchiveKey;
 use async_trait::async_trait;
-use futures::stream::BoxStream;
 
-pub type ReplayArchiveObjectStream = BoxStream<'static, anyhow::Result<ReplayArchiveObject>>;
-
+/// One page of listed replay archive keys.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ReplayArchiveObject {
-    pub key: ReplayArchiveKey,
-    pub bytes: Vec<u8>,
+pub struct ReplayArchiveKeyPage {
+    pub keys: Vec<ReplayArchiveKey>,
+    /// Opaque token to pass to the next `list_keys_page` call; `None` when this is the last page.
+    pub next_page_token: Option<String>,
 }
 
 /// Read-side access to replay archive objects.
 ///
-/// Implementations should hide backend-specific path parsing and return normalized archive objects.
+/// Implementations should hide backend-specific path parsing and return normalized archive keys.
 #[async_trait]
 pub trait ReplayArchiveStorageReader {
-    /// Lists all stored replay archive objects.
-    async fn list_objects(&self) -> ReplayArchiveObjectStream;
+    /// Lists one page of stored replay archive object keys without fetching payloads.
+    ///
+    /// Pass `None` to start listing and the previous page's `next_page_token` to continue.
+    /// Paging lets callers interleave listing with payload downloads instead of waiting for a
+    /// full listing of a large archive.
+    async fn list_keys_page(
+        &self,
+        page_token: Option<String>,
+    ) -> anyhow::Result<ReplayArchiveKeyPage>;
+
+    /// Fetches the payload of a single archived object.
+    async fn fetch_object(&self, key: &ReplayArchiveKey) -> anyhow::Result<Vec<u8>>;
 }

--- a/lib/replay_archive/src/recovery.rs
+++ b/lib/replay_archive/src/recovery.rs
@@ -1,4 +1,6 @@
+use crate::kms::GcpKmsIdentity;
 use crate::{ReplayArchiveKey, ReplayArchiveStorageReader, format_block_hash};
+use age_core::format::{FileKey, Stanza};
 use alloy::primitives::{BlockHash, BlockNumber, Sealed};
 use anyhow::Context as _;
 use futures::StreamExt as _;
@@ -74,7 +76,7 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
     replay_db_path: &Path,
     anchor_block_number: BlockNumber,
     anchor_block_hash: BlockHash,
-    identity: Option<age::x25519::Identity>,
+    identity: Option<ArchiveIdentity>,
 ) -> anyhow::Result<usize> {
     tracing::info!(
         input_root = %input_root.display(),
@@ -83,11 +85,17 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
         %anchor_block_hash,
         "Starting replay archive RocksDB recovery"
     );
-    if let Some(identity) = &identity {
-        tracing::info!(
+    match &identity {
+        Some(ArchiveIdentity::X25519(identity)) => tracing::info!(
             "Replay archive RocksDB recovery will decrypt objects in memory, public key: {}",
             identity.to_public(),
-        );
+        ),
+        Some(ArchiveIdentity::GcpKms(identity)) => tracing::info!(
+            "Replay archive RocksDB recovery will decrypt objects in memory \
+             via GCP KMS key version {}",
+            identity.key_version(),
+        ),
+        None => {}
     }
     let decoder = ReplayRecordDecoder { identity };
 
@@ -293,8 +301,23 @@ async fn read_verified_replay_record(
     canonical_record.context("replay archive record count was non-zero but no record was loaded")
 }
 
+/// age identity used for replay archive record decryption.
+pub enum ArchiveIdentity {
+    X25519(age::x25519::Identity),
+    GcpKms(GcpKmsIdentity),
+}
+
+impl age::Identity for ArchiveIdentity {
+    fn unwrap_stanza(&self, stanza: &Stanza) -> Option<Result<FileKey, age::DecryptError>> {
+        match self {
+            Self::X25519(identity) => identity.unwrap_stanza(stanza),
+            Self::GcpKms(identity) => identity.unwrap_stanza(stanza),
+        }
+    }
+}
+
 struct ReplayRecordDecoder {
-    identity: Option<age::x25519::Identity>,
+    identity: Option<ArchiveIdentity>,
 }
 
 impl ReplayRecordDecoder {
@@ -518,7 +541,7 @@ mod tests {
             replay_db.path(),
             1,
             block_hash,
-            Some(identity),
+            Some(ArchiveIdentity::X25519(identity)),
         )
         .await
         .unwrap();

--- a/lib/replay_archive/src/recovery.rs
+++ b/lib/replay_archive/src/recovery.rs
@@ -3,8 +3,10 @@ use crate::{ReplayArchiveKey, ReplayArchiveStorageReader, format_block_hash};
 use age_core::format::{FileKey, Stanza};
 use alloy::primitives::{BlockHash, BlockNumber, Sealed};
 use anyhow::Context as _;
-use futures::StreamExt as _;
+use futures::{StreamExt as _, TryStreamExt as _};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use zksync_os_storage::db::BlockReplayStorage;
 use zksync_os_storage_api::{ReplayRecord, WriteReplay};
@@ -63,21 +65,32 @@ pub async fn recover_replay_records_to_rocksdb(
         anchor_block_number,
         anchor_block_hash,
         None,
+        DEFAULT_DECRYPT_CONCURRENCY,
     )
     .await
 }
+
+/// Default number of replay records decoded concurrently during recovery.
+pub const DEFAULT_DECRYPT_CONCURRENCY: usize = 32;
 
 /// Rebuilds node replay RocksDB from downloaded replay records.
 ///
 /// If `identity` is provided, every downloaded object is decrypted in memory before replay record
 /// decoding. No decrypted archive objects are written to disk.
+///
+/// Records are decoded up to `decrypt_concurrency` blocks at a time. The canonical chain walk is
+/// inherently sequential (the parent hash lives inside the decrypted record), so it decodes
+/// windows of consecutive block numbers speculatively and then verifies linkage in memory. This
+/// matters for identities whose file key unwrap is a network call, like GCP KMS.
 pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
     input_root: &Path,
     replay_db_path: &Path,
     anchor_block_number: BlockNumber,
     anchor_block_hash: BlockHash,
     identity: Option<ArchiveIdentity>,
+    decrypt_concurrency: usize,
 ) -> anyhow::Result<usize> {
+    anyhow::ensure!(decrypt_concurrency > 0, "decrypt concurrency must be > 0");
     tracing::info!(
         input_root = %input_root.display(),
         replay_db_path = %replay_db_path.display(),
@@ -97,10 +110,13 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
         ),
         None => {}
     }
-    let decoder = ReplayRecordDecoder { identity };
+    let decoder = Arc::new(ReplayRecordDecoder { identity });
+    // Keep the decode pipeline saturated while bounding how many decoded records are held in
+    // memory at once.
+    let window_size = (decrypt_concurrency as u64) * 2;
 
     let mut canonical_chain = Vec::new();
-    let mut block_number = anchor_block_number;
+    let mut window_top = anchor_block_number;
     let mut block_hash = anchor_block_hash;
 
     tracing::info!(
@@ -109,35 +125,62 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
         "Walking canonical replay archive chain from anchor"
     );
     loop {
-        let replay_record =
-            read_verified_replay_record(input_root, block_number, block_hash, &decoder)
-                .await
-                .with_context(|| {
-                    format!("failed to recover replay record #{block_number}, {block_hash}")
-                })?;
-        anyhow::ensure!(
-            replay_record.block_context.block_number == block_number,
-            "replay record path block number {block_number} does not match record block number {}",
-            replay_record.block_context.block_number
-        );
-        let previous_block_hash = replay_record.block_context.block_hashes.0[255]
-            .to_be_bytes()
-            .into();
+        let window_start = (window_top + 1).saturating_sub(window_size);
+        let mut window: HashMap<BlockNumber, Vec<(BlockHash, ReplayRecord)>> =
+            futures::stream::iter(window_start..=window_top)
+                .map(|block_number| {
+                    let decoder = decoder.clone();
+                    let input_root = input_root.to_path_buf();
+                    async move {
+                        let candidates =
+                            read_candidate_records(&input_root, block_number, &decoder)
+                                .await
+                                .with_context(|| {
+                                    format!("failed to recover replay record #{block_number}")
+                                })?;
+                        anyhow::Ok((block_number, candidates))
+                    }
+                })
+                .buffer_unordered(decrypt_concurrency)
+                .try_collect()
+                .await?;
 
-        canonical_chain.push((block_number, block_hash));
-        log_recovery_progress(canonical_chain.len(), || {
-            tracing::info!(
-                records = canonical_chain.len(),
-                block_number,
-                %block_hash,
-                "Walked canonical replay archive records"
+        for block_number in (window_start..=window_top).rev() {
+            let candidates = window
+                .remove(&block_number)
+                .context("replay archive recovery window is missing a block")?;
+            let replay_record = candidates
+                .into_iter()
+                .find_map(|(hash, record)| (hash == block_hash).then_some(record))
+                .with_context(|| {
+                    format!(
+                        "missing replay archive records for block #{block_number}, {block_hash}"
+                    )
+                })?;
+            anyhow::ensure!(
+                replay_record.block_context.block_number == block_number,
+                "replay record path block number {block_number} does not match record block number {}",
+                replay_record.block_context.block_number
             );
-        });
-        if block_number == 0 {
+            let previous_block_hash = replay_record.block_context.block_hashes.0[255]
+                .to_be_bytes()
+                .into();
+
+            canonical_chain.push((block_number, block_hash));
+            log_recovery_progress(canonical_chain.len(), || {
+                tracing::info!(
+                    records = canonical_chain.len(),
+                    block_number,
+                    %block_hash,
+                    "Walked canonical replay archive records"
+                );
+            });
+            block_hash = previous_block_hash;
+        }
+        if window_start == 0 {
             break;
         }
-        block_number -= 1;
-        block_hash = previous_block_hash;
+        window_top = window_start - 1;
     }
 
     tracing::info!(
@@ -152,15 +195,31 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
         replay_db_path = %replay_db_path.display(),
         "Writing recovered replay records to RocksDB"
     );
-    for (block_number, block_hash) in canonical_chain {
-        let replay_record =
-            read_verified_replay_record(input_root, block_number, block_hash, &decoder)
+    // `buffered` keeps up to `decrypt_concurrency` records decoding ahead of the sequential
+    // writes while preserving the genesis-upward order.
+    let mut records = futures::stream::iter(canonical_chain)
+        .map(|(block_number, block_hash)| {
+            let decoder = decoder.clone();
+            let input_root = input_root.to_path_buf();
+            async move {
+                let replay_record = read_verified_replay_record(
+                    &input_root,
+                    block_number,
+                    block_hash,
+                    &decoder,
+                )
                 .await
                 .with_context(|| {
                     format!(
                         "failed to read replay record #{block_number}, {block_hash} for writing"
                     )
                 })?;
+                anyhow::Ok((block_number, block_hash, replay_record))
+            }
+        })
+        .buffered(decrypt_concurrency);
+    while let Some(record) = records.next().await {
+        let (block_number, block_hash, replay_record) = record?;
         anyhow::ensure!(
             replay_storage
                 .write(Sealed::new_unchecked(replay_record, block_hash), false)
@@ -236,11 +295,62 @@ async fn write_downloaded_object(
     Ok(())
 }
 
+/// Reads and decodes all `(block_hash, record)` candidates present for a block number.
+async fn read_candidate_records(
+    input_root: &Path,
+    block_number: BlockNumber,
+    decoder: &Arc<ReplayRecordDecoder>,
+) -> anyhow::Result<Vec<(BlockHash, ReplayRecord)>> {
+    let block_dir = input_root.join(block_number.to_string());
+    let mut entries = tokio::fs::read_dir(&block_dir).await.with_context(|| {
+        format!(
+            "missing replay archive records for block #{block_number} at {}",
+            block_dir.display()
+        )
+    })?;
+
+    let mut candidates = Vec::new();
+    while let Some(entry) = entries.next_entry().await.with_context(|| {
+        format!(
+            "failed to read replay archive block directory {}",
+            block_dir.display()
+        )
+    })? {
+        let file_type = entry.file_type().await.with_context(|| {
+            format!(
+                "failed to read replay archive entry file type {}",
+                entry.path().display()
+            )
+        })?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let block_hash: BlockHash = file_name
+            .to_str()
+            .and_then(|name| name.parse().ok())
+            .with_context(|| {
+                format!(
+                    "replay archive directory entry {} is not a block hash",
+                    entry.path().display()
+                )
+            })?;
+        let record =
+            read_verified_replay_record(input_root, block_number, block_hash, decoder).await?;
+        candidates.push((block_hash, record));
+    }
+    anyhow::ensure!(
+        !candidates.is_empty(),
+        "no replay archive records found for block #{block_number}"
+    );
+    Ok(candidates)
+}
+
 async fn read_verified_replay_record(
     input_root: &Path,
     block_number: BlockNumber,
     block_hash: BlockHash,
-    decoder: &ReplayRecordDecoder,
+    decoder: &Arc<ReplayRecordDecoder>,
 ) -> anyhow::Result<ReplayRecord> {
     let replay_record_dir = input_root
         .join(block_number.to_string())
@@ -279,7 +389,9 @@ async fn read_verified_replay_record(
                 entry.path().display()
             )
         })?;
-        let record = decoder.decode(record_bytes, &entry.path())?;
+        let record = decoder
+            .decode_off_thread(record_bytes, entry.path())
+            .await?;
         if let Some(canonical_record) = &canonical_record {
             anyhow::ensure!(
                 canonical_record == &record,
@@ -321,6 +433,19 @@ struct ReplayRecordDecoder {
 }
 
 impl ReplayRecordDecoder {
+    /// Decodes on the blocking thread pool: a `GcpKms` identity blocks on a KMS call while
+    /// unwrapping the file key, which must not happen on an async worker thread.
+    async fn decode_off_thread(
+        self: &Arc<Self>,
+        record_bytes: Vec<u8>,
+        path: PathBuf,
+    ) -> anyhow::Result<ReplayRecord> {
+        let decoder = self.clone();
+        tokio::task::spawn_blocking(move || decoder.decode(record_bytes, &path))
+            .await
+            .context("replay archive record decode task panicked")?
+    }
+
     fn decode(&self, mut record_bytes: Vec<u8>, path: &Path) -> anyhow::Result<ReplayRecord> {
         if let Some(identity) = &self.identity {
             record_bytes = age::decrypt(identity, record_bytes.as_slice()).with_context(|| {
@@ -542,6 +667,7 @@ mod tests {
             1,
             block_hash,
             Some(ArchiveIdentity::X25519(identity)),
+            DEFAULT_DECRYPT_CONCURRENCY,
         )
         .await
         .unwrap();

--- a/lib/replay_archive/src/recovery.rs
+++ b/lib/replay_archive/src/recovery.rs
@@ -1,10 +1,12 @@
 use crate::kms::GcpKmsIdentity;
-use crate::{ReplayArchiveKey, ReplayArchiveStorageReader, format_block_hash};
+use crate::{
+    ReplayArchiveKey, ReplayArchiveSession, ReplayArchiveStorageReader, format_block_hash,
+};
 use age_core::format::{FileKey, Stanza};
 use alloy::primitives::{BlockHash, BlockNumber, Sealed};
 use anyhow::Context as _;
 use futures::{StreamExt as _, TryStreamExt as _};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
@@ -20,6 +22,9 @@ use zksync_os_storage_api::{ReplayRecord, WriteReplay};
 /// ```
 ///
 /// This keeps all session copies for the same replay record next to each other.
+///
+/// Objects already present under `output_root` are skipped without re-downloading, so an
+/// interrupted download can be restarted with the same arguments.
 pub async fn download_all_replay_archive_objects<Reader>(
     reader: &Reader,
     output_root: &Path,
@@ -31,16 +36,38 @@ where
         output_root = %output_root.display(),
         "Starting replay archive object download"
     );
-    let mut objects = reader.list_objects().await;
+    let existing = scan_existing_downloaded_objects(output_root).await?;
+    if !existing.is_empty() {
+        tracing::info!(
+            existing = existing.len(),
+            "Resuming download; objects already present locally are skipped"
+        );
+    }
+
+    // Listing and downloading are interleaved page by page: downloads start right after the
+    // first listing page instead of waiting for a full listing of a large archive.
+    let mut page_token = None;
     let mut downloaded = 0;
 
-    while let Some(object) = objects.next().await {
-        let object = object?;
-        write_downloaded_object(output_root, &object.key, object.bytes).await?;
-        downloaded += 1;
-        log_recovery_progress(downloaded, || {
-            tracing::info!(downloaded, "Downloaded replay archive objects");
-        });
+    loop {
+        let page = reader.list_keys_page(page_token.take()).await?;
+
+        for key in page.keys {
+            if existing.contains(&key) {
+                continue;
+            }
+            let bytes = reader.fetch_object(&key).await?;
+            write_downloaded_object(output_root, &key, bytes).await?;
+            downloaded += 1;
+            log_recovery_progress(downloaded, || {
+                tracing::info!(downloaded, "Downloaded replay archive objects");
+            });
+        }
+
+        match page.next_page_token {
+            Some(token) => page_token = Some(token),
+            None => break,
+        }
     }
 
     tracing::info!(downloaded, "Finished replay archive object download");
@@ -244,9 +271,76 @@ pub async fn recover_replay_records_to_rocksdb_with_optional_decryption(
 }
 
 fn log_recovery_progress(count: usize, log: impl FnOnce()) {
-    if count <= 10 || count.is_power_of_two() || count.is_multiple_of(1_000) {
+    if count.is_multiple_of(50) {
         log();
     }
+}
+
+/// Scans an existing download output root for already-downloaded objects.
+///
+/// Entries that do not parse as `<block_number>/<block_hash>/<session>` are ignored,
+/// including `.partial` files left behind by an interrupted write: they get re-downloaded
+/// and overwritten.
+async fn scan_existing_downloaded_objects(
+    output_root: &Path,
+) -> anyhow::Result<HashSet<ReplayArchiveKey>> {
+    let mut existing = HashSet::new();
+    if !tokio::fs::try_exists(output_root).await? {
+        return Ok(existing);
+    }
+
+    let mut block_entries = tokio::fs::read_dir(output_root).await.with_context(|| {
+        format!(
+            "failed to read replay archive recovery root {}",
+            output_root.display()
+        )
+    })?;
+    while let Some(block_entry) = block_entries.next_entry().await? {
+        let Ok(block_number) = block_entry
+            .file_name()
+            .to_string_lossy()
+            .parse::<BlockNumber>()
+        else {
+            continue;
+        };
+        if !block_entry.file_type().await?.is_dir() {
+            continue;
+        }
+
+        let mut hash_entries = tokio::fs::read_dir(block_entry.path()).await?;
+        while let Some(hash_entry) = hash_entries.next_entry().await? {
+            let Ok(block_hash) = hash_entry
+                .file_name()
+                .to_string_lossy()
+                .parse::<BlockHash>()
+            else {
+                continue;
+            };
+            if !hash_entry.file_type().await?.is_dir() {
+                continue;
+            }
+
+            let mut session_entries = tokio::fs::read_dir(hash_entry.path()).await?;
+            while let Some(session_entry) = session_entries.next_entry().await? {
+                let file_name = session_entry.file_name();
+                let file_name = file_name.to_string_lossy();
+                // Session node ids may contain dots, so a `.partial` leftover would parse
+                // as a session; exclude it explicitly.
+                if file_name.ends_with(".partial") {
+                    continue;
+                }
+                let Ok(session) = file_name.parse::<ReplayArchiveSession>() else {
+                    continue;
+                };
+                if !session_entry.file_type().await?.is_file() {
+                    continue;
+                }
+                existing.insert(ReplayArchiveKey::new(session, block_number, block_hash));
+            }
+        }
+    }
+
+    Ok(existing)
 }
 
 async fn write_downloaded_object(
@@ -269,29 +363,43 @@ async fn write_downloaded_object(
         )
     })?;
 
+    // Write to a temporary name and rename so that an object file only exists under its
+    // final name once fully written; interrupted downloads leave `.partial` files that the
+    // resume scan ignores and the next attempt overwrites.
+    let partial_path = output_path.with_file_name(format!("{}.partial", key.session.folder_name()));
     let mut file = tokio::fs::OpenOptions::new()
         .write(true)
-        .create_new(true)
-        .open(&output_path)
+        .create(true)
+        .truncate(true)
+        .open(&partial_path)
         .await
         .with_context(|| {
             format!(
                 "failed to create replay archive recovery object {}",
-                output_path.display()
+                partial_path.display()
             )
         })?;
     file.write_all(&object).await.with_context(|| {
         format!(
             "failed to write replay archive recovery object {}",
-            output_path.display()
+            partial_path.display()
         )
     })?;
     file.flush().await.with_context(|| {
         format!(
             "failed to flush replay archive recovery object {}",
-            output_path.display()
+            partial_path.display()
         )
     })?;
+    drop(file);
+    tokio::fs::rename(&partial_path, &output_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to finalize replay archive recovery object {}",
+                output_path.display()
+            )
+        })?;
     Ok(())
 }
 
@@ -568,6 +676,66 @@ mod tests {
             .await
             .unwrap(),
             b"second"
+        );
+    }
+
+    #[tokio::test]
+    async fn restarted_download_skips_complete_objects_and_redownloads_partial_ones() {
+        let archive_root = tempfile::tempdir().unwrap();
+        let output_root = tempfile::tempdir().unwrap();
+        let block_hash = B256::with_last_byte(1);
+
+        let session = ReplayArchiveSession::new(42, "node-a").unwrap();
+        let storage =
+            FileSystemReplayArchiveStorage::init(archive_root.path().to_path_buf(), session)
+                .await
+                .unwrap();
+        storage
+            .append_object(7, block_hash, b"first".to_vec())
+            .await
+            .unwrap();
+        storage
+            .append_object(8, block_hash, b"second".to_vec())
+            .await
+            .unwrap();
+
+        let reader = FileSystemReplayArchiveReader::new(archive_root.path().to_path_buf());
+        let downloaded = download_all_replay_archive_objects(&reader, output_root.path())
+            .await
+            .unwrap();
+        assert_eq!(downloaded, 2);
+
+        // A fully downloaded tree is a no-op to re-download.
+        let downloaded = download_all_replay_archive_objects(&reader, output_root.path())
+            .await
+            .unwrap();
+        assert_eq!(downloaded, 0);
+
+        // Simulate an interrupted download: one object exists only as a truncated
+        // `.partial` leftover. It must be re-downloaded, not treated as complete.
+        let hash_dir = output_root
+            .path()
+            .join("8")
+            .join(crate::format_block_hash(block_hash));
+        tokio::fs::remove_file(hash_dir.join("42-node-a"))
+            .await
+            .unwrap();
+        tokio::fs::write(hash_dir.join("42-node-a.partial"), b"sec")
+            .await
+            .unwrap();
+
+        let downloaded = download_all_replay_archive_objects(&reader, output_root.path())
+            .await
+            .unwrap();
+        assert_eq!(downloaded, 1);
+        assert_eq!(
+            tokio::fs::read(hash_dir.join("42-node-a")).await.unwrap(),
+            b"second"
+        );
+        assert!(
+            !tokio::fs::try_exists(hash_dir.join("42-node-a.partial"))
+                .await
+                .unwrap()
         );
     }
 

--- a/lib/replay_archive/src/s3.rs
+++ b/lib/replay_archive/src/s3.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ReplayArchiveKey, ReplayArchiveObject, ReplayArchiveObjectStream, ReplayArchiveSession,
-    ReplayArchiveStorage, ReplayArchiveStorageReader,
+    ReplayArchiveKey, ReplayArchiveKeyPage, ReplayArchiveSession, ReplayArchiveStorage,
+    ReplayArchiveStorageReader,
 };
 use alloy::primitives::{BlockHash, BlockNumber};
 use anyhow::Context as _;
@@ -8,10 +8,7 @@ use async_trait::async_trait;
 use aws_config::{BehaviorVersion, ConfigLoader, Region, meta::region::RegionProviderChain};
 use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
 use aws_sdk_s3::{Client, primitives::ByteStream};
-use futures::StreamExt as _;
 use std::path::PathBuf;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 
 /// Authentication mode for S3 replay archive access.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -185,16 +182,66 @@ impl S3ReplayArchiveReader {
 
 #[async_trait]
 impl ReplayArchiveStorageReader for S3ReplayArchiveReader {
-    async fn list_objects(&self) -> ReplayArchiveObjectStream {
-        let config = self.config.clone();
-        let client = self.client.clone();
-        let (sender, receiver) = mpsc::channel(crate::REPLAY_ARCHIVE_OBJECT_LIST_CHANNEL_SIZE);
-        tokio::spawn(async move {
-            if let Err(err) = list_objects(config, client, sender.clone()).await {
-                let _ = sender.send(Err(err)).await;
+    async fn list_keys_page(
+        &self,
+        page_token: Option<String>,
+    ) -> anyhow::Result<ReplayArchiveKeyPage> {
+        let mut request = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.config.bucket_base_url);
+        if let Some(token) = page_token {
+            request = request.continuation_token(token);
+        }
+        let response = request.send().await.with_context(|| {
+            format!(
+                "failed to list replay archive S3 objects in s3://{}",
+                self.config.bucket_base_url
+            )
+        })?;
+
+        let mut keys = Vec::new();
+        for object in response.contents() {
+            let Some(object_key) = object.key() else {
+                continue;
+            };
+            if let Some(key) = crate::parse_archive_object_key(object_key)? {
+                keys.push(key);
             }
-        });
-        ReceiverStream::new(receiver).boxed()
+        }
+        Ok(ReplayArchiveKeyPage {
+            keys,
+            next_page_token: response.next_continuation_token().map(str::to_owned),
+        })
+    }
+
+    async fn fetch_object(&self, key: &ReplayArchiveKey) -> anyhow::Result<Vec<u8>> {
+        let object_key = key.object_path();
+        let bytes = self
+            .client
+            .get_object()
+            .bucket(&self.config.bucket_base_url)
+            .key(&object_key)
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to read replay archive S3 object s3://{}/{}",
+                    self.config.bucket_base_url, object_key
+                )
+            })?
+            .body
+            .collect()
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to collect replay archive S3 object s3://{}/{}",
+                    self.config.bucket_base_url, object_key
+                )
+            })?
+            .into_bytes()
+            .to_vec();
+        Ok(bytes)
     }
 }
 
@@ -223,75 +270,6 @@ fn get_client_config(auth_mode: S3ReplayArchiveAuthMode) -> ConfigLoader {
             aws_config::defaults(BehaviorVersion::latest()).no_credentials()
         }
     }
-}
-
-async fn list_objects(
-    config: S3ReplayArchiveConfig,
-    client: Client,
-    sender: mpsc::Sender<anyhow::Result<ReplayArchiveObject>>,
-) -> anyhow::Result<()> {
-    let mut continuation_token = None;
-
-    loop {
-        let mut request = client.list_objects_v2().bucket(&config.bucket_base_url);
-        if let Some(token) = &continuation_token {
-            request = request.continuation_token(token);
-        }
-
-        let response = request.send().await.with_context(|| {
-            format!(
-                "failed to list replay archive S3 objects in s3://{}",
-                config.bucket_base_url
-            )
-        })?;
-
-        for object in response.contents() {
-            let Some(object_key) = object.key() else {
-                continue;
-            };
-            let Some(key) = crate::parse_archive_object_key(object_key)? else {
-                continue;
-            };
-            let bytes = client
-                .get_object()
-                .bucket(&config.bucket_base_url)
-                .key(object_key)
-                .send()
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to read replay archive S3 object s3://{}/{}",
-                        config.bucket_base_url, object_key
-                    )
-                })?
-                .body
-                .collect()
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to collect replay archive S3 object s3://{}/{}",
-                        config.bucket_base_url, object_key
-                    )
-                })?
-                .into_bytes()
-                .to_vec();
-
-            if sender
-                .send(Ok(ReplayArchiveObject { key, bytes }))
-                .await
-                .is_err()
-            {
-                return Ok(());
-            }
-        }
-
-        let Some(next_token) = response.next_continuation_token() else {
-            break;
-        };
-        continuation_token = Some(next_token.to_owned());
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1669,6 +1669,17 @@ pub enum ReplayArchiveEncryptionConfig {
         /// age X25519 recipient public key. The node only needs this public key.
         recipient: String,
     },
+    GcpKms {
+        /// GCP KMS key version resource name
+        /// (`projects/../locations/../keyRings/../cryptoKeys/../cryptoKeyVersions/..`).
+        /// The key must have purpose `ASYMMETRIC_DECRYPT` and an `RSA_DECRYPT_OAEP_*_SHA256`
+        /// algorithm. The node only fetches the public key and encrypts locally; it does not
+        /// need decrypt permissions.
+        kms_key_version: String,
+        /// Path to the GCP credentials file for KMS access. Ambient authentication (e.g.
+        /// workload identity) is used when absent.
+        kms_credential_file_path: Option<PathBuf>,
+    },
 }
 
 impl From<ReplayArchiveConfig> for zksync_os_replay_archive::ReplayArchiveConfig {
@@ -1739,6 +1750,15 @@ impl From<ReplayArchiveEncryptionConfig>
             ReplayArchiveEncryptionConfig::AgeX25519 { recipient } => {
                 zksync_os_replay_archive::ReplayArchiveEncryptionConfig::AgeX25519 { recipient }
             }
+            ReplayArchiveEncryptionConfig::GcpKms {
+                kms_key_version,
+                kms_credential_file_path,
+            } => zksync_os_replay_archive::ReplayArchiveEncryptionConfig::GcpKms {
+                config: zksync_os_replay_archive::GcpKmsConfig {
+                    key_version: kms_key_version,
+                    credentials_file: kms_credential_file_path,
+                },
+            },
         }
     }
 }
@@ -2601,9 +2621,37 @@ mod tests {
                 ReplayArchiveEncryptionConfig::AgeX25519 { recipient } => {
                     assert_eq!(recipient, "age1recipient");
                 }
-                ReplayArchiveEncryptionConfig::Noop => {
-                    panic!("expected age X25519 replay archive encryption")
+                _ => panic!("expected age X25519 replay archive encryption"),
+            },
+            _ => panic!("expected file system replay archive config"),
+        }
+    }
+
+    #[test]
+    fn replay_archive_config_parses_gcp_kms_encryption() {
+        let config = parse_replay_archive_config([
+            ("REPLAY_ARCHIVE_TYPE", "FileSystem"),
+            ("REPLAY_ARCHIVE_ROOT_PATH", "/tmp/replay-archive"),
+            ("REPLAY_ARCHIVE_ENCRYPTION_TYPE", "GcpKms"),
+            (
+                "REPLAY_ARCHIVE_ENCRYPTION_KMS_KEY_VERSION",
+                "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+            ),
+        ]);
+
+        match config {
+            ReplayArchiveConfig::FileSystem { encryption, .. } => match encryption {
+                ReplayArchiveEncryptionConfig::GcpKms {
+                    kms_key_version,
+                    kms_credential_file_path,
+                } => {
+                    assert_eq!(
+                        kms_key_version,
+                        "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1"
+                    );
+                    assert_eq!(kms_credential_file_path, None);
                 }
+                _ => panic!("expected GCP KMS replay archive encryption"),
             },
             _ => panic!("expected file system replay archive config"),
         }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1669,6 +1669,8 @@ pub enum ReplayArchiveEncryptionConfig {
         /// age X25519 recipient public key. The node only needs this public key.
         recipient: String,
     },
+    /// GCP KMS encryption using ambient authentication (workload identity). This is the
+    /// recommended mode when the node runs on GCP.
     GcpKms {
         /// GCP KMS key version resource name
         /// (`projects/../locations/../keyRings/../cryptoKeys/../cryptoKeyVersions/..`).
@@ -1676,9 +1678,14 @@ pub enum ReplayArchiveEncryptionConfig {
         /// algorithm. The node only fetches the public key and encrypts locally; it does not
         /// need decrypt permissions.
         kms_key_version: String,
-        /// Path to the GCP credentials file for KMS access. Ambient authentication (e.g.
-        /// workload identity) is used when absent.
-        kms_credential_file_path: Option<PathBuf>,
+    },
+    /// GCP KMS encryption authenticating via a credentials file, for deployments not running
+    /// on GCP.
+    GcpKmsWithCredentialFile {
+        /// GCP KMS key version resource name; see `GcpKms`.
+        kms_key_version: String,
+        /// Path to the GCP credentials file.
+        kms_credential_file_path: PathBuf,
     },
 }
 
@@ -1750,13 +1757,24 @@ impl From<ReplayArchiveEncryptionConfig>
             ReplayArchiveEncryptionConfig::AgeX25519 { recipient } => {
                 zksync_os_replay_archive::ReplayArchiveEncryptionConfig::AgeX25519 { recipient }
             }
-            ReplayArchiveEncryptionConfig::GcpKms {
+            ReplayArchiveEncryptionConfig::GcpKms { kms_key_version } => {
+                zksync_os_replay_archive::ReplayArchiveEncryptionConfig::GcpKms {
+                    config: zksync_os_replay_archive::GcpKmsConfig {
+                        key_version: kms_key_version,
+                        auth_mode: zksync_os_replay_archive::GcpKmsAuthMode::Authenticated,
+                    },
+                }
+            }
+            ReplayArchiveEncryptionConfig::GcpKmsWithCredentialFile {
                 kms_key_version,
                 kms_credential_file_path,
             } => zksync_os_replay_archive::ReplayArchiveEncryptionConfig::GcpKms {
                 config: zksync_os_replay_archive::GcpKmsConfig {
                     key_version: kms_key_version,
-                    credentials_file: kms_credential_file_path,
+                    auth_mode:
+                        zksync_os_replay_archive::GcpKmsAuthMode::AuthenticatedWithCredentialFile(
+                            kms_credential_file_path,
+                        ),
                 },
             },
         }
@@ -2641,15 +2659,11 @@ mod tests {
 
         match config {
             ReplayArchiveConfig::FileSystem { encryption, .. } => match encryption {
-                ReplayArchiveEncryptionConfig::GcpKms {
-                    kms_key_version,
-                    kms_credential_file_path,
-                } => {
+                ReplayArchiveEncryptionConfig::GcpKms { kms_key_version } => {
                     assert_eq!(
                         kms_key_version,
                         "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1"
                     );
-                    assert_eq!(kms_credential_file_path, None);
                 }
                 _ => panic!("expected GCP KMS replay archive encryption"),
             },


### PR DESCRIPTION
Adds a GCP KMS recipient/identity to the age-based replay archive encryption, on top of #1426 (reuses its google-cloud-auth stack).

Node side: `REPLAY_ARCHIVE_ENCRYPTION_TYPE=GcpKms` + `REPLAY_ARCHIVE_ENCRYPTION_KMS_KEY_VERSION=projects/../cryptoKeyVersions/..` (ASYMMETRIC_DECRYPT, RSA_DECRYPT_OAEP_*_SHA256), or `GcpKmsWithCredentialFile` off-GCP - mirrors the Gcs/GcsWithCredentialFile auth shape. The node fetches the public key once at startup and wraps each record's age file key locally with RSA-OAEP - encrypt needs only `viewPublicKey`, no decrypt permissions, and the archive format stays age v1 (custom stanza).

Recovery side: `replay_archive_recovery recover-rocksdb --kms-key-version ...` unwraps the file key of every record with one KMS `AsymmetricDecrypt` call - no age secret key exists anywhere, decryption is IAM-revocable and Cloud-Audit-logged per record. Records decode concurrently (`--decrypt-concurrency`, default 32): the chain walk decodes windows of consecutive block numbers speculatively and verifies linkage in memory, and the write pass pipelines decoding ahead of ordered RocksDB writes.

Why: with X25519 the whole archive is retroactively exposed if the single `AGE-SECRET-KEY` line leaks; with KMS the private key never leaves Google's HSM/software keystore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)