### PR TITLE
refactor(operator_signer): use official GCP KMS SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -886,7 +886,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -1265,7 +1265,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "tower",
  "tracing",
@@ -1334,12 +1334,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -3468,17 +3462,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3900,6 +3893,15 @@ checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
  "spin",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -4453,7 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5708,7 +5710,7 @@ dependencies = [
  "once_cell",
  "prost 0.14.1",
  "prost-types 0.14.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -5878,6 +5880,223 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3494870d06f3cbbb3561ada6f234982549e3a2fb31e719ef258e6eadb9ae09a"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "google-cloud-gax",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.3.1",
+ "reqwest 0.13.4",
+ "rustc_version 0.4.1",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3103a4a9013f1aed573ca56e19a9680b0211643a99ea85caf524b397d6be8be3"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "http 1.3.1",
+ "pin-project",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-gax-internal"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0df265fba091ed7e00ecd0755009423310163f8b52820f007b6b4d97f4c6617"
+dependencies = [
+ "bytes",
+ "futures",
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "h2",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "lazy_static",
+ "opentelemetry 0.32.0",
+ "opentelemetry-semantic-conventions 0.32.1",
+ "opentelemetry_sdk 0.32.1",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "reqwest 0.13.4",
+ "rustc_version 0.4.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry 0.33.0",
+]
+
+[[package]]
+name = "google-cloud-iam-v1"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cdf5acc7ef946ee2db7a7f62bd436d8395a6543b4beef110cdc061fcf578bb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-type",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-kms-v1"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74792e4d57d9d02a0ad6f443d657abfaca925d84a21b34e23b5655227f4b5840"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-iam-v1",
+ "google-cloud-location",
+ "google-cloud-longrunning",
+ "google-cloud-lro",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-location"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280d5acdba8fcb1232c0719ed788d85b7e362b82cbb425b7050d3ce46f075ede"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-longrunning"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6ce05df0aea2c08472983ce2bbbed9483cbb637b89ff69a7c4ef94371fe4f2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-lro"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cca2b991d619525d72a170ca7f413cb520872702442da22ac9af650a8e786"
+dependencies = [
+ "google-cloud-gax",
+ "google-cloud-gax-internal",
+ "google-cloud-longrunning",
+ "google-cloud-rpc",
+ "google-cloud-wkt",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-rpc"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2162c08a89118130979ba261080e960e44cdcb2d6e2ab8ca9b1da245285d353"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-type"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63acc3a92a85f96bab021c3a3e29b53bbacc97651e1b524d4c2991960a63eb82"
+dependencies = [
+ "bytes",
+ "google-cloud-wkt",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "google-cloud-wkt"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46df1fcc3ab69164af3f4199ed21f45b5dbc56d9f03211eb4fa20116d442364b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "governor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5910,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6317,9 +6536,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6332,7 +6551,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -8254,12 +8472,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.22",
@@ -8274,7 +8506,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
 
@@ -8285,10 +8517,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.3.1",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.31.0",
  "prost 0.14.1",
  "reqwest 0.12.28",
  "thiserror 2.0.17",
@@ -8303,8 +8535,8 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prost 0.14.1",
  "tonic",
  "tonic-prost",
@@ -8317,6 +8549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8325,12 +8563,28 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.5",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -9598,9 +9852,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -10180,7 +10434,7 @@ source = "git+https://github.com/paradigmxyz/reth.git?tag=v2.3.0#9384bc53d8c0c77
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_with",
  "thiserror 2.0.17",
  "tokio",
@@ -10539,7 +10793,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.9.5",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -10726,12 +10980,12 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "eyre",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry-semantic-conventions 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.0",
  "tracing-subscriber 0.3.22",
  "url",
 ]
@@ -11672,9 +11926,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -11709,9 +11963,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -12297,16 +12551,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.12.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -13511,9 +13765,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -13528,6 +13782,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
@@ -13542,9 +13797,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.1",
@@ -13755,14 +14010,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
 dependencies = [
  "js-sys",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "rustversion",
  "smallvec",
  "thiserror 2.0.17",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-subscriber 0.3.22",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
+ "tracing",
+ "tracing-core",
  "tracing-subscriber 0.3.22",
  "web-time",
 ]
@@ -16072,11 +16341,11 @@ dependencies = [
  "anyhow",
  "chrono",
  "itertools 0.14.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry-semantic-conventions 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "reth-tasks",
  "sentry",
  "serde",
@@ -16087,7 +16356,7 @@ dependencies = [
  "tokio-metrics",
  "tracing",
  "tracing-logfmt",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.0",
  "tracing-subscriber 0.3.22",
  "url",
  "vise",
@@ -16099,7 +16368,13 @@ name = "zksync_os_operator_signer"
 version = "0.20.11"
 dependencies = [
  "alloy",
+ "alloy-signer",
  "anyhow",
+ "async-trait",
+ "crc32c",
+ "google-cloud-gax",
+ "google-cloud-kms-v1",
+ "k256",
  "tokio",
  "tracing",
 ]
@@ -16677,6 +16952,12 @@ dependencies = [
  "zksync_os_merkle_tree_api",
  "zksync_os_rpc_api",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ alloy = { version = "2.0.5", default-features = false, features = [
     "serde-bincode-compat",
 ] }
 alloy-rlp = { version = "0.3.13" }
+alloy-signer = { version = "2.0.5", default-features = false }
 anyhow = "1"
 async-trait = "0.1"
 aws-config = { version = "1.8.17", default-features = false, features = [
@@ -81,6 +82,14 @@ aws-sdk-s3 = { version = "1.133.0", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",
     "default-https-client",
+] }
+crc32c = "0.6.8"
+google-cloud-gax = "1.12.0"
+google-cloud-kms-v1 = "1.12.0"
+k256 = { version = "0.13.4", default-features = false, features = [
+    "ecdsa",
+    "pem",
+    "std",
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"

--- a/lib/operator_signer/Cargo.toml
+++ b/lib/operator_signer/Cargo.toml
@@ -12,11 +12,16 @@ categories.workspace = true
 [dependencies]
 alloy = { workspace = true, default-features = false, features = [
     "signer-local",
-    "signer-gcp",
     "k256",
     "network",
     "consensus",
 ] }
+alloy-signer.workspace = true
+async-trait.workspace = true
+crc32c.workspace = true
+google-cloud-gax.workspace = true
+google-cloud-kms-v1.workspace = true
+k256.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 anyhow.workspace = true

--- a/lib/operator_signer/src/gcp.rs
+++ b/lib/operator_signer/src/gcp.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Duration;
 
 use alloy::{
     consensus::SignableTransaction,
@@ -26,6 +27,10 @@ use k256::{
 
 /// Total number of attempts, including the initial request, for transient KMS failures.
 const KMS_RETRY_ATTEMPTS: u32 = 4;
+
+/// Per-attempt request timeout. The SDK sets no timeout by default, so without this a
+/// stalled connection would hang a sign call (and the l1_sender pipeline) indefinitely.
+const KMS_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 struct KmsRetryPolicy;
@@ -213,6 +218,7 @@ impl TxSigner<Signature> for GcpKmsSigner {
 pub(crate) async fn create_gcp_signer(resource_name: &str) -> anyhow::Result<GcpKmsSigner> {
     let client = KeyManagementService::builder()
         .with_retry_policy(kms_retry_policy())
+        .with_attempt_timeout(KMS_ATTEMPT_TIMEOUT)
         .build()
         .await
         .context("failed to create GCP KMS client using Application Default Credentials")?;

--- a/lib/operator_signer/src/gcp.rs
+++ b/lib/operator_signer/src/gcp.rs
@@ -1,102 +1,431 @@
-use alloy::signers::gcp::{
-    GcpKeyRingRef, GcpSigner, KeySpecifier,
-    gcloud_sdk::{
-        GoogleApi,
-        google::cloud::kms::v1::key_management_service_client::KeyManagementServiceClient,
-    },
+use std::fmt;
+
+use alloy::{
+    consensus::SignableTransaction,
+    network::TxSigner,
+    primitives::{Address, B256, ChainId, Signature},
+    signers::utils::public_key_to_address,
 };
-use anyhow::Context;
+use alloy_signer::{Error as SignerError, Signer, sign_transaction_with_chain_id};
+use anyhow::Context as _;
+use async_trait::async_trait;
+use google_cloud_gax::{
+    options::RequestOptionsBuilder as _,
+    retry_policy::{Aip194Strict, RetryPolicy, RetryPolicyExt as _},
+    retry_result::RetryResult,
+    retry_state::RetryState,
+};
+use google_cloud_kms_v1::{
+    client::KeyManagementService,
+    model::{Digest, crypto_key_version::CryptoKeyVersionAlgorithm},
+};
+use k256::{
+    ecdsa::{self, RecoveryId, VerifyingKey},
+    pkcs8::DecodePublicKey as _,
+};
 
-/// Creates a GCP KMS signer from a resource name.
-///
-/// The key must use the `EC_SIGN_SECP256K1_SHA256` algorithm.
-/// If the key uses a different algorithm (e.g. RSA, P-256), signer creation
-/// will fail because the public key cannot be decoded as a secp256k1 key.
-pub(crate) async fn create_gcp_signer(resource_name: &str) -> anyhow::Result<GcpSigner> {
-    let parts = parse_kms_resource_name(resource_name)?;
-    let keyring = GcpKeyRingRef::new(&parts.project_id, &parts.location, &parts.keyring_name);
-    let specifier = KeySpecifier::new(keyring, &parts.key_id, parts.version);
+/// Total number of attempts, including the initial request, for transient KMS failures.
+const KMS_RETRY_ATTEMPTS: u32 = 4;
 
-    let client = GoogleApi::from_function(
-        KeyManagementServiceClient::new,
-        "https://cloudkms.googleapis.com",
-        None,
-    )
-    .await
-    .context("failed to create GCP KMS client")?;
+#[derive(Debug)]
+struct KmsRetryPolicy;
 
-    GcpSigner::new(client, specifier, None).await.map_err(|e| {
-        anyhow::anyhow!(
-            "failed to initialize GCP KMS signer for '{resource_name}': {e}. \
-                 Ensure the key uses EC_SIGN_SECP256K1_SHA256 algorithm"
+impl RetryPolicy for KmsRetryPolicy {
+    fn on_error(&self, state: &RetryState, error: google_cloud_gax::error::Error) -> RetryResult {
+        use google_cloud_gax::error::rpc::Code;
+
+        let retryable = error.is_timeout()
+            || error
+                .http_status_code()
+                .is_some_and(|status| matches!(status, 408 | 429 | 500..=599))
+            || error.status().is_some_and(|status| {
+                matches!(
+                    status.code,
+                    Code::DeadlineExceeded | Code::ResourceExhausted | Code::Internal
+                )
+            });
+        if state.idempotent && retryable {
+            RetryResult::Continue(error)
+        } else {
+            Aip194Strict.on_error(state, error)
+        }
+    }
+}
+
+fn kms_retry_policy() -> impl RetryPolicy {
+    KmsRetryPolicy.with_attempt_limit(KMS_RETRY_ATTEMPTS)
+}
+
+/// Google Cloud KMS-backed Ethereum signer.
+#[derive(Clone)]
+pub struct GcpKmsSigner {
+    client: KeyManagementService,
+    key_name: String,
+    chain_id: Option<ChainId>,
+    public_key: VerifyingKey,
+    address: Address,
+}
+
+impl fmt::Debug for GcpKmsSigner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GcpKmsSigner")
+            .field("key_name", &self.key_name)
+            .field("chain_id", &self.chain_id)
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GcpKmsSigner {
+    async fn new(
+        client: KeyManagementService,
+        key_name: String,
+        chain_id: Option<ChainId>,
+    ) -> anyhow::Result<Self> {
+        let response = client
+            .get_public_key()
+            .set_name(&key_name)
+            .with_idempotency(true)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch GCP KMS public key for '{key_name}'"))?;
+
+        anyhow::ensure!(
+            response.name == key_name,
+            "GCP KMS returned public key for '{}', expected '{key_name}'",
+            response.name
+        );
+        anyhow::ensure!(
+            response.algorithm == CryptoKeyVersionAlgorithm::EcSignSecp256K1Sha256,
+            "GCP KMS key '{key_name}' uses {}, expected EC_SIGN_SECP256K1_SHA256",
+            response.algorithm.name().unwrap_or("an unknown algorithm")
+        );
+        if let Some(expected_checksum) = response.pem_crc32c {
+            anyhow::ensure!(
+                i64::from(crc32c::crc32c(response.pem.as_bytes())) == expected_checksum,
+                "GCP KMS public key checksum mismatch for '{key_name}'"
+            );
+        }
+
+        let public_key = VerifyingKey::from_public_key_pem(&response.pem)
+            .context("failed to parse GCP KMS secp256k1 public key PEM")?;
+        let address = public_key_to_address(&public_key);
+
+        Ok(Self {
+            client,
+            key_name,
+            chain_id,
+            public_key,
+            address,
+        })
+    }
+
+    async fn sign_digest(&self, digest: &B256) -> anyhow::Result<Signature> {
+        let digest_checksum = i64::from(crc32c::crc32c(digest.as_slice()));
+        let response = self
+            .client
+            .asymmetric_sign()
+            .set_name(&self.key_name)
+            .set_digest(Digest::new().set_sha256(digest.to_vec()))
+            .set_digest_crc32c(digest_checksum)
+            // Signing the same digest again is side-effect-free, so transient POST failures are
+            // safe to retry through the SDK's bounded retry policy.
+            .with_idempotency(true)
+            .send()
+            .await
+            .with_context(|| format!("GCP KMS signing with '{}' failed", self.key_name))?;
+
+        anyhow::ensure!(
+            response.name == self.key_name,
+            "GCP KMS signed with '{}', expected '{}'",
+            response.name,
+            self.key_name
+        );
+        anyhow::ensure!(
+            response.verified_digest_crc32c,
+            "GCP KMS did not verify the digest checksum for '{}'",
+            self.key_name
+        );
+        let expected_checksum = response.signature_crc32c.with_context(|| {
+            format!(
+                "GCP KMS response omitted the signature checksum for '{}'",
+                self.key_name
+            )
+        })?;
+        anyhow::ensure!(
+            i64::from(crc32c::crc32c(&response.signature)) == expected_checksum,
+            "GCP KMS signature checksum mismatch for '{}'",
+            self.key_name
+        );
+
+        let signature = ecdsa::Signature::from_der(&response.signature)
+            .context("failed to decode GCP KMS DER signature")?;
+        let signature = signature.normalize_s().unwrap_or(signature);
+        let recovery_id = RecoveryId::trial_recovery_from_prehash(
+            &self.public_key,
+            digest.as_slice(),
+            &signature,
         )
-    })
+        .context("failed to recover parity from GCP KMS signature")?;
+        Ok((signature, recovery_id).into())
+    }
 }
 
-/// Parsed components of a KMS resource name.
-struct KmsResourceParts {
-    project_id: String,
-    location: String,
-    keyring_name: String,
-    key_id: String,
-    version: u64,
+#[async_trait]
+impl Signer for GcpKmsSigner {
+    async fn sign_hash(&self, hash: &B256) -> alloy::signers::Result<Signature> {
+        self.sign_digest(hash).await.map_err(SignerError::other)
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<ChainId>) {
+        self.chain_id = chain_id;
+    }
 }
 
-/// Parses a KMS resource name into its components.
-///
-/// Expected format:
-/// `projects/{project}/locations/{location}/keyRings/{ring}/cryptoKeys/{key}/cryptoKeyVersions/{version}`
-fn parse_kms_resource_name(resource_name: &str) -> anyhow::Result<KmsResourceParts> {
-    let parts: Vec<&str> = resource_name.split('/').collect();
-    anyhow::ensure!(
-        parts.len() == 10
-            && parts[0] == "projects"
-            && parts[2] == "locations"
-            && parts[4] == "keyRings"
-            && parts[6] == "cryptoKeys"
-            && parts[8] == "cryptoKeyVersions",
-        "invalid KMS resource name format: expected \
-         'projects/{{project}}/locations/{{location}}/keyRings/{{ring}}/cryptoKeys/{{key}}/cryptoKeyVersions/{{version}}', \
-         got '{resource_name}'"
-    );
+#[async_trait]
+impl TxSigner<Signature> for GcpKmsSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
 
-    let version: u64 = parts[9]
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid key version number: '{}'", parts[9]))?;
+    async fn sign_transaction(
+        &self,
+        transaction: &mut dyn SignableTransaction<Signature>,
+    ) -> alloy::signers::Result<Signature> {
+        sign_transaction_with_chain_id!(
+            self,
+            transaction,
+            self.sign_hash(&transaction.signature_hash()).await
+        )
+    }
+}
 
-    Ok(KmsResourceParts {
-        project_id: parts[1].to_owned(),
-        location: parts[3].to_owned(),
-        keyring_name: parts[5].to_owned(),
-        key_id: parts[7].to_owned(),
-        version,
-    })
+/// Creates a signer using the official Google Cloud client and Application Default Credentials.
+pub(crate) async fn create_gcp_signer(resource_name: &str) -> anyhow::Result<GcpKmsSigner> {
+    let client = KeyManagementService::builder()
+        .with_retry_policy(kms_retry_policy())
+        .build()
+        .await
+        .context("failed to create GCP KMS client using Application Default Credentials")?;
+
+    GcpKmsSigner::new(client, resource_name.to_owned(), None)
+        .await
+        .with_context(|| format!("failed to initialize GCP KMS signer for '{resource_name}'"))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use google_cloud_gax::{options::RequestOptions, response::Response};
+    use google_cloud_kms_v1::model::{
+        AsymmetricSignRequest, AsymmetricSignResponse, GetPublicKeyRequest, PublicKey,
+    };
+    use k256::{
+        ecdsa::{SigningKey, signature::hazmat::PrehashSigner as _},
+        pkcs8::{EncodePublicKey as _, LineEnding},
+    };
+
     use super::*;
 
-    #[test]
-    fn test_parse_kms_resource_name_valid() {
-        let resource = "projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1";
-        let parts = parse_kms_resource_name(resource).unwrap();
-        assert_eq!(parts.project_id, "my-project");
-        assert_eq!(parts.location, "us-central1");
-        assert_eq!(parts.keyring_name, "my-ring");
-        assert_eq!(parts.key_id, "my-key");
-        assert_eq!(parts.version, 1);
+    const KEY_NAME: &str =
+        "projects/project/locations/global/keyRings/ring/cryptoKeys/key/cryptoKeyVersions/1";
+    const CLIENT_SECRET: &str = "credential-must-not-appear-in-debug";
+
+    #[derive(Clone)]
+    struct TestKmsStub {
+        signing_key: SigningKey,
+        algorithm: CryptoKeyVersionAlgorithm,
+        corrupt_signature_checksum: bool,
+        request_count: Arc<Mutex<(usize, usize)>>,
+    }
+
+    impl fmt::Debug for TestKmsStub {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(CLIENT_SECRET)
+        }
+    }
+
+    impl TestKmsStub {
+        fn new() -> Self {
+            Self {
+                signing_key: SigningKey::from_bytes((&[7_u8; 32]).into()).unwrap(),
+                algorithm: CryptoKeyVersionAlgorithm::EcSignSecp256K1Sha256,
+                corrupt_signature_checksum: false,
+                request_count: Arc::new(Mutex::new((0, 0))),
+            }
+        }
+    }
+
+    impl google_cloud_kms_v1::stub::KeyManagementService for TestKmsStub {
+        fn get_public_key(
+            &self,
+            request: GetPublicKeyRequest,
+            options: RequestOptions,
+        ) -> impl Future<Output = google_cloud_kms_v1::Result<Response<PublicKey>>> + Send {
+            assert_eq!(request.name, KEY_NAME);
+            assert_eq!(options.idempotent(), Some(true));
+            self.request_count.lock().unwrap().0 += 1;
+
+            let pem = self
+                .signing_key
+                .verifying_key()
+                .to_public_key_pem(LineEnding::LF)
+                .unwrap();
+            let response = PublicKey::new()
+                .set_name(KEY_NAME)
+                .set_algorithm(self.algorithm.clone())
+                .set_pem_crc32c(i64::from(crc32c::crc32c(pem.as_bytes())))
+                .set_pem(pem);
+            async move { Ok(Response::from(response)) }
+        }
+
+        fn asymmetric_sign(
+            &self,
+            request: AsymmetricSignRequest,
+            options: RequestOptions,
+        ) -> impl Future<Output = google_cloud_kms_v1::Result<Response<AsymmetricSignResponse>>> + Send
+        {
+            assert_eq!(request.name, KEY_NAME);
+            assert_eq!(options.idempotent(), Some(true));
+            let digest = request.digest.unwrap().sha256().unwrap().clone();
+            assert_eq!(
+                request.digest_crc32c,
+                Some(i64::from(crc32c::crc32c(&digest)))
+            );
+            self.request_count.lock().unwrap().1 += 1;
+
+            let signature: ecdsa::Signature = self.signing_key.sign_prehash(&digest).unwrap();
+            let signature = signature.to_der().as_bytes().to_vec();
+            let checksum =
+                i64::from(crc32c::crc32c(&signature)) + i64::from(self.corrupt_signature_checksum);
+            let response = AsymmetricSignResponse::new()
+                .set_name(KEY_NAME)
+                .set_verified_digest_crc32c(true)
+                .set_signature_crc32c(checksum)
+                .set_signature(signature);
+            async move { Ok(Response::from(response)) }
+        }
+    }
+
+    async fn signer(stub: TestKmsStub) -> anyhow::Result<GcpKmsSigner> {
+        GcpKmsSigner::new(
+            KeyManagementService::from_stub(stub),
+            KEY_NAME.to_owned(),
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn signs_hash_and_recovers_expected_address() {
+        let stub = TestKmsStub::new();
+        let request_count = stub.request_count.clone();
+        let signer = signer(stub).await.unwrap();
+        let digest = B256::repeat_byte(0x42);
+
+        let signature = signer.sign_hash(&digest).await.unwrap();
+
+        assert_eq!(
+            signature.recover_address_from_prehash(&digest).unwrap(),
+            Signer::address(&signer)
+        );
+        assert_eq!(*request_count.lock().unwrap(), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_key_algorithm() {
+        let mut stub = TestKmsStub::new();
+        stub.algorithm = CryptoKeyVersionAlgorithm::EcSignP256Sha256;
+
+        let error = signer(stub).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("expected EC_SIGN_SECP256K1_SHA256")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_corrupt_signature_checksum() {
+        let mut stub = TestKmsStub::new();
+        stub.corrupt_signature_checksum = true;
+        let signer = signer(stub).await.unwrap();
+
+        let error = signer.sign_hash(&B256::ZERO).await.unwrap_err();
+        assert!(error.to_string().contains("signature checksum mismatch"));
+    }
+
+    #[tokio::test]
+    async fn debug_does_not_include_client_details() {
+        let signer = signer(TestKmsStub::new()).await.unwrap();
+
+        let debug = format!("{signer:?}");
+        assert!(debug.contains(KEY_NAME), "{debug}");
+        assert!(!debug.contains(CLIENT_SECRET), "{debug}");
     }
 
     #[test]
-    fn test_parse_kms_resource_name_invalid() {
-        assert!(parse_kms_resource_name("invalid/resource/name").is_err());
-        assert!(parse_kms_resource_name("").is_err());
+    fn retry_policy_is_bounded_and_only_retries_transient_idempotent_errors() {
+        use google_cloud_gax::error::{
+            Error as GaxError,
+            rpc::{Code, Status},
+        };
+
+        let rpc_error = |code| GaxError::service(Status::default().set_code(code));
+        let http_error =
+            |status| GaxError::service_with_http_metadata(Status::default(), Some(status), None);
+        for error in [
+            GaxError::timeout("test timeout"),
+            rpc_error(Code::Unavailable),
+            rpc_error(Code::DeadlineExceeded),
+            rpc_error(Code::ResourceExhausted),
+            rpc_error(Code::Internal),
+            http_error(408),
+            http_error(429),
+            http_error(500),
+            http_error(599),
+        ] {
+            assert!(
+                kms_retry_policy()
+                    .on_error(&RetryState::new(true), error)
+                    .is_continue()
+            );
+        }
         assert!(
-            parse_kms_resource_name(
-                "projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/notanumber"
-            )
-            .is_err()
+            kms_retry_policy()
+                .on_error(
+                    &RetryState::new(true).set_attempt_count(KMS_RETRY_ATTEMPTS - 1),
+                    rpc_error(Code::Unavailable),
+                )
+                .is_continue()
+        );
+        assert!(
+            kms_retry_policy()
+                .on_error(
+                    &RetryState::new(true).set_attempt_count(KMS_RETRY_ATTEMPTS),
+                    rpc_error(Code::Unavailable),
+                )
+                .is_exhausted()
+        );
+        assert!(
+            kms_retry_policy()
+                .on_error(&RetryState::new(false), rpc_error(Code::ResourceExhausted),)
+                .is_permanent()
+        );
+        assert!(
+            kms_retry_policy()
+                .on_error(&RetryState::new(true), rpc_error(Code::PermissionDenied),)
+                .is_permanent()
         );
     }
 }

--- a/lib/operator_signer/src/lib.rs
+++ b/lib/operator_signer/src/lib.rs
@@ -1,10 +1,10 @@
 use alloy::network::EthereumWallet;
 use alloy::primitives::Address;
 use alloy::signers::Signer;
-use alloy::signers::gcp::GcpSigner;
 use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::utils::secret_key_to_address;
+use gcp::GcpKmsSigner;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
@@ -26,7 +26,7 @@ pub enum SignerConfig {
         /// `projects/{project}/locations/{location}/keyRings/{ring}/cryptoKeys/{key}/cryptoKeyVersions/{version}`
         resource_name: String,
         /// Lazily-initialized GCP signer, shared across clones.
-        cached_signer: Arc<OnceCell<GcpSigner>>,
+        cached_signer: Arc<OnceCell<GcpKmsSigner>>,
     },
 }
 
@@ -55,7 +55,7 @@ impl SignerConfig {
     }
 
     /// Returns the cached GCP signer, creating it on first call.
-    async fn get_gcp_signer(&self) -> anyhow::Result<&GcpSigner> {
+    async fn get_gcp_signer(&self) -> anyhow::Result<&GcpKmsSigner> {
         match self {
             Self::GcpKms {
                 resource_name,


### PR DESCRIPTION
## Summary

- replace the Alloy GCP signer, which is coupled to the retired `gcloud-sdk`, with a small Alloy signer adapter backed by the official `google-cloud-kms-v1` client
- use Application Default Credentials for GKE Workload Identity, external Workload Identity Federation, and local ADC without application-level credential parsing
- keep the existing `SignerConfig::gcp_kms` configuration and lazy client cache unchanged
- use bounded GAX retries for transient KMS failures and the auth library retry path for token acquisition and refresh
- validate the KMS key algorithm, resource identity, and CRC32C request/response integrity
- reuse `k256` and Alloy for DER parsing, low-S normalization, recovery ID derivation, transaction chain handling, and signature conversion
- add mock-KMS coverage for signing, idempotency, integrity failures, algorithm validation, retry bounds, and debug redaction

Supersedes #1454. This addresses the same transient STS/KMS failure path while removing the retired SDK instead of adding an application-level retry/configuration layer around it.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -- -D warnings`
- [x] `cargo test -p zksync_os_operator_signer`
- [x] `cargo nextest run --workspace --exclude zksync_os_integration_tests` (337 passed)