### PR TITLE
fix(deps): update crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3997,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0204 (invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared`) was published today and now fails the cargo-deny advisories check on main and on every open PR — today's scheduled Security audit run on main is red.

This bumps the locked `crossbeam-epoch` from 0.9.18 to 0.9.20 (semver-patch), where the issue is fixed. Lockfile-only change, no manifest edits.

Verified locally with `cargo deny check advisories`: the vulnerability is no longer reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)