### PR TITLE
fix(sequencer): retry GKMS failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16100,6 +16100,8 @@ version = "0.20.11"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
+ "backon",
  "tokio",
  "tracing",
 ]

--- a/lib/operator_signer/Cargo.toml
+++ b/lib/operator_signer/Cargo.toml
@@ -17,6 +17,11 @@ alloy = { workspace = true, default-features = false, features = [
     "network",
     "consensus",
 ] }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
+backon.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["sync", "rt", "macros", "time", "test-util"] }

--- a/lib/operator_signer/src/lib.rs
+++ b/lib/operator_signer/src/lib.rs
@@ -5,10 +5,15 @@ use alloy::signers::gcp::GcpSigner;
 use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::utils::secret_key_to_address;
+use backon::Retryable;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 mod gcp;
+mod retry;
+
+pub use retry::GkmsRetryPolicy;
+use retry::RetryingSigner;
 
 /// Configuration for how a signing key is provided.
 ///
@@ -25,6 +30,10 @@ pub enum SignerConfig {
         /// Full resource name of the KMS key version, e.g.
         /// `projects/{project}/locations/{location}/keyRings/{ring}/cryptoKeys/{key}/cryptoKeyVersions/{version}`
         resource_name: String,
+        /// Retry policy for KMS network operations (client creation, public key fetch,
+        /// transaction signing). Starts as [`GkmsRetryPolicy::default`]; override via
+        /// [`set_gkms_retry_policy`](Self::set_gkms_retry_policy).
+        retry_policy: GkmsRetryPolicy,
         /// Lazily-initialized GCP signer, shared across clones.
         cached_signer: Arc<OnceCell<GcpSigner>>,
     },
@@ -36,9 +45,11 @@ impl Clone for SignerConfig {
             Self::Local(sk) => Self::Local(sk.clone()),
             Self::GcpKms {
                 resource_name,
+                retry_policy,
                 cached_signer,
             } => Self::GcpKms {
                 resource_name: resource_name.clone(),
+                retry_policy: *retry_policy,
                 cached_signer: cached_signer.clone(),
             },
         }
