### PR TITLE
fix(sequencer): detect EIP-7594 blob support via eth_config

### DIFF
--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -289,9 +289,11 @@ where
                         }
                         tx_request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
 
-                        // Fusaka is active on all real chains, so send the EIP-7594 blob format by
-                        // default. Anvil does not support EIP-7594 yet, so fall back to EIP-4844
-                        // there (see https://github.com/foundry-rs/foundry/issues/12222).
+                        // Send the EIP-7594 blob format when the chain's active fork accepts it
+                        // (probed via `eth_config`, falling back to a chain-id heuristic — see
+                        // `ProviderCapabilities::supports_eip7594`). Pre-Fusaka chains and Anvil
+                        // get the legacy EIP-4844 format
+                        // (see https://github.com/foundry-rs/foundry/issues/12222).
                         if self.provider.capabilities().supports_eip7594 {
                             tx_request.set_blob_sidecar(BlobTransactionSidecarVariant::Eip7594(
                                 blob_sidecar.try_into_7594(EnvKzgSettings::Default.get())?,
@@ -702,8 +704,9 @@ where
             )
             .build();
 
-        // Mirror the submission path: EIP-7594 by default, EIP-4844 only on Anvil. Only consumed
-        // by `build_l1_simulation_request` when a command actually carries a blob sidecar.
+        // Mirror the submission path: EIP-7594 if the chain's active fork accepts it, EIP-4844
+        // otherwise. Only consumed by `build_l1_simulation_request` when a command actually
+        // carries a blob sidecar.
         let use_eip7594_sidecar = self.provider.capabilities().supports_eip7594;
 
         let block_state_calls = commands

--- a/lib/provider/src/lib.rs
+++ b/lib/provider/src/lib.rs
@@ -82,7 +82,9 @@ pub struct ProviderCapabilities {
     /// Whether the RPC implements `eth_getHeaderBy*`. When false, header lookups use
     /// `eth_getBlockBy*` instead.
     pub get_header: bool,
-    /// Whether the underlying node supports the EIP-7594 (Fusaka/PeerDAS) blob format.
+    /// Whether the chain accepts the EIP-7594 (Fusaka/PeerDAS) blob sidecar format. Determined
+    /// from the active fork reported by `eth_config` (EIP-7910) when available, otherwise by
+    /// assuming every chain except the Anvil dev default (chain id 31337) is post-Fusaka.
     pub supports_eip7594: bool,
 }
 
@@ -106,19 +108,81 @@ impl ProviderCapabilities {
         if !finalized_tag {
             tracing::info!("provider lacks the `finalized` block tag; degrading to latest");
         }
-        // A local Anvil dev node (detected by chain id) does not support EIP-7594 blobs yet. On any
-        // probe failure we assume a real node that does support them.
-        let supports_eip7594 = provider
-            .get_chain_id()
-            .await
-            .map(|id| id != ANVIL_L1_CHAIN_ID)
-            .unwrap_or(true);
+        // Prefer asking the node which fork is active via `eth_config` (EIP-7910, mandatory on
+        // Fusaka-ready clients): the EIP-7594 sidecar format is accepted if the chain's current
+        // fork is Osaka or later, regardless of what the client software could support. When the
+        // method is missing or unrecognized, fall back to the chain-id heuristic: a local Anvil
+        // dev node does not support EIP-7594 blobs, and on any probe failure we assume a real
+        // node that does support them.
+        let supports_eip7594 = match Self::probe_eth_config_eip7594(provider).await {
+            Some(supported) => {
+                tracing::info!(
+                    supported,
+                    "determined EIP-7594 blob support from the eth_config fork report"
+                );
+                supported
+            }
+            None => provider
+                .get_chain_id()
+                .await
+                .map(|id| id != ANVIL_L1_CHAIN_ID)
+                .unwrap_or(true),
+        };
         Self {
             get_header,
             finalized_tag,
             supports_eip7594,
         }
     }
+
+    /// Probes EIP-7910 `eth_config` for whether the chain's *currently active* fork accepts the
+    /// EIP-7594 (Fusaka/PeerDAS) blob sidecar format. Returns `None` when the method is missing
+    /// or the response shape is not understood, letting the caller fall back to a heuristic.
+    async fn probe_eth_config_eip7594(provider: &impl Provider<Ethereum>) -> Option<bool> {
+        let config: serde_json::Value = match provider
+            .client()
+            .request("eth_config", NoParams::default())
+            .await
+        {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::info!(
+                    %err,
+                    "eth_config unavailable; using chain-id heuristic for EIP-7594 support"
+                );
+                return None;
+            }
+        };
+        let supported = eth_config_reports_eip7594(&config);
+        if supported.is_none() {
+            tracing::info!(
+                "unrecognized eth_config response; using chain-id heuristic for EIP-7594 support"
+            );
+        }
+        supported
+    }
+}
+
+/// The P256VERIFY (secp256r1) precompile of EIP-7951, which activates in the Osaka fork together
+/// with EIP-7594. `eth_config` does not name forks, so this precompile appearing in the active
+/// fork's precompile map is the signal that the chain accepts cell-proof blob sidecars.
+const P256VERIFY_PRECOMPILE: &str = "0x0000000000000000000000000000000000000100";
+
+/// Interprets an EIP-7910 `eth_config` response: `Some(true)` when the currently active fork
+/// includes EIP-7594, `Some(false)` when it provably does not, `None` when the response carries
+/// no recognizable precompile map. Tolerates both name→address (the EIP-7910 shape) and
+/// address→name precompile-map orientations.
+fn eth_config_reports_eip7594(config: &serde_json::Value) -> Option<bool> {
+    let is_p256verify = |entry: &str| {
+        entry.eq_ignore_ascii_case("P256VERIFY")
+            || entry.eq_ignore_ascii_case(P256VERIFY_PRECOMPILE)
+    };
+    let precompiles = config.get("current")?.get("precompiles")?.as_object()?;
+    Some(
+        precompiles
+            .iter()
+            .any(|(key, value)| is_p256verify(key) || value.as_str().is_some_and(is_p256verify)),
+    )
 }
 
 /// Per-address cache of contract deployment blocks. Cloning a [`NodeProvider`] shares this cache
