### PR TITLE
perf(provider): skip logs cache historical backfill on cold start

### DIFF
--- a/lib/provider/src/logs_cache.rs
+++ b/lib/provider/src/logs_cache.rs
@@ -237,7 +237,13 @@ impl LogsCache {
         let mut recent = self.recent.write().await;
         if recent.synced_with_hash != latest_hash && recent.capacity > 0 {
             let target_head = latest_snapshot.number;
-            let floor = target_head.saturating_sub(recent.capacity as u64 - 1);
+            // On a cold cache, start from the current head instead of backfilling `capacity`
+            // historical blocks
+            let floor = if recent.first_block.is_none() {
+                target_head
+            } else {
+                target_head.saturating_sub(recent.capacity as u64 - 1)
+            };
             self.update_block(
                 provider,
                 &mut recent,


### PR DESCRIPTION
## Summary

On first use the recent-logs cache backfilled all `capacity` blocks, each with an unfiltered full-block `eth_getLogs` (measured: 128 calls, 61.9 MB total on Sepolia) plus `eth_getBlockByNumber`, sequentially and while holding the cache write lock. Since the warm-up runs inline on the first get_logs call through the provider, it silently stalled external-node startup.

Start a cold cache from the current head instead: queries over blocks the cache does not have fall back to direct RPC either way, so the backfill only traded a few early cache misses for minutes of startup time. The cache still fills incrementally as new heads arrive.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

