### PR TITLE
feat: Add Azure HSM signing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version 0.4.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tracing",
+]
+
+[[package]]
+name = "azure_identity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "azure_security_keyvault_keys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb869c31138eaf27e4bb4854e51810964cf689925d2ce0a790e9be37188e45fb"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "rustc_version 0.4.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6622,7 +6688,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -7557,7 +7623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -9431,7 +9497,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -9469,7 +9535,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14230,6 +14296,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "typespec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14447,13 +14564,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -14878,7 +14995,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16370,10 +16487,15 @@ dependencies = [
  "alloy-signer",
  "anyhow",
  "async-trait",
+ "azure_core",
+ "azure_identity",
+ "azure_security_keyvault_keys",
+ "base64 0.22.1",
  "crc32c",
  "google-cloud-gax",
  "google-cloud-kms-v1",
  "k256",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ aws-sdk-s3 = { version = "1.133.0", default-features = false, features = [
     "rt-tokio",
     "default-https-client",
 ] }
+azure_core = "1.1.0"
+azure_identity = "1.0.0"
+azure_security_keyvault_keys = "1.0.0"
 crc32c = "0.6.8"
 google-cloud-gax = "1.12.0"
 google-cloud-kms-v1 = "1.12.0"

--- a/docs/src/design/base_token_price_updater.md
+++ b/docs/src/design/base_token_price_updater.md
@@ -43,7 +43,7 @@ then the component will also periodically update "ETH:token" price ratio on L1. 
 still work without it but there will be a warning in logs and ratio on L1 won't change meaning that price
 for L1->L2 txs can eventually get outdated.
 
-You can use either a local private key or a GCP KMS key via the `token_multiplier_setter_sk` field:
+You can use a local private key, a GCP KMS key, or an Azure Key Vault key via the `token_multiplier_setter_sk` field:
 
 ```yaml
 # Option 1: Local private key (plain hex string)
@@ -55,6 +55,12 @@ base_token_price_updater:
   token_multiplier_setter_sk:
     type: gcp_kms
     resource: "projects/{project}/locations/{location}/keyRings/{ring}/cryptoKeys/{key}/cryptoKeyVersions/{version}"
+
+# Option 3: Azure Key Vault / Managed HSM key (structured object; the key version is required)
+base_token_price_updater:
+  token_multiplier_setter_sk:
+    type: azure_kms
+    key_id: "https://{vault}.vault.azure.net/keys/{name}/{version}"
 ```
 
 ## Mainnet recommendation

