### PR TITLE
perf(l1_watcher): batch-sweep startup commit discovery

### DIFF
--- a/integration-tests/tests/node/rebuild.rs
+++ b/integration-tests/tests/node/rebuild.rs
@@ -22,7 +22,7 @@ use zksync_os_integration_tests::wallets::load_operator_private_key;
 use zksync_os_integration_tests::{
     CURRENT_TO_L1, StoppedTester, TestEnvironment, Tester, test_multisetup,
 };
-use zksync_os_l1_watcher::{fetch_batch, fetch_batch_commit_tx_hash};
+use zksync_os_l1_watcher::fetch_live_committed_batch;
 use zksync_os_operator_signer::SignerConfig;
 use zksync_os_server::config::{RebuildBounds, RebuildConfig};
 
@@ -36,12 +36,7 @@ async fn fetch_committed_batch(
     batch_number: u64,
 ) -> anyhow::Result<(B256, u64, u64)> {
     let l1_state = fetch_l1_state(tester).await?;
-    let batch = fetch_batch(
-        &l1_state.diamond_proxy_sl,
-        batch_number,
-        tester.config().l1_watcher_config.max_blocks_to_process,
-    )
-    .await?;
+    let (batch, _) = fetch_live_committed_batch(&l1_state.diamond_proxy_sl, batch_number).await?;
     Ok((
         batch.batch_info.hash(),
         batch.first_block_number(),
@@ -60,12 +55,9 @@ async fn fetch_on_chain_batch_commit_tx_hash(
     batch_number: u64,
 ) -> anyhow::Result<B256> {
     let l1_state = fetch_l1_state(tester).await?;
-    fetch_batch_commit_tx_hash(
-        &l1_state.diamond_proxy_sl,
-        batch_number,
-        tester.config().l1_watcher_config.max_blocks_to_process,
-    )
-    .await
+    let (_, commit_tx_hash) =
+        fetch_live_committed_batch(&l1_state.diamond_proxy_sl, batch_number).await?;
+    Ok(commit_tx_hash)
 }
 
 /// Returns the hash of L2 block `block_number`, erroring if the block does not exist.

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -794,12 +794,13 @@ impl<P: Provider> ZkChain<P> {
         self.instance.provider()
     }
 
-    pub async fn stored_batch_hash(&self, batch_number: u64) -> Result<B256> {
+    pub async fn stored_batch_hash(&self, batch_number: u64, block_id: BlockId) -> Result<B256> {
         self.instance
             .storedBatchHash(U256::from(batch_number))
+            .block(block_id)
             .call()
             .await
-            .enrich("storedBatchHash", None)
+            .enrich("storedBatchHash", Some(block_id))
     }
 
     pub async fn get_total_batches_committed(&self, block_id: BlockId) -> Result<u64> {

--- a/lib/l1_watcher/src/commit_watcher.rs
+++ b/lib/l1_watcher/src/commit_watcher.rs
@@ -52,16 +52,21 @@ impl<Finality: WriteFinality> L1CommitWatcher<Finality> {
 
         let provider = zk_chain.provider().clone();
         let address = (*zk_chain.address()).into();
-        let max_blocks_to_process = config.max_blocks_to_process;
 
         let resolve_start = move |()| async move {
             let last_committed_batch = finality.get_finality_status().last_committed_batch;
-            let last_l1_block = util::find_l1_commit_block_by_batch_number(
-                zk_chain,
-                last_committed_batch,
-                max_blocks_to_process,
-            )
-            .await?;
+            // The startup sweep in `CommittedBatchProvider` already resolved the live commit
+            // block of the committed frontier batch; fall back to an L1 search when it is
+            // unavailable (batch 0 at genesis).
+            let last_l1_block = match committed_batch_provider.commit_l1_block(last_committed_batch)
+            {
+                Some(block) => block,
+                None => {
+                    util::find_l1_commit_block_by_batch_number(&zk_chain, last_committed_batch)
+                        .await?
+                        .0
+                }
+            };
             tracing::info!(last_committed_batch, last_l1_block, "resolved on L1");
 
             let processor = Self {

--- a/lib/l1_watcher/src/committed_batch_provider.rs
+++ b/lib/l1_watcher/src/committed_batch_provider.rs
@@ -1,14 +1,21 @@
 use crate::util;
-use alloy::primitives::{BlockNumber, TxHash};
+use alloy::eips::BlockId;
+use alloy::primitives::{B256, BlockNumber, TxHash};
+use alloy::providers::Provider;
+use alloy::rpc::types::Filter;
+use alloy::sol_types::SolEvent;
 use anyhow::Context;
 use futures::stream::{self, StreamExt};
 use rangemap::RangeInclusiveMap;
 use reth_tasks::Runtime;
 use std::collections::HashMap;
+use std::ops::RangeInclusive;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::time::sleep;
-use zksync_os_batch_types::DiscoveredCommittedBatch;
+use zksync_os_batch_types::{CommittedBatchInfo, DiscoveredCommittedBatch};
+use zksync_os_contract_interface::IExecutor;
+use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::ZkChain;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_contract_interface::models::StoredBatchInfo;
@@ -28,10 +35,10 @@ const WAIT_FOR_BATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// - `PriorityTreeManager`, which reconstructs / advances the priority tree using committed batch
 ///   boundaries.
 ///
-/// Construct it with [`Self::new`], which eagerly loads the startup frontier batches needed by
-/// startup bookkeeping. Then run [`Self::init`] in a background task to populate the remaining
-/// historical committed range while consumers use [`Self::wait_for_batch`] to block until a
-/// specific batch becomes available.
+/// Construct it with [`Self::new`], which locates every startup batch's commit with a single
+/// `eth_getLogs` sweep and eagerly loads the startup frontier batches needed by startup
+/// bookkeeping. The remaining historical committed range is populated by a background task while
+/// consumers use [`Self::wait_for_batch`] to block until a specific batch becomes available.
 #[derive(Debug, Clone)]
 pub struct CommittedBatchProvider {
     inner: Arc<RwLock<Inner>>,
@@ -43,6 +50,9 @@ pub struct CommittedBatchProvider {
 struct Inner {
     batches: HashMap<u64, DiscoveredCommittedBatch>,
     block_range_index: RangeInclusiveMap<BlockNumber, u64>,
+    /// L1 block where each batch's commit was observed during the startup sweep. Not populated
+    /// for batches inserted by live watchers — no consumer needs those.
+    commit_locations: HashMap<u64, BlockNumber>,
 }
 
 impl CommittedBatchProvider {
@@ -51,7 +61,7 @@ impl CommittedBatchProvider {
     pub async fn new(
         runtime: &Runtime,
         l1_state: &L1State,
-        max_l1_blocks_to_scan: u64,
+        max_l1_blocks_per_logs_query: u64,
         load_genesis_batch_info: impl AsyncFnOnce() -> StoredBatchInfo,
     ) -> anyhow::Result<Self> {
         let provider = Self {
@@ -61,7 +71,10 @@ impl CommittedBatchProvider {
         // Special case for genesis
         if l1_state.last_executed_batch == 0 {
             let batch_info = load_genesis_batch_info().await;
-            let batch_hash_l1 = l1_state.diamond_proxy_l1.stored_batch_hash(0).await?;
+            let batch_hash_l1 = l1_state
+                .diamond_proxy_l1
+                .stored_batch_hash(0, BlockId::latest())
+                .await?;
             anyhow::ensure!(
                 batch_hash_l1 == batch_info.hash(),
                 "genesis batch hash mismatch: L1 {}, local {}",
@@ -74,30 +87,34 @@ impl CommittedBatchProvider {
             });
         }
 
-        let (prioritized_batch_numbers, _) = startup_batch_numbers(
+        let (prioritized_batch_numbers, remaining_batch_numbers) = startup_batch_numbers(
             l1_state.last_committed_batch,
             l1_state.last_proved_batch,
             l1_state.last_executed_batch,
             l1_state.last_finalized_executed_batch,
         );
+        // One sweep covers both load phases: the prioritized set contains the extremes of the
+        // startup range (finalized executed = min, committed = max), so the swept window spans
+        // every startup batch's live commit.
+        let swept = Arc::new(
+            sweep_startup_commits(
+                &provider.diamond_proxy_l1,
+                max_l1_blocks_per_logs_query,
+                prioritized_batch_numbers
+                    .iter()
+                    .chain(&remaining_batch_numbers)
+                    .copied(),
+            )
+            .await?,
+        );
         provider
-            .load_batch_numbers(max_l1_blocks_to_scan, prioritized_batch_numbers)
+            .load_swept_batches(&swept, prioritized_batch_numbers)
             .await?;
 
         let provider_for_init = provider.clone();
-        let last_committed = l1_state.last_committed_batch;
-        let last_proved = l1_state.last_proved_batch;
-        let last_executed = l1_state.last_executed_batch;
-        let last_finalized_executed = l1_state.last_finalized_executed_batch;
         runtime.spawn_critical_task("committed batch provider init", async move {
             provider_for_init
-                .init(
-                    last_committed,
-                    last_proved,
-                    last_executed,
-                    last_finalized_executed,
-                    max_l1_blocks_to_scan,
-                )
+                .load_swept_batches(&swept, remaining_batch_numbers)
                 .await
                 .expect("failed to initialize CommittedBatchProvider");
         });
@@ -105,29 +122,27 @@ impl CommittedBatchProvider {
         Ok(provider)
     }
 
-    /// Loads the remaining historical committed batches discovered on startup.
-    async fn init(
-        &self,
-        last_committed_batch: u64,
-        last_proved_batch: u64,
-        last_executed_batch: u64,
-        last_finalized_executed_batch: u64,
-        max_l1_blocks_to_scan: u64,
-    ) -> anyhow::Result<()> {
-        let (_, remaining_batch_numbers) = startup_batch_numbers(
-            last_committed_batch,
-            last_proved_batch,
-            last_executed_batch,
-            last_finalized_executed_batch,
-        );
-        self.load_batch_numbers(max_l1_blocks_to_scan, remaining_batch_numbers)
-            .await?;
-        Ok(())
-    }
-
     pub(crate) fn insert(&self, batch: DiscoveredCommittedBatch) {
         let mut inner = self.inner.write().expect("lock poisoned");
         inner.insert(batch);
+    }
+
+    fn insert_with_commit_location(
+        &self,
+        batch: DiscoveredCommittedBatch,
+        commit_l1_block: BlockNumber,
+    ) {
+        let mut inner = self.inner.write().expect("lock poisoned");
+        inner
+            .commit_locations
+            .insert(batch.number(), commit_l1_block);
+        inner.insert(batch);
+    }
+
+    /// L1 block in which `batch_number`'s commit was observed during the startup sweep.
+    pub fn commit_l1_block(&self, batch_number: u64) -> Option<BlockNumber> {
+        let inner = self.inner.read().expect("lock poisoned");
+        inner.commit_locations.get(&batch_number).copied()
     }
 
     /// Waits until the requested batch is available in memory.
@@ -159,24 +174,56 @@ impl CommittedBatchProvider {
         inner.batches.get(&batch_number).cloned()
     }
 
-    /// Fetches a batch set with bounded concurrency to reduce startup latency without issuing an
-    /// unbounded number of L1 requests.
-    async fn load_batch_numbers(
+    /// Assembles and stores a batch set from swept commit events with bounded concurrency: per
+    /// batch only the commit transaction (for its calldata) and a `storedBatchHash` liveness
+    /// check remain to be fetched.
+    async fn load_swept_batches(
         &self,
-        max_l1_blocks_to_scan: u64,
+        swept: &HashMap<u64, SweptCommit>,
         batch_numbers: Vec<u64>,
     ) -> anyhow::Result<()> {
         stream::iter(batch_numbers)
             .map(|batch_number| async move {
-                let discovered_batch =
-                    fetch_batch(&self.diamond_proxy_l1, batch_number, max_l1_blocks_to_scan)
-                        .await?;
-                tracing::info!(
-                    batch_number = discovered_batch.number(),
-                    "discovered committed batch {} on startup",
-                    discovered_batch.number()
+                let swept_commit = swept.get(&batch_number).with_context(|| {
+                    format!(
+                        "batch {batch_number} not found in the L1 commit sweep \
+                         (reverted after startup state was read?)"
+                    )
+                })?;
+                let commit_info = util::fetch_commit_batch_info(
+                    &self.diamond_proxy_l1,
+                    swept_commit.tx_hash,
+                    batch_number,
+                )
+                .await?;
+                let batch_info = CommittedBatchInfo {
+                    commit_info,
+                    commitment: swept_commit.commitment,
+                }
+                .into_stored();
+                // The sweep cannot tell a live commit from one that was reverted and never
+                // re-committed; the live `storedBatchHash` can. Also validates the calldata
+                // decoding end to end.
+                let live_hash = self
+                    .diamond_proxy_l1
+                    .stored_batch_hash(batch_number, BlockId::latest())
+                    .await?;
+                anyhow::ensure!(
+                    batch_info.hash() == live_hash,
+                    "batch {batch_number} reconstructed from the L1 commit sweep does not hash \
+                     to the live `storedBatchHash` value {live_hash}",
                 );
-                self.insert(discovered_batch);
+                tracing::info!(
+                    batch_number,
+                    "discovered committed batch {batch_number} on startup"
+                );
+                self.insert_with_commit_location(
+                    DiscoveredCommittedBatch {
+                        batch_info,
+                        block_range: swept_commit.block_range.clone(),
+                    },
+                    swept_commit.l1_block_number,
+                );
                 anyhow::Ok(())
             })
             .buffer_unordered(INIT_MAX_PARALLEL_BATCH_FETCHES)
@@ -186,6 +233,136 @@ impl CommittedBatchProvider {
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(())
     }
+}
+
+/// Locates the live commits of all `batch_numbers` with one predicate search and one chunked
+/// `eth_getLogs` sweep.
+///
+/// The swept window starts at the *oldest* requested batch's commit block — for startup, the
+/// last finalized executed batch — so a long execution/finalization stall blocks node startup
+/// proportionally (see [`sweep_committed_batch_events`] for the cost model).
+async fn sweep_startup_commits(
+    diamond_proxy_l1: &ZkChain<NodeProvider>,
+    max_blocks_per_query: u64,
+    batch_numbers: impl Iterator<Item = u64>,
+) -> anyhow::Result<HashMap<u64, SweptCommit>> {
+    let (Some(min_batch), Some(max_batch)) = batch_numbers.fold((None, None), |(min, max), n| {
+        (Some(n.min(min.unwrap_or(n))), Some(n.max(max.unwrap_or(n))))
+    }) else {
+        return Ok(HashMap::new());
+    };
+
+    let latest = diamond_proxy_l1.provider().get_block_number().await?;
+    // With every requested batch committed as of `latest`, each batch's `storedBatchHash` there
+    // belongs to its live commit — `load_swept_batches` relies on this for its liveness checks.
+    let total_committed = diamond_proxy_l1
+        .get_total_batches_committed(latest.into())
+        .await?;
+    anyhow::ensure!(
+        total_committed >= max_batch,
+        "batch {max_batch} is not committed on L1 \
+         (batches committed as of block {latest}: {total_committed})",
+    );
+    let (from_block, _) = util::find_l1_commit_block_by_batch_number(diamond_proxy_l1, min_batch)
+        .await
+        .with_context(|| format!("failed to find live L1 commit block for batch {min_batch}"))?;
+    // No live commit of a batch above `min_batch` can precede `min_batch`'s live commit block:
+    // it would require a later revert below `min_batch`, which would have reverted that batch as
+    // well. So the swept window covers every requested batch.
+    sweep_committed_batch_events(diamond_proxy_l1, from_block, max_blocks_per_query).await
+}
+
+/// A batch commit collected by [`sweep_committed_batch_events`]: the batch's last
+/// `ReportCommittedBatchRangeZKsyncOS` and `BlockCommit` event pair within the swept range.
+#[derive(Debug, Clone)]
+struct SweptCommit {
+    /// Range of L2 blocks that belong to this batch.
+    block_range: RangeInclusive<BlockNumber>,
+    /// Batch commitment from the `BlockCommit` event.
+    commitment: B256,
+    /// Transaction that committed the batch.
+    tx_hash: TxHash,
+    /// Settlement-layer block the commit was observed in.
+    l1_block_number: BlockNumber,
+}
+
+/// Collects the latest `ReportCommittedBatchRangeZKsyncOS` + `BlockCommit` event pair per batch
+/// number in `[from_block, latest]` with a single chunked `eth_getLogs` pass.
+///
+/// Reverted-and-recommitted batches resolve to their latest commit by keep-last semantics, but a
+/// commit that was reverted and never re-committed still lingers in the result — callers must
+/// verify liveness (e.g. against `storedBatchHash`) before trusting an entry.
+///
+/// Runtime is linear in the swept range (one sequential `eth_getLogs` per `max_blocks_per_query`
+/// blocks), so this can take minutes when `from_block` lags days behind the L1 tip.
+async fn sweep_committed_batch_events(
+    zk_chain: &ZkChain<NodeProvider>,
+    from_block: BlockNumber,
+    max_blocks_per_query: u64,
+) -> anyhow::Result<HashMap<u64, SweptCommit>> {
+    let provider = zk_chain.provider();
+    let latest = provider.get_block_number().await?;
+    tracing::info!(from_block, latest, "sweeping L1 for committed batch events");
+
+    // The two events of one commit are folded independently and zipped afterwards; both maps use
+    // keep-last semantics so a re-commit within the range overrides the reverted original.
+    let mut reports: HashMap<u64, (RangeInclusive<BlockNumber>, TxHash, BlockNumber)> =
+        HashMap::new();
+    let mut commitments: HashMap<u64, B256> = HashMap::new();
+
+    let mut current_block = from_block;
+    while current_block <= latest {
+        let filter_to_block = latest.min(current_block + max_blocks_per_query - 1);
+        let filter = Filter::new()
+            .address(*zk_chain.address())
+            .event_signature(vec![
+                ReportCommittedBatchRangeZKsyncOS::SIGNATURE_HASH,
+                IExecutor::BlockCommit::SIGNATURE_HASH,
+            ])
+            .from_block(current_block)
+            .to_block(filter_to_block);
+        let mut logs = provider.get_logs(&filter).await?;
+        // `eth_getLogs` results are expected in (block, log index) order already; sort
+        // defensively since keep-last semantics depend on it.
+        logs.sort_by_key(|log| (log.block_number, log.log_index));
+        for log in logs {
+            match log.topic0() {
+                Some(topic) if *topic == ReportCommittedBatchRangeZKsyncOS::SIGNATURE_HASH => {
+                    let report = ReportCommittedBatchRangeZKsyncOS::decode_log(&log.inner)?.data;
+                    reports.insert(
+                        report.batchNumber,
+                        (
+                            report.firstBlockNumber..=report.lastBlockNumber,
+                            log.transaction_hash.expect("indexed log without tx hash"),
+                            log.block_number.expect("indexed log without block number"),
+                        ),
+                    );
+                }
+                Some(topic) if *topic == IExecutor::BlockCommit::SIGNATURE_HASH => {
+                    let commit = IExecutor::BlockCommit::decode_log(&log.inner)?.data;
+                    commitments.insert(commit.batchNumber.to::<u64>(), commit.commitment);
+                }
+                topic => anyhow::bail!("unexpected event topic in commit sweep: {topic:?}"),
+            }
+        }
+        current_block = filter_to_block + 1;
+    }
+
+    Ok(reports
+        .into_iter()
+        .filter_map(|(batch_number, (block_range, tx_hash, l1_block_number))| {
+            let commitment = *commitments.get(&batch_number)?;
+            Some((
+                batch_number,
+                SweptCommit {
+                    block_range,
+                    commitment,
+                    tx_hash,
+                    l1_block_number,
+                },
+            ))
+        })
+        .collect())
 }
 
 impl Inner {
@@ -218,49 +395,33 @@ fn startup_batch_numbers(
     (prioritized_in_range, remaining_batch_numbers)
 }
 
-/// Resolves a committed batch from L1 by first finding the block that committed it and then
-/// decoding the corresponding stored batch data.
-pub async fn fetch_batch(
+/// Resolves the currently live (non-reverted) commit of `batch_number` from the settlement layer,
+/// returning the discovered batch together with the hash of the transaction that committed it
+/// (not to be confused with the batch header hash itself). See
+/// [`util::find_l1_commit_block_by_batch_number`] for how liveness is established.
+pub async fn fetch_live_committed_batch(
     diamond_proxy_sl: &ZkChain<NodeProvider>,
     batch_number: u64,
-    max_l1_blocks_to_scan: u64,
-) -> anyhow::Result<DiscoveredCommittedBatch> {
-    let sl_block_with_commit = util::find_l1_commit_block_by_batch_number(
-        diamond_proxy_sl.clone(),
-        batch_number,
-        max_l1_blocks_to_scan,
-    )
-    .await
-    .with_context(|| format!("failed to find L1 commit block for batch {batch_number}"))?;
+) -> anyhow::Result<(DiscoveredCommittedBatch, TxHash)> {
+    let (sl_block_with_commit, live_hash) =
+        util::find_l1_commit_block_by_batch_number(diamond_proxy_sl, batch_number)
+            .await
+            .with_context(|| {
+                format!("failed to find live L1 commit block for batch {batch_number}")
+            })?;
 
-    util::fetch_stored_batch_data(diamond_proxy_sl, sl_block_with_commit, batch_number)
-        .await?
-        .with_context(|| format!("failed to find committed batch {batch_number} on L1"))
-}
-
-/// Resolves the L1 transaction hash of the Commit transaction of batch `batch_number` (not to be confused with batch header hash itself)
-pub async fn fetch_batch_commit_tx_hash(
-    diamond_proxy_sl: &ZkChain<NodeProvider>,
-    batch_number: u64,
-    max_l1_blocks_to_scan: u64,
-) -> anyhow::Result<TxHash> {
-    let sl_block_with_commit = util::find_l1_commit_block_by_batch_number(
-        diamond_proxy_sl.clone(),
-        batch_number,
-        max_l1_blocks_to_scan,
-    )
-    .await
-    .with_context(|| format!("failed to find L1 commit block for batch {batch_number}"))?;
-
-    util::find_commit_log(diamond_proxy_sl, sl_block_with_commit, batch_number)
-        .await?
-        .map(|(_, tx_hash)| tx_hash)
-        .with_context(|| {
-            format!(
-                "failed to find commit tx for batch {batch_number} in L1 block \
-                 {sl_block_with_commit}"
-            )
-        })
+    let (batch, commit_tx_hash) =
+        util::fetch_stored_batch_data(diamond_proxy_sl, sl_block_with_commit, batch_number)
+            .await?
+            .with_context(|| format!("failed to find committed batch {batch_number} on L1"))?;
+    // A mismatch means the commit events in `sl_block_with_commit` disagree with
+    // `storedBatchHash` (e.g. a revert landed mid-lookup) — fail rather than return stale data.
+    anyhow::ensure!(
+        batch.batch_info.hash() == live_hash,
+        "batch {batch_number} reconstructed from L1 block {sl_block_with_commit} does not hash \
+         to the live `storedBatchHash` value {live_hash}",
+    );
+    Ok((batch, commit_tx_hash))
 }
 
 #[cfg(test)]

--- a/lib/l1_watcher/src/execute_watcher.rs
+++ b/lib/l1_watcher/src/execute_watcher.rs
@@ -56,7 +56,7 @@ impl<Finality: WriteFinality> L1ExecuteWatcher<Finality> {
             let current_l1_block = zk_chain.provider().get_block_number().await?;
             let last_executed_batch = finality.get_finality_status().last_executed_batch;
             let last_l1_block =
-                util::find_l1_execute_block_by_batch_number(zk_chain, last_executed_batch).await?;
+                util::find_l1_execute_block_by_batch_number(&zk_chain, last_executed_batch).await?;
             tracing::info!(
                 current_l1_block,
                 last_executed_batch,
@@ -102,7 +102,7 @@ impl<Finality: WriteFinality> L1FinalizedExecuteWatcher<Finality> {
             let last_finalized_executed_batch =
                 finality.get_finality_status().last_finalized_executed_batch;
             let last_l1_block = util::find_l1_execute_block_by_batch_number(
-                zk_chain,
+                &zk_chain,
                 last_finalized_executed_batch,
             )
             .await?;

--- a/lib/l1_watcher/src/gateway_migration_watcher.rs
+++ b/lib/l1_watcher/src/gateway_migration_watcher.rs
@@ -51,7 +51,7 @@ impl GatewayMigrationWatcher {
         let resolve_start = move |next_migration_number: u64| async move {
             let chain_asset_handler_address = bridgehub.chain_asset_handler_address().await?;
             let next_l1_block = util::find_block_by_migration_number(
-                zk_chain.clone(),
+                &zk_chain,
                 chain_asset_handler_address,
                 l2_chain_id,
                 next_migration_number,

--- a/lib/l1_watcher/src/lib.rs
+++ b/lib/l1_watcher/src/lib.rs
@@ -28,9 +28,7 @@ mod sink;
 pub use sink::EventSink;
 
 mod committed_batch_provider;
-pub use committed_batch_provider::{
-    CommittedBatchProvider, fetch_batch, fetch_batch_commit_tx_hash,
-};
+pub use committed_batch_provider::{CommittedBatchProvider, fetch_live_committed_batch};
 
 mod persist_batch_watcher;
 pub use persist_batch_watcher::L1PersistBatchWatcher;

--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -46,7 +46,6 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
             "initializing L1 persist batch watcher"
         );
 
-        let max_blocks_to_process = config.max_blocks_to_process;
         let provider = zk_chain.provider().clone();
         let address = (*zk_chain.address()).into();
 
@@ -57,18 +56,14 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 "resolving L1 persist batch watcher start block"
             );
 
-            // Start at `last_persisted_batch` so we re-validate it on resume, unless we're at
-            // genesis — in which case `0` triggers the batch-0 fast path inside
-            // `find_l1_commit_block_by_batch_number`.
-            let start_block = util::find_l1_commit_block_by_batch_number(
-                zk_chain,
-                last_persisted_batch,
-                max_blocks_to_process,
-            )
-            .await
-            .with_context(|| {
-                format!("failed to find L1 commit for batch #{last_persisted_batch}")
-            })?;
+            // Start at `last_persisted_batch` so we re-validate it on resume; at genesis batch 0
+            // resolves to the deployment block, scanning the whole history.
+            let (start_block, _) =
+                util::find_l1_commit_block_by_batch_number(&zk_chain, last_persisted_batch)
+                    .await
+                    .with_context(|| {
+                        format!("failed to find L1 commit for batch #{last_persisted_batch}")
+                    })?;
 
             let processor = Self {
                 batch_storage,

--- a/lib/l1_watcher/src/tx_watcher.rs
+++ b/lib/l1_watcher/src/tx_watcher.rs
@@ -44,7 +44,7 @@ impl L1TxWatcher {
 
         let resolve_start = move |next_l1_priority_id: u64| async move {
             let next_l1_block =
-                find_l1_block_by_priority_id(zk_chain_l1.clone(), next_l1_priority_id).await?;
+                find_l1_block_by_priority_id(&zk_chain_l1, next_l1_priority_id).await?;
             tracing::info!(next_l1_block, "resolved on L1");
             let processor = Self {
                 next_l1_priority_id,
@@ -60,15 +60,17 @@ impl L1TxWatcher {
 }
 
 async fn find_l1_block_by_priority_id(
-    zk_chain: ZkChain<NodeProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     next_l1_priority_id: u64,
 ) -> anyhow::Result<BlockNumber> {
     let deployment_block = zk_chain.deployment_block().await?;
     util::find_l1_block_by_predicate(
-        Arc::new(zk_chain),
+        zk_chain.provider(),
         deployment_block,
-        move |zk, block| async move {
-            let res = zk.get_total_priority_txs_at_block(block.into()).await?;
+        move |block| async move {
+            let res = zk_chain
+                .get_total_priority_txs_at_block(block.into())
+                .await?;
             Ok(res >= next_l1_priority_id)
         },
     )

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::watcher::{L1WatcherError, StartResolver};
 use crate::{EventSink, L1WatcherConfig, ProcessL1Event, util};
@@ -107,7 +106,7 @@ impl L1UpgradeTxWatcher {
 
         let resolve_start = move |current_protocol_version: ProtocolSemanticVersion| async move {
             let last_l1_block =
-                find_l1_block_by_protocol_version(zk_chain_l1, current_protocol_version.clone())
+                find_l1_block_by_protocol_version(&zk_chain_l1, current_protocol_version.clone())
                     .await?;
             tracing::info!(last_l1_block, "checking block starting from");
 
@@ -770,17 +769,17 @@ async fn fetch_upgrade_cut_log_at(
 }
 
 async fn find_l1_block_by_protocol_version(
-    zk_chain: ZkChain<NodeProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     protocol_version: ProtocolSemanticVersion,
 ) -> anyhow::Result<BlockNumber> {
     let protocol_version = protocol_version.packed()?;
 
     let deployment_block = zk_chain.deployment_block().await?;
     util::find_l1_block_by_predicate(
-        Arc::new(zk_chain),
+        zk_chain.provider(),
         deployment_block,
-        move |zk, block| async move {
-            let res = zk.get_raw_protocol_version(block.into()).await?;
+        move |block| async move {
+            let res = zk_chain.get_raw_protocol_version(block.into()).await?;
             Ok(res >= protocol_version)
         },
     )

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -1,11 +1,10 @@
 use crate::watcher::L1WatcherError;
 use alloy::consensus::Transaction;
-use alloy::primitives::{Address, BlockNumber, Log, TxHash, U256};
+use alloy::primitives::{Address, B256, BlockNumber, Log, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use backon::{ConstantBuilder, Retryable};
-use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 use zksync_os_batch_types::{CommittedBatchInfo, DiscoveredCommittedBatch};
@@ -13,8 +12,23 @@ use zksync_os_contract_interface::IChainAssetHandler;
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
 use zksync_os_contract_interface::calldata::CommitCalldata;
 use zksync_os_contract_interface::is_method_missing;
+use zksync_os_contract_interface::models::CommitBatchInfo;
 use zksync_os_contract_interface::{IExecutor, ZkChain};
 use zksync_os_provider::NodeProvider;
+
+/// Retry policy for data that can transiently lag right after a commit is observed on a
+/// load-balanced RPC.
+const COMMIT_DATA_RETRY_POLICY: ConstantBuilder = ConstantBuilder::new()
+    .with_delay(Duration::from_millis(200))
+    .with_max_times(50);
+
+/// Distance of the first downward gallop probe from the latest block.
+///
+/// Startup searches almost always target transitions within the last few hundred L1 blocks (the
+/// unfinalized frontier), so bracketing from the tip costs O(log(distance-from-tip)) probes at
+/// recent — and therefore warm — state instead of O(log(range)) probes at deep-history blocks,
+/// which archive RPCs serve much more slowly.
+const GALLOP_INITIAL_DISTANCE: u64 = 1_000;
 
 /// Finds the first block where `IChainAssetHandler::migrationNumber(chain_id) >= migration_number`
 /// using binary search. Returns latest block if migration number is not reached yet.
@@ -22,7 +36,7 @@ use zksync_os_provider::NodeProvider;
 /// Used by [`GatewayMigrationWatcher`][crate::GatewayMigrationWatcher] (on L1) to determine the
 /// block from which to start scanning for migration events.
 pub async fn find_block_by_migration_number(
-    zk_chain: ZkChain<NodeProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     chain_asset_handler: Address,
     chain_id: u64,
     migration_number: u64,
@@ -55,10 +69,10 @@ pub async fn find_block_by_migration_number(
     // partially up. The predicate still guards against CAH being absent for the V30→V31 migration
     // window where the proxy existed before CAH was deployed.
     let start_block = zk_chain.deployment_block().await?;
-    find_l1_block_by_predicate(Arc::new(zk_chain), start_block, move |zk, block| {
+    find_l1_block_by_predicate(zk_chain.provider(), start_block, move |block| {
         let instance = instance.clone();
         async move {
-            let code = zk
+            let code = instance
                 .provider()
                 .get_code_at(*instance.address())
                 .block_id(block.into())
@@ -85,37 +99,64 @@ pub async fn find_block_by_migration_number(
     .await
 }
 
-/// Maximum number of L1 blocks that we can scan in a reasonable amount of time.
-///
-/// Rough calculations: 10min * 10 req/s * 1000 blocks/req = 600 * 10 * 1000 = 6_000_000
-const MAX_L1_BLOCKS_TO_SCAN_LINEARLY: u64 = 6_000_000;
-
-/// Binary-searches `[start_block_number, latest]` for the first block at which `predicate` returns
+/// Searches `[start_block_number, latest]` for the first block at which `predicate` returns
 /// `true`. The predicate must be monotonic over the search range (caller's responsibility).
+///
+/// Postcondition relied upon by callers: `predicate(result) == true`, and either
+/// `predicate(result - 1) == false` or `result == start_block_number`.
 ///
 /// **Caller must ensure `start_block_number >= contract.deployment_block`** — the predicate is
 /// invoked without a code-presence guard, so calling it at blocks where the contract is not yet
 /// deployed will produce undefined results (typically an RPC error or a `false`-returning revert).
 pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool>>>(
-    zk_chain: Arc<ZkChain<NodeProvider>>,
+    provider: &NodeProvider,
     start_block_number: BlockNumber,
-    predicate: impl Fn(Arc<ZkChain<NodeProvider>>, u64) -> Fut,
+    predicate: impl Fn(BlockNumber) -> Fut,
 ) -> anyhow::Result<BlockNumber> {
-    let latest = zk_chain.provider().get_block_number().await?;
+    let latest = provider.get_block_number().await?;
 
     // Ensure the predicate is true by the upper bound, or bail early.
-    if !predicate(zk_chain.clone(), latest).await? {
+    if !predicate(latest).await? {
         anyhow::bail!(
             "Condition not satisfied up to latest block: contract not deployed yet \
              or target not reached.",
         );
     }
 
-    // Binary search on [start_block_number, latest] for the first block where predicate is true.
+    find_first_true_block(start_block_number, latest, predicate).await
+}
+
+/// Core of [`find_l1_block_by_predicate`]: gallop from the tip, then binary-search the bracket.
+///
+/// Requires `predicate(latest) == true` (checked by the caller). Far-from-tip transitions cost up
+/// to ~log2(range / initial distance) extra probes over a plain binary search.
+async fn find_first_true_block<Fut: Future<Output = anyhow::Result<bool>>>(
+    start_block_number: BlockNumber,
+    latest: BlockNumber,
+    predicate: impl Fn(BlockNumber) -> Fut,
+) -> anyhow::Result<BlockNumber> {
+    // Gallop: probe latest-d, latest-2d, latest-4d, ... until the predicate is false or the
+    // probe clamps at `start_block_number`.
     let (mut lo, mut hi) = (start_block_number, latest);
+    let mut distance = GALLOP_INITIAL_DISTANCE;
     while lo < hi {
-        let mid = (lo + hi) / 2;
-        if predicate(zk_chain.clone(), mid).await? {
+        let probe = latest.saturating_sub(distance).max(lo);
+        if predicate(probe).await? {
+            hi = probe;
+            if probe == lo {
+                break;
+            }
+            distance = distance.saturating_mul(2);
+        } else {
+            lo = probe + 1;
+            break;
+        }
+    }
+
+    // Binary search on [lo, hi] for the first block where the predicate is true.
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if predicate(mid).await? {
             hi = mid;
         } else {
             lo = mid + 1;
@@ -125,195 +166,62 @@ pub async fn find_l1_block_by_predicate<Fut: Future<Output = anyhow::Result<bool
     Ok(lo)
 }
 
-/// Looks for an L1 event that happened in block range `[start_block_number; latest_block]`
-/// and matching provided predicate. Returns latest L1 block that contains such an event or `None`
-/// if there is not any.
-async fn find_last_matching_event<E: SolEvent + Debug>(
-    address: Address,
-    provider: &NodeProvider,
-    start_block_number: BlockNumber,
-    max_blocks_to_scan: u64,
-    predicate: impl Fn(&E) -> bool,
-) -> anyhow::Result<Option<BlockNumber>> {
-    let mut current_block = start_block_number;
-    let latest_block = provider.get_block_number().await?;
-
-    tracing::debug!(
-        %address,
-        start_block_number,
-        latest_block,
-        max_blocks_to_scan,
-        signature = E::SIGNATURE,
-        "looking for last matching event"
-    );
-
-    // Early return if latest block is behind start block. This can happen if we hit different
-    // L1 nodes between calls where the second node is behind the first.
-    if latest_block < start_block_number {
-        tracing::info!(
-            "latest block is behind start block (hitting different L1 nodes?), skipping revert checks"
-        );
-        return Ok(None);
-    }
-
-    let blocks_to_scan = latest_block + 1 - start_block_number;
-    if blocks_to_scan > MAX_L1_BLOCKS_TO_SCAN_LINEARLY {
-        tracing::warn!(blocks_to_scan, "scanning a lot of L1 blocks");
-    }
-
-    let mut filter = Filter::new()
-        .address(address)
-        .event_signature(E::SIGNATURE_HASH);
-    let mut last_block_with_event = None;
-    while current_block < latest_block {
-        // Inspect up to `max_blocks_to_scan` L1 blocks at a time
-        let filter_to_block = latest_block.min(current_block + max_blocks_to_scan - 1);
-        filter = filter.from_block(current_block).to_block(filter_to_block);
-        let logs = provider.get_logs(&filter).await?;
-        tracing::trace!(
-            from_block = current_block,
-            to_block = filter_to_block,
-            log_count = logs.len(),
-            "fetched logs"
-        );
-        for log in logs {
-            let event = E::decode_log(&log.inner)?.data;
-            if predicate(&event) {
-                let l1_block = log
-                    .block_number
-                    .expect("indexed event log without block number");
-                tracing::debug!(
-                    %address,
-                    ?event,
-                    "found new matching event on L1"
-                );
-                last_block_with_event = Some(l1_block);
-            }
-        }
-        current_block = filter_to_block + 1;
-    }
-    Ok(last_block_with_event)
-}
-
-/// Looks for an L1 batch revert event that happened in block range `[start_block_number; latest_block]`
-/// and has affected batch `batch_number`. Returns latest L1 block that contains such an event or `None`
-/// if there is not any.
+/// Finds the settlement-layer block containing the live (non-reverted) commit of `batch_number`,
+/// returning it together with the batch's live `storedBatchHash` value.
 ///
-/// Batch `batch_number` MUST have been committed before `start_block_number`.
-async fn find_latest_l1_revert(
+/// Every commit writes `storedBatchHashes[batch_number] = hash(StoredBatchInfo)`; re-commits
+/// overwrite it and reverts do not clear it — hence the guard that the batch is currently
+/// committed. Under that guard, `storedBatchHash(batch_number, block) == <live hash>` is a
+/// monotonic predicate whose first `true` block is the live commit block, so no `BlocksRevert`
+/// scanning is needed.
+///
+/// Works for batch 0 too: its stored hash is written at contract initialization, so the result
+/// is the deployment block (genesis has no commit event or transaction).
+pub(crate) async fn find_l1_commit_block_by_batch_number(
     zk_chain: &ZkChain<NodeProvider>,
     batch_number: u64,
-    start_block_number: BlockNumber,
-    max_blocks_to_scan: u64,
-) -> anyhow::Result<Option<BlockNumber>> {
-    find_last_matching_event::<IExecutor::BlocksRevert>(
-        *zk_chain.address(),
-        zk_chain.provider(),
-        start_block_number,
-        max_blocks_to_scan,
-        |e| e.totalBatchesCommitted < batch_number,
-    )
-    .await
-}
-
-/// Finds first L1 block that contains **non-reverted** batch commitment event on L1 matching
-/// requested batch.
-///
-/// Returns latest L1 block is there is none.
-///
-/// For any batch `B` that was reverted in tx `T` belonging to L1 block `b` the following MUST hold:
-/// `b` CAN contain commit event for `B` that happened either before `T` or after `T` but MUST NOT
-/// contain both. See comments inside the implementation for more details.
-pub async fn find_l1_commit_block_by_batch_number(
-    zk_chain: ZkChain<NodeProvider>,
-    batch_number: u64,
-    max_l1_blocks_to_scan: u64,
-) -> anyhow::Result<BlockNumber> {
-    let is_batch_committed = move |zk: Arc<ZkChain<NodeProvider>>, block: BlockNumber| async move {
-        let res = zk.get_total_batches_committed(block.into()).await?;
-        Ok(res >= batch_number)
-    };
-    let deployment_block = zk_chain.deployment_block().await?;
-    // This predicate is not monotonic because committed batches can be reverted. Even then, this
-    // binary search will find **some** L1 block that commits our batch. If revert and another commit
-    // happen after the found L1 block, then we will find them as handled by logic in the rest of the
-    // function. If there are none, then we will not find anything and return this L1 block as a
-    // result.
-    let l1_block_with_commit = find_l1_block_by_predicate(
-        Arc::new(zk_chain.clone()),
-        deployment_block,
-        is_batch_committed,
-    )
-    .await?;
-    tracing::debug!(
-        batch_number,
-        l1_block_with_commit,
-        "found first L1 block containing batch commitment"
+) -> anyhow::Result<(BlockNumber, B256)> {
+    let latest = zk_chain.provider().get_block_number().await?;
+    let total_committed = zk_chain.get_total_batches_committed(latest.into()).await?;
+    anyhow::ensure!(
+        total_committed >= batch_number,
+        "batch {batch_number} is not committed on L1 \
+         (batches committed as of block {latest}: {total_committed})",
     );
+    let live_hash = zk_chain
+        .stored_batch_hash(batch_number, latest.into())
+        .await?;
 
-    let last_l1_block_with_revert = find_latest_l1_revert(
-        &zk_chain,
-        batch_number,
-        // Start from next block as current block might contain unrelated reverts. Note that our
-        // batch was observed as committed at the END of block `l1_block_with_commit` so any
-        // preceding reverts are irrelevant.
-        l1_block_with_commit + 1,
-        max_l1_blocks_to_scan,
+    let deployment_block = zk_chain.deployment_block().await?;
+    let live_commit_block = find_l1_block_by_predicate(
+        zk_chain.provider(),
+        deployment_block,
+        move |block| async move {
+            Ok(zk_chain
+                .stored_batch_hash(batch_number, block.into())
+                .await?
+                == live_hash)
+        },
     )
     .await?;
-    match last_l1_block_with_revert {
-        Some(last_l1_block_with_revert) => {
-            tracing::info!(
-                batch_number,
-                last_l1_block_with_revert,
-                "looking for batch commitment after last revert"
-            );
-            // Run binary search one more time but start from `last_l1_block_with_revert` now.
-            // `last_l1_block_with_revert` might contain EITHER commit event for our batch that
-            // happened BEFORE revert or AFTER revert. But it cannot contain both, otherwise L1
-            // Watcher will index reverted commit first. To mitigate this, we can make L1 Watcher
-            // interactively resistant to reverts that happened in the same block (it would watch
-            // for both `BlockCommit` and `BlocksRevert`). This scenario should not happen in the
-            // current implementation, however, and hence can be safely ignored for now.
-            let l1_block_with_commit = find_l1_block_by_predicate(
-                Arc::new(zk_chain),
-                last_l1_block_with_revert,
-                is_batch_committed,
-            )
-            .await?;
-            tracing::info!(
-                batch_number,
-                l1_block_with_commit,
-                "found non-reverted batch commitment on L1"
-            );
-            Ok(l1_block_with_commit)
-        }
-        None => {
-            tracing::info!(
-                batch_number,
-                l1_block_with_commit,
-                "no batch reverts found on L1"
-            );
-            Ok(l1_block_with_commit)
-        }
-    }
+    Ok((live_commit_block, live_hash))
 }
 
 /// Finds first L1 block that contains batch execution event on L1 matching requested batch.
 ///
 /// Returns latest L1 block is there is none.
 pub async fn find_l1_execute_block_by_batch_number(
-    zk_chain: ZkChain<NodeProvider>,
+    zk_chain: &ZkChain<NodeProvider>,
     batch_number: u64,
 ) -> anyhow::Result<BlockNumber> {
-    // Execution cannot be reverted, so unlike in `find_l1_commit_block_by_batch_number`, we do not need
-    // to take L1 reverts into account here.
+    // Execution cannot be reverted, so a plain total-count predicate is safe here, unlike for
+    // commits (see `find_l1_commit_block_by_batch_number`).
     let deployment_block = zk_chain.deployment_block().await?;
     find_l1_block_by_predicate(
-        Arc::new(zk_chain),
+        zk_chain.provider(),
         deployment_block,
-        move |zk, block| async move {
-            let res = zk.get_total_batches_executed(block.into()).await?;
+        move |block| async move {
+            let res = zk_chain.get_total_batches_executed(block.into()).await?;
             Ok(res >= batch_number)
         },
     )
@@ -321,13 +229,13 @@ pub async fn find_l1_execute_block_by_batch_number(
 }
 
 /// Fetches and decodes stored batch data for batch `batch_number` that is expected to have been
-/// committed in `l1_block_number`. Returns `None` if requested batch has not been committed in
-/// the given L1 block.
+/// committed in `l1_block_number`, returning it together with the commit transaction hash.
+/// Returns `None` if requested batch has not been committed in the given L1 block.
 pub async fn fetch_stored_batch_data(
     zk_chain: &ZkChain<NodeProvider>,
     l1_block_number: BlockNumber,
     batch_number: u64,
-) -> anyhow::Result<Option<DiscoveredCommittedBatch>> {
+) -> anyhow::Result<Option<(DiscoveredCommittedBatch, TxHash)>> {
     let Some((commit_log, tx_hash)) =
         find_commit_log(zk_chain, l1_block_number, batch_number).await?
     else {
@@ -337,10 +245,13 @@ pub async fn fetch_stored_batch_data(
         .await?
         .into_stored();
 
-    Ok(Some(DiscoveredCommittedBatch {
-        batch_info,
-        block_range: commit_log.firstBlockNumber..=commit_log.lastBlockNumber,
-    }))
+    Ok(Some((
+        DiscoveredCommittedBatch {
+            batch_info,
+            block_range: commit_log.firstBlockNumber..=commit_log.lastBlockNumber,
+        },
+        tx_hash,
+    )))
 }
 
 /// Finds the `ReportCommittedBatchRangeZKsyncOS` commit event for `batch_number` in
@@ -361,16 +272,21 @@ pub(crate) async fn find_commit_log(
                 .to_block(l1_block_number),
         )
         .await?;
-    Ok(logs.into_iter().find_map(|log| {
-        let batch_log = ReportCommittedBatchRangeZKsyncOS::decode_log(&log.inner)
-            .expect("unable to decode `ReportCommittedBatchRangeZKsyncOS` log");
-        (batch_log.batchNumber == batch_number).then(|| {
-            (
-                batch_log,
-                log.transaction_hash.expect("indexed log without tx hash"),
-            )
+    // Take the *last* matching log in the block: if the batch was committed, reverted and
+    // re-committed within a single L1 block, only the latest commit is the live one.
+    Ok(logs
+        .into_iter()
+        .filter_map(|log| {
+            let batch_log = ReportCommittedBatchRangeZKsyncOS::decode_log(&log.inner)
+                .expect("unable to decode `ReportCommittedBatchRangeZKsyncOS` log");
+            (batch_log.batchNumber == batch_number).then(|| {
+                (
+                    batch_log,
+                    log.transaction_hash.expect("indexed log without tx hash"),
+                )
+            })
         })
-    }))
+        .next_back())
 }
 
 /// Fetches batch commit transaction and extra data from L1 required to construct `CommitedBatch`.
@@ -385,32 +301,7 @@ pub async fn fetch_committed_batch_data(
     // event (which carries the commitment) are independent given the batch number, so we fetch
     // them concurrently. Both can transiently lag right after the commit is observed when hitting
     // a load-balanced RPC, so each is retried.
-    let retry_policy = || {
-        ConstantBuilder::default()
-            .with_delay(Duration::from_millis(200))
-            .with_max_times(50)
-    };
-
-    let tx_fut = async {
-        (|| async {
-            let tx = zk_chain
-                .provider()
-                .get_transaction_by_hash(tx_hash)
-                .await
-                .map_err(|e| L1WatcherError::Other(e.into()))?
-                .ok_or_else(|| {
-                    L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
-                })?;
-            tx.block_number.ok_or_else(|| {
-                L1WatcherError::Other(anyhow::anyhow!(
-                    "commit tx {tx_hash} has no block number (still pending)"
-                ))
-            })?;
-            Ok::<_, L1WatcherError>(tx)
-        })
-        .retry(retry_policy())
-        .await
-    };
+    let tx_fut = fetch_commit_batch_info(zk_chain, tx_hash, batch_number);
 
     // The batch commitment is emitted in the `BlockCommit` event (indexed by batch number) of the
     // commit transaction. Reading it from L1 directly is safe and accurate, unlike deriving it from
@@ -433,28 +324,20 @@ pub async fn fetch_committed_batch_data(
                 .await
                 .map_err(|e| L1WatcherError::Other(e.into()))?
                 .into_iter()
-                .next()
+                // Take the *last* event in the block — same-block re-commit handling, see
+                // `find_commit_log`.
+                .next_back()
                 .ok_or_else(|| {
                     L1WatcherError::Other(anyhow::anyhow!(
                         "`BlockCommit` event for batch {batch_number} not found in L1 block {l1_block_number}"
                     ))
                 })
         })
-        .retry(retry_policy())
+        .retry(COMMIT_DATA_RETRY_POLICY)
         .await
     };
 
-    let (tx, log) = tokio::try_join!(tx_fut, log_fut)?;
-
-    let CommitCalldata {
-        commit_batch_info, ..
-    } = CommitCalldata::decode(tx.input()).map_err(L1WatcherError::Other)?;
-    if commit_batch_info.batch_number != batch_number {
-        return Err(L1WatcherError::Other(anyhow::anyhow!(
-            "commit tx {tx_hash} encodes batch {} but batch {batch_number} was expected",
-            commit_batch_info.batch_number
-        )));
-    }
+    let (commit_batch_info, log) = tokio::try_join!(tx_fut, log_fut)?;
 
     let commitment = IExecutor::BlockCommit::decode_log(&log.inner)
         .map_err(|e| {
@@ -468,4 +351,108 @@ pub async fn fetch_committed_batch_data(
         commit_info: commit_batch_info,
         commitment,
     })
+}
+
+/// Fetches the commit transaction of batch `batch_number` and decodes the `CommitBatchInfo` its
+/// calldata carries. Retries if the transaction is pending (exists but has no block number yet)
+/// or not yet visible.
+pub(crate) async fn fetch_commit_batch_info(
+    zk_chain: &ZkChain<NodeProvider>,
+    tx_hash: TxHash,
+    batch_number: u64,
+) -> Result<CommitBatchInfo, L1WatcherError> {
+    let tx = (|| async {
+        let tx = zk_chain
+            .provider()
+            .get_transaction_by_hash(tx_hash)
+            .await
+            .map_err(|e| L1WatcherError::Other(e.into()))?
+            .ok_or_else(|| {
+                L1WatcherError::Other(anyhow::anyhow!("commit tx {tx_hash} not found"))
+            })?;
+        tx.block_number.ok_or_else(|| {
+            L1WatcherError::Other(anyhow::anyhow!(
+                "commit tx {tx_hash} has no block number (still pending)"
+            ))
+        })?;
+        Ok::<_, L1WatcherError>(tx)
+    })
+    .retry(COMMIT_DATA_RETRY_POLICY)
+    .await?;
+
+    let CommitCalldata {
+        commit_batch_info, ..
+    } = CommitCalldata::decode(tx.input()).map_err(L1WatcherError::Other)?;
+    if commit_batch_info.batch_number != batch_number {
+        return Err(L1WatcherError::Other(anyhow::anyhow!(
+            "commit tx {tx_hash} encodes batch {} but batch {batch_number} was expected",
+            commit_batch_info.batch_number
+        )));
+    }
+    Ok(commit_batch_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_first_true_block;
+    use std::sync::Mutex;
+
+    /// Runs the search against a synthetic monotonic predicate (`block >= first_true`) and
+    /// returns the result along with every probed block.
+    fn search_with_probes(start: u64, latest: u64, first_true: u64) -> (u64, Vec<u64>) {
+        let probes = Mutex::new(Vec::new());
+        let result = futures::executor::block_on(find_first_true_block(start, latest, |block| {
+            probes.lock().unwrap().push(block);
+            async move { Ok(block >= first_true) }
+        }))
+        .unwrap();
+        (result, probes.into_inner().unwrap())
+    }
+
+    #[test]
+    fn finds_transition_near_tip_with_few_shallow_probes() {
+        let (result, probes) = search_with_probes(9_200_000, 11_270_000, 11_269_900);
+        assert_eq!(result, 11_269_900);
+        // Bracketing from the tip must beat a full-range binary search (~21 probes here) and
+        // stay within recent blocks.
+        assert!(
+            probes.len() <= 15,
+            "took {} probes: {probes:?}",
+            probes.len()
+        );
+        assert!(probes.iter().all(|&block| block >= 11_260_000));
+    }
+
+    #[test]
+    fn finds_deep_transition() {
+        let (result, probes) = search_with_probes(0, 11_270_000, 42);
+        assert_eq!(result, 42);
+        assert!(probes.iter().all(|&block| block <= 11_270_000));
+    }
+
+    #[test]
+    fn returns_start_when_predicate_true_everywhere() {
+        let (result, _) = search_with_probes(9_200_000, 11_270_000, 0);
+        assert_eq!(result, 9_200_000);
+    }
+
+    #[test]
+    fn returns_latest_when_transition_at_latest() {
+        let (result, _) = search_with_probes(0, 11_270_000, 11_270_000);
+        assert_eq!(result, 11_270_000);
+    }
+
+    #[test]
+    fn probes_never_go_below_start() {
+        let (result, probes) = search_with_probes(11_269_000, 11_270_000, 11_269_500);
+        assert_eq!(result, 11_269_500);
+        assert!(probes.iter().all(|&block| block >= 11_269_000));
+    }
+
+    #[test]
+    fn handles_start_equal_to_latest() {
+        let (result, probes) = search_with_probes(5, 5, 3);
+        assert_eq!(result, 5);
+        assert!(probes.is_empty());
+    }
 }

--- a/node/bin/src/l1_revert.rs
+++ b/node/bin/src/l1_revert.rs
@@ -5,7 +5,7 @@ use backon::{ConstantBuilder, Retryable};
 use std::time::Duration;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_contract_interface::{IValidatorTimelock, ZkChain};
-use zksync_os_l1_watcher::{fetch_batch, fetch_batch_commit_tx_hash};
+use zksync_os_l1_watcher::fetch_live_committed_batch;
 use zksync_os_operator_signer::SignerConfig;
 use zksync_os_provider::{EthWalletProvider, NodeProvider};
 
@@ -29,7 +29,6 @@ struct RevertPlan {
 async fn derive_last_l1_batch_to_keep(
     from_block_number: u64,
     l1_state: &L1State,
-    max_blocks_to_process: u64,
 ) -> anyhow::Result<u64> {
     let last_committed_batch = l1_state.last_committed_batch;
     let last_executed_batch = l1_state.last_executed_batch;
@@ -43,8 +42,9 @@ async fn derive_last_l1_batch_to_keep(
     );
 
     let fetch_committed = |batch: u64| async move {
-        fetch_batch(&l1_state.diamond_proxy_sl, batch, max_blocks_to_process)
+        fetch_live_committed_batch(&l1_state.diamond_proxy_sl, batch)
             .await
+            .map(|(batch_data, _commit_tx_hash)| batch_data)
             .with_context(|| format!("failed to fetch committed batch {batch} from L1"))
     };
 
@@ -223,7 +223,6 @@ async fn ensure_revert(
 async fn plan_l1_revert(
     rebuild: &RebuildConfig,
     l1_state: &L1State,
-    max_blocks_to_process: u64,
 ) -> anyhow::Result<Option<RevertPlan>> {
     match rebuild {
         RebuildConfig::BlockRebuild { .. } => Ok(None),
@@ -238,13 +237,10 @@ async fn plan_l1_revert(
                 "DangerBlockRebuildWithL1Revert: deriving batch to revert from from_block_number"
             );
 
-            let last_l1_batch_to_keep = derive_last_l1_batch_to_keep(
-                bounds.from_block_number,
-                l1_state,
-                max_blocks_to_process,
-            )
-            .await
-            .context("failed to derive last_l1_batch_to_keep")?;
+            let last_l1_batch_to_keep =
+                derive_last_l1_batch_to_keep(bounds.from_block_number, l1_state)
+                    .await
+                    .context("failed to derive last_l1_batch_to_keep")?;
 
             Ok(Some(RevertPlan {
                 last_l1_batch_to_keep,
@@ -274,13 +270,12 @@ async fn plan_l1_revert(
                 l1_state.last_executed_batch,
             );
 
-            let on_chain_commit_tx_hash = fetch_batch_commit_tx_hash(
-                &l1_state.diamond_proxy_sl,
-                from_batch_number,
-                max_blocks_to_process,
-            )
-            .await
-            .context("failed to fetch on-chain commit tx hash for L1Revert from_batch_number")?;
+            let (_, on_chain_commit_tx_hash) =
+                fetch_live_committed_batch(&l1_state.diamond_proxy_sl, from_batch_number)
+                    .await
+                    .context(
+                        "failed to fetch on-chain commit tx hash for L1Revert from_batch_number",
+                    )?;
 
             if on_chain_commit_tx_hash != *from_batch_commit_tx_hash {
                 tracing::info!(
@@ -323,9 +318,8 @@ pub async fn revert_l1_on_startup(
         .genesis_config
         .chain_id
         .context("`genesis.chain_id` is required for startup rebuild")?;
-    let max_blocks = config.l1_watcher_config.max_blocks_to_process;
 
-    match plan_l1_revert(rebuild, l1_state, max_blocks).await? {
+    match plan_l1_revert(rebuild, l1_state).await? {
         None => Ok(false),
         Some(plan) => {
             perform_l1_revert(&plan, l1_state, chain_id, l1_provider)


### PR DESCRIPTION
## Summary

Speeds up external-node startup by reworking how `CommittedBatchProvider` discovers committed batches on L1. On a stage EN this cuts the batch-discovery phase (`L1 state` → `Node state on startup`) from **~114s to ~13s**; together with the logs-cache fix (#1452) total startup dropped from ~136s to ~26s.

Previously every batch in the startup range got an independent binary search over the full L1 history (~21 sequential archive `eth_call`s each) plus its own chunked `BlocksRevert` log scan — ~500 sequential deep-history RPCs for a typical ~24-batch range whose commits all sit within a few hundred blocks of the tip.

Three changes, sharing one idea — **verify commit liveness via `storedBatchHash` instead of scanning revert logs**:

- **Hash-based commit lookup.** `find_l1_commit_block_by_batch_number` now searches with that predicate and returns the live commit block directly
- **One sweep instead of N searches.** Startup now runs a single search for the *oldest* batch, then one chunked `eth_getLogs` pass collecting every batch's `ReportCommittedBatchRangeZKsyncOS`+`BlockCommit` events. Note: the sweep is linear in the swept window, so it can take minutes if execution finalization lags days behind the tip (still cheaper than the per-batch scans it replaces).
- **Gallop from the tip.** `find_l1_block_by_predicate` brackets exponentially from `latest` before binary-searching: ~12 probes at recent (warm) blocks instead of ~21 at deep history. 

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

