### PR TITLE
fix(node): retry listener prebind on transient AddrInUse

### DIFF
--- a/node/bin/src/ports.rs
+++ b/node/bin/src/ports.rs
@@ -1,8 +1,16 @@
 use crate::config::Config;
 use anyhow::Context;
+use std::io::ErrorKind;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::time::Instant;
 use zksync_os_network::NetworkPorts;
+
+/// How long to keep retrying a bind that fails with `AddrInUse`; a port pinned across restart
+/// (e.g. in integration tests) may be transiently occupied by another process's socket.
+const BIND_RETRY_TIMEOUT: Duration = Duration::from_secs(5);
+const BIND_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Actual ports bound by each service after `run()` starts.
 /// Fields are `None` when the corresponding service is disabled in config.
@@ -86,7 +94,18 @@ async fn bind_tcp_listener(address: &str, service: Service) -> anyhow::Result<Tc
     let addr: SocketAddr = address
         .parse()
         .with_context(|| format!("malformed {service} bind address {address:?}"))?;
-    TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("failed to prebind {service} listener at {address}"))
+    let deadline = Instant::now() + BIND_RETRY_TIMEOUT;
+    loop {
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(err) if err.kind() == ErrorKind::AddrInUse && Instant::now() < deadline => {
+                tracing::warn!(%addr, %service, "bind address in use; retrying");
+                tokio::time::sleep(BIND_RETRY_INTERVAL).await;
+            }
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to prebind {service} listener at {address}"));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Retry TCP listener prebinding for up to 5 seconds (250ms interval) when the bind fails with `AddrInUse`, instead of failing immediately. Any other bind error still fails fast.

## Why

Integration tests pin previously OS-assigned ephemeral ports across node restarts (`preserve_http_ports_on_restart`). Between stop and start, another process's short-lived socket — e.g. an outbound connection that got the same local ephemeral port — can transiently occupy the port, causing restart tests to flake with:

```
failed to prebind status listener at 0.0.0.0:42993
Caused by: Address already in use (os error 98)
```

Such occupants typically disappear within seconds, so a bounded retry window reclaims the port. In production (fixed ports) this only delays a genuine "port taken" error by a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)