### PR TITLE
fix(l1-sender): retry nonce-class L1 rejections instead of crashing the node

### DIFF
--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -46,8 +46,7 @@ pub struct L1SenderConfig<Input> {
     pub nonce_error_max_attempts: usize,
 
     /// Backoff before retrying after a nonce-class rejection. Gives the node time to settle
-    /// its pool/state view after a block import; the provider re-fills the nonce from a fresh
-    /// pending-count on every attempt.
+    /// its pool/state view after a block import; the retry re-sends the same nonce.
     pub nonce_error_retry_backoff: Duration,
 
     pub phantom_data: PhantomData<Input>,

--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -9,6 +9,11 @@ pub const DEFAULT_REQUIRED_CONFIRMATIONS_L1: u64 = 3;
 /// Kept low because a Gateway with a single connected chain may not produce enough blocks to reach
 /// the L1 default.
 pub const DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY: u64 = 1;
+/// Default max submission attempts per L1 transaction when the node rejects it with a
+/// nonce-class error.
+pub const DEFAULT_NONCE_ERROR_MAX_ATTEMPTS: usize = 5;
+/// Default backoff between attempts after a nonce-class rejection.
+pub const DEFAULT_NONCE_ERROR_RETRY_BACKOFF: Duration = Duration::from_secs(2);
 
 /// Configuration of L1 sender.
 #[derive(Clone, Debug)]
@@ -35,6 +40,15 @@ pub struct L1SenderConfig<Input> {
 
     /// Settlement-layer blocks (inclusive of the inclusion block) before a transaction is confirmed.
     pub required_confirmations: u64,
+
+    /// Max submission attempts per L1 transaction when the node rejects it with a nonce-class
+    /// error.
+    pub nonce_error_max_attempts: usize,
+
+    /// Backoff before retrying after a nonce-class rejection. Gives the node time to settle
+    /// its pool/state view after a block import; the provider re-fills the nonce from a fresh
+    /// pending-count on every attempt.
+    pub nonce_error_retry_backoff: Duration,
 
     pub phantom_data: PhantomData<Input>,
 }

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -314,7 +314,30 @@ where
                     L1_SENDER_METRICS.balance_required_for_tx[&Input::COMPONENT_ID.as_str()]
                         .set(balance_required);
 
-                    let pending_tx = self.provider.send_transaction(tx_request).await?;
+                    // A nonce-class rejection is a definitive refusal (the tx was not admitted to the pool).
+                    // Each retry re-runs the nonce filler against a fresh pending-count, so bounded retries
+                    // self-heal instead of crashing the node.
+                    let mut send_attempt = 1;
+                    let pending_tx = loop {
+                        match self.provider.send_transaction(tx_request.clone()).await {
+                            Ok(pending_tx) => break pending_tx,
+                            Err(err)
+                                if is_nonce_error(&err)
+                                    && send_attempt < self.config.nonce_error_max_attempts =>
+                            {
+                                tracing::warn!(
+                                    command_name,
+                                    range,
+                                    send_attempt,
+                                    %err,
+                                    "L1 node rejected the transaction with a nonce error; retrying"
+                                );
+                                tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
+                                send_attempt += 1;
+                            }
+                            Err(err) => return Err(err.into()),
+                        }
+                    };
                     let submitted_at = Instant::now();
                     let tx_hash = *pending_tx.tx_hash();
                     let receipt_fut = self.wait_for_confirmed_receipt(tx_hash);
@@ -923,6 +946,19 @@ where
     }
 }
 
+/// Nonce-class `eth_sendRawTransaction` rejections.
+fn is_nonce_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ErrorResp(payload) => {
+            let message = payload.message.to_lowercase();
+            message.contains("nonce too low")
+                || message.contains("nonce too high")
+                || message.contains("nonce gap")
+        }
+        _ => false,
+    }
+}
+
 /// Combines operator-configured fee caps with the network's EIP-1559 estimate.
 ///
 /// `max_fee_per_gas` and `max_fee_per_blob_gas` are taken verbatim from
