### PR TITLE
feat(status): add /status/ready readiness probe

### DIFF
--- a/lib/status/src/health.rs
+++ b/lib/status/src/health.rs
@@ -13,3 +13,11 @@ pub(crate) async fn health(
 ) -> (StatusCode, Json<HealthResponse>) {
     (StatusCode::OK, Json(HealthResponse { healthy: true }))
 }
+
+pub(crate) async fn ready(state: axum::extract::State<AppState>) -> StatusCode {
+    if state.ready.get().is_some() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}

--- a/lib/status/src/lib.rs
+++ b/lib/status/src/lib.rs
@@ -9,11 +9,12 @@ mod health;
 mod pipeline;
 mod status;
 
-use crate::health::health;
+use crate::health::{health, ready};
 use crate::pipeline::pipeline;
 use crate::status::status;
 use axum::{Router, routing::get};
 use reth_tasks::shutdown::GracefulShutdown;
+use std::sync::{Arc, OnceLock};
 use tokio::{net::TcpListener, sync::watch};
 use zksync_os_backpressure::PipelineSnapshot;
 use zksync_os_raft::RaftConsensusStatus;
@@ -24,6 +25,7 @@ pub use status::{ConsensusStatus, StatusResponse};
 pub struct StatusServerState {
     pub pipeline_snapshot: watch::Receiver<PipelineSnapshot>,
     pub consensus_raft_status_rx: Option<watch::Receiver<Option<RaftConsensusStatus>>>,
+    pub ready: Arc<OnceLock<()>>,
 }
 
 pub(crate) type AppState = StatusServerState;
@@ -37,6 +39,7 @@ pub async fn run_status_server(
     let app = Router::new()
         .route("/status", get(status))
         .route("/status/health", get(health))
+        .route("/status/ready", get(ready))
         .route("/status/pipeline", get(pipeline))
         .with_state(state);
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -56,7 +56,7 @@ use anyhow::Context;
 use priority_tree_pipeline_step::PriorityTreePipelineStep;
 use reth_tasks::Runtime;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
@@ -929,6 +929,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         rx
     };
 
+    let rpc_ready: Arc<OnceLock<()>> = Arc::new(OnceLock::new());
+
     // ======== Start Status Server ========
     let status_port = if config.status_server_config.enabled {
         let status_listener = prebound_status_listener
@@ -940,6 +942,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         let status_state = StatusServerState {
             pipeline_snapshot: pipeline_snapshot_rx,
             consensus_raft_status_rx: raft_status_rx,
+            ready: rpc_ready.clone(),
         };
         runtime.spawn_critical_with_graceful_shutdown_signal(
             "status server",
@@ -966,6 +969,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         repositories_for_wait
             .wait_for_db_ready_to_process_blocks()
             .await;
+        // `rpc::spawn` awaits this future before serving.
+        let _ = rpc_ready.set(());
     };
     let rpc_policy_client = config
         .sequencer_config


### PR DESCRIPTION
Adds `/status/ready`: 200 once the RPC server is serving (after `wait_for_db`), 503 while starting up — a k8s readiness-probe target.

**What it gains now:** a booting/restarting sequencer is pulled from the `sequencer-all` load balancer until it can actually serve, instead of black-holing traffic for the ~26s boot. Kills read drops on EN/partial restarts, and is the prerequisite for staggered rollout (flux `dependsOn`+`wait` needs a real readiness signal, not just "process up"). Does not address the MN write gap during the main node's own boot (no sequencing failover — separate track).

Stacked on `#1460`; the gitops probe config must ship after this image (else 404 → all not-ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)