### PR TITLE
fix(revm-checker): feed REVM the hardcoded prevrandao ZKsync OS actually uses

### DIFF
--- a/integration-tests/tests/node/mod.rs
+++ b/integration-tests/tests/node/mod.rs
@@ -4,3 +4,4 @@ mod mempool;
 mod rebuild;
 mod replay_archive;
 mod restart;
+mod revm_checker;

--- a/integration-tests/tests/node/revm_checker.rs
+++ b/integration-tests/tests/node/revm_checker.rs
@@ -1,0 +1,72 @@
+use alloy::network::{ReceiptResponse, TransactionBuilder};
+use alloy::primitives::{U256, bytes};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, ReceiptAssert};
+use zksync_os_integration_tests::provider::ZksyncTestingProvider;
+use zksync_os_integration_tests::{CURRENT_TO_L1, NEXT_TO_L1, TestEnvironment, test_multisetup};
+
+/// ZKsync OS hardcodes PREVRANDAO to `1` (the VM's `prevrandao` cargo feature is off in
+/// production builds), while `block_context.mix_hash` is zeroed by the sequencer. The REVM
+/// consistency checker used to feed `mix_hash` to REVM as prevrandao, so any contract
+/// reading `block.prevrandao` tripped a false divergence.
+///
+/// Runs such a contract with revert-on-divergence enabled: a divergence panics the node,
+/// which would fail block finalization below. Only protocol v31+ (execution version 6,
+/// AtlasV3) exercised the buggy path, so the NEXT setup is the load-bearing one.
+#[test_multisetup([CURRENT_TO_L1, NEXT_TO_L1])]
+async fn prevrandao_does_not_trip_revm_consistency_checker(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    config.sequencer_config.revm_consistency_checker_enabled = true;
+    config
+        .sequencer_config
+        .revm_consistency_checker_revert_on_divergence = true;
+    let tester = env.launch(config).await?;
+
+    // Runtime: `PREVRANDAO; PUSH1 0; SSTORE; STOP` — every call stores `block.prevrandao`
+    // into slot 0. Init code returns those 5 bytes from the tail of the first memory word.
+    let init_code = bytes!("0x6444600055006000526005601bf3");
+
+    let deploy_receipt = tester
+        .l2_provider
+        .send_transaction(TransactionRequest::default().with_deploy_code(init_code))
+        .await?
+        .expect_successful_receipt()
+        .await?;
+    let contract = deploy_receipt
+        .contract_address()
+        .expect("no contract deployed");
+
+    let call_receipt = tester
+        .l2_provider
+        .send_transaction(TransactionRequest::default().with_to(contract))
+        .await?
+        .expect_successful_receipt()
+        .await?;
+
+    let stored = tester
+        .l2_provider
+        .get_storage_at(contract, U256::ZERO)
+        .await?;
+    assert_eq!(
+        stored,
+        U256::ONE,
+        "ZKsync OS serves a constant `1` for PREVRANDAO"
+    );
+
+    // Finalization runs downstream of the consistency checker, so it only completes if the
+    // checker processed the block without detecting a divergence.
+    tester
+        .l2_zk_provider
+        .wait_finalized_with_timeout(
+            call_receipt
+                .block_number()
+                .expect("receipt has block number"),
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+
+    Ok(())
+}

--- a/lib/revm_consistency_checker/src/node.rs
+++ b/lib/revm_consistency_checker/src/node.rs
@@ -166,38 +166,37 @@ where
                 let block_basefee: u64 =
                     replay_record.block_context.eip1559_basefee.saturating_to();
 
-                // AtlasV1/V2 didn't honor `block_context.mix_hash` for prevrandao (ZKsync OS
-                // hardcoded `1`) and didn't surface blob fees. Both fields only became
-                // meaningful with AtlasV3 — gating them keeps the historical check accurate.
+                // ZKsync OS hardcodes PREVRANDAO to `1` in production builds: the VM's
+                // `prevrandao` cargo feature (which would honor block randomness) is only
+                // enabled for test runners. `block_context.mix_hash` — currently always
+                // zeroed by the sequencer — must therefore not reach REVM, or any contract
+                // reading `block.prevrandao` diverges.
+                let prevrandao = B256::from(U256::ONE);
+
+                // Blob fees only became meaningful with AtlasV3.
                 //
                 // The pre-AtlasV3 `blob_excess_gas_and_price` must still be `Some`: all Atlas
                 // specs map to Cancun and revm's header validation rejects a missing value.
                 // Use the same value `BlockEnv::default()` would have produced, since that's
                 // what the pre-PR checker effectively passed.
-                let (prevrandao, blob_excess_gas_and_price) =
-                    if ZkSpecId::AtlasV3.is_enabled_in(zk_spec) {
-                        let blob_fee: u64 = replay_record.block_context.blob_fee.saturating_to();
-                        let blob_excess_gas = calculate_excess_blob_gas_from_blob_base_fee(
-                            blob_fee,
-                            BLOB_BASE_FEE_UPDATE_FRACTION,
-                        );
-                        let blob_excess = BlobExcessGasAndPrice::new(
-                            blob_excess_gas,
-                            BLOB_BASE_FEE_UPDATE_FRACTION
-                                .try_into()
-                                .expect("Blob base fee update fraction should fit into u64"),
-                        );
-                        (
-                            replay_record.block_context.mix_hash.into(),
-                            Some(blob_excess),
-                        )
-                    } else {
-                        let pre_v3_blob_default = BlobExcessGasAndPrice::new(
-                            0,
-                            revm::primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
-                        );
-                        (B256::from(U256::ONE), Some(pre_v3_blob_default))
-                    };
+                let blob_excess_gas_and_price = if ZkSpecId::AtlasV3.is_enabled_in(zk_spec) {
+                    let blob_fee: u64 = replay_record.block_context.blob_fee.saturating_to();
+                    let blob_excess_gas = calculate_excess_blob_gas_from_blob_base_fee(
+                        blob_fee,
+                        BLOB_BASE_FEE_UPDATE_FRACTION,
+                    );
+                    Some(BlobExcessGasAndPrice::new(
+                        blob_excess_gas,
+                        BLOB_BASE_FEE_UPDATE_FRACTION
+                            .try_into()
+                            .expect("Blob base fee update fraction should fit into u64"),
+                    ))
+                } else {
+                    Some(BlobExcessGasAndPrice::new(
+                        0,
+                        revm::primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
+                    ))
+                };
 
                 // For each block, we create an in-memory cache database to accumulate transaction state changes separately
                 let state_provider =


### PR DESCRIPTION
## What

The REVM consistency checker's AtlasV3 branch passed `block_context.mix_hash` to REVM as `prevrandao`. Production ZKsync OS builds compile without the VM's `prevrandao` cargo feature (it is only enabled by the `eth_runner`/`evm_tester` configs), so `get_mix_hash()` returns a constant `1` regardless — while the sequencer fills `mix_hash` with `Default::default()` (`0`, marked `// todo` in `BlockContextProvider`). Any contract reading `block.prevrandao` on a v31 (execution version 6) chain therefore tripped a false divergence.

First seen on the genlayer testnet: `REVM consistency check failed for block number 14737627` — a dice contract computing `keccak256(block.timestamp, block.prevrandao, msg.sender) % 6 + 1` stored `5` on chain (prevrandao `1`) while checker-REVM computed `1` (prevrandao `0`). Verified byte-for-byte: the on-chain keccak matches the prevrandao=1 preimage, the checker's value matches the prevrandao=0 preimage.

The checker now always feeds REVM `prevrandao = 1`, mirroring the production VM; the AtlasV3 gating remains for blob fees only.

## Testing

New integration test deploys a minimal contract whose runtime is `PREVRANDAO; PUSH1 0; SSTORE; STOP`, calls it with `revm_consistency_checker_revert_on_divergence = true`, asserts the stored value is `1`, and waits for block finalization (which runs downstream of the checker). Runs on both `CURRENT_TO_L1` (v30 → AtlasV2) and `NEXT_TO_L1` (v31 → AtlasV3); only the latter exercised the buggy path.

- With the fix: both variants pass.
- Negative check (old behavior temporarily restored): the `next_to_l1` variant fails — the checker detects the divergence and panics the node, so the test provably guards this regression.

Note for a future execution version: if ZKsync OS enables real prevrandao (VM `prevrandao` feature + sequencer populating `mix_hash`), the checker must switch to `mix_hash` gated on that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)