--- a/lib/base_token_adjuster/src/lib.rs
+++ b/lib/base_token_adjuster/src/lib.rs
@@ -45,7 +45,7 @@ pub struct BaseTokenPriceUpdaterConfig {
     /// Signer configuration to update base token price on L1.
     /// Must be consistent with the key set on the chain admin contract.
     /// It's not used for chains with ETH as base token and it's expected to be set for all other chains.
-    /// Supports both local private keys and GCP KMS keys.
+    /// Supports local private keys, GCP KMS keys, and Azure Key Vault keys.
     pub token_multiplier_setter_signer: Option<SignerConfig>,
     /// Max fee per gas we are willing to spend (in wei).
     pub max_fee_per_gas_wei: u128,

--- a/lib/operator_signer/Cargo.toml
+++ b/lib/operator_signer/Cargo.toml
@@ -18,10 +18,17 @@ alloy = { workspace = true, default-features = false, features = [
 ] }
 alloy-signer.workspace = true
 async-trait.workspace = true
+azure_core.workspace = true
+azure_identity.workspace = true
+azure_security_keyvault_keys.workspace = true
 crc32c.workspace = true
 google-cloud-gax.workspace = true
 google-cloud-kms-v1.workspace = true
 k256.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 anyhow.workspace = true
+
+[dev-dependencies]
+base64.workspace = true
+serde_json.workspace = true

--- a/lib/operator_signer/src/azure.rs
+++ b/lib/operator_signer/src/azure.rs
@@ -1,0 +1,621 @@
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::{
+    consensus::SignableTransaction,
+    network::TxSigner,
+    primitives::{Address, B256, ChainId, Signature},
+    signers::utils::public_key_to_address,
+};
+use alloy_signer::{Error as SignerError, Signer, sign_transaction_with_chain_id};
+use anyhow::Context as _;
+use async_trait::async_trait;
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use azure_core::http::{ExponentialRetryOptions, RetryOptions};
+use azure_identity::{
+    DeveloperToolsCredential, ManagedIdentityCredential, WorkloadIdentityCredential,
+};
+use azure_security_keyvault_keys::{
+    KeyClient, KeyClientOptions, ResourceId,
+    models::{
+        CurveName, KeyClientGetKeyOptions, KeyClientSignOptions, KeyType, SignParameters,
+        SignatureAlgorithm,
+    },
+};
+use k256::ecdsa::{self, RecoveryId, VerifyingKey};
+
+/// Bounds each Key Vault operation, including the SDK's internal retries. The SDK sets no
+/// transport read timeout, so without this a stalled connection would hang a sign call
+/// (and the l1_sender pipeline) indefinitely.
+const KEY_VAULT_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Signing the same digest again is side-effect-free, so the SDK's bounded retries on
+/// transient failures (408/429/5xx and transport errors) are safe. Kept under
+/// `KEY_VAULT_TIMEOUT` so retries are not cut off mid-flight.
+fn key_vault_retry_options() -> RetryOptions {
+    RetryOptions::exponential(ExponentialRetryOptions {
+        max_retries: 3,
+        max_total_elapsed: azure_core::time::Duration::seconds(30),
+        ..Default::default()
+    })
+}
+
+/// Azure Key Vault (or Managed HSM)-backed Ethereum signer.
+#[derive(Clone)]
+pub struct AzureKmsSigner {
+    // Arc because `KeyClient` is not `Clone`, but the signer is cloned for wallet registration.
+    client: Arc<KeyClient>,
+    key_name: String,
+    key_version: String,
+    /// Full key identifier URL, kept for logs and error messages.
+    key_id: String,
+    chain_id: Option<ChainId>,
+    public_key: VerifyingKey,
+    address: Address,
+}
+
+impl fmt::Debug for AzureKmsSigner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AzureKmsSigner")
+            .field("key_id", &self.key_id)
+            .field("chain_id", &self.chain_id)
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AzureKmsSigner {
+    async fn new(
+        client: Arc<KeyClient>,
+        key_name: String,
+        key_version: String,
+        key_id: String,
+        chain_id: Option<ChainId>,
+    ) -> anyhow::Result<Self> {
+        let key = with_timeout(
+            &key_id,
+            "get_key",
+            client.get_key(
+                &key_name,
+                Some(KeyClientGetKeyOptions {
+                    key_version: Some(key_version.clone()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await
+        .with_context(|| format!("failed to fetch Azure Key Vault public key for '{key_id}'"))?
+        .into_model()
+        .with_context(|| format!("failed to decode Azure Key Vault key '{key_id}'"))?;
+
+        let jwk = key
+            .key
+            .with_context(|| format!("Azure Key Vault returned no key material for '{key_id}'"))?;
+        verify_kid(jwk.kid.as_deref(), &key_name, &key_version, &key_id)?;
+        anyhow::ensure!(
+            matches!(jwk.kty, Some(KeyType::Ec | KeyType::EcHsm)),
+            "Azure Key Vault key '{key_id}' is not an elliptic-curve key"
+        );
+        anyhow::ensure!(
+            jwk.crv == Some(CurveName::P256K),
+            "Azure Key Vault key '{key_id}' uses curve {:?}, expected P-256K (secp256k1)",
+            jwk.crv
+        );
+
+        // SEC1 uncompressed point: 0x04 || x || y.
+        let mut sec1 = [0_u8; 65];
+        sec1[0] = 0x04;
+        sec1[1..33].copy_from_slice(&coordinate(jwk.x, "x", &key_id)?);
+        sec1[33..].copy_from_slice(&coordinate(jwk.y, "y", &key_id)?);
+        let public_key = VerifyingKey::from_sec1_bytes(&sec1)
+            .context("failed to parse Azure Key Vault secp256k1 public key")?;
+        let address = public_key_to_address(&public_key);
+
+        Ok(Self {
+            client,
+            key_name,
+            key_version,
+            key_id,
+            chain_id,
+            public_key,
+            address,
+        })
+    }
+
+    async fn sign_digest(&self, digest: &B256) -> anyhow::Result<Signature> {
+        let parameters = SignParameters {
+            algorithm: Some(SignatureAlgorithm::Es256K),
+            value: Some(digest.to_vec()),
+        };
+        let response = with_timeout(
+            &self.key_id,
+            "sign",
+            self.client.sign(
+                &self.key_name,
+                parameters.try_into()?,
+                Some(KeyClientSignOptions {
+                    key_version: Some(self.key_version.clone()),
+                    ..Default::default()
+                }),
+            ),
+        )
+        .await
+        .with_context(|| format!("Azure Key Vault signing with '{}' failed", self.key_id))?
+        .into_model()
+        .with_context(|| {
+            format!(
+                "failed to decode Azure Key Vault sign response for '{}'",
+                self.key_id
+            )
+        })?;
+
+        verify_kid(
+            response.kid.as_deref(),
+            &self.key_name,
+            &self.key_version,
+            &self.key_id,
+        )?;
+        let raw = response.result.with_context(|| {
+            format!(
+                "Azure Key Vault sign response for '{}' omitted the signature",
+                self.key_id
+            )
+        })?;
+
+        // ES256K returns the raw 64-byte `r || s` encoding (IEEE P1363), not DER.
+        let signature = ecdsa::Signature::from_slice(&raw)
+            .context("failed to decode Azure Key Vault ES256K signature (expected 64-byte r||s)")?;
+        let signature = signature.normalize_s().unwrap_or(signature);
+        let recovery_id = RecoveryId::trial_recovery_from_prehash(
+            &self.public_key,
+            digest.as_slice(),
+            &signature,
+        )
+        .context("failed to recover parity from Azure Key Vault signature")?;
+        Ok((signature, recovery_id).into())
+    }
+}
+
+#[async_trait]
+impl Signer for AzureKmsSigner {
+    async fn sign_hash(&self, hash: &B256) -> alloy::signers::Result<Signature> {
+        self.sign_digest(hash).await.map_err(SignerError::other)
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<ChainId>) {
+        self.chain_id = chain_id;
+    }
+}
+
+#[async_trait]
+impl TxSigner<Signature> for AzureKmsSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        transaction: &mut dyn SignableTransaction<Signature>,
+    ) -> alloy::signers::Result<Signature> {
+        sign_transaction_with_chain_id!(
+            self,
+            transaction,
+            self.sign_hash(&transaction.signature_hash()).await
+        )
+    }
+}
+
+async fn with_timeout<T>(
+    key_id: &str,
+    operation: &str,
+    future: impl Future<Output = azure_core::Result<T>>,
+) -> anyhow::Result<T> {
+    tokio::time::timeout(KEY_VAULT_TIMEOUT, future)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Azure Key Vault {operation} for '{key_id}' timed out after {KEY_VAULT_TIMEOUT:?}"
+            )
+        })?
+        .map_err(Into::into)
+}
+
+/// Ensures a response refers to the exact key (vault, name, and version) this signer was
+/// configured with, comparing parsed identifiers rather than raw URLs to stay robust to
+/// case/formatting.
+fn verify_kid(
+    kid: Option<&str>,
+    key_name: &str,
+    key_version: &str,
+    key_id: &str,
+) -> anyhow::Result<()> {
+    let kid = kid.with_context(|| {
+        format!("Azure Key Vault response for '{key_id}' omitted the key identifier")
+    })?;
+    let resource: ResourceId = kid
+        .parse()
+        .with_context(|| format!("failed to parse Azure Key Vault key identifier '{kid}'"))?;
+    let expected: ResourceId = key_id.parse().with_context(|| {
+        format!("failed to parse configured Azure Key Vault key identifier '{key_id}'")
+    })?;
+    anyhow::ensure!(
+        resource.vault_url.eq_ignore_ascii_case(&expected.vault_url)
+            && resource.name == key_name
+            && resource.version.as_deref() == Some(key_version),
+        "Azure Key Vault responded for key '{kid}', expected '{key_id}'"
+    );
+    Ok(())
+}
+
+fn coordinate(value: Option<Vec<u8>>, name: &str, key_id: &str) -> anyhow::Result<[u8; 32]> {
+    let value = value.with_context(|| {
+        format!("Azure Key Vault key '{key_id}' is missing the '{name}' coordinate")
+    })?;
+    anyhow::ensure!(
+        value.len() <= 32,
+        "'{name}' coordinate of Azure Key Vault key '{key_id}' is {} bytes, expected at most 32",
+        value.len()
+    );
+    // JWK integers may be shorter than the field size when leading bytes are zero.
+    let mut out = [0_u8; 32];
+    out[32 - value.len()..].copy_from_slice(&value);
+    Ok(out)
+}
+
+/// Bounds each credential source's token attempt. On real Azure hosting, IMDS and token
+/// exchanges answer in well under a second; outside Azure the IMDS address (169.254.169.254)
+/// often black-holes instead of refusing, which would otherwise stall the whole chain.
+const CREDENTIAL_SOURCE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Tries each credential source in order and returns the first token successfully acquired.
+/// The first source to succeed is locked in and used exclusively afterwards, so a hanging
+/// earlier source (e.g. IMDS off-Azure) is only paid for once.
+///
+/// `azure_identity` ships no `DefaultAzureCredential`-style chain, so we compose the
+/// production sources (AKS workload identity, VM/App Service managed identity) with the
+/// developer-tools fallback (Azure CLI) ourselves. Sources whose environment prerequisites
+/// are missing fail at construction and are skipped from the chain.
+#[derive(Debug)]
+struct ChainedTokenCredential {
+    sources: Vec<Arc<dyn TokenCredential>>,
+    selected: std::sync::OnceLock<usize>,
+}
+
+#[async_trait]
+impl TokenCredential for ChainedTokenCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        options: Option<TokenRequestOptions<'_>>,
+    ) -> azure_core::Result<AccessToken> {
+        if let Some(&selected) = self.selected.get() {
+            return self.sources[selected].get_token(scopes, options).await;
+        }
+        let mut last_error = None;
+        for (index, source) in self.sources.iter().enumerate() {
+            match tokio::time::timeout(
+                CREDENTIAL_SOURCE_TIMEOUT,
+                source.get_token(scopes, options.clone()),
+            )
+            .await
+            {
+                Ok(Ok(token)) => {
+                    let _ = self.selected.set(index);
+                    return Ok(token);
+                }
+                Ok(Err(error)) => {
+                    tracing::debug!(%error, "Azure credential source failed, trying next");
+                    last_error = Some(error);
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        "Azure credential source timed out after {CREDENTIAL_SOURCE_TIMEOUT:?}, trying next"
+                    );
+                    last_error = Some(azure_core::Error::with_message(
+                        azure_core::error::ErrorKind::Credential,
+                        format!("credential source timed out after {CREDENTIAL_SOURCE_TIMEOUT:?}"),
+                    ));
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| {
+            azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Credential,
+                "no Azure credential sources available",
+            )
+        }))
+    }
+}
+
+fn chained_credential() -> anyhow::Result<Arc<dyn TokenCredential>> {
+    let sources: Vec<Arc<dyn TokenCredential>> = [
+        WorkloadIdentityCredential::new(None).map(|c| c as _),
+        ManagedIdentityCredential::new(None).map(|c| c as _),
+        DeveloperToolsCredential::new(None).map(|c| c as _),
+    ]
+    .into_iter()
+    .filter_map(Result::ok)
+    .collect();
+    anyhow::ensure!(
+        !sources.is_empty(),
+        "no Azure credential source available (workload identity, managed identity, or Azure CLI)"
+    );
+    Ok(Arc::new(ChainedTokenCredential {
+        sources,
+        selected: std::sync::OnceLock::new(),
+    }))
+}
+
+/// Creates a signer from a full key identifier URL, e.g.
+/// `https://{vault}.vault.azure.net/keys/{name}/{version}`.
+pub(crate) async fn create_azure_signer(key_id: &str) -> anyhow::Result<AzureKmsSigner> {
+    let resource: ResourceId = key_id
+        .parse()
+        .with_context(|| format!("invalid Azure Key Vault key identifier '{key_id}'"))?;
+    // Without a pinned version, key rotation would silently change the operator address.
+    let version = resource.version.clone().with_context(|| {
+        format!("Azure Key Vault key identifier '{key_id}' must include a key version")
+    })?;
+
+    let mut options = KeyClientOptions::default();
+    options.client_options.retry = key_vault_retry_options();
+    let client = KeyClient::new(&resource.vault_url, chained_credential()?, Some(options))
+        .context("failed to create Azure Key Vault client")?;
+
+    AzureKmsSigner::new(
+        Arc::new(client),
+        resource.name,
+        version,
+        key_id.to_owned(),
+        None,
+    )
+    .await
+    .with_context(|| format!("failed to initialize Azure Key Vault signer for '{key_id}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use azure_core::http::{
+        AsyncRawResponse, Body, Method, Request, StatusCode, Transport,
+        headers::{AUTHORIZATION, Headers, WWW_AUTHENTICATE},
+    };
+    use azure_security_keyvault_keys::models::{JsonWebKey, Key};
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use k256::ecdsa::{SigningKey, signature::hazmat::PrehashSigner as _};
+
+    use super::*;
+
+    const VAULT_URL: &str = "https://test-vault.vault.azure.net";
+    const KEY_NAME: &str = "operator";
+    const KEY_VERSION: &str = "0123456789abcdef";
+    const CLIENT_SECRET: &str = "credential-must-not-appear-in-debug";
+
+    fn key_id() -> String {
+        format!("{VAULT_URL}/keys/{KEY_NAME}/{KEY_VERSION}")
+    }
+
+    struct StubCredential;
+
+    impl fmt::Debug for StubCredential {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(CLIENT_SECRET)
+        }
+    }
+
+    #[async_trait]
+    impl TokenCredential for StubCredential {
+        async fn get_token(
+            &self,
+            _scopes: &[&str],
+            _options: Option<TokenRequestOptions<'_>>,
+        ) -> azure_core::Result<AccessToken> {
+            Ok(AccessToken::new(
+                "test-token",
+                azure_core::time::OffsetDateTime::now_utc() + azure_core::time::Duration::hours(1),
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestKeyVault {
+        signing_key: SigningKey,
+        crv: CurveName,
+        respond_kid: String,
+        corrupt_signature: bool,
+        request_count: Arc<Mutex<(usize, usize)>>,
+    }
+
+    impl TestKeyVault {
+        fn new() -> Self {
+            Self {
+                signing_key: SigningKey::from_bytes((&[7_u8; 32]).into()).unwrap(),
+                crv: CurveName::P256K,
+                respond_kid: key_id(),
+                corrupt_signature: false,
+                request_count: Arc::new(Mutex::new((0, 0))),
+            }
+        }
+
+        fn json_response(body: Vec<u8>) -> AsyncRawResponse {
+            AsyncRawResponse::from_bytes(StatusCode::Ok, Headers::new(), body)
+        }
+    }
+
+    #[async_trait]
+    impl azure_core::http::HttpClient for TestKeyVault {
+        async fn execute_request(&self, request: &Request) -> azure_core::Result<AsyncRawResponse> {
+            // Key Vault uses challenge-based auth: the SDK probes with an unauthenticated,
+            // body-less request first and expects a challenge naming the token scope.
+            if request.headers().get_optional_str(&AUTHORIZATION).is_none() {
+                let mut headers = Headers::new();
+                headers.insert(
+                    WWW_AUTHENTICATE,
+                    r#"Bearer authorization="https://login.microsoftonline.com/test-tenant", resource="https://vault.azure.net""#,
+                );
+                return Ok(AsyncRawResponse::from_bytes(
+                    StatusCode::Unauthorized,
+                    headers,
+                    Vec::new(),
+                ));
+            }
+            assert!(
+                request
+                    .url()
+                    .path()
+                    .starts_with(&format!("/keys/{KEY_NAME}/{KEY_VERSION}"))
+            );
+            match request.method() {
+                Method::Get => {
+                    self.request_count.lock().unwrap().0 += 1;
+                    let point = self.signing_key.verifying_key().to_encoded_point(false);
+                    let jwk = JsonWebKey {
+                        kid: Some(self.respond_kid.clone()),
+                        kty: Some(KeyType::EcHsm),
+                        crv: Some(self.crv.clone()),
+                        x: Some(point.x().unwrap().to_vec()),
+                        y: Some(point.y().unwrap().to_vec()),
+                        ..Default::default()
+                    };
+                    let mut key = Key::default();
+                    key.key = Some(jwk);
+                    Ok(Self::json_response(serde_json::to_vec(&key).unwrap()))
+                }
+                Method::Post => {
+                    assert!(request.url().path().ends_with("/sign"));
+                    self.request_count.lock().unwrap().1 += 1;
+                    let Body::Bytes(body) = request.body() else {
+                        panic!("expected an in-memory request body");
+                    };
+                    let parsed: serde_json::Value = serde_json::from_slice(body).unwrap();
+                    assert_eq!(parsed["alg"], "ES256K");
+                    let digest = URL_SAFE_NO_PAD
+                        .decode(parsed["value"].as_str().unwrap())
+                        .unwrap();
+
+                    let signature: ecdsa::Signature =
+                        self.signing_key.sign_prehash(&digest).unwrap();
+                    let mut raw = signature.to_bytes().to_vec();
+                    if self.corrupt_signature {
+                        raw[10] ^= 0xff;
+                    }
+                    let response = serde_json::json!({
+                        "kid": self.respond_kid,
+                        "value": URL_SAFE_NO_PAD.encode(&raw),
+                    });
+                    Ok(Self::json_response(serde_json::to_vec(&response).unwrap()))
+                }
+                method => panic!("unexpected request method {method:?}"),
+            }
+        }
+    }
+
+    async fn signer(stub: TestKeyVault) -> anyhow::Result<AzureKmsSigner> {
+        let mut options = KeyClientOptions::default();
+        options.client_options.transport = Some(Transport::new(Arc::new(stub)));
+        let client = KeyClient::new(VAULT_URL, Arc::new(StubCredential), Some(options)).unwrap();
+        AzureKmsSigner::new(
+            Arc::new(client),
+            KEY_NAME.to_owned(),
+            KEY_VERSION.to_owned(),
+            key_id(),
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn signs_hash_and_recovers_expected_address() {
+        let stub = TestKeyVault::new();
+        let request_count = stub.request_count.clone();
+        let signer = signer(stub).await.unwrap();
+        let digest = B256::repeat_byte(0x42);
+
+        let signature = signer.sign_hash(&digest).await.unwrap();
+
+        assert_eq!(
+            signature.recover_address_from_prehash(&digest).unwrap(),
+            Signer::address(&signer)
+        );
+        assert_eq!(*request_count.lock().unwrap(), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_curve() {
+        let mut stub = TestKeyVault::new();
+        stub.crv = CurveName::P256;
+
+        let error = signer(stub).await.unwrap_err();
+        assert!(error.to_string().contains("expected P-256K"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn rejects_key_identifier_mismatch() {
+        let mut stub = TestKeyVault::new();
+        stub.respond_kid = format!("{VAULT_URL}/keys/other-key/{KEY_VERSION}");
+
+        let error = signer(stub).await.unwrap_err();
+        assert!(error.to_string().contains("responded for key"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn rejects_kid_from_different_vault() {
+        let mut stub = TestKeyVault::new();
+        stub.respond_kid =
+            format!("https://other-vault.vault.azure.net/keys/{KEY_NAME}/{KEY_VERSION}");
+
+        let error = signer(stub).await.unwrap_err();
+        assert!(error.to_string().contains("responded for key"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn accepts_kid_with_different_url_casing() {
+        let mut stub = TestKeyVault::new();
+        stub.respond_kid =
+            format!("HTTPS://TEST-VAULT.vault.azure.net/keys/{KEY_NAME}/{KEY_VERSION}");
+
+        signer(stub).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_corrupt_signature() {
+        let mut stub = TestKeyVault::new();
+        stub.corrupt_signature = true;
+        let signer = signer(stub).await.unwrap();
+
+        let error = signer.sign_hash(&B256::ZERO).await.unwrap_err();
+        assert!(error.to_string().contains("recover parity"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn requires_pinned_key_version() {
+        let error = create_azure_signer(&format!("{VAULT_URL}/keys/{KEY_NAME}"))
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("must include a key version"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn debug_does_not_include_client_details() {
+        let signer = signer(TestKeyVault::new()).await.unwrap();
+
+        let debug = format!("{signer:?}");
+        assert!(debug.contains(&key_id()), "{debug}");
+        assert!(!debug.contains(CLIENT_SECRET), "{debug}");
+    }
+}

--- a/lib/operator_signer/src/lib.rs
+++ b/lib/operator_signer/src/lib.rs
@@ -4,18 +4,20 @@ use alloy::signers::Signer;
 use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::utils::secret_key_to_address;
+use azure::AzureKmsSigner;
 use gcp::GcpKmsSigner;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
+mod azure;
 mod gcp;
 
 /// Configuration for how a signing key is provided.
 ///
-/// For GCP KMS keys, the signer (and its underlying API client) is created lazily
+/// For cloud KMS keys, the signer (and its underlying API client) is created lazily
 /// on first use and cached for subsequent calls. Cloned configs share the same cache
 /// via `Arc`, so multiple calls to [`address`](Self::address) and
-/// [`register_with_wallet`](Self::register_with_wallet) only create one GCP client.
+/// [`register_with_wallet`](Self::register_with_wallet) only create one API client.
 #[derive(Debug)]
 pub enum SignerConfig {
     /// Use a local private key for signing.
@@ -28,6 +30,14 @@ pub enum SignerConfig {
         /// Lazily-initialized GCP signer, shared across clones.
         cached_signer: Arc<OnceCell<GcpKmsSigner>>,
     },
+    /// Use an Azure Key Vault (or Managed HSM) key for signing.
+    AzureKms {
+        /// Full key identifier URL pinned to a version, e.g.
+        /// `https://{vault}.vault.azure.net/keys/{name}/{version}`
+        key_id: String,
+        /// Lazily-initialized Azure signer, shared across clones.
+        cached_signer: Arc<OnceCell<AzureKmsSigner>>,
+    },
 }
 
 impl Clone for SignerConfig {
@@ -39,6 +49,13 @@ impl Clone for SignerConfig {
                 cached_signer,
             } => Self::GcpKms {
                 resource_name: resource_name.clone(),
+                cached_signer: cached_signer.clone(),
+            },
+            Self::AzureKms {
+                key_id,
+                cached_signer,
+            } => Self::AzureKms {
+                key_id: key_id.clone(),
                 cached_signer: cached_signer.clone(),
             },
         }
@@ -54,6 +71,14 @@ impl SignerConfig {
         }
     }
 
+    /// Creates an Azure Key Vault config with an empty signer cache.
+    pub fn azure_kms(key_id: String) -> Self {
+        Self::AzureKms {
+            key_id,
+            cached_signer: Arc::new(OnceCell::new()),
+        }
+    }
+
     /// Returns the cached GCP signer, creating it on first call.
     async fn get_gcp_signer(&self) -> anyhow::Result<&GcpKmsSigner> {
         match self {
@@ -65,13 +90,28 @@ impl SignerConfig {
                     .get_or_try_init(|| gcp::create_gcp_signer(resource_name))
                     .await
             }
-            Self::Local(_) => anyhow::bail!("get_gcp_signer called on Local variant"),
+            _ => anyhow::bail!("get_gcp_signer called on non-GCP variant"),
+        }
+    }
+
+    /// Returns the cached Azure signer, creating it on first call.
+    async fn get_azure_signer(&self) -> anyhow::Result<&AzureKmsSigner> {
+        match self {
+            Self::AzureKms {
+                key_id,
+                cached_signer,
+            } => {
+                cached_signer
+                    .get_or_try_init(|| azure::create_azure_signer(key_id))
+                    .await
+            }
+            _ => anyhow::bail!("get_azure_signer called on non-Azure variant"),
         }
     }
 
     /// Returns the Ethereum address for this signer.
     ///
-    /// For local keys the address is derived locally. For GCP KMS keys a network
+    /// For local keys the address is derived locally. For cloud KMS keys a network
     /// call is made on first invocation to fetch the public key; subsequent calls
     /// return the cached address.
     pub async fn address(&self) -> anyhow::Result<Address> {
@@ -81,12 +121,16 @@ impl SignerConfig {
                 let signer = self.get_gcp_signer().await?;
                 Ok(signer.address())
             }
+            Self::AzureKms { .. } => {
+                let signer = self.get_azure_signer().await?;
+                Ok(signer.address())
+            }
         }
     }
 
     /// Creates the appropriate signer, registers it with the wallet, and returns the Ethereum address.
     ///
-    /// For GCP KMS, reuses the cached signer (cloning it for wallet registration).
+    /// For cloud KMS keys, reuses the cached signer (cloning it for wallet registration).
     pub async fn register_with_wallet(
         &self,
         wallet: &mut EthereumWallet,
@@ -102,6 +146,13 @@ impl SignerConfig {
                 let signer = self.get_gcp_signer().await?.clone();
                 let address = signer.address();
                 tracing::info!(%address, %resource_name, "registered GCP KMS signer");
+                wallet.register_signer(signer);
+                Ok(address)
+            }
+            Self::AzureKms { key_id, .. } => {
+                let signer = self.get_azure_signer().await?.clone();
+                let address = signer.address();
+                tracing::info!(%address, %key_id, "registered Azure Key Vault signer");
                 wallet.register_signer(signer);
                 Ok(address)
             }

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1119,8 +1119,9 @@ impl From<RpcRateLimitsConfig> for zksync_os_rpc::RateLimits {
 /// L1 sender configuration. The signing key fields are only required on the Main Node;
 /// External Nodes do not send L1 transactions and may omit them.
 ///
-/// Each operator accepts either a hex private key string (backward-compatible) or a GCP KMS
-/// resource object: `{"type": "gcp_kms", "resource": "projects/.../cryptoKeyVersions/N"}`.
+/// Each operator accepts either a hex private key string (backward-compatible) or a cloud KMS
+/// object: `{"type": "gcp_kms", "resource": "projects/.../cryptoKeyVersions/N"}` or
+/// `{"type": "azure_kms", "key_id": "https://{vault}.vault.azure.net/keys/{name}/{version}"}`.
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
 pub struct L1SenderConfig {
     /// Signer to commit batches to L1.
@@ -1131,7 +1132,7 @@ pub struct L1SenderConfig {
     pub operator_commit_sk: Option<SignerConfig>,
 
     /// Signer to submit proofs to L1.
-    /// Can be arbitrary funded address - proof submission is permissionless.
+    /// Must hold `PROVER_ROLE` for the chain on the ValidatorTimelock (permissioned).
     /// Not required for External Nodes, which do not send L1 transactions.
     /// On a Main Node, required at runtime only when settling on L1 (see `operator_commit_sk`).
     #[config(secret, alias = "operator_prove_pk", with = SignerConfigDeserializer)]

--- a/node/bin/src/config/util.rs
+++ b/node/bin/src/config/util.rs
@@ -13,6 +13,8 @@ use zksync_os_operator_signer::SignerConfig;
 /// Accepts either:
 /// - A hex string (with or without `0x` prefix): parsed as a local private key (backward-compatible)
 /// - An object `{"type": "gcp_kms", "resource": "projects/..."}`: a GCP KMS key
+/// - An object `{"type": "azure_kms", "key_id": "https://{vault}.vault.azure.net/keys/{name}/{version}"}`:
+///   an Azure Key Vault (or Managed HSM) key
 #[derive(Debug)]
 pub struct SignerConfigDeserializer;
 
@@ -52,8 +54,17 @@ impl DeserializeParam<SignerConfig> for SignerConfigDeserializer {
                                 })?;
                         Ok(SignerConfig::gcp_kms(resource.to_string()))
                     }
+                    "azure_kms" => {
+                        let key_id =
+                            obj.get("key_id").and_then(|v| v.as_str()).ok_or_else(|| {
+                                ErrorWithOrigin::custom(
+                                    "missing 'key_id' field in azure_kms signer config",
+                                )
+                            })?;
+                        Ok(SignerConfig::azure_kms(key_id.to_string()))
+                    }
                     other => Err(ErrorWithOrigin::custom(format!(
-                        "unknown signer type '{other}', expected 'gcp_kms'"
+                        "unknown signer type '{other}', expected 'gcp_kms' or 'azure_kms'"
                     ))),
                 }
             }
@@ -71,6 +82,9 @@ impl DeserializeParam<SignerConfig> for SignerConfigDeserializer {
             }
             SignerConfig::GcpKms { resource_name, .. } => {
                 serde_json::json!({"type": "gcp_kms", "resource": resource_name})
+            }
+            SignerConfig::AzureKms { key_id, .. } => {
+                serde_json::json!({"type": "azure_kms", "key_id": key_id})
             }
         }
     }


### PR DESCRIPTION
## Summary

One of the chains have infrastructure deployed in Azure. Adding support for Azure HSM signing similar for how this is done with GKMS. The code was tested with real Azure account locally. 

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

