### PR TITLE
test: add timeout and retry to L1 node capability probing

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1229,9 +1229,28 @@ impl AnvilL1 {
 
         tracing::info!("L1 chain started on {}", address);
 
+        // `NodeProvider::new` probes Anvil's capabilities over a transport with no request
+        // timeout; an Anvil that wedges right after passing the readiness check above would
+        // otherwise hang the test until nextest's terminate timeout.
+        let provider = (|| async {
+            tokio::time::timeout(Duration::from_secs(10), NodeProvider::new(provider.clone()))
+                .await
+                .context("timed out probing L1 node capabilities")?
+                .context("failed to probe L1 node capabilities")
+        })
+        .retry(
+            ConstantBuilder::default()
+                .with_delay(Duration::from_millis(200))
+                .with_max_times(5),
+        )
+        .notify(|err: &anyhow::Error, dur: Duration| {
+            tracing::info!(%err, ?dur, "retrying L1 node capability probing");
+        })
+        .await?;
+
         Ok(Self {
             address,
-            provider: NodeProvider::new(provider).await?,
+            provider,
             wallet,
             _tempdir: Arc::new(tempdir),
         })


### PR DESCRIPTION
## Summary

Fixes a flaky integration-test hang where a test would stall for the full 20-minute nextest terminate timeout right after logging `L1 chain started` (seen in CI stress runs, e.g. `rpc::pubsub::new_block_pubsub::current_to_l1`).

The capability probes in `NodeProvider::new` run over a transport with no request timeout and no retry, so an Anvil instance that stops responding right after passing the `get_chain_id` readiness check blocks the test forever. This wraps the probing in a 10s timeout with retries, mirroring the readiness check just above it, so a wedged Anvil surfaces as a fast retry or a clear error instead of a silent 20-minute hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)