### PR TITLE
ci: re-enable code coverage job on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,38 +99,35 @@ jobs:
           compare_to_earlier_commit: false # Do not compare with `main` due to different number of iterations
 
 
-  # Temporary disable code coverage measurements in main due to llvm-cov issue with rustc v1.89:
-  # https://github.com/rust-lang/rust/issues/141577
-  # TODO: re-enable the job after upgrading Rust to >=1.90
   ######################################
   # Measure code coverage on main push #
   ######################################
-  # code-coverage:
-  #   # Code coverage is measured only on push to main branch
-  #   # as it slows down PR testing significantly (2m -> 15m for tests execution)
-  #   # due to overhead with LLVM instrumentation.
-  #   # So, we keep the main numbers, but not force every PR to wait for it.
-  #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-  #   runs-on: matterlabs-ci-runner-high-performance
-  #   env:
-  #     RUSTC_BOOTSTRAP: 1
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #
-  #     - name: Setup runner
-  #       uses: ./.github/actions/runner-setup
-  #
-  #     - name: Measure coverage
-  #       run: cargo llvm-cov --lcov --output-path lcov.info nextest --workspace --release --profile coverage
-  #
-  #     - name: Generate codecov report
-  #       uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
-  #       if: always() && !cancelled()
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         files: lcov.info
-  #         slug: ${{ github.repository }}
+  code-coverage:
+    # Code coverage is measured only on push to main branch
+    # as it slows down PR testing significantly (2m -> 15m for tests execution)
+    # due to overhead with LLVM instrumentation.
+    # So, we keep the main numbers, but not force every PR to wait for it.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: matterlabs-ci-runner-high-performance
+    env:
+      RUSTC_BOOTSTRAP: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup runner
+        uses: ./.github/actions/runner-setup
+
+      - name: Measure coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info nextest --workspace --release --profile coverage
+
+      - name: Generate codecov report
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+        if: always() && !cancelled()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          slug: ${{ github.repository }}
 
 
   ############################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
     # as it slows down PR testing significantly (2m -> 15m for tests execution)
     # due to overhead with LLVM instrumentation.
     # So, we keep the main numbers, but not force every PR to wait for it.
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: matterlabs-ci-runner-high-performance
     env:
       RUSTC_BOOTSTRAP: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
     # as it slows down PR testing significantly (2m -> 15m for tests execution)
     # due to overhead with LLVM instrumentation.
     # So, we keep the main numbers, but not force every PR to wait for it.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: matterlabs-ci-runner-high-performance
     env:
       RUSTC_BOOTSTRAP: 1


### PR DESCRIPTION
## What

Re-enables the `code-coverage` job in `ci.yml` that was temporarily disabled due to a cargo-llvm-cov issue with rustc 1.89 ([rust-lang/rust#141577](https://github.com/rust-lang/rust/issues/141577)).

## Why now

- The upstream issue was closed as fixed on 2025-09-01.
- The workspace toolchain is `nightly-2026-01-22`, well past both the fix and the ">=1.90" bar from the TODO.
- The `coverage` nextest profile and the `cargo-llvm-cov` install in `runner-setup` are still in place.

The job is uncommented as-is, with the `actions/checkout` pin updated to v7.0.0 to match #1441.

## Verification

The job only runs on push to `main`, so it won't execute on this PR — the first real run happens after merge. Worth watching the first main push to confirm coverage lands in Codecov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