@@ -46,23 +57,48 @@ impl Clone for SignerConfig {
 }
 
 impl SignerConfig {
-    /// Creates a GCP KMS config with an empty signer cache.
+    /// Creates a GCP KMS config with an empty signer cache and the default retry policy.
     pub fn gcp_kms(resource_name: String) -> Self {
         Self::GcpKms {
             resource_name,
+            retry_policy: GkmsRetryPolicy::default(),
             cached_signer: Arc::new(OnceCell::new()),
         }
     }
 
+    /// Overrides the retry policy for GCP KMS operations. No-op for local keys.
+    pub fn set_gkms_retry_policy(&mut self, policy: GkmsRetryPolicy) {
+        match self {
+            Self::GcpKms { retry_policy, .. } => *retry_policy = policy,
+            Self::Local(_) => {}
+        }
+    }
+
     /// Returns the cached GCP signer, creating it on first call.
+    ///
+    /// Creation involves network calls (KMS client setup + public key fetch), so it is
+    /// retried per the key's [`GkmsRetryPolicy`].
     async fn get_gcp_signer(&self) -> anyhow::Result<&GcpSigner> {
         match self {
             Self::GcpKms {
                 resource_name,
+                retry_policy,
                 cached_signer,
             } => {
                 cached_signer
-                    .get_or_try_init(|| gcp::create_gcp_signer(resource_name))
+                    .get_or_try_init(|| async {
+                        (|| gcp::create_gcp_signer(resource_name))
+                            .retry(retry_policy.exponential())
+                            .notify(|err, delay| {
+                                tracing::warn!(
+                                    %resource_name,
+                                    ?delay,
+                                    %err,
+                                    "failed to create GCP KMS signer; retrying"
+                                );
+                            })
+                            .await
+                    })
                     .await
             }
             Self::Local(_) => anyhow::bail!("get_gcp_signer called on Local variant"),
@@ -86,7 +122,9 @@ impl SignerConfig {
 
     /// Creates the appropriate signer, registers it with the wallet, and returns the Ethereum address.
     ///
-    /// For GCP KMS, reuses the cached signer (cloning it for wallet registration).
+    /// For GCP KMS, reuses the cached signer (cloning it for wallet registration). The
+    /// registered signer retries failed sign attempts per the key's [`GkmsRetryPolicy`],
+    /// since every KMS signing RPC goes over the network and can fail transiently.
     pub async fn register_with_wallet(
         &self,
         wallet: &mut EthereumWallet,
@@ -98,11 +136,19 @@ impl SignerConfig {
                 wallet.register_signer(signer);
                 Ok(address)
             }
-            Self::GcpKms { resource_name, .. } => {
+            Self::GcpKms {
+                resource_name,
+                retry_policy,
+                ..
+            } => {
                 let signer = self.get_gcp_signer().await?.clone();
                 let address = signer.address();
                 tracing::info!(%address, %resource_name, "registered GCP KMS signer");
-                wallet.register_signer(signer);
+                wallet.register_signer(RetryingSigner::new(
+                    signer,
+                    *retry_policy,
+                    resource_name.clone(),
+                ));
                 Ok(address)
             }
         }

--- a/lib/operator_signer/src/retry.rs
+++ b/lib/operator_signer/src/retry.rs
@@ -18,9 +18,9 @@ pub struct GkmsRetryPolicy {
 
 impl Default for GkmsRetryPolicy {
     fn default() -> Self {
-        // Exponential 1s -> 60s
+        // Exponential backoff of 1s, 2s, 4s, 8s between 5 attempts (~15s total).
         Self {
-            max_attempts: 10,
+            max_attempts: 5,
             min_delay: Duration::from_secs(1),
             max_delay: Duration::from_secs(60),
         }
@@ -220,10 +220,10 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_budget_is_about_five_minutes() {
+    fn default_policy_budget_is_about_fifteen_seconds() {
         let delays: Vec<_> = GkmsRetryPolicy::default().backoff().collect();
-        assert_eq!(delays.len(), 9);
+        assert_eq!(delays.len(), 4);
         let total: Duration = delays.iter().sum();
-        assert_eq!(total, Duration::from_secs(1 + 2 + 4 + 8 + 16 + 32 + 60 * 3));
+        assert_eq!(total, Duration::from_secs(1 + 2 + 4 + 8));
     }
 }

--- a/lib/operator_signer/src/retry.rs
+++ b/lib/operator_signer/src/retry.rs
@@ -1,0 +1,229 @@
+use alloy::consensus::SignableTransaction;
+use alloy::network::TxSigner;
+use alloy::primitives::{Address, Signature};
+use backon::{BackoffBuilder, ExponentialBuilder};
+use std::time::Duration;
+
+/// Retry policy applied to every Google Cloud KMS operation (client creation,
+/// public key fetch, transaction signing) for all GKMS-backed keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GkmsRetryPolicy {
+    /// Max attempts per operation, including the initial one.
+    pub max_attempts: usize,
+    /// Delay before the first retry; doubles on each subsequent retry.
+    pub min_delay: Duration,
+    /// Upper bound for the delay between retries.
+    pub max_delay: Duration,
+}
+
+impl Default for GkmsRetryPolicy {
+    fn default() -> Self {
+        // Exponential 1s -> 60s
+        Self {
+            max_attempts: 10,
+            min_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(60),
+        }
+    }
+}
+
+impl GkmsRetryPolicy {
+    /// Backoff builder for use with [`backon::Retryable`].
+    pub(crate) fn exponential(&self) -> ExponentialBuilder {
+        ExponentialBuilder::default()
+            .with_min_delay(self.min_delay)
+            .with_max_delay(self.max_delay)
+            .with_max_times(self.max_attempts.saturating_sub(1))
+    }
+
+    /// Delays to sleep between attempts; yields `max_attempts - 1` items.
+    fn backoff(&self) -> impl Iterator<Item = Duration> {
+        self.exponential().build()
+    }
+}
+
+/// Wraps a [`TxSigner`] whose signing goes over the network (GCP KMS) and
+/// retries failed sign attempts per the given policy.
+pub(crate) struct RetryingSigner<S> {
+    inner: S,
+    policy: GkmsRetryPolicy,
+    resource_name: String,
+}
+
+impl<S> RetryingSigner<S> {
+    pub(crate) fn new(inner: S, policy: GkmsRetryPolicy, resource_name: String) -> Self {
+        Self {
+            inner,
+            policy,
+            resource_name,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: TxSigner<Signature> + Send + Sync> TxSigner<Signature> for RetryingSigner<S> {
+    fn address(&self) -> Address {
+        self.inner.address()
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> alloy::signers::Result<Signature> {
+        let mut backoff = self.policy.backoff();
+        let mut attempt = 1usize;
+        loop {
+            match self.inner.sign_transaction(&mut *tx).await {
+                Ok(signature) => return Ok(signature),
+                Err(err) => match backoff.next() {
+                    Some(delay) => {
+                        tracing::warn!(
+                            resource_name = %self.resource_name,
+                            attempt,
+                            ?delay,
+                            %err,
+                            "GKMS transaction signing failed; retrying"
+                        );
+                        tokio::time::sleep(delay).await;
+                        attempt += 1;
+                    }
+                    None => {
+                        tracing::error!(
+                            resource_name = %self.resource_name,
+                            attempts = attempt,
+                            %err,
+                            "GKMS transaction signing failed; retry budget exhausted"
+                        );
+                        return Err(err);
+                    }
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::consensus::TxLegacy;
+    use alloy::signers::local::PrivateKeySigner;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Delegates to a real local signer, failing the first `remaining_failures` calls.
+    struct FlakySigner {
+        inner: PrivateKeySigner,
+        remaining_failures: AtomicUsize,
+        calls: AtomicUsize,
+    }
+
+    impl FlakySigner {
+        fn new(failures: usize) -> Self {
+            Self {
+                inner: PrivateKeySigner::random(),
+                remaining_failures: AtomicUsize::new(failures),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TxSigner<Signature> for FlakySigner {
+        fn address(&self) -> Address {
+            self.inner.address()
+        }
+
+        async fn sign_transaction(
+            &self,
+            tx: &mut dyn SignableTransaction<Signature>,
+        ) -> alloy::signers::Result<Signature> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let should_fail = self
+                .remaining_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok();
+            if should_fail {
+                return Err(alloy::signers::Error::other(std::io::Error::other(
+                    "transient GKMS failure",
+                )));
+            }
+            self.inner.sign_transaction(tx).await
+        }
+    }
+
+    fn test_policy() -> GkmsRetryPolicy {
+        GkmsRetryPolicy {
+            max_attempts: 5,
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(40),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovers_after_transient_failures() {
+        let signer = RetryingSigner::new(FlakySigner::new(3), test_policy(), "test-key".into());
+        let mut tx = TxLegacy::default();
+        let signature = signer
+            .sign_transaction(&mut tx)
+            .await
+            .expect("must succeed within the retry budget");
+        assert_eq!(signer.inner.calls.load(Ordering::SeqCst), 4);
+        let recovered = signature
+            .recover_address_from_prehash(&tx.signature_hash())
+            .unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gives_up_after_max_attempts() {
+        let signer = RetryingSigner::new(
+            FlakySigner::new(usize::MAX),
+            test_policy(),
+            "test-key".into(),
+        );
+        let mut tx = TxLegacy::default();
+        let err = signer
+            .sign_transaction(&mut tx)
+            .await
+            .expect_err("must fail once the retry budget is exhausted");
+        assert_eq!(signer.inner.calls.load(Ordering::SeqCst), 5);
+        assert!(err.to_string().contains("transient GKMS failure"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn single_attempt_policy_does_not_retry() {
+        let policy = GkmsRetryPolicy {
+            max_attempts: 1,
+            ..test_policy()
+        };
+        let signer = RetryingSigner::new(FlakySigner::new(usize::MAX), policy, "test-key".into());
+        let mut tx = TxLegacy::default();
+        signer
+            .sign_transaction(&mut tx)
+            .await
+            .expect_err("must fail without retrying");
+        assert_eq!(signer.inner.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        let policy = GkmsRetryPolicy {
+            max_attempts: 6,
+            min_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(4),
+        };
+        let delays: Vec<_> = policy.backoff().collect();
+        assert_eq!(
+            delays,
+            [1, 2, 4, 4, 4].map(Duration::from_secs).to_vec(),
+            "expected exponential growth capped at max_delay"
+        );
+    }
+
+    #[test]
+    fn default_policy_budget_is_about_five_minutes() {
+        let delays: Vec<_> = GkmsRetryPolicy::default().backoff().collect();
+        assert_eq!(delays.len(), 9);
+        let total: Duration = delays.iter().sum();
+        assert_eq!(total, Duration::from_secs(1 + 2 + 4 + 8 + 16 + 32 + 60 * 3));
+    }
+}

--- a/node/bin/src/config/build_external_config.rs
+++ b/node/bin/src/config/build_external_config.rs
@@ -1,10 +1,10 @@
 use crate::config::{
     BackpressureConfig, BaseTokenPriceUpdaterConfig, BatchVerificationConfig, BatcherConfig,
     Config, ConsensusConfig, ExternalPriceApiClientConfig, FeeConfig, GasAdjusterConfig,
-    GatewaySenderConfig, GeneralConfig, GenesisConfig, InteropFeeUpdaterConfig, L1SenderConfig,
-    L1WatcherConfig, MempoolConfig, MempoolTxValidatorConfig, NetworkConfig, ObservabilityConfig,
-    ProverApiConfig, ProverInputGeneratorConfig, ProviderConfig, ReplayArchiveConfig, RpcConfig,
-    SequencerConfig, StatusServerConfig,
+    GatewaySenderConfig, GeneralConfig, GenesisConfig, GkmsConfig, InteropFeeUpdaterConfig,
+    L1SenderConfig, L1WatcherConfig, MempoolConfig, MempoolTxValidatorConfig, NetworkConfig,
+    ObservabilityConfig, ProverApiConfig, ProverInputGeneratorConfig, ProviderConfig,
+    ReplayArchiveConfig, RpcConfig, SequencerConfig, StatusServerConfig,
 };
 use smart_config::{ConfigRepository, ConfigSources, Json, Yaml};
 use std::fs;
@@ -89,6 +89,12 @@ pub async fn build_external_config(repo: ConfigRepository<'_>) -> Config {
         .expect("Failed to load Gateway sender config")
         .parse()
         .expect("Failed to parse Gateway sender config");
+
+    let gkms_config = repo
+        .single::<GkmsConfig>()
+        .expect("Failed to load gkms config")
+        .parse()
+        .expect("Failed to parse gkms config");
 
     let l1_watcher_config = repo
         .single::<L1WatcherConfig>()
@@ -187,6 +193,7 @@ pub async fn build_external_config(repo: ConfigRepository<'_>) -> Config {
         sequencer_config,
         l1_sender_config,
         gateway_sender_config,
+        gkms_config,
         l1_watcher_config,
         batcher_config,
         prover_input_generator_config,
@@ -202,6 +209,7 @@ pub async fn build_external_config(repo: ConfigRepository<'_>) -> Config {
         fee_config,
         backpressure_config,
     }
+    .apply_gkms_retry_policy()
 }
 
 /// Loads JSON / YAML config files into [`ConfigSources`] in the provided order, inferring the

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -32,7 +32,7 @@ use zksync_os_mempool::SubPoolLimit;
 use zksync_os_network::{NodeRecord, PeerId, SecretKey};
 use zksync_os_observability::LogFormat;
 use zksync_os_observability::opentelemetry::OpenTelemetryLevel;
-use zksync_os_operator_signer::SignerConfig;
+use zksync_os_operator_signer::{GkmsRetryPolicy, SignerConfig};
 use zksync_os_raft::RaftConsensusConfig;
 use zksync_os_tx_validators::deployment_filter;
 use zksync_os_types::{NodeRole, PubdataMode};
@@ -73,6 +73,7 @@ pub struct Config {
     pub l1_sender_config: L1SenderConfig,
     #[config_validate(async_validate(Self::validate_gw_operator_signers))]
     pub gateway_sender_config: GatewaySenderConfig,
+    pub gkms_config: GkmsConfig,
     pub l1_watcher_config: L1WatcherConfig,
     pub batcher_config: BatcherConfig,
     pub prover_input_generator_config: ProverInputGeneratorConfig,
@@ -228,6 +229,9 @@ impl Config {
         schema
             .insert(&GatewaySenderConfig::DESCRIPTION, "gateway_sender")
             .expect("Failed to insert gateway_sender config");
+        schema
+            .insert(&GkmsConfig::DESCRIPTION, "gkms")
+            .expect("Failed to insert gkms config");
         schema
             .insert(&L1WatcherConfig::DESCRIPTION, "l1_watcher")
             .expect("Failed to insert l1_watcher config");
@@ -1319,6 +1323,57 @@ pub struct ForceTransactionResubmissionConfig {
 
 fn is_positive_f64(&val: &f64) -> bool {
     val > 0.0
+}
+
+/// Retry policy shared by all Google Cloud KMS keys. Retries protect the node from transient
+/// Google API failures; once the budget is exhausted the error crashes the node.
+#[derive(Clone, Copy, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
+#[config(derive(Default))]
+pub struct GkmsConfig {
+    /// Max attempts per GKMS operation, including the initial one.
+    #[config(default_t = GkmsRetryPolicy::default().max_attempts)]
+    pub retry_max_attempts: usize,
+
+    /// Delay before the first retry; doubles on each subsequent retry.
+    #[config(default_t = GkmsRetryPolicy::default().min_delay)]
+    pub retry_min_delay: Duration,
+
+    /// Upper bound for the delay between retries.
+    #[config(default_t = GkmsRetryPolicy::default().max_delay)]
+    pub retry_max_delay: Duration,
+}
+
+impl From<GkmsConfig> for GkmsRetryPolicy {
+    fn from(config: GkmsConfig) -> Self {
+        Self {
+            max_attempts: config.retry_max_attempts,
+            min_delay: config.retry_min_delay,
+            max_delay: config.retry_max_delay,
+        }
+    }
+}
+
+impl Config {
+    /// Returns the config with [`GkmsConfig`] applied to every long-running signer key.
+    #[must_use]
+    fn apply_gkms_retry_policy(mut self) -> Self {
+        let policy = GkmsRetryPolicy::from(self.gkms_config);
+        let signers = [
+            self.l1_sender_config.operator_commit_sk.as_mut(),
+            self.l1_sender_config.operator_prove_sk.as_mut(),
+            self.l1_sender_config.operator_execute_sk.as_mut(),
+            self.gateway_sender_config.operator_commit_sk.as_mut(),
+            self.gateway_sender_config.operator_prove_sk.as_mut(),
+            self.gateway_sender_config.operator_execute_sk.as_mut(),
+            self.base_token_price_updater_config
+                .token_multiplier_setter_sk
+                .as_mut(),
+        ];
+        for signer in signers.into_iter().flatten() {
+            signer.set_gkms_retry_policy(policy);
+        }
+        self
+    }
 }
 
 /// Gateway sender configuration. Used by the L1Sender pipeline components when the chain is
@@ -2612,6 +2667,7 @@ mod tests {
                 max_batch_diff_to_upstream: None,
             },
             gateway_sender_config: GatewaySenderConfig::default(),
+            gkms_config: GkmsConfig::default(),
             l1_watcher_config: L1WatcherConfig::default(),
             batcher_config: BatcherConfig::default(),
             prover_input_generator_config: ProverInputGeneratorConfig::default(),
@@ -2814,6 +2870,53 @@ mod tests {
         assert!(
             err.contains("unsupported URL scheme"),
             "expected scheme rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn gkms_retry_policy_is_applied_to_all_operator_signers() {
+        fn gcp_signer(key: &str) -> SignerConfig {
+            SignerConfig::gcp_kms(format!(
+                "projects/p/locations/l/keyRings/r/cryptoKeys/{key}/cryptoKeyVersions/1"
+            ))
+        }
+        fn policy_of(signer: &Option<SignerConfig>) -> GkmsRetryPolicy {
+            match signer.as_ref().unwrap() {
+                SignerConfig::GcpKms { retry_policy, .. } => *retry_policy,
+                SignerConfig::Local(_) => panic!("expected a GCP KMS signer"),
+            }
+        }
+
+        let mut config = base_config(NodeRole::MainNode);
+        config.l1_sender_config.operator_commit_sk = Some(gcp_signer("commit"));
+        config.gateway_sender_config.operator_prove_sk = Some(gcp_signer("gw-prove"));
+        config
+            .base_token_price_updater_config
+            .token_multiplier_setter_sk = Some(gcp_signer("setter"));
+        config.gkms_config = GkmsConfig {
+            retry_max_attempts: 3,
+            retry_min_delay: Duration::from_millis(100),
+            retry_max_delay: Duration::from_secs(2),
+        };
+
+        let config = config.apply_gkms_retry_policy();
+
+        let expected = GkmsRetryPolicy::from(config.gkms_config);
+        assert_eq!(
+            policy_of(&config.l1_sender_config.operator_commit_sk),
+            expected
+        );
+        assert_eq!(
+            policy_of(&config.gateway_sender_config.operator_prove_sk),
+            expected
+        );
+        assert_eq!(
+            policy_of(
+                &config
+                    .base_token_price_updater_config
+                    .token_multiplier_setter_sk
+            ),
+            expected
         );
     }
 }


### PR DESCRIPTION
## Summary

A hosted node crashed when a Google KMS signing operation failed to reach `https://sts.googleapis.com/v1/token` (OAuth token refresh):

```
Critical task `l1_sender_execute` panicked: `pipeline segment failed: local usage error:
status: 'Unknown error', self: "http error: error sending request for url (https://sts.googleapis.com/v1/token)"`
```

Every GKMS operation goes over the network (client creation, public key fetch, and each transaction signing, incl. the token refresh performed by `gcloud_sdk` under the hood), and there were no retries on that path — a single transient Google API failure took the whole node down.

This PR wraps all GKMS operations with a bounded exponential-backoff retry, governed by a single policy shared by all GKMS keys. Each retry is logged with a `warn`; once the budget is exhausted the error propagates as before, so a permanently broken key (revoked IAM, deleted version) still surfaces via a crash.

## Configuration

New optional `gkms` section — the defaults give a per-operation budget of ~15 seconds (5 attempts, delays 1s, 2s, 4s, 8s). **Existing deployments need no changes.**

```yaml
gkms:
  retry_max_attempts: 5    # attempts per operation, incl. the initial one (default: 5)
  retry_min_delay: 1s      # delay before the first retry, doubles each retry (default: 1s)
  retry_max_delay: 1min    # cap for the delay between retries (default: 1min)
```
or via environment variables: `GKMS_RETRY_MAX_ATTEMPTS`, `GKMS_RETRY_MIN_DELAY`, `GKMS_RETRY_MAX_DELAY`.