@@ -990,6 +1026,45 @@ impl L1SenderFeeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nonce_error_classification() {
+        use alloy::rpc::json_rpc::ErrorPayload;
+        use alloy::transports::TransportErrorKind;
+
+        let resp = |message: &str| {
+            TransportError::ErrorResp(ErrorPayload {
+                code: -32000,
+                message: message.to_string().into(),
+                data: None,
+            })
+        };
+
+        // reth rejects a nonce-gapped blob transaction with exactly "nonce too high"; geth
+        // appends details after the same prefix; some clients capitalize.
+        assert!(is_nonce_error(&resp("nonce too high")));
+        assert!(is_nonce_error(&resp(
+            "nonce too high: tx nonce 7, gapped nonce 5"
+        )));
+        assert!(is_nonce_error(&resp(
+            "nonce too low: next nonce 5, tx nonce 3"
+        )));
+        assert!(is_nonce_error(&resp("Nonce too high")));
+        assert!(is_nonce_error(&resp("nonce gap for sender")));
+
+        // Non-nonce rejections and transport-level failures are not retryable here: a
+        // transport failure is ambiguous (the tx may have been admitted), so it must
+        // propagate rather than trigger a re-send.
+        assert!(!is_nonce_error(&resp(
+            "insufficient funds for gas * price + value"
+        )));
+        assert!(!is_nonce_error(&resp(
+            "replacement transaction underpriced"
+        )));
+        assert!(!is_nonce_error(&TransportErrorKind::custom_str(
+            "error sending request"
+        )));
+    }
 
     #[test]
     fn blob_simulation_request_is_buildable_only_with_sidecar() {

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -236,11 +236,19 @@ where
             L1_SENDER_METRICS.parallel_transactions[&command_name].set(commands.len() as u64);
 
             let operator_address = self.operator_address().await?;
+            // One pending-count read per cycle. The account is quiescent here (prior cycle's txs
+            // are confirmed), so this baseline is race-free; used for both simulation and sends.
+            let base_nonce = self
+                .provider
+                .get_transaction_count(operator_address)
+                .pending()
+                .await
+                .context("get pending nonce for L1 sender cycle")?;
             let sim_fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;
             let gas_limits = self
-                .estimate_gas_limits(&commands, operator_address, sim_fee_params)
+                .estimate_gas_limits(&commands, operator_address, sim_fee_params, base_nonce)
                 .await?;
             tracing::info!(
                 command_name,
@@ -254,8 +262,8 @@ where
             // This holds true because l1 transactions are included in the order of sender nonce.
             // Keep this in mind if changing sending logic (that is, if adding `buffer` we'd need to set nonce manually)
             let pending_txs: Vec<PendingTx<Input>> =
-            futures::stream::iter(commands.into_iter().zip(gas_limits))
-                .then(|(mut cmd, gas_limit)| {
+            futures::stream::iter(commands.into_iter().zip(gas_limits).enumerate())
+                .then(|(nonce_offset, (mut cmd, gas_limit))| {
                     let range = range.clone();
                     async move {
                     let fee_params = self
@@ -266,6 +274,7 @@ where
                     .await?;
                     let mut tx_request = TransactionRequest::default()
                         .with_from(operator_address)
+                        .with_nonce(base_nonce + nonce_offset as u64)
                         .with_max_fee_per_gas(fee_params.max_fee_per_gas)
                         .with_max_priority_fee_per_gas(fee_params.max_priority_fee_per_gas)
                         .with_gas_limit(gas_limit)
@@ -314,9 +323,9 @@ where
                     L1_SENDER_METRICS.balance_required_for_tx[&Input::COMPONENT_ID.as_str()]
                         .set(balance_required);
 
-                    // A nonce-class rejection is a definitive refusal (the tx was not admitted to the pool).
-                    // Each retry re-runs the nonce filler against a fresh pending-count, so bounded retries
-                    // self-heal instead of crashing the node.
+                    // A nonce-class rejection is a definitive refusal (tx not admitted), typically a
+                    // transient pool/state view inconsistency around a block import. The nonce is
+                    // fixed for this cycle, so re-sending it unchanged after a backoff self-heals.
                     let mut send_attempt = 1;
                     let pending_tx = loop {
                         match self.provider.send_transaction(tx_request.clone()).await {
@@ -704,15 +713,10 @@ where
         commands: &[Input],
         operator_address: Address,
         fee_params: FeeParams,
+        // Sequential nonces start here — anvil's EIP-4844 parsing requires `nonce` and
+        // `gas_limit` even with `validation=false`. Matches the send nonces.
+        starting_nonce: u64,
     ) -> anyhow::Result<Vec<u64>> {
-        // Sequential nonces from the operator's pending count — anvil's EIP-4844 parsing
-        // requires `nonce` and `gas_limit` even with `validation=false`.
-        let starting_nonce = self
-            .provider
-            .get_transaction_count(operator_address)
-            .pending()
-            .await
-            .context("get pending nonce for L1 sender gas estimation")?;
         // Some L1 providers check sender balance even with `validation=false`; override
         // to bypass.
         let balance_override = StateOverridesBuilder::default()

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -25,6 +25,7 @@ use zksync_os_l1_sender::commands::commit::CommitCommand;
 use zksync_os_l1_sender::commands::execute::ExecuteCommand;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
 use zksync_os_l1_sender::config::{
+    DEFAULT_NONCE_ERROR_MAX_ATTEMPTS, DEFAULT_NONCE_ERROR_RETRY_BACKOFF,
     DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY, DEFAULT_REQUIRED_CONFIRMATIONS_L1,
 };
 use zksync_os_mempool::SubPoolLimit;
@@ -1267,6 +1268,16 @@ pub struct L1SenderConfig {
     #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_L1)]
     pub required_confirmations: u64,
 
+    /// Max submission attempts per L1 transaction when the L1 node rejects it with a
+    /// nonce-class error.
+    #[config(default_t = DEFAULT_NONCE_ERROR_MAX_ATTEMPTS)]
+    pub nonce_error_max_attempts: usize,
+
+    /// Backoff between attempts after a nonce-class rejection. Gives the L1 node time to
+    /// settle its pool/state view after a block import.
+    #[config(default_t = DEFAULT_NONCE_ERROR_RETRY_BACKOFF)]
+    pub nonce_error_retry_backoff: Duration,
+
     /// Whether L1 senders are enabled.
     /// Only affects the Main Node.
     /// Only useful for debug. When L1 senders are disabled,
@@ -1365,6 +1376,16 @@ pub struct GatewaySenderConfig {
     /// Gateway blocks (inclusive of the inclusion block) before a transaction is confirmed.
     #[config(default_t = DEFAULT_REQUIRED_CONFIRMATIONS_GATEWAY)]
     pub required_confirmations: u64,
+
+    /// Max submission attempts per Gateway transaction when the Gateway node rejects it with
+    /// a nonce-class error.
+    #[config(default_t = DEFAULT_NONCE_ERROR_MAX_ATTEMPTS)]
+    pub nonce_error_max_attempts: usize,
+
+    /// Backoff between attempts after a nonce-class rejection. Gives the Gateway node time
+    /// to settle its pool/state view after a block import.
+    #[config(default_t = DEFAULT_NONCE_ERROR_RETRY_BACKOFF)]
+    pub nonce_error_retry_backoff: Duration,
 }
 
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig)]
@@ -2131,6 +2152,8 @@ impl L1SenderConfig {
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
             required_confirmations: self.required_confirmations,
+            nonce_error_max_attempts: self.nonce_error_max_attempts,
+            nonce_error_retry_backoff: self.nonce_error_retry_backoff,
             phantom_data: Default::default(),
         }
     }
@@ -2189,6 +2212,8 @@ impl GatewaySenderConfig {
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
             required_confirmations: self.required_confirmations,
+            nonce_error_max_attempts: self.nonce_error_max_attempts,
+            nonce_error_retry_backoff: self.nonce_error_retry_backoff,
             phantom_data: Default::default(),
         }
     }
@@ -2580,6 +2605,8 @@ mod tests {
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),
                 required_confirmations: DEFAULT_REQUIRED_CONFIRMATIONS_L1,
+                nonce_error_max_attempts: DEFAULT_NONCE_ERROR_MAX_ATTEMPTS,
+                nonce_error_retry_backoff: DEFAULT_NONCE_ERROR_RETRY_BACKOFF,
                 enabled: true,
                 pubdata_mode: Some(PubdataMode::Blobs),
                 max_batch_diff_to_upstream: None,


### PR DESCRIPTION
## Summary

`l1_sender_commit` occasionally panics with:

```
Critical task `l1_sender_commit` panicked: `pipeline segment failed: server returned an error response: error code -32000: nonce too high`
```

The nonce for each L1 transaction is derived from the node's `eth_getTransactionCount(pending)`. When a block containing our previous transactions is imported on the L1 node mid-burst, the node's pool/state views are momentarily inconsistent, and a freshly submitted transaction can be seen as nonce-gapped. Gapped **blob** transactions are rejected outright (reth: `-32000 "nonce too high"`) instead of being queued — and any send error was fatal for the whole node. The rejection is transient: the same transaction is accepted seconds later (which is why a restart always recovered).

## Fix

Classify nonce-class `eth_sendRawTransaction` rejections (`nonce too low` / `nonce too high` / `nonce gap`) and retry them with a bounded backoff. Such a rejection is a definitive refusal — the transaction was **not** admitted to the pool — so re-sending is safe. Each retry re-runs with the same nonce. All other errors (including ambiguous transport failures) still propagate and remain fatal.

## Config

Two new **optional** settings, available in both `l1_sender` and `gateway_sender` sections (shown with default values):

```yaml
l1_sender:
  # Total submission attempts per transaction on nonce-class rejections
  # (5 = 1 initial send + up to 4 retries). Set to 1 to disable retrying.
  nonce_error_max_attempts: 5
  # Backoff between attempts.
  nonce_error_retry_backoff: 2s

gateway_sender:
  nonce_error_max_attempts: 5
  nonce_error_retry_backoff: 2s
```

No action needed on rollout — defaults apply if unset.
