### PR TITLE
perf(l1_sender): improve fees and metrics usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,18 @@ If the PR title uses the breaking-change marker (`feat!: ...`, `fix!: ...`), you
 ### Wire format immutability
 
 Do **not** modify existing versioned wire format files under `lib/network/src/wire/replays/v*.rs`. Add a new versioned file instead.
+
+### Comments
+Comment **why**, not **what**. The code shows what it does; comments explain intent, invariants, and non-obvious decisions. No comments on self-evident code.
+
+✅ **Comment when:**
+- Non-obvious behavior or edge cases
+- Performance trade-offs
+- Safety requirements (unsafe blocks must always be documented)
+- Limitations, constraints, assumptions or gotchas
+- Why simpler alternatives don't work
+
+❌ **Don't comment when:**
+- Code is self-explanatory
+- Just restating the code in English
+- Describing what changed in this PR

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -244,9 +244,12 @@ where
                 .pending()
                 .await
                 .context("get pending nonce for L1 sender cycle")?;
-            // Resolved once per cycle and reused for both simulation and every send below:
-            // L1 fees move at most once per L1 block, slower than a send cycle, and each
-            // resolution costs an RPC round-trip per command otherwise.
+            // Resolved once per cycle and reused for both simulation and every send below.
+            // Freshness is not load-bearing: the submitted max-fee/blob-fee caps are
+            // config-bound (`apply_fee_caps` only trims the priority tip by the estimate),
+            // and fee adequacy is decided at inclusion time — txs sit in the pool longer
+            // than any intra-cycle drift. Re-resolving per command would cost an RPC
+            // round-trip per tx without adding protection.
             let fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -244,10 +244,12 @@ where
                 .pending()
                 .await
                 .context("get pending nonce for L1 sender cycle")?;
-            // Resolved once per cycle, not per command: fee caps are config-bound and
-            // whether a fee is high enough is decided when the tx is mined, not now. So
-            // re-reading fees between sends wouldn't change what we submit — it would only
-            // add an RPC round-trip per tx.
+            // The only fee read per send cycle (one drain of up to `command_limit`
+            // commands); the send loop below reuses these params for every command instead
+            // of resolving again per tx. That's safe because fee caps are config-bound and
+            // whether a fee is high enough is decided when the tx is mined, not now — so
+            // per-command reads would only add an RPC round-trip per tx without changing
+            // what we submit.
             let fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -244,12 +244,10 @@ where
                 .pending()
                 .await
                 .context("get pending nonce for L1 sender cycle")?;
-            // Resolved once per cycle and reused for both simulation and every send below.
-            // Freshness is not load-bearing: the submitted max-fee/blob-fee caps are
-            // config-bound (`apply_fee_caps` only trims the priority tip by the estimate),
-            // and fee adequacy is decided at inclusion time — txs sit in the pool longer
-            // than any intra-cycle drift. Re-resolving per command would cost an RPC
-            // round-trip per tx without adding protection.
+            // Resolved once per cycle, not per command: fee caps are config-bound and
+            // whether a fee is high enough is decided when the tx is mined, not now. So
+            // re-reading fees between sends wouldn't change what we submit — it would only
+            // add an RPC round-trip per tx.
             let fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;
@@ -263,8 +261,8 @@ where
                 "estimated gas limits via eth_simulateV1",
             );
 
