### PR TITLE
ci: pin spec tests geth job to Python 3.12

### DIFF
--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -65,7 +65,10 @@ jobs:
       - name: Install python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: 3.13
+          # coincurve 20.0.0 (pinned by execution-spec-tests) has no prebuilt cp313 wheel, and
+          # its source build is broken by scikit-build-core >= 1.0; 3.12 is the newest Python
+          # with a prebuilt wheel.
+          python-version: 3.12
 
       - name: Install pip dependencies
         run: pip install -r ./python-scripts/requirements.txt


### PR DESCRIPTION
## Summary

The `geth-tests` job of the Eth spec tests workflow has been failing on every run since at least July 10 with:

```
× Failed to build `coincurve==20.0.0`
╰─▶ ERROR: Use build.verbose instead of cmake.verbose for scikit-build-core >= 0.10
```

coincurve 20.0.0 (pinned by execution-spec-tests) ships no prebuilt cp313 wheel, so under the job's Python 3.13 pin it is built from source. The source build resolves its build backend (scikit-build-core) unpinned, and the scikit-build-core 1.0 release (July 6) turned coincurve's deprecated `cmake.verbose` setting into a hard error. The same build passed in the last green run on June 22, before 1.0 existed.

Pinning the job to Python 3.12 — the newest version with a prebuilt manylinux wheel — avoids the source build entirely. The `zk-os-tests` job already runs the same suite on the runner's system Python 3.10 via a prebuilt wheel and is unaffected.

After merge, the fix can be verified immediately with `gh workflow run spec-tests.yaml` instead of waiting for the 3-hour cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)