### PR TITLE
test: re-enable v31 integration test matrix on L1

### DIFF
--- a/.github/scripts/test-configs.sh
+++ b/.github/scripts/test-configs.sh
@@ -12,7 +12,7 @@ CONFIGS=(
   "v30 default|local-chains/v30.2/l1-state.json|local-chains/v30.2/default/config.yaml"
   "v30 multi-chain 1|local-chains/v30.2/l1-state.json|local-chains/v30.2/multi_chain/chain_6565.yaml"
   "v30 multi-chain 2|local-chains/v30.2/l1-state.json|local-chains/v30.2/multi_chain/chain_6566.yaml"
-#  "v31 default|local-chains/v31.0/l1-state.json|local-chains/v31.0/default/config.yaml"
+  "v31 default|local-chains/v31.0/l1-state.json|local-chains/v31.0/default/config.yaml"
 )
 
 cleanup() {

--- a/integration-tests/tests/node/external_node.rs
+++ b/integration-tests/tests/node/external_node.rs
@@ -10,8 +10,8 @@ use backon::{ConstantBuilder, Retryable};
 use zksync_os_integration_tests::BATCH_VERIFICATION_KEYS;
 use zksync_os_integration_tests::provider::ZksyncTestingProvider;
 use zksync_os_integration_tests::{
-    CURRENT_TO_L1, TestEnvironment, Tester, assert_traits::ReceiptAssert, contracts::EventEmitter,
-    test_multisetup,
+    CURRENT_TO_L1, NEXT_TO_L1, TestEnvironment, Tester, assert_traits::ReceiptAssert,
+    contracts::EventEmitter, test_multisetup,
 };
 use zksync_os_server::config::Config;
 
@@ -24,7 +24,7 @@ async fn launch_en(
     main_node.launch_from_config(config).await
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn batch_verification_works(env: TestEnvironment) -> anyhow::Result<()> {
     let mut config = env.default_config().await?;
     config.batch_verification_config.server_enabled = true;
@@ -129,7 +129,7 @@ async fn batch_verification_with_2_ens(env: TestEnvironment) -> anyhow::Result<(
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn transaction_replay(main_node: Tester) -> anyhow::Result<()> {
     let en1 = launch_en(&main_node, |_| {}).await?;
 

--- a/integration-tests/tests/protocol/erc20.rs
+++ b/integration-tests/tests/protocol/erc20.rs
@@ -12,11 +12,11 @@ use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::TestERC20::TestERC20Instance;
 use zksync_os_integration_tests::contracts::{IL2AssetRouter, L1AssetRouter, TestERC20};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, Tester, test_multisetup};
 use zksync_os_provider::NodeProvider;
 use zksync_os_types::{L2ToL1Log, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, ZkTxType};
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn erc20_deposit(tester: Tester) -> anyhow::Result<()> {
     let alice = tester.l1_wallet().default_signer().address();
 
@@ -58,7 +58,7 @@ async fn erc20_deposit(tester: Tester) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn erc20_transfer(tester: Tester) -> anyhow::Result<()> {
     // We use L2 wallet's default signer as Alice because it already has L2 ETH.
     let alice = tester.l2_wallet.default_signer().address();
@@ -102,7 +102,7 @@ async fn erc20_transfer(tester: Tester) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn erc20_withdrawal(tester: Tester) -> anyhow::Result<()> {
     // We use L2 wallet's default signer as Alice because it already has L2 ETH.
     let alice = tester.l2_wallet.default_signer().address();

--- a/integration-tests/tests/protocol/l1.rs
+++ b/integration-tests/tests/protocol/l1.rs
@@ -10,12 +10,12 @@ use zksync_os_contract_interface::Bridgehub;
 use zksync_os_contract_interface::IMailbox::NewPriorityRequest;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::{L1AssetRouter, L2BaseToken};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, Tester, test_multisetup};
 use zksync_os_types::{
     L1PriorityTxType, L1TxType, L2ToL1Log, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, ZkTxType,
 };
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn l1_deposit(tester: Tester) -> anyhow::Result<()> {
     // Test that we can deposit L2 funds from a rich L1 account
     let alice = tester.l1_wallet().default_signer().address();
@@ -129,7 +129,7 @@ async fn l1_deposit(tester: Tester) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn l1_withdraw(tester: Tester) -> anyhow::Result<()> {
     // Test that we can withdraw L2 funds to L1
     let alice = tester.l2_wallet.default_signer().address();
@@ -160,8 +160,10 @@ async fn l1_withdraw(tester: Tester) -> anyhow::Result<()> {
 
     let alice_l1_final_balance = tester.l1_provider().get_balance(alice).await?;
     let alice_l2_final_balance = tester.l2_provider.get_balance(alice).await?;
-    assert!(alice_l1_final_balance >= alice_l1_initial_balance - l1_fee + amount);
-    assert!(alice_l2_final_balance <= alice_l2_initial_balance - l2_fee - amount);
+    // Rearranged to avoid U256 underflow: the test wallet may hold no L1 ETH at all before the
+    // withdrawal arrives (e.g. on freshly generated chain states).
+    assert!(alice_l1_final_balance + l1_fee >= alice_l1_initial_balance + amount);
+    assert!(alice_l2_final_balance + l2_fee + amount <= alice_l2_initial_balance);
 
     Ok(())
 }

--- a/integration-tests/tests/prover.rs
+++ b/integration-tests/tests/prover.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "prover-tests")]
 
-use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, TestEnvironment, test_multisetup};
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn prover(env: TestEnvironment) -> anyhow::Result<()> {
     // Test that prover can successfully prove at least one batch
     let mut config = env.default_config().await?;

--- a/integration-tests/tests/rpc/api.rs
+++ b/integration-tests/tests/rpc/api.rs
@@ -13,7 +13,9 @@ use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_integration_tests::assert_traits::ReceiptAssert;
 use zksync_os_integration_tests::contracts::Counter::CounterInstance;
 use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
-use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
+use zksync_os_integration_tests::{
+    CURRENT_TO_L1, NEXT_TO_L1, TestEnvironment, Tester, test_multisetup,
+};
 use zksync_os_provider::NodeProvider;
 use zksync_os_rpc_api::types::BatchStorageProof;
 use zksync_os_server::config::FeeConfig;
@@ -145,7 +147,7 @@ async fn get_gas_price_uses_configured_scale_factor(env: TestEnvironment) -> any
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn send_raw_transaction_sync(tester: Tester) -> anyhow::Result<()> {
     // Test that the node supports `eth_sendRawTransactionSync`
     let alice = tester.l2_wallet.default_signer().address();

--- a/integration-tests/tests/rpc/call.rs
+++ b/integration-tests/tests/rpc/call.rs
@@ -7,9 +7,9 @@ use alloy::rpc::types::state::{AccountOverride, StateOverride};
 use std::collections::HashMap;
 use zksync_os_integration_tests::assert_traits::EthCallAssert;
 use zksync_os_integration_tests::contracts::{EventEmitter, SimpleRevert, TracingSecondary};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, Tester, test_multisetup};
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn call_genesis(tester: Tester) -> anyhow::Result<()> {
     // Test that the node can run `eth_call` on genesis
     tester
@@ -20,7 +20,7 @@ async fn call_genesis(tester: Tester) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn call_pending(tester: Tester) -> anyhow::Result<()> {
     // Test that the node can run `eth_call` on pending block
     tester

--- a/integration-tests/tests/rpc/simulate.rs
+++ b/integration-tests/tests/rpc/simulate.rs
@@ -14,7 +14,7 @@ use alloy::rpc::types::state::{AccountOverride, StateOverridesBuilder};
 use alloy::sol_types::{SolCall, SolEvent};
 use zksync_os_integration_tests::contracts::EventEmitter::TestEvent;
 use zksync_os_integration_tests::contracts::{Counter, EventEmitter};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, Tester, test_multisetup};
 
 /// Simulate a single ETH transfer in one block and verify that gas was consumed.
 #[test_multisetup([CURRENT_TO_L1])]
@@ -144,7 +144,7 @@ async fn simulate_state_carries_across_blocks(tester: Tester) -> anyhow::Result<
 /// Simulate the transaction shape used by the settlement-layer sender through `eth_simulateV1`.
 ///
 /// L1 commit transactions carry blob sidecars.
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn simulate_settlement_sender_tx_shape(tester: Tester) -> anyhow::Result<()> {
     let provider = tester.l1_provider();
     let sender = tester.l1_wallet().default_signer().address();

--- a/integration-tests/tests/rpc/transactions.rs
+++ b/integration-tests/tests/rpc/transactions.rs
@@ -5,9 +5,9 @@ use alloy::providers::Provider;
 use alloy::rpc::types::{AccessListItem, TransactionRequest};
 use tokio::time::Instant;
 use zksync_os_integration_tests::assert_traits::{ReceiptAssert, ReceiptsAssert};
-use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, Tester, test_multisetup};
 
-#[test_multisetup([CURRENT_TO_L1])]
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
 async fn basic_transfers(tester: Tester) -> anyhow::Result<()> {
     // Test that the node can process 100 concurrent transfers to random accounts
     let alice = tester.l2_wallet.default_signer().address();


### PR DESCRIPTION
## Summary

Restores v31 integration tests after Gateway removal and v31 local state re-generation

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