-            // Blob base fee applies only to commands carrying blob sidecars (commit path);
-            // fetch it once per cycle instead of once per command.
+            // Only blob-carrying commands (commit path) need the blob base fee, so fetch
+            // it once per cycle instead of paying an RPC round-trip per command.
             let blob_base_fee = if commands.iter().any(|cmd| cmd.blob_sidecar().is_some()) {
                 let fee = self.provider.get_blob_base_fee().await?;
                 L1_SENDER_METRICS.report_blob_base_fee(fee)?;

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -244,11 +244,14 @@ where
                 .pending()
                 .await
                 .context("get pending nonce for L1 sender cycle")?;
-            let sim_fee_params = self
+            // Resolved once per cycle and reused for both simulation and every send below:
+            // L1 fees move at most once per L1 block, slower than a send cycle, and each
+            // resolution costs an RPC round-trip per command otherwise.
+            let fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;
             let gas_limits = self
-                .estimate_gas_limits(&commands, operator_address, sim_fee_params, base_nonce)
+                .estimate_gas_limits(&commands, operator_address, fee_params, base_nonce)
                 .await?;
             tracing::info!(
                 command_name,
@@ -256,6 +259,16 @@ where
                 ?gas_limits,
                 "estimated gas limits via eth_simulateV1",
             );
+
+            // Blob base fee applies only to commands carrying blob sidecars (commit path);
+            // fetch it once per cycle instead of once per command.
+            let blob_base_fee = if commands.iter().any(|cmd| cmd.blob_sidecar().is_some()) {
+                let fee = self.provider.get_blob_base_fee().await?;
+                L1_SENDER_METRICS.report_blob_base_fee(fee)?;
+                Some(fee)
+            } else {
+                None
+            };
 
             // It's important to preserve the order of commands -
             // so that we send them downstream also in order.
@@ -266,12 +279,6 @@ where
                 .then(|(nonce_offset, (mut cmd, gas_limit))| {
                     let range = range.clone();
                     async move {
-                    let fee_params = self
-                        .resolve_fee_params(
-                        fee_config,
-                        force_transaction_resubmission,
-                    )
-                    .await?;
                     let mut tx_request = TransactionRequest::default()
                         .with_from(operator_address)
                         .with_nonce(base_nonce + nonce_offset as u64)
@@ -284,9 +291,8 @@ where
                     let mut blob_gas_limit = 0;
                     if let Some(blob_sidecar) = cmd.blob_sidecar() {
                         blob_gas_limit = blob_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
-                        let fee_per_blob_gas = self.provider.get_blob_base_fee().await?;
-                        L1_SENDER_METRICS
-                            .report_blob_base_fee(fee_per_blob_gas)?;
+                        let fee_per_blob_gas = blob_base_fee
+                            .context("blob base fee not prefetched for a cycle with blob sidecars")?;
                         let max_fee_per_blob_gas = fee_params.max_fee_per_blob_gas;
 
                         if fee_per_blob_gas > max_fee_per_blob_gas {
@@ -694,7 +700,6 @@ where
         let configured_params = fee_config.configured_fee_params();
         let estimated = self.provider.estimate_eip1559_fees().await?;
         L1_SENDER_METRICS.report_l1_eip_1559_estimation(estimated)?;
-        self.report_custom_priority_fee_metrics().await?;
 
         tracing::debug!(
             max_priority_fee_per_gas_gwei = ?format_units(estimated.max_priority_fee_per_gas, "gwei"),
@@ -843,6 +848,14 @@ where
                 .await?;
             L1_SENDER_METRICS.balance[&command_name].set(balance.parse()?);
             L1_SENDER_METRICS.nonce[&command_name].set(nonce);
+            // Dashboard-only estimates; a failed poll must not take the sender down.
+            if let Err(err) = self.report_custom_priority_fee_metrics().await {
+                tracing::warn!(
+                    command_name,
+                    %err,
+                    "failed to report priority-fee estimate metrics"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Under sustained compute-heavy load, `l1_sender_commit` is the pipeline bottleneck: the batch diff to upstream grows to `max_batch_diff_to_upstream` and the node suspends transaction acceptance (`pipeline backpressure: ... BatchDiffToUpstreamTooHigh`).

Profiling an incident showed each command send paying **~12 sequential RPC round-trips (~4.0s at ~330ms each against a hosted L1 endpoint)**:

- a full fee re-resolution per command, including **9 metrics-only `eth_feeHistory` calls** (3 windows × 3 percentiles, consumed by nothing but Prometheus gauges), 
- a per-command `eth_blobBaseFee` fetch (commit only),
- and finally the actual `eth_sendRawTransaction`.

### Changes

- **Resolve fee params once per cycle** (already done for gas simulation) and reuse them   for every send. Estimate freshness is not load-bearing here: the per-tx   `max_fee_per_gas` / `max_fee_per_blob_gas` are config-bound caps (`apply_fee_caps` only trims the priority tip by the estimate), and fee adequacy is decided at inclusion time — txs wait in the pool longer than any intra-cycle fee drift.

- **Fetch the blob base fee once per cycle**, and only when the cycle actually carries blob sidecars. The fetched value feeds a warning and a gauge; the tx always carries the configured cap, so this is behavior-neutral for submissions.
- **Report the 3×3 priority-fee comparison gauges from the existing 60s `report_operator_metrics_loop`**, non-fatally, instead of on every send. Previously a transient `eth_feeHistory` failure mid-send failed the whole cycle; now it logs a warning. Gauges keep updating — including while the sender is idle, which the old placement never did.

Per-command send cost drops to one `eth_sendRawTransaction` round-trip (**~206 → ~22 RPCs per 16-command commit cycle**).

| Metric | Before | After |
|---|---|---|
| Gap between consecutive submissions | 4.0s | 1.0s |
| Fee + gas-estimation phase per cycle | ~8s | ~1–2s |
| Commit throughput ceiling | ~1 batch/8.4s | ~1 batch/4.7s |

### Testing

- Crate unit tests, plus `cargo nextest run --workspace` (322 passed) and CI-exact clippy.
- Integration: `uncommitted_blocks_are_settled_after_batcher_reenabled` (full commit/prove/execute round-trip on a fresh L1, including node restart and in-flight recovery) and the `restart`/revert test group (6 tests), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code