@@ -820,9 +884,11 @@ mod tests {
     async fn uses_get_header_when_supported() {
         let asserter = Asserter::new();
         // Probe: get_header(latest) ok -> get_header supported; get_header(finalized) ok ->
-        // finalized supported; get_chain_id -> non-anvil.
+        // finalized supported; eth_config unavailable -> chain-id heuristic; get_chain_id ->
+        // non-anvil.
         asserter.push_success(&header_with_number(1));
         asserter.push_success(&header_with_number(1));
+        asserter.push_failure(unsupported_method());
         asserter.push_success(&U64::from(1));
         let provider = NodeProvider::new(mocked_provider(&asserter))
             .await
@@ -845,9 +911,11 @@ mod tests {
     async fn falls_back_to_get_block_when_get_header_unsupported() {
         let asserter = Asserter::new();
         // Probe: get_header(latest) fails -> get_header unsupported; get_block(finalized) ok ->
-        // finalized supported; get_chain_id -> non-anvil.
+        // finalized supported; eth_config unavailable -> chain-id heuristic; get_chain_id ->
+        // non-anvil.
         asserter.push_failure(unsupported_method());
         asserter.push_success(&block_with_number(1));
+        asserter.push_failure(unsupported_method());
         asserter.push_success(&U64::from(1));
         let provider = NodeProvider::new(mocked_provider(&asserter))
             .await
@@ -870,8 +938,10 @@ mod tests {
     async fn degrades_to_latest_when_finalized_unsupported() {
         let asserter = Asserter::new();
         // Probe: get_header(latest) ok -> get_header supported; get_header(finalized) fails ->
-        // finalized unsupported; get_chain_id -> non-anvil.
+        // finalized unsupported; eth_config unavailable -> chain-id heuristic; get_chain_id ->
+        // non-anvil.
         asserter.push_success(&header_with_number(1));
+        asserter.push_failure(unsupported_method());
         asserter.push_failure(unsupported_method());
         asserter.push_success(&U64::from(1));
         let provider = NodeProvider::new(mocked_provider(&asserter))
@@ -891,12 +961,104 @@ mod tests {
         assert!(asserter.read_q().is_empty(), "all responses consumed");
     }
 
+    /// EIP-7910 `eth_config` response with the given active-fork precompile map, mirroring the
+    /// shape Besu/geth return.
+    fn eth_config_with_precompiles(precompiles: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "current": {
+                "activationTime": 0,
+                "blobSchedule": { "baseFeeUpdateFraction": 5007716, "max": 9, "target": 6 },
+                "chainId": "0x9",
+                "forkId": "0x3d641a85",
+                "precompiles": precompiles,
+            },
+            "next": null,
+            "last": null,
+        })
+    }
+
+    #[tokio::test]
+    async fn eth_config_osaka_enables_eip7594() {
+        let asserter = Asserter::new();
+        // Probe: headers ok; eth_config reports P256VERIFY (Osaka active) -> EIP-7594 supported.
+        // No chain-id response is queued: the heuristic must not run when eth_config answers.
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&eth_config_with_precompiles(serde_json::json!({
+            "ECREC": "0x0000000000000000000000000000000000000001",
+            "KZG_POINT_EVALUATION": "0x000000000000000000000000000000000000000a",
+            "P256VERIFY": "0x0000000000000000000000000000000000000100",
+        })));
+        let provider = NodeProvider::new(mocked_provider(&asserter))
+            .await
+            .expect("mocked provider construction should succeed");
+        assert!(provider.capabilities().supports_eip7594);
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn eth_config_pre_osaka_disables_eip7594_regardless_of_chain_id() {
+        let asserter = Asserter::new();
+        // A Cancun-level fork report (what Besu returns on a cancun-only chain): the KZG point
+        // evaluation precompile is present but P256VERIFY is not -> classic EIP-4844 sidecars,
+        // even though the chain id would heuristically be treated as post-Fusaka.
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&eth_config_with_precompiles(serde_json::json!({
+            "ECREC": "0x0000000000000000000000000000000000000001",
+            "SHA256": "0x0000000000000000000000000000000000000002",
+            "KZG_POINT_EVALUATION": "0x000000000000000000000000000000000000000a",
+        })));
+        let provider = NodeProvider::new(mocked_provider(&asserter))
+            .await
+            .expect("mocked provider construction should succeed");
+        assert!(!provider.capabilities().supports_eip7594);
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
+    }
+
+    #[tokio::test]
+    async fn unrecognized_eth_config_falls_back_to_chain_id_heuristic() {
+        let asserter = Asserter::new();
+        // eth_config responds with an unexpected shape -> fall back to get_chain_id (non-anvil).
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&header_with_number(1));
+        asserter.push_success(&serde_json::json!({ "unexpected": "shape" }));
+        asserter.push_success(&U64::from(1));
+        let provider = NodeProvider::new(mocked_provider(&asserter))
+            .await
+            .expect("mocked provider construction should succeed");
+        assert!(provider.capabilities().supports_eip7594);
+        assert!(asserter.read_q().is_empty(), "all responses consumed");
+    }
+
+    #[test]
+    fn eth_config_parser_handles_both_map_orientations() {
+        let by_name = serde_json::json!({
+            "current": { "precompiles": { "P256VERIFY": "0x0000000000000000000000000000000000000100" } }
+        });
+        assert_eq!(eth_config_reports_eip7594(&by_name), Some(true));
+
+        let by_address = serde_json::json!({
+            "current": { "precompiles": { "0x0000000000000000000000000000000000000100": "P256VERIFY" } }
+        });
+        assert_eq!(eth_config_reports_eip7594(&by_address), Some(true));
+
+        let cancun = serde_json::json!({
+            "current": { "precompiles": { "ECREC": "0x0000000000000000000000000000000000000001" } }
+        });
+        assert_eq!(eth_config_reports_eip7594(&cancun), Some(false));
+
+        assert_eq!(eth_config_reports_eip7594(&serde_json::json!({})), None);
+    }
+
     #[tokio::test]
     async fn anvil_chain_id_disables_eip7594() {
         let asserter = Asserter::new();
-        // Probe: get_header(latest) ok; get_header(finalized) ok; get_chain_id -> anvil.
+        // Probe: get_header(latest) ok; get_header(finalized) ok; eth_config unavailable ->
+        // chain-id heuristic; get_chain_id -> anvil.
         asserter.push_success(&header_with_number(1));
         asserter.push_success(&header_with_number(1));
+        asserter.push_failure(unsupported_method());
         asserter.push_success(&U64::from(ANVIL_L1_CHAIN_ID));
         let provider = NodeProvider::new(mocked_provider(&asserter))
             .await


### PR DESCRIPTION
## Problem

When sending blob transactions to L1, the server picks the sidecar format based on the chain id alone: `31337` (Anvil) gets the legacy EIP-4844 format, everything else gets the new EIP-7594 (Fusaka) format.

This guess is wrong for chains that are not on Fusaka but use a non-Anvil chain id — e.g. a private Besu network. There, every commit tx is rejected by the L1 (`blobs failed kzg validation`) and the node shuts down. There is no way to override the guess via config.

## Solution

Ask the L1 node instead of guessing: on startup the server calls `eth_config` (EIP-7910) and picks the blob format based on the fork that is actually active on the chain.

If the RPC does not expose `eth_config` (older nodes, whitelisting proxies), the server falls back to the previous chain-id heuristic, so existing setups keep working unchanged.

Validated against a live Besu QBFT network on Cancun (now gets EIP-4844 sidecars and commits land) and a Sepolia RPC without `eth_config` (falls back, keeps EIP-7594).
