### PR TITLE
fix(network): drop external IP probe at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16311,7 +16311,6 @@ dependencies = [
  "reth-chainspec",
  "reth-discv5",
  "reth-eth-wire",
- "reth-net-nat",
  "reth-network",
  "reth-network-peers",
  "reth-provider",

--- a/lib/network/Cargo.toml
+++ b/lib/network/Cargo.toml
@@ -44,7 +44,6 @@ metrics.workspace = true
 
 reth-network.workspace = true
 reth-network-peers.workspace = true
-reth-net-nat.workspace = true
 reth-eth-wire.workspace = true
 reth-discv5.workspace = true
 reth-chainspec.workspace = true

--- a/lib/network/src/service.rs
+++ b/lib/network/src/service.rs
@@ -19,7 +19,6 @@ use futures::future::join_all;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_discv5::discv5;
 use reth_eth_wire::HelloMessageWithProtocols;
-use reth_net_nat::NatResolver;
 use reth_network::error::NetworkError;
 use reth_network::types::peers::config::PeerBackoffDurations;
 use reth_network::{
@@ -329,14 +328,6 @@ impl NetworkService {
         // are captured. This must happen before `NetworkManager::builder()` because that is where
         // reth initializes its metric handles (via `Default::default()` on each metrics struct).
         crate::metrics::install_recorder();
-        match NatResolver::Any.external_addr().await {
-            None => {
-                tracing::info!("could not resolve external IP (STUN)");
-            }
-            Some(ip) => {
-                tracing::info!(%ip, "resolved external IP (STUN)");
-            }
-        };
         let rlpx_address = SocketAddr::new(IpAddr::V4(config.address), config.port);
         let configured_port = config.port;
         let discv5_listen_config = discv5::ListenConfig::Ipv4 {


### PR DESCRIPTION
`NatResolver::Any.external_addr()` at network startup (UPnP + ipinfo.io/icanhazip.com/ifconfig.me) only feeds an INFO log line -- reth NAT is disabled (`.disable_nat()`) and the ENR address comes from discv5 peer PONGs. On egress-restricted clusters it trips network policy (observed as POLICY_DENIED drop noise on every sequencer start on cari-testnet) and stalls startup up to 10s waiting on the reqwest timeout. Remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)