### PR TITLE
fix(tree_manager): track tree RocksDB writes as graceful shutdown tasks

### DIFF
--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1226,7 +1226,10 @@ async fn run_main_node_pipeline(
                     )
                 }),
         )
-        .pipe(TreeManager { tree: tree.clone() });
+        .pipe(TreeManager {
+            tree: tree.clone(),
+            runtime: runtime.clone(),
+        });
 
     if !config.batcher_config.enabled {
         tracing::warn!(
@@ -1492,7 +1495,10 @@ async fn run_en_pipeline(
                     )
                 }),
         )
-        .pipe(TreeManager { tree: tree.clone() })
+        .pipe(TreeManager {
+            tree: tree.clone(),
+            runtime: runtime.clone(),
+        })
         .pipe_if(
             config.batch_verification_config.client_enabled,
             BatchVerificationResponder::new(

--- a/node/bin/src/tree_manager.rs
+++ b/node/bin/src/tree_manager.rs
@@ -1,9 +1,10 @@
 use alloy::primitives::BlockNumber;
 use anyhow::Context;
 use async_trait::async_trait;
+use reth_tasks::Runtime;
 use std::path::Path;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use vise::{Buckets, Gauge, Histogram, Metrics, Unit};
 use zksync_os_batch_types::BlockMerkleTreeData;
 use zksync_os_genesis::Genesis;
@@ -20,6 +21,7 @@ const MAX_BLOCKS_PER_ITERATION: usize = 32;
 
 pub(crate) struct TreeManager {
     pub tree: MerkleTree<RocksDBWrapper>,
+    pub runtime: Runtime,
 }
 
 #[async_trait]
@@ -65,10 +67,11 @@ impl PipelineComponent for TreeManager {
             let first_block_number = blocks[0].block_number();
             if first_block_number <= last_processed_block {
                 let mut tree_clone = self.tree.clone();
-                tokio::task::spawn_blocking(move || {
+                self.spawn_tree_task(move || {
                     tree_clone.truncate_recent_versions(first_block_number)
                 })
-                .await??;
+                .await
+                .context("tree truncation task dropped its result sender")??;
             }
 
             let last_block_number = blocks.last().unwrap().block_number();
@@ -78,23 +81,25 @@ impl PipelineComponent for TreeManager {
             );
 
             let db_clone = self.tree.db().clone();
-            let tree_blocks = tokio::task::spawn_blocking(move || {
-                let patched = Patched::new(db_clone);
-                let mut patched_tree = MerkleTree::new(patched)?;
-                let tree_blocks = blocks
-                    .into_iter()
-                    .map(|block| Self::update_tree(&mut patched_tree, block))
-                    .collect::<anyhow::Result<Vec<_>>>()?;
+            let tree_blocks = self
+                .spawn_tree_task(move || {
+                    let patched = Patched::new(db_clone);
+                    let mut patched_tree = MerkleTree::new(patched)?;
+                    let tree_blocks = blocks
+                        .into_iter()
+                        .map(|block| Self::update_tree(&mut patched_tree, block))
+                        .collect::<anyhow::Result<Vec<_>>>()?;
 
-                // Single RocksDB write for all blocks.
-                let flush_time = TREE_METRICS.flush_time.start();
-                patched_tree.flush()?;
-                let flush_time = flush_time.observe();
-                tracing::debug!(?flush_time, "flushed Merkle tree updates to disk");
+                    // Single RocksDB write for all blocks.
+                    let flush_time = TREE_METRICS.flush_time.start();
+                    patched_tree.flush()?;
+                    let flush_time = flush_time.observe();
+                    tracing::debug!(?flush_time, "flushed Merkle tree updates to disk");
 
-                anyhow::Ok(tree_blocks)
-            })
-            .await??;
+                    anyhow::Ok(tree_blocks)
+                })
+                .await
+                .context("tree update task dropped its result sender")??;
 
             let range_time = range_time.observe();
             tracing::debug!(
@@ -136,6 +141,35 @@ impl PipelineComponent for TreeManager {
 }
 
 impl TreeManager {
+    /// Runs a tree RocksDB operation on the blocking pool, tracked as a graceful task.
+    /// Pipeline shutdown drops the segment's `run` future mid-await, but blocking tasks
+    /// cannot be cancelled; holding the shutdown guard until the task finishes guarantees
+    /// the tree RocksDB is not written to after [graceful_shutdown_with_timeout] returns.
+    fn spawn_tree_task<T, F>(&self, f: F) -> oneshot::Receiver<anyhow::Result<T>>
+    where
+        F: FnOnce() -> anyhow::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let (result_tx, result_rx) = oneshot::channel();
+        let mut handle = tokio::task::spawn_blocking(f);
+        self.runtime.spawn_critical_with_graceful_shutdown_signal(
+            "tree update",
+            |shutdown| async move {
+                tokio::select! {
+                    result = &mut handle => {
+                        let _ = result_tx.send(result.map_err(anyhow::Error::from).and_then(|r| r));
+                    }
+                    _guard = shutdown => {
+                        // Wait for the blocking task while holding the shutdown guard. This blocks
+                        // shutdown until the tree update finishes and frees up the tree DB.
+                        let _ = handle.await;
+                    }
+                }
+            },
+        );
+        result_rx
+    }
+
     pub async fn load_or_initialize_tree(
         path: &Path,
         genesis: &Genesis,


### PR DESCRIPTION
## Summary

Fixes a shutdown race in `TreeManager`: its Merkle tree truncation and batch flush ran on raw `tokio::task::spawn_blocking`. On shutdown, the pipeline builder's `select!` drops the component's `run` future, but blocking tasks cannot be cancelled and were not tracked by the graceful-shutdown accounting — so `graceful_shutdown_with_timeout` could report success while a tree flush was still writing to RocksDB.

Anything relying on the "graceful shutdown done ⇒ no more DB writes" guarantee could race with the in-flight write: in-process restarts, snapshots/backups taken right after shutdown, or wiping storage for recovery. The visible symptom was a flaky integration test failure where `remove_dir_all` on the node's RocksDB directory failed with `Directory not empty (os error 39)` right after a clean `stop()`.

The fix routes both blocking calls through a `spawn_tree_task` wrapper that registers a graceful-tracked watcher: on the happy path it forwards the result, and on shutdown it holds the shutdown guard until the blocking task completes. This mirrors the pattern already used by `ProverInputGenerator::spawn_computation` for exactly the same reason, with one addition: join errors are flattened into the result channel, so a panic in the tree task still fails the pipeline segment instead of hanging the receiver.

Follow-up worth discussing (not in this PR): this is the second component to need this hand-rolled wrapper. Lifting it into `zksync_os_pipeline` (e.g. `spawn_graceful_blocking` on `Runtime`), or making the pipeline builder drain blocking work before deregistering a segment, would remove the footgun for future components. If your component does blocking DB work, see `TreeManager::spawn_tree_task`.

## Testing

- The race is too narrow to reproduce locally (millisecond-wide flush window; it shows on slower CI runners), so verification is by analysis plus regression coverage.
- `cargo nextest run -p zksync_os_integration_tests --profile no-pig` over the stop/restart-heavy tests (`replay_archive`, `restart`, `rebuild`): 15/15 pass — also confirms shutdown does not hang now that it waits for in-flight tree writes.
- `cargo clippy --all-targets --all-features --workspace` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
