### PR TITLE
feat(network): restrict external nodes to trusted peers only

### DIFF
--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -346,6 +346,8 @@ impl NetworkService {
         let boot_nodes = resolve_boot_nodes_with_retry(config.boot_nodes.clone()).await?;
         tracing::info!(?genesis, ?fork_id, "initializing p2p network service");
         let (protocol_tx, protocol_rx) = mpsc::unbounded_channel();
+        // ENs only sync/verify against trusted peers; a main node must still accept untrusted ENs.
+        let trusted_nodes_only = matches!(protocol_config, ZksProtocolConfig::ExternalNode(_));
         let cfg_builder = RethNetworkConfig::builder(config.secret_key, runtime)
             .boot_nodes(boot_nodes)
             // Configure node identity
@@ -403,7 +405,8 @@ impl NetworkService {
                     .with_enforce_enr_fork_id(true)
                     // Treat boot nodes as trusted peers: always keep and redial them (e.g. an EN
                     // pinning the main node) so replay sync never gets stranded on non-serving peers.
-                    .with_trusted_nodes(config.boot_nodes.clone()),
+                    .with_trusted_nodes(config.boot_nodes.clone())
+                    .with_trusted_nodes_only(trusted_nodes_only),
             )
             .discovery_addr(rlpx_address)
             // Disable transaction gossip as it is unsupported by ZKsync OS


### PR DESCRIPTION
Enable reth `trusted_nodes_only` on external nodes, so an EN only connects to its configured boot/trusted peers — reth won't dial or accept anyone else. Main nodes keep it off (they must still accept untrusted ENs to serve replays).

**Why:** blocks are unsigned, so an EN syncing from an arbitrary discovered peer could be fed forged blocks. An EN only ever syncs/verifies against the main node anyway.

**Note:** breaking — an EN whose `boot_nodes` omits its main node will no longer connect/sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)