### PR TITLE
feat(storage)!: schema migration runner + contract replay WAL block hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16847,6 +16847,7 @@ dependencies = [
 name = "zksync_os_rocksdb"
 version = "0.21.0"
 dependencies = [
+ "anyhow",
  "num_cpus",
  "once_cell",
  "rocksdb",

--- a/lib/rocksdb/Cargo.toml
+++ b/lib/rocksdb/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 vise.workspace = true
 
 num_cpus.workspace = true

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -670,10 +670,23 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
     /// so that tombstoned space is actually reclaimed instead of waiting for background
     /// compaction to get to it.
     pub fn compact_range_cf(&self, cf: CF) {
-        let cf = self.column_family(cf);
+        let cf_name = cf.name();
+        tracing::info!(
+            db_name = CF::DB_NAME,
+            cf_name,
+            "starting column family compaction"
+        );
+        let started_at = Instant::now();
+        let cf_handle = self.column_family(cf);
         self.inner
             .db
-            .compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
+            .compact_range_cf(cf_handle, None::<&[u8]>, None::<&[u8]>);
+        tracing::info!(
+            db_name = CF::DB_NAME,
+            cf_name,
+            elapsed = ?started_at.elapsed(),
+            "column family compaction finished"
+        );
     }
 
     /// Returns size stats for the specified column family.

--- a/lib/rocksdb/src/db.rs
+++ b/lib/rocksdb/src/db.rs
@@ -32,6 +32,14 @@ use crate::metrics::{
 /// Not properly dropped RocksDB instances can lead to DB corruption.
 static ROCKSDB_INSTANCE_COUNTER: (Mutex<usize>, Condvar) = (Mutex::new(0), Condvar::new());
 
+/// Name of the reserved column family holding wrapper-managed metadata (currently the schema
+/// version stamped by [`crate::migrations`]). Managed outside [`NamedColumnFamily::ALL`] so that
+/// per-database CF enums don't need to declare it.
+pub(crate) const SCHEMA_META_CF_NAME: &str = "__schema_meta";
+
+/// Key under [`SCHEMA_META_CF_NAME`] holding the database schema version.
+pub(crate) const SCHEMA_VERSION_KEY: &[u8] = b"schema_version";
+
 /// Describes column family used in a [`RocksDB`] instance.
 pub trait NamedColumnFamily: 'static + Copy {
     /// Name of the database. Used in metrics reporting.
@@ -416,6 +424,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
                 // The default CF is created on RocksDB instantiation in any case; it doesn't need
                 // to be explicitly opened.
                 let is_obsolete = cf_name != rocksdb::DEFAULT_COLUMN_FAMILY_NAME
+                    && cf_name != SCHEMA_META_CF_NAME
                     && !cfs_and_options.contains_key(cf_name);
                 is_obsolete.then_some(cf_name)
             })
@@ -433,7 +442,9 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         let cf_names = cfs_and_options.keys().copied().collect();
         let all_cfs_and_options = cfs_and_options
             .into_iter()
-            .chain(obsolete_cfs.into_iter().map(|name| (name, (false, None))));
+            .chain(obsolete_cfs.into_iter().map(|name| (name, (false, None))))
+            // Created on first open thanks to `create_missing_column_families`.
+            .chain([(SCHEMA_META_CF_NAME, (false, None))]);
         let cfs = all_cfs_and_options.map(|(cf_name, (requires_tuning, prefix_extractor_len))| {
             let mut block_based_options = BlockBasedOptions::default();
             block_based_options.set_bloom_filter(10.0, false);
@@ -618,6 +629,51 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             .db
             .cf_handle(cf.name())
             .unwrap_or_else(|| panic!("Column family `{}` doesn't exist", cf.name()))
+    }
+
+    fn schema_meta_cf(&self) -> &ColumnFamily {
+        self.inner
+            .db
+            .cf_handle(SCHEMA_META_CF_NAME)
+            .expect("`__schema_meta` column family is created on open")
+    }
+
+    /// Reads the schema version stamped by [`crate::migrations`]. `None` means the database was
+    /// last written by a binary predating the migration runner (treated as version 0).
+    pub fn schema_version(&self) -> Result<Option<u32>, rocksdb::Error> {
+        Ok(self
+            .inner
+            .db
+            .get_cf(self.schema_meta_cf(), SCHEMA_VERSION_KEY)?
+            .map(|bytes| {
+                u32::from_be_bytes(
+                    bytes
+                        .as_slice()
+                        .try_into()
+                        .expect("schema version must be 4 bytes"),
+                )
+            }))
+    }
+
+    pub(crate) fn stamp_schema_version(&self, version: u32) -> Result<(), rocksdb::Error> {
+        let mut options = WriteOptions::new();
+        options.set_sync(self.sync_writes);
+        self.inner.db.put_cf_opt(
+            self.schema_meta_cf(),
+            SCHEMA_VERSION_KEY,
+            version.to_be_bytes(),
+            &options,
+        )
+    }
+
+    /// Compacts the whole key range of the column family. Used by migrations after bulk deletes
+    /// so that tombstoned space is actually reclaimed instead of waiting for background
+    /// compaction to get to it.
+    pub fn compact_range_cf(&self, cf: CF) {
+        let cf = self.column_family(cf);
+        self.inner
+            .db
+            .compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
     }
 
     /// Returns size stats for the specified column family.

--- a/lib/rocksdb/src/lib.rs
+++ b/lib/rocksdb/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod db;
 mod metrics;
+pub mod migrations;
 
 pub use db::{RocksDB, RocksDBOptions, StalledWritesRetries, WeakRocksDB};
 pub use rocksdb;

--- a/lib/rocksdb/src/migrations.rs
+++ b/lib/rocksdb/src/migrations.rs
@@ -62,6 +62,18 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             CF::DB_NAME,
         );
 
+        let pending_migrations: Vec<_> = migrations[current_version as usize..]
+            .iter()
+            .map(|migration| migration.name())
+            .collect();
+        tracing::info!(
+            db_name = CF::DB_NAME,
+            current_version,
+            latest_version,
+            ?pending_migrations,
+            "checked schema version"
+        );
+
         for migration in &migrations[current_version as usize..] {
             let started_at = std::time::Instant::now();
             tracing::info!(

--- a/lib/rocksdb/src/migrations.rs
+++ b/lib/rocksdb/src/migrations.rs
@@ -1,0 +1,234 @@
+//! Schema migrations for [`RocksDB`] databases.
+//!
+//! Each database tracks a schema version in a reserved `__schema_meta` column family that the
+//! wrapper manages outside the database's [`NamedColumnFamily`] enum. A database that has never
+//! run a migration reads as version 0.
+//!
+//! Migrations run at open, in ascending `target_version` order, and the version is stamped after
+//! each one completes. Opening a database stamped with a version higher than the binary supports
+//! fails with an explicit error instead of the decode panic a format mismatch would otherwise
+//! produce deep inside a read path.
+//!
+//! Migrations currently run in blocking mode only: the database is not served until pending
+//! migrations finish. A background (resumable, concurrent with serving) mode is planned together
+//! with its first consumer — the row-rewrite migration of the replay WAL unification.
+
+use crate::db::{NamedColumnFamily, RocksDB};
+
+/// A single schema migration for a database described by `CF`.
+///
+/// # Idempotency
+///
+/// The version is stamped only after [`Migration::run`] returns, so a crash mid-migration means
+/// the whole migration reruns on the next open. Implementations MUST therefore be idempotent:
+/// re-running over already-migrated rows must be a no-op.
+pub trait Migration<CF: NamedColumnFamily>: Send + Sync {
+    /// Schema version this migration upgrades the database to. Must be unique per database and
+    /// form a strictly increasing sequence starting at 1 in the list passed to
+    /// [`RocksDB::run_migrations`].
+    fn target_version(&self) -> u32;
+
+    /// Short human-readable name for logs.
+    fn name(&self) -> &'static str;
+
+    /// Applies the migration. Runs at open, before the database serves any reads or writes.
+    fn run(&self, db: &RocksDB<CF>) -> anyhow::Result<()>;
+}
+
+impl<CF: NamedColumnFamily> RocksDB<CF> {
+    /// Runs all migrations pending for this database and stamps the schema version after each.
+    ///
+    /// Consumes and returns `self` to fit the open-time builder chain. `migrations` must be
+    /// sorted by strictly increasing `target_version` with no gaps from 1; a database can then
+    /// upgrade from any older version, including 0 (never migrated).
+    pub fn run_migrations(self, migrations: &[&dyn Migration<CF>]) -> anyhow::Result<Self> {
+        for (index, migration) in migrations.iter().enumerate() {
+            anyhow::ensure!(
+                migration.target_version() == index as u32 + 1,
+                "migration list for `{}` must have strictly increasing versions starting at 1; \
+                 `{}` at position {index} targets version {}",
+                CF::DB_NAME,
+                migration.name(),
+                migration.target_version(),
+            );
+        }
+        let latest_version = migrations.len() as u32;
+        let current_version = self.schema_version()?.unwrap_or(0);
+        anyhow::ensure!(
+            current_version <= latest_version,
+            "database `{}` has schema version {current_version}, but this binary only supports \
+             versions up to {latest_version}; downgrading below the binary that migrated this \
+             database is not supported",
+            CF::DB_NAME,
+        );
+
+        for migration in &migrations[current_version as usize..] {
+            let started_at = std::time::Instant::now();
+            tracing::info!(
+                db_name = CF::DB_NAME,
+                migration = migration.name(),
+                target_version = migration.target_version(),
+                "running schema migration"
+            );
+            migration.run(&self).map_err(|err| {
+                err.context(format!(
+                    "schema migration `{}` (to version {}) of `{}` failed",
+                    migration.name(),
+                    migration.target_version(),
+                    CF::DB_NAME,
+                ))
+            })?;
+            self.stamp_schema_version(migration.target_version())?;
+            tracing::info!(
+                db_name = CF::DB_NAME,
+                migration = migration.name(),
+                target_version = migration.target_version(),
+                elapsed = ?started_at.elapsed(),
+                "schema migration finished"
+            );
+        }
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Copy, Clone, Debug)]
+    enum TestColumnFamily {
+        Data,
+    }
+
+    impl NamedColumnFamily for TestColumnFamily {
+        const DB_NAME: &'static str = "migrations_test";
+        const ALL: &'static [Self] = &[TestColumnFamily::Data];
+
+        fn name(&self) -> &'static str {
+            "data"
+        }
+    }
+
+    struct MarkerMigration {
+        version: u32,
+        runs: AtomicUsize,
+        fail: bool,
+    }
+
+    impl MarkerMigration {
+        fn new(version: u32) -> Self {
+            Self {
+                version,
+                runs: AtomicUsize::new(0),
+                fail: false,
+            }
+        }
+    }
+
+    impl Migration<TestColumnFamily> for MarkerMigration {
+        fn target_version(&self) -> u32 {
+            self.version
+        }
+
+        fn name(&self) -> &'static str {
+            "marker"
+        }
+
+        fn run(&self, _db: &RocksDB<TestColumnFamily>) -> anyhow::Result<()> {
+            self.runs.fetch_add(1, Ordering::Relaxed);
+            anyhow::ensure!(!self.fail, "intentional failure");
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn runs_pending_migrations_once_and_stamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = MarkerMigration::new(1);
+        let second = MarkerMigration::new(2);
+
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        assert_eq!(db.schema_version().unwrap(), None);
+        let db = db.run_migrations(&[&first, &second]).unwrap();
+        assert_eq!(db.schema_version().unwrap(), Some(2));
+        assert_eq!(first.runs.load(Ordering::Relaxed), 1);
+        assert_eq!(second.runs.load(Ordering::Relaxed), 1);
+        drop(db);
+
+        // Reopening runs nothing: both migrations are stamped.
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let db = db.run_migrations(&[&first, &second]).unwrap();
+        assert_eq!(db.schema_version().unwrap(), Some(2));
+        assert_eq!(first.runs.load(Ordering::Relaxed), 1);
+        assert_eq!(second.runs.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn applies_only_migrations_newer_than_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = MarkerMigration::new(1);
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let db = db.run_migrations(&[&first]).unwrap();
+        drop(db);
+
+        let second = MarkerMigration::new(2);
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        db.run_migrations(&[&first, &second]).unwrap();
+        assert_eq!(first.runs.load(Ordering::Relaxed), 1);
+        assert_eq!(second.runs.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn refuses_database_from_the_future() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = MarkerMigration::new(1);
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let db = db.run_migrations(&[&first]).unwrap();
+        drop(db);
+
+        // A binary that only knows an empty migration list must refuse to open.
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let err = db.run_migrations(&[]).unwrap_err();
+        assert!(
+            err.to_string().contains("downgrading below"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn failed_migration_is_not_stamped_and_reruns() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut failing = MarkerMigration::new(1);
+        failing.fail = true;
+
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let err = db.run_migrations(&[&failing]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("intentional failure"),
+            "unexpected error: {err:#}"
+        );
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        assert_eq!(db.schema_version().unwrap(), None);
+        drop(db);
+
+        // The migration reruns after the failure, i.e., it was not stamped.
+        let succeeding = MarkerMigration::new(1);
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let db = db.run_migrations(&[&succeeding]).unwrap();
+        assert_eq!(succeeding.runs.load(Ordering::Relaxed), 1);
+        assert_eq!(db.schema_version().unwrap(), Some(1));
+    }
+
+    #[test]
+    fn rejects_non_contiguous_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        let wrong = MarkerMigration::new(2);
+        let db = RocksDB::<TestColumnFamily>::new(dir.path()).unwrap();
+        let err = db.run_migrations(&[&wrong]).unwrap_err();
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -38,28 +38,29 @@ pub struct BlockReplayStorage {
 
 /// Column families for storage of block replay commands.
 ///
+/// `Context`, `ContextV2` and `ArchivedContext` together replace one former CF that held every
+/// row, canonical or archived, with its full [`BlockContext`] embedded. Canonical (number-keyed)
+/// rows now go to `ContextV2` and archived (hash-keyed) rows to `ArchivedContext`, both stripped
+/// (see [`StoredBlockContextV2`]); nothing writes to `Context` anymore — it only holds rows left
+/// over from before the split, in the old unstripped format.
+///
 /// TODO(RocksDB migration): The four `Starting*` column families below correspond to fields
 /// in [`BlockStartCursors`]. They are stored separately for historical reasons (each was added
 /// independently). A future migration should consolidate them into a single column family
 /// serializing the entire `BlockStartCursors` struct.
 #[derive(Copy, Clone, Debug)]
 pub enum BlockReplayColumnFamily {
-    /// Full [`BlockContext`], including the 256 previous block hashes (~8 KiB per block). Holds
-    /// hash-keyed archived rows written before [`Self::ArchivedContext`] existed. Number-keyed
-    /// rows only appear here when written by binaries predating [`Self::ContextV2`]; the
-    /// [`ContractBlockContexts`] migration converts and deletes them. Never written to going
-    /// forward; new archived rows go to [`Self::ArchivedContext`] instead.
+    /// Legacy full [`BlockContext`] rows (~8 KiB each, 256-hash window included), predating the
+    /// `ContextV2`/`ArchivedContext` split. Canonical (number-keyed) rows here are converted and
+    /// deleted by [`ContractBlockContexts`]; archived (hash-keyed) ones are left as they are.
     Context,
-    /// Stripped [`BlockContext`] for canonical rows: everything except the 256 previous block
-    /// hashes, which are derivable data and get reconstructed from [`Self::CanonicalHash`] on
-    /// read (see [`StoredBlockContextV2`]).
+    /// Stripped canonical rows. The 256-hash window is derivable and reconstructed from
+    /// [`Self::CanonicalHash`] on read.
     ContextV2,
-    /// Hash-keyed archived rows (blocks displaced by an override), holding the same
-    /// [`StoredBlockContextV2`] as [`Self::ContextV2`]. Its `parent_hash` field is what makes
-    /// archived rows self-sufficient: the window and `previous_block_timestamp` are reconstructed
-    /// on read by walking `parent_hash` pointers through this CF until reaching a hash still on
-    /// the live canonical chain, then finishing with one `CanonicalHash` lookup (see
-    /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]). Unlike [`Self::Context`],
+    /// Stripped archived rows (blocks displaced by an override). The window and
+    /// `previous_block_timestamp` are reconstructed on read by walking `parent_hash` pointers
+    /// through this CF to the live canonical chain, then one [`Self::CanonicalHash`] lookup (see
+    /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]) — unlike [`Self::Context`],
     /// this doesn't depend on `CanonicalHash` staying unchanged, so it's correct on any read, no
     /// matter how long after the override or in how different a process.
     ArchivedContext,

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -2,7 +2,6 @@ use alloy::primitives::{Address, B256, BlockHash, BlockNumber, Sealed, U256};
 use anyhow::Context as _;
 use std::convert::TryInto;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use vise::Unit;
 use vise::{Buckets, Histogram, Metrics};
@@ -35,17 +34,6 @@ pub struct BlockReplayStorage {
     db: RocksDB<BlockReplayColumnFamily>,
     /// Shared by all blocks; stripped rows don't persist it (see [`StoredBlockContextV2`]).
     chain_id: u64,
-    /// The block number and original hash of the row most recently archived by an override.
-    /// Bridges the one moment, within a multi-block override wave, where `CanonicalHash[N]`
-    /// already points at `N`'s replacement but block `N+1` still needs `N`'s *original* hash to
-    /// archive itself correctly. Cleared on plain appends and on a non-consecutive override,
-    /// where the live `CanonicalHash` is safe to read directly instead (see [`WriteReplay::write`]).
-    ///
-    /// In-memory only: a crash mid-wave loses it, so the next archived row falls back to
-    /// `CanonicalHash`, which by then points at the new chain — the resulting row's window would
-    /// need correcting when the unification migration removes this in favor of parent hashes on
-    /// every row. Already-archived rows and canonical data are unaffected either way.
-    last_archived: Arc<Mutex<Option<(BlockNumber, BlockHash)>>>,
 }
 
 /// Column families for storage of block replay commands.
@@ -66,11 +54,11 @@ pub enum BlockReplayColumnFamily {
     /// hashes, which are derivable data and get reconstructed from [`Self::CanonicalHash`] on
     /// read (see [`StoredBlockContextV2`]).
     ContextV2,
-    /// Hash-keyed archived rows (blocks displaced by an override), holding [`StoredBlockContextV2`]
-    /// plus the row's own `parent_hash` instead of the full hash window. The window and
-    /// `previous_block_timestamp` are reconstructed on read by walking `parent_hash` pointers
-    /// through this CF until reaching a hash still on the live canonical chain, then finishing
-    /// with one `CanonicalHash` lookup (see
+    /// Hash-keyed archived rows (blocks displaced by an override), holding the same
+    /// [`StoredBlockContextV2`] as [`Self::ContextV2`]. Its `parent_hash` field is what makes
+    /// archived rows self-sufficient: the window and `previous_block_timestamp` are reconstructed
+    /// on read by walking `parent_hash` pointers through this CF until reaching a hash still on
+    /// the live canonical chain, then finishing with one `CanonicalHash` lookup (see
     /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]). Unlike [`Self::Context`],
     /// this doesn't depend on `CanonicalHash` staying unchanged, so it's correct on any read, no
     /// matter how long after the override or in how different a process.
@@ -143,7 +131,6 @@ impl BlockReplayStorage {
         let this = Self {
             db,
             chain_id: genesis.chain_id(),
-            last_archived: Arc::default(),
         };
         let inserted_genesis = if this.latest_record_checked().is_none() {
             let genesis_tx = genesis.genesis_upgrade_tx().await;
@@ -181,11 +168,7 @@ impl BlockReplayStorage {
             .with_sync_writes()
             .run_migrations(MIGRATIONS)
             .expect("replay WAL schema migration failed");
-        Self {
-            db,
-            chain_id,
-            last_archived: Arc::default(),
-        }
+        Self { db, chain_id }
     }
 
     fn write_replay_unchecked(&self, sealed_record: Sealed<ReplayRecord>, kind: WriteKind) {
@@ -194,7 +177,7 @@ impl BlockReplayStorage {
         // TODO: We want to change the key to be block_hash for all blocks
         let db_key = match kind {
             WriteKind::Canonical => record.block_context.block_number.to_be_bytes().to_vec(),
-            WriteKind::Archived { .. } => block_hash.0.to_vec(),
+            WriteKind::Archived => block_hash.0.to_vec(),
         };
         // TODO(RocksDB migration): BlockStartCursors fields are stored in separate column families
         // for historical reasons. A future migration should consolidate them into a single CF
@@ -208,17 +191,21 @@ impl BlockReplayStorage {
             .expect("Failed to serialize record.transactions");
         let node_version_value = record.node_version.to_string().as_bytes().to_vec();
 
+        // Stripped either way: the 256-hash window is never persisted. Canonical rows are
+        // indexed in `CanonicalHash` for fast reconstruction; archived rows keep their own
+        // `parent_hash` (part of the stripped struct) and are reconstructed on read by walking
+        // those pointers (see `resolve_window_and_previous_timestamp`) — correct regardless of
+        // what happens to `CanonicalHash` afterwards.
+        let stripped_context_value = bincode::encode_to_vec(
+            StoredBlockContextV2::strip(record.block_context),
+            bincode::config::standard(),
+        )
+        .expect("Failed to serialize stripped record.context");
+
         // Batch writes: replay entry, latest pointer and canonical hash mapping
         let mut batch: WriteBatch<'_, BlockReplayColumnFamily> = self.db.new_write_batch();
         match kind {
             WriteKind::Canonical => {
-                // Canonical rows don't persist the 256 previous block hashes: they are derivable
-                // from `CanonicalHash` and get reconstructed on read.
-                let stripped_context_value = bincode::encode_to_vec(
-                    StoredBlockContextV2::strip(record.block_context),
-                    bincode::config::standard(),
-                )
-                .expect("Failed to serialize stripped record.context");
                 batch.put_cf(
                     BlockReplayColumnFamily::ContextV2,
                     &db_key,
@@ -230,24 +217,11 @@ impl BlockReplayStorage {
                     &block_hash.0,
                 );
             }
-            WriteKind::Archived { parent_hash } => {
-                // Archived rows keep their own `parent_hash` instead of the full hash window:
-                // the window (and `previous_block_timestamp`) are reconstructed on read by
-                // walking `parent_hash` pointers (see
-                // `resolve_window_and_previous_timestamp`), which stays correct regardless of
-                // what happens to `CanonicalHash` afterwards.
-                let archived_value = bincode::encode_to_vec(
-                    StoredArchivedContext {
-                        parent_hash,
-                        stripped: StoredBlockContextV2::strip(record.block_context),
-                    },
-                    bincode::config::standard(),
-                )
-                .expect("Failed to serialize archived record.context");
+            WriteKind::Archived => {
                 batch.put_cf(
                     BlockReplayColumnFamily::ArchivedContext,
                     &db_key,
-                    &archived_value,
+                    &stripped_context_value,
                 );
             }
         }
@@ -395,7 +369,7 @@ impl BlockReplayStorage {
             })
     }
 
-    fn get_archived(&self, key: &[u8]) -> Option<StoredArchivedContext> {
+    fn get_archived(&self, key: &[u8]) -> Option<StoredBlockContextV2> {
         self.db
             .get_cf(BlockReplayColumnFamily::ArchivedContext, key)
             .expect("Cannot read from DB")
@@ -440,7 +414,7 @@ impl BlockReplayStorage {
             match self.get_archived(current_hash.0.as_slice()) {
                 Some(archived) => {
                     if step == 0 {
-                        previous_block_timestamp = archived.stripped.timestamp;
+                        previous_block_timestamp = archived.timestamp;
                     }
                     if step + 1 == total {
                         break;
@@ -500,7 +474,7 @@ impl BlockReplayStorage {
             let (block_hashes, previous_block_timestamp) =
                 self.resolve_window_and_previous_timestamp(block_number, archived.parent_hash);
             return Some((
-                archived.stripped.into_context(self.chain_id, block_hashes),
+                archived.into_context(self.chain_id, block_hashes),
                 previous_block_timestamp,
             ));
         }
@@ -574,21 +548,20 @@ impl ReadReplay for BlockReplayStorage {
 
 impl BlockReplayStorage {
     /// Like [`ReadReplay::get_replay_record`], but resolves the hash window and
-    /// `previous_block_timestamp` from `parent_hash` instead of the live canonical chain. Used
-    /// when archiving a row that is about to be overridden: if an earlier override in the same
-    /// wave already replaced this row's parent, the live chain no longer has the parent this row
-    /// was actually executed against, so the caller must supply it explicitly (see
-    /// [`WriteReplay::write`]'s `last_archived`).
+    /// `previous_block_timestamp` from this row's own `parent_hash` instead of the live canonical
+    /// chain. Used when archiving a row that is about to be overridden: if an earlier override in
+    /// the same wave already replaced this row's parent, the live chain no longer has the parent
+    /// this row was actually executed against — but the row's own `parent_hash` is unaffected by
+    /// that, since it was fixed when this row was (last) written.
     fn get_replay_record_with_original_parent(
         &self,
         block_number: BlockNumber,
-        parent_hash: BlockHash,
     ) -> Option<ReplayRecord> {
         let key = block_number.to_be_bytes();
         let (block_context, previous_block_timestamp) =
             if let Some(stored) = self.get_stored_context_v2(&key) {
                 let (block_hashes, previous_block_timestamp) =
-                    self.resolve_window_and_previous_timestamp(block_number, parent_hash);
+                    self.resolve_window_and_previous_timestamp(block_number, stored.parent_hash);
                 (
                     stored.into_context(self.chain_id, block_hashes),
                     previous_block_timestamp,
@@ -805,20 +778,8 @@ impl WriteReplay for BlockReplayStorage {
 
         if block_context.block_number <= current_latest_record {
             let block_number = block_context.block_number;
-            let mut last_archived = self.last_archived.lock().unwrap();
-            // The original parent hash of the row about to be overridden (see `last_archived`).
-            let parent_hash = if block_number == 0 {
-                // Unused: genesis has no parent, and the resolvers below short-circuit on
-                // `block_number == 0` without consulting it.
-                BlockHash::ZERO
-            } else {
-                match *last_archived {
-                    Some((last_number, last_hash)) if last_number + 1 == block_number => last_hash,
-                    _ => self.get_canonical_block_hash(block_number - 1),
-                }
-            };
             let old_record = self
-                .get_replay_record_with_original_parent(block_number, parent_hash)
+                .get_replay_record_with_original_parent(block_number)
                 .expect("Old record must exist");
             if &old_record != block_record {
                 let old_record_hash = self.get_canonical_block_hash(block_number);
@@ -830,14 +791,9 @@ impl WriteReplay for BlockReplayStorage {
                 );
                 self.write_replay_unchecked(
                     Sealed::new_unchecked(old_record, old_record_hash),
-                    WriteKind::Archived { parent_hash },
+                    WriteKind::Archived,
                 );
-                *last_archived = Some((block_number, old_record_hash));
             }
-        } else {
-            // A plain append means whatever chain the last wave produced is final; a future
-            // override at these heights is built on it, not on the cached parent hash.
-            *self.last_archived.lock().unwrap() = None;
         }
 
         self.write_replay_unchecked(sealed_record, WriteKind::Canonical);
@@ -849,11 +805,10 @@ impl WriteReplay for BlockReplayStorage {
 /// How [`BlockReplayStorage::write_replay_unchecked`] should persist a row.
 #[derive(Clone, Copy, Debug)]
 enum WriteKind {
-    /// A canonical (number-keyed) row: stripped of the hash window, indexed in `CanonicalHash`.
+    /// A canonical (number-keyed) row, additionally indexed in `CanonicalHash`.
     Canonical,
-    /// A row displaced by an override (hash-keyed): stripped of the hash window in favor of its
-    /// own `parent_hash`, from which the window is reconstructed on read.
-    Archived { parent_hash: BlockHash },
+    /// A row displaced by an override (hash-keyed).
+    Archived,
 }
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.0000001..=1.0, 2.0);
@@ -1002,22 +957,19 @@ impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
     }
 }
 
-/// [`BlockContext`] as persisted in the `ArchivedContext` CF: the stripped fields plus this row's
-/// own parent hash, in place of the 256-hash window. See
-/// [`BlockReplayStorage::resolve_window_and_previous_timestamp`] for how the window and
-/// `previous_block_timestamp` get reconstructed from a chain of these.
-#[derive(Debug, bincode::Encode, bincode::Decode)]
-struct StoredArchivedContext {
-    #[bincode(with_serde)]
-    parent_hash: BlockHash,
-    stripped: StoredBlockContextV2,
-}
-
-/// [`BlockContext`] as persisted in the `ContextV2` CF: without the 256 previous block hashes
-/// (derivable from the `CanonicalHash` CF, ~8 KiB per block; see
-/// [`BlockReplayStorage::read_block_hashes`]) and without the chain id (shared by all blocks,
-/// known from configuration / L1, not persisted at all — supplied by [`BlockReplayStorage`]'s
-/// in-memory `chain_id` field on read).
+/// [`BlockContext`] as persisted in the `ContextV2` and `ArchivedContext` CFs: without the 256
+/// previous block hashes, and without the chain id (shared by all blocks, known from
+/// configuration / L1, not persisted at all — supplied by [`BlockReplayStorage`]'s in-memory
+/// `chain_id` field on read). In their place, this row's own immediate parent hash — fixed when
+/// the row was (last) written, independent of whatever `CanonicalHash` currently says.
+///
+/// For a canonical row, this is redundant with `CanonicalHash[block_number - 1]` in the common
+/// case, but it's what lets an override archive the row it's about to replace correctly without
+/// tracking any override-wave state: block `N`'s current row always has the parent hash it was
+/// actually built on, even if `N - 1`'s own canonical entry has since moved on to a different
+/// chain. For an archived row, it's the only copy of that fact, and lets the window and
+/// `previous_block_timestamp` be reconstructed later by walking a chain of these (see
+/// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]).
 ///
 /// The exhaustive destructuring in the conversions below keeps this struct in sync with
 /// [`BlockContext`]: a field added there fails compilation here, prompting a decision on whether
@@ -1041,6 +993,8 @@ struct StoredBlockContextV2 {
     execution_version: u32,
     #[bincode(with_serde)]
     blob_fee: U256,
+    #[bincode(with_serde)]
+    parent_hash: BlockHash,
 }
 
 impl StoredBlockContextV2 {
@@ -1048,7 +1002,7 @@ impl StoredBlockContextV2 {
         let BlockContext {
             chain_id: _,
             block_number,
-            block_hashes: _,
+            block_hashes,
             timestamp,
             eip1559_basefee,
             pubdata_price,
@@ -1072,6 +1026,7 @@ impl StoredBlockContextV2 {
             mix_hash,
             execution_version,
             blob_fee,
+            parent_hash: BlockHash::from(block_hashes.0[255]),
         }
     }
 
@@ -1088,6 +1043,7 @@ impl StoredBlockContextV2 {
             mix_hash,
             execution_version,
             blob_fee,
+            parent_hash: _,
         } = self;
         BlockContext {
             chain_id,
@@ -1466,6 +1422,45 @@ mod tests {
         );
         // The new canonical rows reconstruct against the repointed index.
         assert_eq!(storage.get_replay_record(3), Some(new3));
+        assert_eq!(storage.get_replay_record(4), Some(new4));
+    }
+
+    #[tokio::test]
+    async fn override_wave_survives_reopening_storage_mid_wave() {
+        // Each row's own `parent_hash` is what it was built on, full stop — nothing needs to be
+        // remembered in memory across writes, not even within a single wave. Reopening storage
+        // between overriding block 3 and block 4 must not change block 4's archival outcome.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+        let chain = make_chain(5);
+        for sealed in &chain {
+            storage.write(sealed.clone(), false).await.unwrap();
+        }
+        let (old3, old4) = (&chain[3], &chain[4]);
+        let mut new3 = old3.as_ref().clone();
+        new3.block_context.timestamp += 100;
+        let new3_hash = fake_hash(103);
+        storage
+            .write(Sealed::new_unchecked(new3.clone(), new3_hash), true)
+            .await
+            .unwrap();
+
+        drop(storage);
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+
+        let mut new4 = old4.as_ref().clone();
+        new4.block_context.timestamp += 100;
+        new4.block_context.block_hashes = new3.block_context.block_hashes.push(new3_hash);
+        new4.previous_block_timestamp = new3.block_context.timestamp;
+        storage
+            .write(Sealed::new_unchecked(new4.clone(), fake_hash(104)), true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
+            Some(old4.as_ref().clone())
+        );
         assert_eq!(storage.get_replay_record(4), Some(new4));
     }
 

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -816,13 +816,11 @@ impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
                 );
             }
 
-            if db
-                .get_cf(BlockReplayColumnFamily::ContextV2, &key)?
-                .is_none()
-            {
-                let legacy_bytes = legacy.as_deref().with_context(|| {
-                    format!("block {number} has neither a stripped nor a legacy context row")
-                })?;
+            if let Some(legacy_bytes) = legacy.as_deref() {
+                // The legacy row is authoritative: rebuild the stripped row from it even when
+                // one already exists. A rebuild executed under a pre-stripped-format binary
+                // (possible during a rollback) updates only the legacy row, leaving a stale
+                // stripped copy behind; this heals it.
                 let context: BlockContext =
                     bincode::serde::decode_from_slice(legacy_bytes, bincode::config::standard())
                         .context("failed to deserialize legacy context")?
@@ -833,11 +831,14 @@ impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
                 )
                 .context("failed to serialize stripped context")?;
                 batch.put_cf(BlockReplayColumnFamily::ContextV2, &key, &stripped);
-            }
-
-            if legacy.is_some() {
                 batch.delete_cf(BlockReplayColumnFamily::Context, &key);
                 deleted += 1;
+            } else {
+                anyhow::ensure!(
+                    db.get_cf(BlockReplayColumnFamily::ContextV2, &key)?
+                        .is_some(),
+                    "block {number} has neither a stripped nor a legacy context row"
+                );
             }
 
             blocks_in_batch += 1;
@@ -1102,6 +1103,22 @@ mod tests {
         // predate the `CanonicalHash` CF, so their hashes must be recovered from successors.
         make_rows_legacy_only(&storage, &chain[..200]);
         delete_canonical_hash_entries(&storage, 0..=100);
+        // Block 50 also carries a stale stripped row (a rebuild under an old binary updates
+        // only the legacy row); the migration must rebuild it from the legacy one.
+        let mut stale = chain[50].block_context;
+        stale.timestamp += 999;
+        let stale_value = bincode::encode_to_vec(
+            StoredBlockContextV2::strip(stale),
+            bincode::config::standard(),
+        )
+        .unwrap();
+        let mut batch = storage.db.new_write_batch();
+        batch.put_cf(
+            BlockReplayColumnFamily::ContextV2,
+            &50u64.to_be_bytes(),
+            &stale_value,
+        );
+        storage.db.write(batch).unwrap();
 
         ContractBlockContexts.run(&storage.db).unwrap();
         // Idempotency: rerunning (e.g. after a crash before the version stamp) is a no-op.

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -1,6 +1,9 @@
 use alloy::primitives::{Address, B256, BlockHash, BlockNumber, Sealed, U256};
+use anyhow::Context as _;
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use vise::Unit;
 use vise::{Buckets, Histogram, Metrics};
@@ -8,6 +11,7 @@ use zksync_os_genesis::Genesis;
 use zksync_os_metadata::NODE_SEMVER_VERSION;
 use zksync_os_rocksdb::RocksDB;
 use zksync_os_rocksdb::db::{NamedColumnFamily, WriteBatch};
+use zksync_os_rocksdb::migrations::Migration;
 use zksync_os_storage_api::{BlockContext, BlockHashes, ReadReplay, ReplayRecord, WriteReplay};
 use zksync_os_types::{BlockStartCursors, ProtocolSemanticVersion};
 
@@ -32,6 +36,16 @@ pub struct BlockReplayStorage {
     db: RocksDB<BlockReplayColumnFamily>,
     /// Shared by all blocks; stripped rows don't persist it (see [`StoredBlockContextV2`]).
     chain_id: u64,
+    /// Hashes of canonical rows displaced by the current override wave (a run of consecutive
+    /// ascending overrides, i.e. a range rebuild or an EN following one). Consulted when
+    /// archiving the next displaced row: `CanonicalHash` entries of already-overridden heights
+    /// point at the new chain, so the archived copy's hash window must take those heights from
+    /// here. Cleared on appends and non-consecutive overrides.
+    ///
+    /// In-memory only: a crash mid-wave loses it, so archived copies of the rest of a resumed
+    /// wave may get new-chain hashes spliced into their windows. Canonical data is unaffected;
+    /// the unification migration (parent hashes on every row) removes this caveat.
+    displaced_hashes: Arc<Mutex<BTreeMap<BlockNumber, BlockHash>>>,
 }
 
 /// Column families for storage of block replay commands.
@@ -42,11 +56,11 @@ pub struct BlockReplayStorage {
 /// serializing the entire `BlockStartCursors` struct.
 #[derive(Copy, Clone, Debug)]
 pub enum BlockReplayColumnFamily {
-    /// Full [`BlockContext`], including the 256 previous block hashes (~8 KiB per block).
-    /// For canonical rows this is a rollback-safety copy — reads prefer [`Self::ContextV2`].
-    /// Non-canonical (hash-keyed) rows live only here.
-    ///
-    /// TODO(RocksDB migration): stop writing canonical rows here and delete existing ones.
+    /// Full [`BlockContext`], including the 256 previous block hashes (~8 KiB per block). Holds
+    /// the non-canonical (hash-keyed) rows displaced by overrides, whose hash windows stop being
+    /// reconstructable once `CanonicalHash` points at the replacing chain. Number-keyed rows
+    /// only appear here when written by binaries predating [`Self::ContextV2`]; the
+    /// [`ContractBlockContexts`] migration converts and deletes them.
     Context,
     /// Stripped [`BlockContext`] for canonical rows: everything except the 256 previous block
     /// hashes, which are derivable data and get reconstructed from [`Self::CanonicalHash`] on
@@ -111,11 +125,14 @@ impl BlockReplayStorage {
     pub async fn new(db_path: &Path, genesis: &Genesis) -> (Self, Option<Sealed<ReplayRecord>>) {
         let db = RocksDB::<BlockReplayColumnFamily>::new(db_path)
             .expect("Failed to open BlockReplayStorage")
-            .with_sync_writes();
+            .with_sync_writes()
+            .run_migrations(MIGRATIONS)
+            .expect("replay WAL schema migration failed");
 
         let this = Self {
             db,
             chain_id: genesis.chain_id(),
+            displaced_hashes: Arc::default(),
         };
         let inserted_genesis = if this.latest_record_checked().is_none() {
             let genesis_tx = genesis.genesis_upgrade_tx().await;
@@ -150,8 +167,14 @@ impl BlockReplayStorage {
     pub fn new_without_genesis(db_path: &Path, chain_id: u64) -> Self {
         let db = RocksDB::<BlockReplayColumnFamily>::new(db_path)
             .expect("Failed to open BlockReplayStorage")
-            .with_sync_writes();
-        Self { db, chain_id }
+            .with_sync_writes()
+            .run_migrations(MIGRATIONS)
+            .expect("replay WAL schema migration failed");
+        Self {
+            db,
+            chain_id,
+            displaced_hashes: Arc::default(),
+        }
     }
 
     fn write_replay_unchecked(&self, sealed_record: Sealed<ReplayRecord>, is_canonical: bool) {
@@ -163,9 +186,6 @@ impl BlockReplayStorage {
         } else {
             block_hash.0.to_vec()
         };
-        let context_value =
-            bincode::serde::encode_to_vec(record.block_context, bincode::config::standard())
-                .expect("Failed to serialize record.context");
         // TODO(RocksDB migration): BlockStartCursors fields are stored in separate column families
         // for historical reasons. A future migration should consolidate them into a single CF
         // serializing the entire BlockStartCursors struct.
@@ -181,9 +201,8 @@ impl BlockReplayStorage {
         // Batch writes: replay entry, latest pointer and canonical hash mapping
         let mut batch: WriteBatch<'_, BlockReplayColumnFamily> = self.db.new_write_batch();
         if is_canonical {
-            // Expand phase of dropping the persisted block hashes: canonical rows are
-            // dual-written. Reads prefer this stripped row; the full legacy row (below) keeps
-            // rollback to older binaries safe until a migration removes it.
+            // Canonical rows don't persist the 256 previous block hashes: they are derivable
+            // from `CanonicalHash` and get reconstructed on read.
             let stripped_context_value = bincode::encode_to_vec(
                 StoredBlockContextV2::strip(record.block_context),
                 bincode::config::standard(),
@@ -199,6 +218,13 @@ impl BlockReplayStorage {
                 &record.block_context.block_number.to_be_bytes(),
                 &block_hash.0,
             );
+        } else {
+            // Non-canonical (displaced) rows keep the full context: their hash windows are not
+            // reconstructable once `CanonicalHash` points at the chain that replaced them.
+            let context_value =
+                bincode::serde::encode_to_vec(record.block_context, bincode::config::standard())
+                    .expect("Failed to serialize record.context");
+            batch.put_cf(BlockReplayColumnFamily::Context, &db_key, &context_value);
         }
         if self
             .latest_record_checked()
@@ -206,7 +232,6 @@ impl BlockReplayStorage {
         {
             batch.put_cf(BlockReplayColumnFamily::Latest, Self::LATEST_KEY, &db_key);
         }
-        batch.put_cf(BlockReplayColumnFamily::Context, &db_key, &context_value);
         batch.put_cf(
             BlockReplayColumnFamily::StartingL1SerialId,
             &db_key,
@@ -294,27 +319,10 @@ impl BlockReplayStorage {
 
     /// Given `block_number` retrieve block's hash.
     fn get_canonical_block_hash(&self, block_number: BlockNumber) -> BlockHash {
+        // Complete for all canonical blocks: backfilled by [`ContractBlockContexts`] and written
+        // with every canonical row since.
         self.get_canonical_block_hash_opt(block_number)
-            .unwrap_or_else(|| {
-                //There are some rare corner cases related to rebuilds right after introducing the CF
-                //I choose to panic in such cases as I really don't expect them to happen
-                let latest = self.latest_record();
-                assert!(latest > block_number);
-                let _ = self
-                    .get_canonical_block_hash_opt(latest)
-                    .expect("Cannot guarantee correctness until latest is updated");
-                // A missing entry implies the block was appended before `CanonicalHash` was
-                // introduced, so its successor's row embeds the hash as the last element.
-                BlockHash::from(
-                    *self
-                        .get_legacy_context(&(block_number + 1).to_be_bytes())
-                        .expect("Record is missing")
-                        .block_hashes
-                        .0
-                        .last()
-                        .unwrap(),
-                )
-            })
+            .unwrap_or_else(|| panic!("no CanonicalHash entry for block {block_number}"))
     }
 
     fn get_canonical_block_hash_opt(&self, block_number: BlockNumber) -> Option<BlockHash> {
@@ -327,14 +335,19 @@ impl BlockReplayStorage {
             .map(|bytes| BlockHash::from_slice(&bytes))
     }
 
-    /// Reconstructs the 256 previous block hashes for the block stored under `key` from the
-    /// `CanonicalHash` CF. The hash of block `M` lands at index `M + 256 - block_number` (most
-    /// recent last); slots before genesis stay zero, mirroring how the genesis context is
-    /// initialized.
+    /// Reconstructs the 256 previous block hashes for the canonical block at `block_number`.
+    /// The hash of block `M` lands at index `M + 256 - block_number` (most recent last); slots
+    /// before genesis stay zero, mirroring how the genesis context is initialized.
     ///
-    /// Entries can only be missing for blocks appended before `CanonicalHash` was introduced;
-    /// those slots are taken from the hashes embedded in the row's legacy copy.
-    fn read_block_hashes(&self, block_number: BlockNumber, key: &[u8]) -> BlockHashes {
+    /// Heights present in `displaced` are taken from there instead of `CanonicalHash`: during an
+    /// override wave the entries of already-overridden heights point at the new chain, while the
+    /// row being archived was executed against the displaced one. Normal reads pass an empty
+    /// map.
+    fn read_block_hashes(
+        &self,
+        block_number: BlockNumber,
+        displaced: &BTreeMap<BlockNumber, BlockHash>,
+    ) -> BlockHashes {
         let mut hashes = [U256::ZERO; 256];
         let first = block_number.saturating_sub(256);
         let keys = (first..block_number)
@@ -343,25 +356,14 @@ impl BlockReplayStorage {
         let results = self
             .db
             .multi_get_cf(BlockReplayColumnFamily::CanonicalHash, keys.iter());
-        let mut embedded = None;
         for (number, result) in (first..block_number).zip(results) {
             let index = (number + 256 - block_number) as usize;
-            hashes[index] = match result.expect("Failed to read from CanonicalHash DB") {
-                Some(bytes) => U256::from_be_slice(&bytes),
-                None => {
-                    let embedded = embedded.get_or_insert_with(|| {
-                        // Only expected for blocks appended before `CanonicalHash` was
-                        // introduced, i.e. only on chains that haven't produced a block since.
-                        tracing::warn!(
-                            block_number,
-                            oldest_missing_entry = number,
-                            "missing CanonicalHash entries; falling back to embedded block hashes"
-                        );
-                        self.get_legacy_context(key)
-                            .expect("canonical rows are dual-written; legacy copy must exist")
-                            .block_hashes
-                    });
-                    embedded.0[index]
+            hashes[index] = if let Some(hash) = displaced.get(&number) {
+                U256::from_be_bytes(hash.0)
+            } else {
+                match result.expect("Failed to read from CanonicalHash DB") {
+                    Some(bytes) => U256::from_be_slice(&bytes),
+                    None => panic!("no CanonicalHash entry for block {number}"),
                 }
             };
         }
@@ -398,9 +400,10 @@ impl BlockReplayStorage {
                 stored.block_number, block_number,
                 "block number mismatch when reading context"
             );
-            return Some(
-                stored.into_context(self.chain_id, self.read_block_hashes(block_number, key)),
-            );
+            return Some(stored.into_context(
+                self.chain_id,
+                self.read_block_hashes(block_number, &BTreeMap::new()),
+            ));
         }
         // No stripped row: either a canonical row written before `ContextV2` existed (or by an
         // older binary during a rollback), or a non-canonical (hash-keyed) row holding a
@@ -448,22 +451,25 @@ impl ReadReplay for BlockReplayStorage {
 }
 
 impl BlockReplayStorage {
-    /// Like [`ReadReplay::get_replay_record`], but takes the block context from the legacy row,
-    /// embedded hashes included. Used by the override path: during a multi-block override the
-    /// `CanonicalHash` entries of already-overridden ancestors point at the new chain, so
-    /// reconstructing the hashes would splice new-chain entries into the record being archived.
+    /// Like [`ReadReplay::get_replay_record`], but resolves the hash window with the heights
+    /// displaced by the current override wave taken from `displaced`. Used when archiving a row
+    /// that is about to be overridden: for those heights `CanonicalHash` already points at the
+    /// new chain, while the archived copy must keep the hashes it was executed with.
     fn get_replay_record_with_original_hashes(
         &self,
         block_number: BlockNumber,
+        displaced: &BTreeMap<BlockNumber, BlockHash>,
     ) -> Option<ReplayRecord> {
         let key = block_number.to_be_bytes();
-        let Some(block_context) = self.get_legacy_context(&key) else {
-            // The legacy copy exists for everything this binary writes; it can only be missing
-            // after rolling back from a version whose migration deleted it. Reconstruction keeps
-            // override writes (e.g. an EN re-writing blocks on restart) working in that state;
-            // it is only inexact for an in-flight multi-block override wave, which a rolled-back
-            // binary should not be running.
-            return self.get_replay_record(block_number);
+        let block_context = if let Some(stored) = self.get_stored_context_v2(&key) {
+            stored.into_context(
+                self.chain_id,
+                self.read_block_hashes(block_number, displaced),
+            )
+        } else {
+            // Rows written by binaries predating the stripped format (only reachable by rolling
+            // back further than supported); their embedded hashes are already the originals.
+            self.get_legacy_context(&key)?
         };
         Some(self.assemble_replay_record(block_number, &key, block_context))
     }
@@ -669,17 +675,25 @@ impl WriteReplay for BlockReplayStorage {
         }
 
         if block_context.block_number <= current_latest_record {
-            // The legacy copy always exists for canonical rows (they are dual-written), and it
-            // is the only correct hash source here: reconstruction would splice new-chain
-            // hashes into the archived record when overriding a range of blocks.
+            let block_number = block_context.block_number;
+            let mut displaced = self.displaced_hashes.lock().unwrap();
+            // A non-consecutive override starts a new wave: the previous wave's chain has
+            // already fully become canonical, so its displaced hashes must not leak into this
+            // wave's archived windows.
+            if displaced
+                .last_key_value()
+                .is_some_and(|(last, _)| last + 1 != block_number)
+            {
+                displaced.clear();
+            }
             let old_record = self
-                .get_replay_record_with_original_hashes(block_context.block_number)
+                .get_replay_record_with_original_hashes(block_number, &displaced)
                 .expect("Old record must exist");
             if &old_record != block_record {
-                let old_record_hash = self.get_canonical_block_hash(block_context.block_number);
+                let old_record_hash = self.get_canonical_block_hash(block_number);
                 let old_record_hash_hex = alloy::hex::encode_prefixed(old_record_hash.0);
                 tracing::warn!(
-                    block_number = block_context.block_number,
+                    block_number,
                     old_record_hash_hex,
                     "Overriding existing block replay record",
                 );
@@ -687,7 +701,12 @@ impl WriteReplay for BlockReplayStorage {
                     Sealed::new_unchecked(old_record, old_record_hash),
                     false,
                 );
+                displaced.insert(block_number, old_record_hash);
             }
+        } else {
+            // A plain append means whatever chain the last wave produced is final; a future
+            // override at these heights was built on it, not on the displaced rows.
+            self.displaced_hashes.lock().unwrap().clear();
         }
 
         self.write_replay_unchecked(sealed_record, true);
@@ -718,10 +737,134 @@ pub struct StorageForcePreimages {
     pub preimages: Vec<(B256, Vec<u8>)>,
 }
 
+/// Migrations of the replay WAL, run by [`BlockReplayStorage`]'s constructors before the
+/// database serves anything.
+static MIGRATIONS: &[&dyn Migration<BlockReplayColumnFamily>] = &[&ContractBlockContexts];
+
+/// Contract phase of dropping the persisted 256 block hashes: for every canonical row, ensures
+/// the `CanonicalHash` entry and the stripped `ContextV2` row exist, then deletes the legacy
+/// full-context row (~8 KiB per block). Non-canonical (hash-keyed) rows are left untouched;
+/// only number keys are visited, so the two can never be confused. Ends with a compaction of the
+/// legacy CF so the tombstoned space is actually reclaimed.
+///
+/// Idempotent: each per-row step is skipped when already done, and every 1000-row chunk commits
+/// atomically, so a crash mid-run resumes cleanly on the next open.
+struct ContractBlockContexts;
+
+impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
+    fn target_version(&self) -> u32 {
+        1
+    }
+
+    fn name(&self) -> &'static str {
+        "contract_block_contexts"
+    }
+
+    fn run(&self, db: &RocksDB<BlockReplayColumnFamily>) -> anyhow::Result<()> {
+        let Some(latest) = db.get_cf(
+            BlockReplayColumnFamily::Latest,
+            BlockReplayStorage::LATEST_KEY,
+        )?
+        else {
+            // Fresh database: rows only ever get written in the contracted layout.
+            return Ok(());
+        };
+        let latest = u64::from_be_bytes(
+            latest
+                .as_slice()
+                .try_into()
+                .context("malformed latest-block pointer")?,
+        );
+
+        let mut batch = db.new_write_batch();
+        let mut blocks_in_batch = 0usize;
+        let mut deleted = 0u64;
+        for number in 0..=latest {
+            let key = number.to_be_bytes();
+            let legacy = db.get_cf(BlockReplayColumnFamily::Context, &key)?;
+
+            if db
+                .get_cf(BlockReplayColumnFamily::CanonicalHash, &key)?
+                .is_none()
+            {
+                // The row predates the `CanonicalHash` CF. Its hash is embedded as the last
+                // element of the successor's legacy window; the successor is only deleted when
+                // its own (later) iteration commits, so it is still readable here.
+                let successor = if number < latest {
+                    db.get_cf(
+                        BlockReplayColumnFamily::Context,
+                        &(number + 1).to_be_bytes(),
+                    )?
+                } else {
+                    None
+                };
+                let successor = successor.with_context(|| {
+                    format!(
+                        "cannot recover the canonical hash of block {number}: no CanonicalHash \
+                         entry and no legacy successor row; append at least one block on a \
+                         pre-contraction node version before migrating"
+                    )
+                })?;
+                let successor_context: BlockContext =
+                    bincode::serde::decode_from_slice(&successor, bincode::config::standard())
+                        .context("failed to deserialize legacy successor context")?
+                        .0;
+                batch.put_cf(
+                    BlockReplayColumnFamily::CanonicalHash,
+                    &key,
+                    &successor_context.block_hashes.0[255].to_be_bytes::<32>(),
+                );
+            }
+
+            if db
+                .get_cf(BlockReplayColumnFamily::ContextV2, &key)?
+                .is_none()
+            {
+                let legacy_bytes = legacy.as_deref().with_context(|| {
+                    format!("block {number} has neither a stripped nor a legacy context row")
+                })?;
+                let context: BlockContext =
+                    bincode::serde::decode_from_slice(legacy_bytes, bincode::config::standard())
+                        .context("failed to deserialize legacy context")?
+                        .0;
+                let stripped = bincode::encode_to_vec(
+                    StoredBlockContextV2::strip(context),
+                    bincode::config::standard(),
+                )
+                .context("failed to serialize stripped context")?;
+                batch.put_cf(BlockReplayColumnFamily::ContextV2, &key, &stripped);
+            }
+
+            if legacy.is_some() {
+                batch.delete_cf(BlockReplayColumnFamily::Context, &key);
+                deleted += 1;
+            }
+
+            blocks_in_batch += 1;
+            if blocks_in_batch >= 1_000 {
+                let full_batch = std::mem::replace(&mut batch, db.new_write_batch());
+                db.write(full_batch)
+                    .context("failed to commit migration chunk")?;
+                blocks_in_batch = 0;
+            }
+            if number.is_multiple_of(1_000_000) {
+                tracing::info!(number, latest, "contracting replay WAL block contexts");
+            }
+        }
+        db.write(batch)
+            .context("failed to commit final migration chunk")?;
+
+        tracing::info!(deleted, "reclaiming legacy context space via compaction");
+        db.compact_range_cf(BlockReplayColumnFamily::Context);
+        Ok(())
+    }
+}
+
 /// [`BlockContext`] as persisted in the `ContextV2` CF: without the 256 previous block hashes
 /// (derivable from the `CanonicalHash` CF, ~8 KiB per block; see
-/// [`BlockReplayStorage::read_block_hashes`]) and without the chain id (shared by all blocks, not
-/// persisted at all — supplied by [`BlockReplayStorage`]'s in-memory `chain_id` field on read).
+/// [`BlockReplayStorage::read_block_hashes`]) and without the chain id (shared by all blocks,
+/// known from configuration / L1, not persisted at all — supplied by [`BlockReplayStorage`]'s
+/// in-memory `chain_id` field on read).
 ///
 /// The exhaustive destructuring in the conversions below keeps this struct in sync with
 /// [`BlockContext`]: a field added there fails compilation here, prompting a decision on whether
@@ -882,12 +1025,17 @@ mod tests {
         storage.db.write(batch).unwrap();
     }
 
-    /// Simulates rows written before `ContextV2` existed (or by an older binary during a
-    /// rollback): only the full legacy row is present.
-    fn delete_stripped_rows(storage: &BlockReplayStorage, blocks: std::ops::RangeInclusive<u64>) {
+    /// Rewrites canonical rows into the layout binaries wrote before the stripped format
+    /// existed: a full legacy `Context` row and no `ContextV2` row.
+    fn make_rows_legacy_only(storage: &BlockReplayStorage, chain: &[Sealed<ReplayRecord>]) {
         let mut batch = storage.db.new_write_batch();
-        for number in blocks {
-            batch.delete_cf(BlockReplayColumnFamily::ContextV2, &number.to_be_bytes());
+        for sealed in chain {
+            let key = sealed.block_context.block_number.to_be_bytes();
+            let context_value =
+                bincode::serde::encode_to_vec(sealed.block_context, bincode::config::standard())
+                    .unwrap();
+            batch.put_cf(BlockReplayColumnFamily::Context, &key, &context_value);
+            batch.delete_cf(BlockReplayColumnFamily::ContextV2, &key);
         }
         storage.db.write(batch).unwrap();
     }
@@ -929,29 +1077,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn falls_back_to_embedded_hashes_when_canonical_hash_missing() {
+    async fn rows_without_stripped_copy_are_served_from_legacy() {
+        // Rows written by binaries predating the stripped format (reachable only by rolling
+        // back further than supported) stay readable through the legacy fallback.
         let dir = tempfile::tempdir().unwrap();
         let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
         let chain = make_chain(300);
         for sealed in &chain {
             storage.write(sealed.clone(), false).await.unwrap();
         }
-        // Blocks 0..=150 simulate rows written before the `CanonicalHash` CF existed: later
-        // blocks' windows overlap them, mixing reconstructed and embedded-fallback entries.
-        delete_canonical_hash_entries(&storage, 0..=150);
+        make_rows_legacy_only(&storage, &chain[100..=200]);
         assert_chain_reads_back(&storage, &chain);
     }
 
     #[tokio::test]
-    async fn rows_without_stripped_copy_are_served_from_legacy() {
+    async fn contract_migration_converts_legacy_rows() {
         let dir = tempfile::tempdir().unwrap();
         let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
         let chain = make_chain(300);
         for sealed in &chain {
             storage.write(sealed.clone(), false).await.unwrap();
         }
-        delete_stripped_rows(&storage, 100..=200);
+        // Blocks 0..200 simulate a pre-contraction database; blocks 0..=100 additionally
+        // predate the `CanonicalHash` CF, so their hashes must be recovered from successors.
+        make_rows_legacy_only(&storage, &chain[..200]);
+        delete_canonical_hash_entries(&storage, 0..=100);
+
+        ContractBlockContexts.run(&storage.db).unwrap();
+        // Idempotency: rerunning (e.g. after a crash before the version stamp) is a no-op.
+        ContractBlockContexts.run(&storage.db).unwrap();
+
         assert_chain_reads_back(&storage, &chain);
+        for sealed in &chain {
+            let key = sealed.block_context.block_number.to_be_bytes();
+            assert!(
+                storage
+                    .db
+                    .get_cf(BlockReplayColumnFamily::Context, &key)
+                    .unwrap()
+                    .is_none(),
+                "legacy row must be deleted"
+            );
+            assert!(storage.get_stored_context_v2(&key).is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn contract_migration_leaves_archived_rows_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+        let chain = make_chain(5);
+        for sealed in &chain {
+            storage.write(sealed.clone(), false).await.unwrap();
+        }
+        let old = &chain[4];
+        let mut replacement = old.as_ref().clone();
+        replacement.block_context.timestamp += 100;
+        storage
+            .write(
+                Sealed::new_unchecked(replacement.clone(), fake_hash(999)),
+                true,
+            )
+            .await
+            .unwrap();
+
+        make_rows_legacy_only(&storage, &chain[..4]);
+        ContractBlockContexts.run(&storage.db).unwrap();
+
+        // The hash-keyed archived copy keeps its full row and its original hashes.
+        assert_eq!(
+            storage
+                .get_replay_record_by_key(4, Some(old.hash().0.to_vec()))
+                .unwrap()
+                .block_context,
+            old.block_context
+        );
+        assert_eq!(storage.get_replay_record(4), Some(replacement));
+    }
+
+    #[tokio::test]
+    async fn contract_migration_needs_recoverable_tip_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+        let chain = make_chain(50);
+        for sealed in &chain {
+            storage.write(sealed.clone(), false).await.unwrap();
+        }
+        // A chain whose every row predates `CanonicalHash`: all hashes except the tip's are
+        // recoverable from successors.
+        make_rows_legacy_only(&storage, &chain);
+        delete_canonical_hash_entries(&storage, 0..=49);
+
+        let err = ContractBlockContexts.run(&storage.db).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("cannot recover the canonical hash of block 49"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[tokio::test]
@@ -978,7 +1199,7 @@ mod tests {
         );
 
         // The replaced record stays readable under its hash key, embedded hashes intact.
-        // Non-canonical rows are never dual-written: only the legacy row exists for them.
+        // Non-canonical rows are archived as full legacy rows, never as stripped ones.
         assert!(storage.get_stored_context_v2(&old.hash().0).is_none());
         assert_eq!(
             storage

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -35,22 +35,16 @@ pub struct BlockReplayStorage {
     db: RocksDB<BlockReplayColumnFamily>,
     /// Shared by all blocks; stripped rows don't persist it (see [`StoredBlockContextV2`]).
     chain_id: u64,
-    /// The block number and original hash of the row most recently archived by an override, if
-    /// any override has happened since the last plain append. Bridges the single moment, within
-    /// a multi-block override wave, between overwriting block `N`'s canonical row and archiving
-    /// block `N+1`'s: at that point `CanonicalHash[N]` already points at `N`'s replacement, so
-    /// `N+1`'s original parent hash — needed to archive it — can no longer be read live and must
-    /// come from here instead. Cleared on plain appends and on a non-consecutive override (a new,
-    /// unrelated wave, whose first member's parent hash is still safe to read live).
+    /// The block number and original hash of the row most recently archived by an override.
+    /// Bridges the one moment, within a multi-block override wave, where `CanonicalHash[N]`
+    /// already points at `N`'s replacement but block `N+1` still needs `N`'s *original* hash to
+    /// archive itself correctly. Cleared on plain appends and on a non-consecutive override,
+    /// where the live `CanonicalHash` is safe to read directly instead (see [`WriteReplay::write`]).
     ///
-    /// Unlike the hash window and `previous_block_timestamp`, which [`ArchivedContext`] rows
-    /// resolve durably by walking `parent_hash` pointers (see
-    /// [`Self::resolve_window_and_previous_timestamp`]), this one hash genuinely has no other
-    /// source once its slot is overwritten — no row (canonical or archived) records its own
-    /// parent hash independently of the live `CanonicalHash` index. In-memory only: a crash
-    /// mid-wave loses it, so the archived copy of the rest of a resumed wave gets its parent hash
-    /// from `CanonicalHash` instead, which by then points at the new chain — a narrower version
-    /// of the same caveat the old `displaced_hashes` map had. Canonical data is unaffected.
+    /// In-memory only: a crash mid-wave loses it, so the next archived row falls back to
+    /// `CanonicalHash`, which by then points at the new chain — the resulting row's window would
+    /// need correcting when the unification migration removes this in favor of parent hashes on
+    /// every row. Already-archived rows and canonical data are unaffected either way.
     last_archived: Arc<Mutex<Option<(BlockNumber, BlockHash)>>>,
 }
 
@@ -73,13 +67,13 @@ pub enum BlockReplayColumnFamily {
     /// read (see [`StoredBlockContextV2`]).
     ContextV2,
     /// Hash-keyed archived rows (blocks displaced by an override), holding [`StoredBlockContextV2`]
-    /// plus the row's own `parent_hash` instead of the full hash window. Reconstructing the
-    /// window (and the row's `previous_block_timestamp`) means walking `parent_hash` pointers
-    /// through this same CF until reaching a hash that isn't archived — i.e. one still part of
-    /// the live canonical chain — then finishing with a `CanonicalHash` lookup (see
+    /// plus the row's own `parent_hash` instead of the full hash window. The window and
+    /// `previous_block_timestamp` are reconstructed on read by walking `parent_hash` pointers
+    /// through this CF until reaching a hash still on the live canonical chain, then finishing
+    /// with one `CanonicalHash` lookup (see
     /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]). Unlike [`Self::Context`],
-    /// this never depends on the live `CanonicalHash` index staying unchanged, so it stays correct
-    /// no matter how long after an override wave, or in how different a process, it is read.
+    /// this doesn't depend on `CanonicalHash` staying unchanged, so it's correct on any read, no
+    /// matter how long after the override or in how different a process.
     ArchivedContext,
     StartingL1SerialId,
     Txs,
@@ -424,15 +418,10 @@ impl BlockReplayStorage {
     }
 
     /// Reconstructs the 256-hash window and `previous_block_timestamp` for a row whose immediate
-    /// parent is `parent_hash`, by walking `parent_hash` pointers through `ArchivedContext`.
-    ///
-    /// The walk stops as soon as it reaches a hash that isn't itself archived — i.e. one still
-    /// part of the live canonical chain. From that point on `CanonicalHash` is guaranteed
-    /// unmutated (overrides only ever touch a wave's own consecutive range, and this hash is
-    /// outside it), so the rest of the window is filled with one batched lookup instead of
-    /// walking further. This is what lets an archived row be read correctly no matter how long
-    /// after the override, or in how different a process, the read happens — unlike the in-memory
-    /// `last_archived` cache used at archival time, this has no other state to lose.
+    /// parent is `parent_hash`, by walking `parent_hash` pointers through `ArchivedContext` until
+    /// reaching a hash that isn't itself archived — one still on the live canonical chain, from
+    /// which point `CanonicalHash` is guaranteed unmutated (overrides only ever touch a wave's own
+    /// consecutive range) — then filling the rest of the window with one batched lookup.
     fn resolve_window_and_previous_timestamp(
         &self,
         block_number: BlockNumber,
@@ -502,14 +491,9 @@ impl BlockReplayStorage {
                 stored.block_number, block_number,
                 "block number mismatch when reading context"
             );
-            let previous_block_timestamp = if block_number == 0 {
-                0
-            } else {
-                self.get_block_timestamp(block_number - 1).unwrap_or(0)
-            };
             return Some((
                 stored.into_context(self.chain_id, self.read_block_hashes(block_number)),
-                previous_block_timestamp,
+                self.previous_timestamp_from_canonical(block_number),
             ));
         }
         if let Some(archived) = self.get_archived(key) {
@@ -528,12 +512,10 @@ impl BlockReplayStorage {
         // for the former (a pre-existing quirk for this legacy archived-row shape; new archived
         // rows resolve it durably above).
         let context = self.get_legacy_context(key)?;
-        let previous_block_timestamp = if block_number == 0 {
-            0
-        } else {
-            self.get_block_timestamp(block_number - 1).unwrap_or(0)
-        };
-        Some((context, previous_block_timestamp))
+        Some((
+            context,
+            self.previous_timestamp_from_canonical(block_number),
+        ))
     }
 
     /// Cheaper than [`ReadReplay::get_context`] when only the timestamp is needed: skips
@@ -546,6 +528,17 @@ impl BlockReplayStorage {
                 self.get_legacy_context(&key)
                     .map(|context| context.timestamp)
             })
+    }
+
+    /// `previous_block_timestamp` for a row whose parent is the current canonical chain: correct
+    /// for canonical rows and legacy (pre-`ArchivedContext`) archived rows, but not for a row
+    /// displaced earlier in an in-progress override wave (see `resolve_window_and_previous_timestamp`).
+    fn previous_timestamp_from_canonical(&self, block_number: BlockNumber) -> u64 {
+        if block_number == 0 {
+            0
+        } else {
+            self.get_block_timestamp(block_number - 1).unwrap_or(0)
+        }
     }
 }
 
@@ -585,7 +578,7 @@ impl BlockReplayStorage {
     /// when archiving a row that is about to be overridden: if an earlier override in the same
     /// wave already replaced this row's parent, the live chain no longer has the parent this row
     /// was actually executed against, so the caller must supply it explicitly (see
-    /// [`WriteReplay::write`](Self)'s `last_archived`).
+    /// [`WriteReplay::write`]'s `last_archived`).
     fn get_replay_record_with_original_parent(
         &self,
         block_number: BlockNumber,
@@ -604,12 +597,10 @@ impl BlockReplayStorage {
                 // Rows written by binaries predating the stripped format (only reachable by rolling
                 // back further than supported); their embedded hashes are already the originals.
                 let context = self.get_legacy_context(&key)?;
-                let previous_block_timestamp = if block_number == 0 {
-                    0
-                } else {
-                    self.get_block_timestamp(block_number - 1).unwrap_or(0)
-                };
-                (context, previous_block_timestamp)
+                (
+                    context,
+                    self.previous_timestamp_from_canonical(block_number),
+                )
             };
         Some(self.assemble_replay_record(
             block_number,
@@ -641,8 +632,6 @@ impl BlockReplayStorage {
             .get_cf(BlockReplayColumnFamily::Txs, key)
             .expect("Failed to read from Txs CF")
             .expect("Txs must be written atomically with Context");
-        // todo: save `previous_block_timestamp` as another column in the next breaking change to
-        //       replay record format
 
         let node_version = self
             .db
@@ -817,10 +806,7 @@ impl WriteReplay for BlockReplayStorage {
         if block_context.block_number <= current_latest_record {
             let block_number = block_context.block_number;
             let mut last_archived = self.last_archived.lock().unwrap();
-            // The original parent hash of the row about to be overridden. Usually still safe to
-            // read live from `CanonicalHash`— unless the immediately preceding block was itself
-            // overridden earlier in this same wave, in which case that already points at its
-            // replacement, and the true original parent is only available from `last_archived`.
+            // The original parent hash of the row about to be overridden (see `last_archived`).
             let parent_hash = if block_number == 0 {
                 // Unused: genesis has no parent, and the resolvers below short-circuit on
                 // `block_number == 0` without consulting it.
@@ -1429,19 +1415,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn multi_block_override_archives_original_hashes() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
-        let chain = make_chain(5);
-        for sealed in &chain {
-            storage.write(sealed.clone(), false).await.unwrap();
-        }
-
-        // Replace blocks 3 and 4 sequentially, as a range rebuild does. By the time block 4 is
-        // overridden, `CanonicalHash[3]` already points at the new chain, so its archived copy
-        // must not be reconstructed from the index — nor must its `previous_block_timestamp`,
-        // which would otherwise pick up new block 3's timestamp instead of old block 3's.
+    /// Overrides blocks 3 and 4 of `chain` sequentially, as a range rebuild does. By the time
+    /// block 4 is overridden, `CanonicalHash[3]` already points at the new chain, exercising the
+    /// multi-block-wave path.
+    async fn override_blocks_3_and_4(
+        storage: &BlockReplayStorage,
+        chain: &[Sealed<ReplayRecord>],
+    ) -> (ReplayRecord, ReplayRecord) {
         let (old3, old4) = (&chain[3], &chain[4]);
         let mut new3 = old3.as_ref().clone();
         new3.block_context.timestamp += 100;
@@ -1458,6 +1438,19 @@ mod tests {
             .write(Sealed::new_unchecked(new4.clone(), fake_hash(104)), true)
             .await
             .unwrap();
+        (new3, new4)
+    }
+
+    #[tokio::test]
+    async fn multi_block_override_archives_original_hashes() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+        let chain = make_chain(5);
+        for sealed in &chain {
+            storage.write(sealed.clone(), false).await.unwrap();
+        }
+        let (old3, old4) = (&chain[3], &chain[4]);
+        let (new3, new4) = override_blocks_3_and_4(&storage, &chain).await;
 
         // The archived copies are byte-correct: old block 4's window ends with old block 3's
         // hash (not the replacement's), and its `previous_block_timestamp` is old block 3's
@@ -1488,23 +1481,8 @@ mod tests {
         for sealed in &chain {
             storage.write(sealed.clone(), false).await.unwrap();
         }
-
         let (old3, old4) = (&chain[3], &chain[4]);
-        let mut new3 = old3.as_ref().clone();
-        new3.block_context.timestamp += 100;
-        let new3_hash = fake_hash(103);
-        storage
-            .write(Sealed::new_unchecked(new3.clone(), new3_hash), true)
-            .await
-            .unwrap();
-        let mut new4 = old4.as_ref().clone();
-        new4.block_context.timestamp += 100;
-        new4.block_context.block_hashes = new3.block_context.block_hashes.push(new3_hash);
-        new4.previous_block_timestamp = new3.block_context.timestamp;
-        storage
-            .write(Sealed::new_unchecked(new4.clone(), fake_hash(104)), true)
-            .await
-            .unwrap();
+        let (_, new4) = override_blocks_3_and_4(&storage, &chain).await;
 
         // A plain append ends the wave, clearing any in-memory state.
         let mut new5 = new4.clone();

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::{Address, B256, BlockHash, BlockNumber, Sealed, U256};
 use anyhow::Context as _;
-use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -36,16 +35,23 @@ pub struct BlockReplayStorage {
     db: RocksDB<BlockReplayColumnFamily>,
     /// Shared by all blocks; stripped rows don't persist it (see [`StoredBlockContextV2`]).
     chain_id: u64,
-    /// Hashes of canonical rows displaced by the current override wave (a run of consecutive
-    /// ascending overrides, i.e. a range rebuild or an EN following one). Consulted when
-    /// archiving the next displaced row: `CanonicalHash` entries of already-overridden heights
-    /// point at the new chain, so the archived copy's hash window must take those heights from
-    /// here. Cleared on appends and non-consecutive overrides.
+    /// The block number and original hash of the row most recently archived by an override, if
+    /// any override has happened since the last plain append. Bridges the single moment, within
+    /// a multi-block override wave, between overwriting block `N`'s canonical row and archiving
+    /// block `N+1`'s: at that point `CanonicalHash[N]` already points at `N`'s replacement, so
+    /// `N+1`'s original parent hash — needed to archive it — can no longer be read live and must
+    /// come from here instead. Cleared on plain appends and on a non-consecutive override (a new,
+    /// unrelated wave, whose first member's parent hash is still safe to read live).
     ///
-    /// In-memory only: a crash mid-wave loses it, so archived copies of the rest of a resumed
-    /// wave may get new-chain hashes spliced into their windows. Canonical data is unaffected;
-    /// the unification migration (parent hashes on every row) removes this caveat.
-    displaced_hashes: Arc<Mutex<BTreeMap<BlockNumber, BlockHash>>>,
+    /// Unlike the hash window and `previous_block_timestamp`, which [`ArchivedContext`] rows
+    /// resolve durably by walking `parent_hash` pointers (see
+    /// [`Self::resolve_window_and_previous_timestamp`]), this one hash genuinely has no other
+    /// source once its slot is overwritten — no row (canonical or archived) records its own
+    /// parent hash independently of the live `CanonicalHash` index. In-memory only: a crash
+    /// mid-wave loses it, so the archived copy of the rest of a resumed wave gets its parent hash
+    /// from `CanonicalHash` instead, which by then points at the new chain — a narrower version
+    /// of the same caveat the old `displaced_hashes` map had. Canonical data is unaffected.
+    last_archived: Arc<Mutex<Option<(BlockNumber, BlockHash)>>>,
 }
 
 /// Column families for storage of block replay commands.
@@ -57,15 +63,24 @@ pub struct BlockReplayStorage {
 #[derive(Copy, Clone, Debug)]
 pub enum BlockReplayColumnFamily {
     /// Full [`BlockContext`], including the 256 previous block hashes (~8 KiB per block). Holds
-    /// the non-canonical (hash-keyed) rows displaced by overrides, whose hash windows stop being
-    /// reconstructable once `CanonicalHash` points at the replacing chain. Number-keyed rows
-    /// only appear here when written by binaries predating [`Self::ContextV2`]; the
-    /// [`ContractBlockContexts`] migration converts and deletes them.
+    /// hash-keyed archived rows written before [`Self::ArchivedContext`] existed. Number-keyed
+    /// rows only appear here when written by binaries predating [`Self::ContextV2`]; the
+    /// [`ContractBlockContexts`] migration converts and deletes them. Never written to going
+    /// forward; new archived rows go to [`Self::ArchivedContext`] instead.
     Context,
     /// Stripped [`BlockContext`] for canonical rows: everything except the 256 previous block
     /// hashes, which are derivable data and get reconstructed from [`Self::CanonicalHash`] on
     /// read (see [`StoredBlockContextV2`]).
     ContextV2,
+    /// Hash-keyed archived rows (blocks displaced by an override), holding [`StoredBlockContextV2`]
+    /// plus the row's own `parent_hash` instead of the full hash window. Reconstructing the
+    /// window (and the row's `previous_block_timestamp`) means walking `parent_hash` pointers
+    /// through this same CF until reaching a hash that isn't archived — i.e. one still part of
+    /// the live canonical chain — then finishing with a `CanonicalHash` lookup (see
+    /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]). Unlike [`Self::Context`],
+    /// this never depends on the live `CanonicalHash` index staying unchanged, so it stays correct
+    /// no matter how long after an override wave, or in how different a process, it is read.
+    ArchivedContext,
     StartingL1SerialId,
     Txs,
     NodeVersion,
@@ -86,6 +101,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
     const ALL: &'static [Self] = &[
         BlockReplayColumnFamily::Context,
         BlockReplayColumnFamily::ContextV2,
+        BlockReplayColumnFamily::ArchivedContext,
         BlockReplayColumnFamily::StartingL1SerialId,
         BlockReplayColumnFamily::Txs,
         BlockReplayColumnFamily::NodeVersion,
@@ -103,6 +119,7 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
         match self {
             BlockReplayColumnFamily::Context => "context",
             BlockReplayColumnFamily::ContextV2 => "context_v2",
+            BlockReplayColumnFamily::ArchivedContext => "archived_context",
             BlockReplayColumnFamily::StartingL1SerialId => "last_processed_l1_tx_id",
             BlockReplayColumnFamily::Txs => "txs",
             BlockReplayColumnFamily::NodeVersion => "node_version",
@@ -132,7 +149,7 @@ impl BlockReplayStorage {
         let this = Self {
             db,
             chain_id: genesis.chain_id(),
-            displaced_hashes: Arc::default(),
+            last_archived: Arc::default(),
         };
         let inserted_genesis = if this.latest_record_checked().is_none() {
             let genesis_tx = genesis.genesis_upgrade_tx().await;
@@ -152,7 +169,7 @@ impl BlockReplayStorage {
                 starting_cursors: BlockStartCursors::default(),
             };
             let sealed_genesis_record = Sealed::new_unchecked(genesis_record, genesis_hash);
-            this.write_replay_unchecked(sealed_genesis_record.clone(), true);
+            this.write_replay_unchecked(sealed_genesis_record.clone(), WriteKind::Canonical);
             Some(sealed_genesis_record)
         } else {
             None
@@ -173,18 +190,17 @@ impl BlockReplayStorage {
         Self {
             db,
             chain_id,
-            displaced_hashes: Arc::default(),
+            last_archived: Arc::default(),
         }
     }
 
-    fn write_replay_unchecked(&self, sealed_record: Sealed<ReplayRecord>, is_canonical: bool) {
+    fn write_replay_unchecked(&self, sealed_record: Sealed<ReplayRecord>, kind: WriteKind) {
         // Prepare record
         let (record, block_hash) = sealed_record.split();
         // TODO: We want to change the key to be block_hash for all blocks
-        let db_key = if is_canonical {
-            record.block_context.block_number.to_be_bytes().to_vec()
-        } else {
-            block_hash.0.to_vec()
+        let db_key = match kind {
+            WriteKind::Canonical => record.block_context.block_number.to_be_bytes().to_vec(),
+            WriteKind::Archived { .. } => block_hash.0.to_vec(),
         };
         // TODO(RocksDB migration): BlockStartCursors fields are stored in separate column families
         // for historical reasons. A future migration should consolidate them into a single CF
@@ -200,31 +216,46 @@ impl BlockReplayStorage {
 
         // Batch writes: replay entry, latest pointer and canonical hash mapping
         let mut batch: WriteBatch<'_, BlockReplayColumnFamily> = self.db.new_write_batch();
-        if is_canonical {
-            // Canonical rows don't persist the 256 previous block hashes: they are derivable
-            // from `CanonicalHash` and get reconstructed on read.
-            let stripped_context_value = bincode::encode_to_vec(
-                StoredBlockContextV2::strip(record.block_context),
-                bincode::config::standard(),
-            )
-            .expect("Failed to serialize stripped record.context");
-            batch.put_cf(
-                BlockReplayColumnFamily::ContextV2,
-                &db_key,
-                &stripped_context_value,
-            );
-            batch.put_cf(
-                BlockReplayColumnFamily::CanonicalHash,
-                &record.block_context.block_number.to_be_bytes(),
-                &block_hash.0,
-            );
-        } else {
-            // Non-canonical (displaced) rows keep the full context: their hash windows are not
-            // reconstructable once `CanonicalHash` points at the chain that replaced them.
-            let context_value =
-                bincode::serde::encode_to_vec(record.block_context, bincode::config::standard())
-                    .expect("Failed to serialize record.context");
-            batch.put_cf(BlockReplayColumnFamily::Context, &db_key, &context_value);
+        match kind {
+            WriteKind::Canonical => {
+                // Canonical rows don't persist the 256 previous block hashes: they are derivable
+                // from `CanonicalHash` and get reconstructed on read.
+                let stripped_context_value = bincode::encode_to_vec(
+                    StoredBlockContextV2::strip(record.block_context),
+                    bincode::config::standard(),
+                )
+                .expect("Failed to serialize stripped record.context");
+                batch.put_cf(
+                    BlockReplayColumnFamily::ContextV2,
+                    &db_key,
+                    &stripped_context_value,
+                );
+                batch.put_cf(
+                    BlockReplayColumnFamily::CanonicalHash,
+                    &record.block_context.block_number.to_be_bytes(),
+                    &block_hash.0,
+                );
+            }
+            WriteKind::Archived { parent_hash } => {
+                // Archived rows keep their own `parent_hash` instead of the full hash window:
+                // the window (and `previous_block_timestamp`) are reconstructed on read by
+                // walking `parent_hash` pointers (see
+                // `resolve_window_and_previous_timestamp`), which stays correct regardless of
+                // what happens to `CanonicalHash` afterwards.
+                let archived_value = bincode::encode_to_vec(
+                    StoredArchivedContext {
+                        parent_hash,
+                        stripped: StoredBlockContextV2::strip(record.block_context),
+                    },
+                    bincode::config::standard(),
+                )
+                .expect("Failed to serialize archived record.context");
+                batch.put_cf(
+                    BlockReplayColumnFamily::ArchivedContext,
+                    &db_key,
+                    &archived_value,
+                );
+            }
         }
         if self
             .latest_record_checked()
@@ -335,19 +366,12 @@ impl BlockReplayStorage {
             .map(|bytes| BlockHash::from_slice(&bytes))
     }
 
-    /// Reconstructs the 256 previous block hashes for the canonical block at `block_number`.
-    /// The hash of block `M` lands at index `M + 256 - block_number` (most recent last); slots
-    /// before genesis stay zero, mirroring how the genesis context is initialized.
-    ///
-    /// Heights present in `displaced` are taken from there instead of `CanonicalHash`: during an
-    /// override wave the entries of already-overridden heights point at the new chain, while the
-    /// row being archived was executed against the displaced one. Normal reads pass an empty
-    /// map.
-    fn read_block_hashes(
-        &self,
-        block_number: BlockNumber,
-        displaced: &BTreeMap<BlockNumber, BlockHash>,
-    ) -> BlockHashes {
+    /// Reconstructs the 256 previous block hashes for the canonical block at `block_number` from
+    /// `CanonicalHash`. The hash of block `M` lands at index `M + 256 - block_number` (most
+    /// recent last); slots before genesis stay zero, mirroring how the genesis context is
+    /// initialized. Always correct for a canonical row: unlike an archived row, it's never
+    /// disconnected from the live index it's read through.
+    fn read_block_hashes(&self, block_number: BlockNumber) -> BlockHashes {
         let mut hashes = [U256::ZERO; 256];
         let first = block_number.saturating_sub(256);
         let keys = (first..block_number)
@@ -358,13 +382,9 @@ impl BlockReplayStorage {
             .multi_get_cf(BlockReplayColumnFamily::CanonicalHash, keys.iter());
         for (number, result) in (first..block_number).zip(results) {
             let index = (number + 256 - block_number) as usize;
-            hashes[index] = if let Some(hash) = displaced.get(&number) {
-                U256::from_be_bytes(hash.0)
-            } else {
-                match result.expect("Failed to read from CanonicalHash DB") {
-                    Some(bytes) => U256::from_be_slice(&bytes),
-                    None => panic!("no CanonicalHash entry for block {number}"),
-                }
+            hashes[index] = match result.expect("Failed to read from CanonicalHash DB") {
+                Some(bytes) => U256::from_be_slice(&bytes),
+                None => panic!("no CanonicalHash entry for block {number}"),
             };
         }
         BlockHashes(hashes)
@@ -381,6 +401,17 @@ impl BlockReplayStorage {
             })
     }
 
+    fn get_archived(&self, key: &[u8]) -> Option<StoredArchivedContext> {
+        self.db
+            .get_cf(BlockReplayColumnFamily::ArchivedContext, key)
+            .expect("Cannot read from DB")
+            .map(|bytes| {
+                bincode::decode_from_slice(&bytes, bincode::config::standard())
+                    .expect("Failed to deserialize archived context")
+                    .0
+            })
+    }
+
     fn get_legacy_context(&self, key: &[u8]) -> Option<BlockContext> {
         self.db
             .get_cf(BlockReplayColumnFamily::Context, key)
@@ -392,25 +423,117 @@ impl BlockReplayStorage {
             })
     }
 
-    fn get_context_by_key(&self, block_number: BlockNumber, key: &[u8]) -> Option<BlockContext> {
-        // Prefer the stripped row: its block hashes are reconstructed from `CanonicalHash`, so
-        // nothing depends on the copy embedded in the legacy row anymore.
+    /// Reconstructs the 256-hash window and `previous_block_timestamp` for a row whose immediate
+    /// parent is `parent_hash`, by walking `parent_hash` pointers through `ArchivedContext`.
+    ///
+    /// The walk stops as soon as it reaches a hash that isn't itself archived — i.e. one still
+    /// part of the live canonical chain. From that point on `CanonicalHash` is guaranteed
+    /// unmutated (overrides only ever touch a wave's own consecutive range, and this hash is
+    /// outside it), so the rest of the window is filled with one batched lookup instead of
+    /// walking further. This is what lets an archived row be read correctly no matter how long
+    /// after the override, or in how different a process, the read happens — unlike the in-memory
+    /// `last_archived` cache used at archival time, this has no other state to lose.
+    fn resolve_window_and_previous_timestamp(
+        &self,
+        block_number: BlockNumber,
+        parent_hash: BlockHash,
+    ) -> (BlockHashes, u64) {
+        if block_number == 0 {
+            return (BlockHashes::default(), 0);
+        }
+        let mut hashes = [U256::ZERO; 256];
+        let first = block_number.saturating_sub(256);
+        let total = (block_number - first) as usize;
+        let mut current_hash = parent_hash;
+        let mut previous_block_timestamp = 0;
+        for step in 0..total {
+            hashes[255 - step] = U256::from_be_bytes(current_hash.0);
+            match self.get_archived(current_hash.0.as_slice()) {
+                Some(archived) => {
+                    if step == 0 {
+                        previous_block_timestamp = archived.stripped.timestamp;
+                    }
+                    if step + 1 == total {
+                        break;
+                    }
+                    current_hash = archived.parent_hash;
+                }
+                None => {
+                    // `current_hash` is still part of the live canonical chain.
+                    let this_number = block_number - 1 - step as u64;
+                    if step == 0 {
+                        previous_block_timestamp = self
+                            .get_block_timestamp(this_number)
+                            .expect("current canonical row must have a timestamp");
+                    }
+                    if this_number > first {
+                        let keys = (first..this_number)
+                            .map(|number| number.to_be_bytes())
+                            .collect::<Vec<_>>();
+                        let results = self
+                            .db
+                            .multi_get_cf(BlockReplayColumnFamily::CanonicalHash, keys.iter());
+                        for (number, result) in (first..this_number).zip(results) {
+                            let index = (number + 256 - block_number) as usize;
+                            hashes[index] =
+                                match result.expect("Failed to read from CanonicalHash DB") {
+                                    Some(bytes) => U256::from_be_slice(&bytes),
+                                    None => panic!("no CanonicalHash entry for block {number}"),
+                                };
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        (BlockHashes(hashes), previous_block_timestamp)
+    }
+
+    /// Resolves a context by key, and the `previous_block_timestamp` to go with it. Checks
+    /// `ContextV2` (canonical), then `ArchivedContext` (a row archived by this or an earlier
+    /// binary), then `Context` (a row predating one of the two stripped formats).
+    fn resolve_context(
+        &self,
+        block_number: BlockNumber,
+        key: &[u8],
+    ) -> Option<(BlockContext, u64)> {
         if let Some(stored) = self.get_stored_context_v2(key) {
             assert_eq!(
                 stored.block_number, block_number,
                 "block number mismatch when reading context"
             );
-            return Some(stored.into_context(
-                self.chain_id,
-                self.read_block_hashes(block_number, &BTreeMap::new()),
+            let previous_block_timestamp = if block_number == 0 {
+                0
+            } else {
+                self.get_block_timestamp(block_number - 1).unwrap_or(0)
+            };
+            return Some((
+                stored.into_context(self.chain_id, self.read_block_hashes(block_number)),
+                previous_block_timestamp,
+            ));
+        }
+        if let Some(archived) = self.get_archived(key) {
+            let (block_hashes, previous_block_timestamp) =
+                self.resolve_window_and_previous_timestamp(block_number, archived.parent_hash);
+            return Some((
+                archived.stripped.into_context(self.chain_id, block_hashes),
+                previous_block_timestamp,
             ));
         }
         // No stripped row: either a canonical row written before `ContextV2` existed (or by an
-        // older binary during a rollback), or a non-canonical (hash-keyed) row holding a
-        // reverted block. Both are served as stored: for the former the embedded hashes are
-        // just as correct, and for the latter they are authoritative — `CanonicalHash` entries
-        // for a reverted block's ancestors may have been overwritten by the new canonical chain.
-        self.get_legacy_context(key)
+        // older binary during a rollback), or an archived row written before `ArchivedContext`
+        // existed. Both are served as stored: for the former the embedded hashes are just as
+        // correct, and for the latter they are authoritative — but `previous_block_timestamp` is
+        // derived from the current canonical neighbor either way, which is only exactly right
+        // for the former (a pre-existing quirk for this legacy archived-row shape; new archived
+        // rows resolve it durably above).
+        let context = self.get_legacy_context(key)?;
+        let previous_block_timestamp = if block_number == 0 {
+            0
+        } else {
+            self.get_block_timestamp(block_number - 1).unwrap_or(0)
+        };
+        Some((context, previous_block_timestamp))
     }
 
     /// Cheaper than [`ReadReplay::get_context`] when only the timestamp is needed: skips
@@ -428,7 +551,8 @@ impl BlockReplayStorage {
 
 impl ReadReplay for BlockReplayStorage {
     fn get_context(&self, block_number: BlockNumber) -> Option<BlockContext> {
-        self.get_context_by_key(block_number, &block_number.to_be_bytes())
+        self.resolve_context(block_number, &block_number.to_be_bytes())
+            .map(|(context, _)| context)
     }
 
     fn get_replay_record_by_key(
@@ -439,8 +563,13 @@ impl ReadReplay for BlockReplayStorage {
         let key = db_key.unwrap_or_else(|| block_number.to_be_bytes().to_vec());
         // Writes are atomic, so if we can't read the context, we can't read the rest of the
         // replay record anyway.
-        let block_context = self.get_context_by_key(block_number, &key)?;
-        Some(self.assemble_replay_record(block_number, &key, block_context))
+        let (block_context, previous_block_timestamp) = self.resolve_context(block_number, &key)?;
+        Some(self.assemble_replay_record(
+            block_number,
+            &key,
+            block_context,
+            previous_block_timestamp,
+        ))
     }
 
     fn latest_record(&self) -> BlockNumber {
@@ -451,30 +580,47 @@ impl ReadReplay for BlockReplayStorage {
 }
 
 impl BlockReplayStorage {
-    /// Like [`ReadReplay::get_replay_record`], but resolves the hash window with the heights
-    /// displaced by the current override wave taken from `displaced`. Used when archiving a row
-    /// that is about to be overridden: for those heights `CanonicalHash` already points at the
-    /// new chain, while the archived copy must keep the hashes it was executed with.
-    fn get_replay_record_with_original_hashes(
+    /// Like [`ReadReplay::get_replay_record`], but resolves the hash window and
+    /// `previous_block_timestamp` from `parent_hash` instead of the live canonical chain. Used
+    /// when archiving a row that is about to be overridden: if an earlier override in the same
+    /// wave already replaced this row's parent, the live chain no longer has the parent this row
+    /// was actually executed against, so the caller must supply it explicitly (see
+    /// [`WriteReplay::write`](Self)'s `last_archived`).
+    fn get_replay_record_with_original_parent(
         &self,
         block_number: BlockNumber,
-        displaced: &BTreeMap<BlockNumber, BlockHash>,
+        parent_hash: BlockHash,
     ) -> Option<ReplayRecord> {
         let key = block_number.to_be_bytes();
-        let block_context = if let Some(stored) = self.get_stored_context_v2(&key) {
-            stored.into_context(
-                self.chain_id,
-                self.read_block_hashes(block_number, displaced),
-            )
-        } else {
-            // Rows written by binaries predating the stripped format (only reachable by rolling
-            // back further than supported); their embedded hashes are already the originals.
-            self.get_legacy_context(&key)?
-        };
-        Some(self.assemble_replay_record(block_number, &key, block_context))
+        let (block_context, previous_block_timestamp) =
+            if let Some(stored) = self.get_stored_context_v2(&key) {
+                let (block_hashes, previous_block_timestamp) =
+                    self.resolve_window_and_previous_timestamp(block_number, parent_hash);
+                (
+                    stored.into_context(self.chain_id, block_hashes),
+                    previous_block_timestamp,
+                )
+            } else {
+                // Rows written by binaries predating the stripped format (only reachable by rolling
+                // back further than supported); their embedded hashes are already the originals.
+                let context = self.get_legacy_context(&key)?;
+                let previous_block_timestamp = if block_number == 0 {
+                    0
+                } else {
+                    self.get_block_timestamp(block_number - 1).unwrap_or(0)
+                };
+                (context, previous_block_timestamp)
+            };
+        Some(self.assemble_replay_record(
+            block_number,
+            &key,
+            block_context,
+            previous_block_timestamp,
+        ))
     }
 
-    /// Assembles a [`ReplayRecord`] around an already-resolved context.
+    /// Assembles a [`ReplayRecord`] around an already-resolved context and
+    /// `previous_block_timestamp`.
     ///
     /// Writes are atomic and a context for this key exists, so the rest of the replay record
     /// must be present too. Hence, we can safely unwrap here.
@@ -483,6 +629,7 @@ impl BlockReplayStorage {
         block_number: u64,
         key: &[u8],
         block_context: BlockContext,
+        previous_block_timestamp: u64,
     ) -> ReplayRecord {
         let starting_l1_priority_id = self
             .db
@@ -496,13 +643,6 @@ impl BlockReplayStorage {
             .expect("Txs must be written atomically with Context");
         // todo: save `previous_block_timestamp` as another column in the next breaking change to
         //       replay record format
-        let previous_block_timestamp = if block_number == 0 {
-            // Genesis does not have previous block and this value should never be used, but we
-            // return `0` here for the flow to work.
-            0
-        } else {
-            self.get_block_timestamp(block_number - 1).unwrap_or(0)
-        };
 
         let node_version = self
             .db
@@ -654,7 +794,7 @@ impl WriteReplay for BlockReplayStorage {
                 "tried to append first replay record with non-zero block number: {}",
                 block_context.block_number
             );
-            self.write_replay_unchecked(sealed_record, true);
+            self.write_replay_unchecked(sealed_record, WriteKind::Canonical);
             latency_observer.observe();
             return Ok(true);
         };
@@ -676,18 +816,23 @@ impl WriteReplay for BlockReplayStorage {
 
         if block_context.block_number <= current_latest_record {
             let block_number = block_context.block_number;
-            let mut displaced = self.displaced_hashes.lock().unwrap();
-            // A non-consecutive override starts a new wave: the previous wave's chain has
-            // already fully become canonical, so its displaced hashes must not leak into this
-            // wave's archived windows.
-            if displaced
-                .last_key_value()
-                .is_some_and(|(last, _)| last + 1 != block_number)
-            {
-                displaced.clear();
-            }
+            let mut last_archived = self.last_archived.lock().unwrap();
+            // The original parent hash of the row about to be overridden. Usually still safe to
+            // read live from `CanonicalHash`— unless the immediately preceding block was itself
+            // overridden earlier in this same wave, in which case that already points at its
+            // replacement, and the true original parent is only available from `last_archived`.
+            let parent_hash = if block_number == 0 {
+                // Unused: genesis has no parent, and the resolvers below short-circuit on
+                // `block_number == 0` without consulting it.
+                BlockHash::ZERO
+            } else {
+                match *last_archived {
+                    Some((last_number, last_hash)) if last_number + 1 == block_number => last_hash,
+                    _ => self.get_canonical_block_hash(block_number - 1),
+                }
+            };
             let old_record = self
-                .get_replay_record_with_original_hashes(block_number, &displaced)
+                .get_replay_record_with_original_parent(block_number, parent_hash)
                 .expect("Old record must exist");
             if &old_record != block_record {
                 let old_record_hash = self.get_canonical_block_hash(block_number);
@@ -699,20 +844,30 @@ impl WriteReplay for BlockReplayStorage {
                 );
                 self.write_replay_unchecked(
                     Sealed::new_unchecked(old_record, old_record_hash),
-                    false,
+                    WriteKind::Archived { parent_hash },
                 );
-                displaced.insert(block_number, old_record_hash);
+                *last_archived = Some((block_number, old_record_hash));
             }
         } else {
             // A plain append means whatever chain the last wave produced is final; a future
-            // override at these heights was built on it, not on the displaced rows.
-            self.displaced_hashes.lock().unwrap().clear();
+            // override at these heights is built on it, not on the cached parent hash.
+            *self.last_archived.lock().unwrap() = None;
         }
 
-        self.write_replay_unchecked(sealed_record, true);
+        self.write_replay_unchecked(sealed_record, WriteKind::Canonical);
         latency_observer.observe();
         Ok(true)
     }
+}
+
+/// How [`BlockReplayStorage::write_replay_unchecked`] should persist a row.
+#[derive(Clone, Copy, Debug)]
+enum WriteKind {
+    /// A canonical (number-keyed) row: stripped of the hash window, indexed in `CanonicalHash`.
+    Canonical,
+    /// A row displaced by an override (hash-keyed): stripped of the hash window in favor of its
+    /// own `parent_hash`, from which the window is reconstructed on read.
+    Archived { parent_hash: BlockHash },
 }
 
 const LATENCIES_FAST: Buckets = Buckets::exponential(0.0000001..=1.0, 2.0);
@@ -859,6 +1014,17 @@ impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
         db.compact_range_cf(BlockReplayColumnFamily::Context);
         Ok(())
     }
+}
+
+/// [`BlockContext`] as persisted in the `ArchivedContext` CF: the stripped fields plus this row's
+/// own parent hash, in place of the 256-hash window. See
+/// [`BlockReplayStorage::resolve_window_and_previous_timestamp`] for how the window and
+/// `previous_block_timestamp` get reconstructed from a chain of these.
+#[derive(Debug, bincode::Encode, bincode::Decode)]
+struct StoredArchivedContext {
+    #[bincode(with_serde)]
+    parent_hash: BlockHash,
+    stripped: StoredBlockContextV2,
 }
 
 /// [`BlockContext`] as persisted in the `ContextV2` CF: without the 256 previous block hashes
@@ -1161,13 +1327,11 @@ mod tests {
         make_rows_legacy_only(&storage, &chain[..4]);
         ContractBlockContexts.run(&storage.db).unwrap();
 
-        // The hash-keyed archived copy keeps its full row and its original hashes.
+        // The hash-keyed archived copy is untouched by the migration (it only visits number
+        // keys) and reads back correctly.
         assert_eq!(
-            storage
-                .get_replay_record_by_key(4, Some(old.hash().0.to_vec()))
-                .unwrap()
-                .block_context,
-            old.block_context
+            storage.get_replay_record_by_key(4, Some(old.hash().0.to_vec())),
+            Some(old.as_ref().clone())
         );
         assert_eq!(storage.get_replay_record(4), Some(replacement));
     }
@@ -1215,8 +1379,8 @@ mod tests {
                 .unwrap()
         );
 
-        // The replaced record stays readable under its hash key, embedded hashes intact.
-        // Non-canonical rows are archived as full legacy rows, never as stripped ones.
+        // The replaced record stays readable under its hash key, window and
+        // `previous_block_timestamp` both reconstructed correctly.
         assert!(storage.get_stored_context_v2(&old.hash().0).is_none());
         assert_eq!(
             storage
@@ -1276,7 +1440,8 @@ mod tests {
 
         // Replace blocks 3 and 4 sequentially, as a range rebuild does. By the time block 4 is
         // overridden, `CanonicalHash[3]` already points at the new chain, so its archived copy
-        // must not be reconstructed from the index.
+        // must not be reconstructed from the index — nor must its `previous_block_timestamp`,
+        // which would otherwise pick up new block 3's timestamp instead of old block 3's.
         let (old3, old4) = (&chain[3], &chain[4]);
         let mut new3 = old3.as_ref().clone();
         new3.block_context.timestamp += 100;
@@ -1294,20 +1459,74 @@ mod tests {
             .await
             .unwrap();
 
-        // The archived copies keep the hashes they were executed with: old block 4's window
-        // ends with old block 3's hash, not the replacement's. (Contexts are compared instead
-        // of full records because `previous_block_timestamp` of archived rows is derived from
-        // the current canonical neighbor on read — a pre-existing quirk.)
-        let old4_read = storage
-            .get_replay_record_by_key(4, Some(old4.hash().0.to_vec()))
-            .unwrap();
-        assert_eq!(old4_read.block_context, old4.block_context);
-        let old3_read = storage
-            .get_replay_record_by_key(3, Some(old3.hash().0.to_vec()))
-            .unwrap();
-        assert_eq!(old3_read.block_context, old3.block_context);
+        // The archived copies are byte-correct: old block 4's window ends with old block 3's
+        // hash (not the replacement's), and its `previous_block_timestamp` is old block 3's
+        // timestamp (not new block 3's) — both resolved by walking `parent_hash` pointers
+        // through `ArchivedContext`, not by any in-memory wave state.
+        assert_eq!(
+            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
+            Some(old4.as_ref().clone())
+        );
+        assert_eq!(
+            storage.get_replay_record_by_key(3, Some(old3.hash().0.to_vec())),
+            Some(old3.as_ref().clone())
+        );
         // The new canonical rows reconstruct against the repointed index.
         assert_eq!(storage.get_replay_record(3), Some(new3));
         assert_eq!(storage.get_replay_record(4), Some(new4));
+    }
+
+    #[tokio::test]
+    async fn archived_rows_read_correctly_after_wave_state_is_gone() {
+        // The whole point of resolving archived rows by walking `parent_hash` pointers instead
+        // of an in-memory wave cache: they must read back correctly even after that cache is
+        // long gone — e.g. a fresh process, reading via `en_replay_record_overrides` well after
+        // the override happened.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+        let chain = make_chain(5);
+        for sealed in &chain {
+            storage.write(sealed.clone(), false).await.unwrap();
+        }
+
+        let (old3, old4) = (&chain[3], &chain[4]);
+        let mut new3 = old3.as_ref().clone();
+        new3.block_context.timestamp += 100;
+        let new3_hash = fake_hash(103);
+        storage
+            .write(Sealed::new_unchecked(new3.clone(), new3_hash), true)
+            .await
+            .unwrap();
+        let mut new4 = old4.as_ref().clone();
+        new4.block_context.timestamp += 100;
+        new4.block_context.block_hashes = new3.block_context.block_hashes.push(new3_hash);
+        new4.previous_block_timestamp = new3.block_context.timestamp;
+        storage
+            .write(Sealed::new_unchecked(new4.clone(), fake_hash(104)), true)
+            .await
+            .unwrap();
+
+        // A plain append ends the wave, clearing any in-memory state.
+        let mut new5 = new4.clone();
+        new5.block_context.block_number = 5;
+        new5.block_context.block_hashes = new4.block_context.block_hashes.push(fake_hash(104));
+        new5.previous_block_timestamp = new4.block_context.timestamp;
+        storage
+            .write(Sealed::new_unchecked(new5, fake_hash(5)), false)
+            .await
+            .unwrap();
+
+        // Reopening drops any remaining in-memory state outright.
+        drop(storage);
+        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
+
+        assert_eq!(
+            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
+            Some(old4.as_ref().clone())
+        );
+        assert_eq!(
+            storage.get_replay_record_by_key(3, Some(old3.hash().0.to_vec())),
+            Some(old3.as_ref().clone())
+        );
     }
 }

--- a/lib/storage/src/db/replay.rs
+++ b/lib/storage/src/db/replay.rs
@@ -2,6 +2,7 @@ use alloy::primitives::{Address, B256, BlockHash, BlockNumber, Sealed, U256};
 use anyhow::Context as _;
 use std::convert::TryInto;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use vise::Unit;
 use vise::{Buckets, Histogram, Metrics};
@@ -34,15 +35,41 @@ pub struct BlockReplayStorage {
     db: RocksDB<BlockReplayColumnFamily>,
     /// Shared by all blocks; stripped rows don't persist it (see [`StoredBlockContextV2`]).
     chain_id: u64,
+    /// The most recently archived row, kept only long enough to derive the next override's
+    /// window via a shift-and-append (the same operation used to build any new block's window)
+    /// if it turns out to continue the same wave. Cleared on any plain append, so a stale entry
+    /// can never be mistaken for an adjacent, unrelated override. This is what makes the embedded
+    /// window of an archived row (see [`BlockReplayColumnFamily::Context`]) correct forever after
+    /// it's written, however long ago or from however different a process it's later read —
+    /// `previous_block_timestamp` is a separate matter, see [`Self::previous_timestamp_from_canonical`].
+    ///
+    /// This is an in-memory optimization, not a durability mechanism: a restart between two
+    /// overrides of the same wave loses it, and the second override then reconstructs live
+    /// against `CanonicalHash`, which is wrong for exactly the position an earlier override in
+    /// the wave already repointed — corrupting that row's window too, not just its
+    /// `previous_block_timestamp`. Accepted because overrides are very rare, multi-block waves
+    /// rarer still, and a restart landing in the middle of one rarer still than that.
+    last_archived: Arc<Mutex<Option<LastArchived>>>,
+}
+
+/// See [`BlockReplayStorage::last_archived`].
+#[derive(Debug, Clone, Copy)]
+struct LastArchived {
+    block_number: BlockNumber,
+    hash: BlockHash,
+    window: BlockHashes,
+    timestamp: u64,
 }
 
 /// Column families for storage of block replay commands.
 ///
-/// `Context`, `ContextV2` and `ArchivedContext` together replace one former CF that held every
-/// row, canonical or archived, with its full [`BlockContext`] embedded. Canonical (number-keyed)
-/// rows now go to `ContextV2` and archived (hash-keyed) rows to `ArchivedContext`, both stripped
-/// (see [`StoredBlockContextV2`]); nothing writes to `Context` anymore — it only holds rows left
-/// over from before the split, in the old unstripped format.
+/// `Context` and `ContextV2` together replace one former CF that held every row, canonical or
+/// archived, with its full [`BlockContext`] embedded (256-hash window included). Canonical
+/// (number-keyed) rows now go to `ContextV2`, stripped of that window (see
+/// [`StoredBlockContextV2`]) since it's reconstructible from [`Self::CanonicalHash`]. Archived
+/// (hash-keyed) rows stay in `Context`, fully embedded: stripping them too would need durable
+/// tracking of in-progress override waves to stay correct (see
+/// [`BlockReplayStorage::last_archived`]), which isn't worth it for how rarely overrides happen.
 ///
 /// TODO(RocksDB migration): The four `Starting*` column families below correspond to fields
 /// in [`BlockStartCursors`]. They are stored separately for historical reasons (each was added
@@ -50,20 +77,14 @@ pub struct BlockReplayStorage {
 /// serializing the entire `BlockStartCursors` struct.
 #[derive(Copy, Clone, Debug)]
 pub enum BlockReplayColumnFamily {
-    /// Legacy full [`BlockContext`] rows (~8 KiB each, 256-hash window included), predating the
-    /// `ContextV2`/`ArchivedContext` split. Canonical (number-keyed) rows here are converted and
-    /// deleted by [`ContractBlockContexts`]; archived (hash-keyed) ones are left as they are.
+    /// Full [`BlockContext`] rows (~8 KiB each, 256-hash window included). Holds every archived
+    /// (hash-keyed) row — the only place they're ever stored — plus canonical (number-keyed) rows
+    /// written before [`Self::ContextV2`] existed, or by a binary predating it during a rollback;
+    /// [`ContractBlockContexts`] converts and deletes the latter.
     Context,
     /// Stripped canonical rows. The 256-hash window is derivable and reconstructed from
     /// [`Self::CanonicalHash`] on read.
     ContextV2,
-    /// Stripped archived rows (blocks displaced by an override). The window and
-    /// `previous_block_timestamp` are reconstructed on read by walking `parent_hash` pointers
-    /// through this CF to the live canonical chain, then one [`Self::CanonicalHash`] lookup (see
-    /// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]) — unlike [`Self::Context`],
-    /// this doesn't depend on `CanonicalHash` staying unchanged, so it's correct on any read, no
-    /// matter how long after the override or in how different a process.
-    ArchivedContext,
     StartingL1SerialId,
     Txs,
     NodeVersion,
@@ -84,7 +105,6 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
     const ALL: &'static [Self] = &[
         BlockReplayColumnFamily::Context,
         BlockReplayColumnFamily::ContextV2,
-        BlockReplayColumnFamily::ArchivedContext,
         BlockReplayColumnFamily::StartingL1SerialId,
         BlockReplayColumnFamily::Txs,
         BlockReplayColumnFamily::NodeVersion,
@@ -102,7 +122,6 @@ impl NamedColumnFamily for BlockReplayColumnFamily {
         match self {
             BlockReplayColumnFamily::Context => "context",
             BlockReplayColumnFamily::ContextV2 => "context_v2",
-            BlockReplayColumnFamily::ArchivedContext => "archived_context",
             BlockReplayColumnFamily::StartingL1SerialId => "last_processed_l1_tx_id",
             BlockReplayColumnFamily::Txs => "txs",
             BlockReplayColumnFamily::NodeVersion => "node_version",
@@ -132,6 +151,7 @@ impl BlockReplayStorage {
         let this = Self {
             db,
             chain_id: genesis.chain_id(),
+            last_archived: Arc::new(Mutex::new(None)),
         };
         let inserted_genesis = if this.latest_record_checked().is_none() {
             let genesis_tx = genesis.genesis_upgrade_tx().await;
@@ -169,7 +189,11 @@ impl BlockReplayStorage {
             .with_sync_writes()
             .run_migrations(MIGRATIONS)
             .expect("replay WAL schema migration failed");
-        Self { db, chain_id }
+        Self {
+            db,
+            chain_id,
+            last_archived: Arc::new(Mutex::new(None)),
+        }
     }
 
     fn write_replay_unchecked(&self, sealed_record: Sealed<ReplayRecord>, kind: WriteKind) {
@@ -192,21 +216,17 @@ impl BlockReplayStorage {
             .expect("Failed to serialize record.transactions");
         let node_version_value = record.node_version.to_string().as_bytes().to_vec();
 
-        // Stripped either way: the 256-hash window is never persisted. Canonical rows are
-        // indexed in `CanonicalHash` for fast reconstruction; archived rows keep their own
-        // `parent_hash` (part of the stripped struct) and are reconstructed on read by walking
-        // those pointers (see `resolve_window_and_previous_timestamp`) — correct regardless of
-        // what happens to `CanonicalHash` afterwards.
-        let stripped_context_value = bincode::encode_to_vec(
-            StoredBlockContextV2::strip(record.block_context),
-            bincode::config::standard(),
-        )
-        .expect("Failed to serialize stripped record.context");
-
         // Batch writes: replay entry, latest pointer and canonical hash mapping
         let mut batch: WriteBatch<'_, BlockReplayColumnFamily> = self.db.new_write_batch();
         match kind {
             WriteKind::Canonical => {
+                // Stripped: the 256-hash window is never persisted for canonical rows, it's
+                // reconstructed on read from `CanonicalHash`, which this write keeps current.
+                let stripped_context_value = bincode::encode_to_vec(
+                    StoredBlockContextV2::strip(record.block_context),
+                    bincode::config::standard(),
+                )
+                .expect("Failed to serialize stripped record.context");
                 batch.put_cf(
                     BlockReplayColumnFamily::ContextV2,
                     &db_key,
@@ -219,11 +239,14 @@ impl BlockReplayStorage {
                 );
             }
             WriteKind::Archived => {
-                batch.put_cf(
-                    BlockReplayColumnFamily::ArchivedContext,
-                    &db_key,
-                    &stripped_context_value,
-                );
+                // Full embed: an archived row has no `CanonicalHash` entry of its own to
+                // reconstruct the window from (see `BlockReplayColumnFamily::Context`).
+                let context_value = bincode::serde::encode_to_vec(
+                    record.block_context,
+                    bincode::config::standard(),
+                )
+                .expect("Failed to serialize record.context");
+                batch.put_cf(BlockReplayColumnFamily::Context, &db_key, &context_value);
             }
         }
         if self
@@ -370,17 +393,6 @@ impl BlockReplayStorage {
             })
     }
 
-    fn get_archived(&self, key: &[u8]) -> Option<StoredBlockContextV2> {
-        self.db
-            .get_cf(BlockReplayColumnFamily::ArchivedContext, key)
-            .expect("Cannot read from DB")
-            .map(|bytes| {
-                bincode::decode_from_slice(&bytes, bincode::config::standard())
-                    .expect("Failed to deserialize archived context")
-                    .0
-            })
-    }
-
     fn get_legacy_context(&self, key: &[u8]) -> Option<BlockContext> {
         self.db
             .get_cf(BlockReplayColumnFamily::Context, key)
@@ -392,70 +404,9 @@ impl BlockReplayStorage {
             })
     }
 
-    /// Reconstructs the 256-hash window and `previous_block_timestamp` for a row whose immediate
-    /// parent is `parent_hash`, by walking `parent_hash` pointers through `ArchivedContext` until
-    /// reaching a hash that isn't itself archived — one still on the live canonical chain, from
-    /// which point `CanonicalHash` is guaranteed unmutated (overrides only ever touch a wave's own
-    /// consecutive range) — then filling the rest of the window with one batched lookup.
-    fn resolve_window_and_previous_timestamp(
-        &self,
-        block_number: BlockNumber,
-        parent_hash: BlockHash,
-    ) -> (BlockHashes, u64) {
-        if block_number == 0 {
-            return (BlockHashes::default(), 0);
-        }
-        let mut hashes = [U256::ZERO; 256];
-        let first = block_number.saturating_sub(256);
-        let total = (block_number - first) as usize;
-        let mut current_hash = parent_hash;
-        let mut previous_block_timestamp = 0;
-        for step in 0..total {
-            hashes[255 - step] = U256::from_be_bytes(current_hash.0);
-            match self.get_archived(current_hash.0.as_slice()) {
-                Some(archived) => {
-                    if step == 0 {
-                        previous_block_timestamp = archived.timestamp;
-                    }
-                    if step + 1 == total {
-                        break;
-                    }
-                    current_hash = archived.parent_hash;
-                }
-                None => {
-                    // `current_hash` is still part of the live canonical chain.
-                    let this_number = block_number - 1 - step as u64;
-                    if step == 0 {
-                        previous_block_timestamp = self
-                            .get_block_timestamp(this_number)
-                            .expect("current canonical row must have a timestamp");
-                    }
-                    if this_number > first {
-                        let keys = (first..this_number)
-                            .map(|number| number.to_be_bytes())
-                            .collect::<Vec<_>>();
-                        let results = self
-                            .db
-                            .multi_get_cf(BlockReplayColumnFamily::CanonicalHash, keys.iter());
-                        for (number, result) in (first..this_number).zip(results) {
-                            let index = (number + 256 - block_number) as usize;
-                            hashes[index] =
-                                match result.expect("Failed to read from CanonicalHash DB") {
-                                    Some(bytes) => U256::from_be_slice(&bytes),
-                                    None => panic!("no CanonicalHash entry for block {number}"),
-                                };
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-        (BlockHashes(hashes), previous_block_timestamp)
-    }
-
-    /// Resolves a context by key, and the `previous_block_timestamp` to go with it. Checks
-    /// `ContextV2` (canonical), then `ArchivedContext` (a row archived by this or an earlier
-    /// binary), then `Context` (a row predating one of the two stripped formats).
+    /// Resolves a context by key, and the `previous_block_timestamp` to go with it. `ContextV2`
+    /// (stripped, canonical) is tried first; everything else — a legacy pre-`ContextV2` canonical
+    /// row, or an archived row, which is always full — is served straight from `Context`.
     fn resolve_context(
         &self,
         block_number: BlockNumber,
@@ -471,21 +422,9 @@ impl BlockReplayStorage {
                 self.previous_timestamp_from_canonical(block_number),
             ));
         }
-        if let Some(archived) = self.get_archived(key) {
-            let (block_hashes, previous_block_timestamp) =
-                self.resolve_window_and_previous_timestamp(block_number, archived.parent_hash);
-            return Some((
-                archived.into_context(self.chain_id, block_hashes),
-                previous_block_timestamp,
-            ));
-        }
-        // No stripped row: either a canonical row written before `ContextV2` existed (or by an
-        // older binary during a rollback), or an archived row written before `ArchivedContext`
-        // existed. Both are served as stored: for the former the embedded hashes are just as
-        // correct, and for the latter they are authoritative — but `previous_block_timestamp` is
-        // derived from the current canonical neighbor either way, which is only exactly right
-        // for the former (a pre-existing quirk for this legacy archived-row shape; new archived
-        // rows resolve it durably above).
+        // `previous_block_timestamp` is derived from the current canonical neighbor, which is
+        // only exactly right for a canonical row — for an archived one it's a pre-existing quirk:
+        // correct unless that neighbor was itself later overridden.
         let context = self.get_legacy_context(key)?;
         Some((
             context,
@@ -505,9 +444,12 @@ impl BlockReplayStorage {
             })
     }
 
-    /// `previous_block_timestamp` for a row whose parent is the current canonical chain: correct
-    /// for canonical rows and legacy (pre-`ArchivedContext`) archived rows, but not for a row
-    /// displaced earlier in an in-progress override wave (see `resolve_window_and_previous_timestamp`).
+    /// `previous_block_timestamp` derived from the current canonical chain at `block_number`'s
+    /// parent slot. Correct for a canonical row. For an archived one it's a best-effort value:
+    /// `previous_block_timestamp` isn't persisted for any row, so a read of an archived row always
+    /// recomputes it live, which is wrong once that parent slot has itself been overridden —
+    /// regardless of `last_archived`, which only ever affects what gets written into an archived
+    /// row's `block_context`, not what a later read of `previous_block_timestamp` returns.
     fn previous_timestamp_from_canonical(&self, block_number: BlockNumber) -> u64 {
         if block_number == 0 {
             0
@@ -549,20 +491,28 @@ impl ReadReplay for BlockReplayStorage {
 
 impl BlockReplayStorage {
     /// Like [`ReadReplay::get_replay_record`], but resolves the hash window and
-    /// `previous_block_timestamp` from this row's own `parent_hash` instead of the live canonical
-    /// chain. Used when archiving a row that is about to be overridden: if an earlier override in
-    /// the same wave already replaced this row's parent, the live chain no longer has the parent
-    /// this row was actually executed against — but the row's own `parent_hash` is unaffected by
-    /// that, since it was fixed when this row was (last) written.
-    fn get_replay_record_with_original_parent(
+    /// `previous_block_timestamp` from `last_archived` — if it holds `block_number - 1`'s
+    /// original data — instead of the live canonical chain. Used when archiving a row that is
+    /// about to be overridden: if an earlier override in the same wave already replaced this
+    /// row's parent, the live chain no longer has the parent this row was actually executed
+    /// against, but `last_archived` does.
+    fn get_replay_record_for_archival(
         &self,
         block_number: BlockNumber,
+        last_archived: &Option<LastArchived>,
     ) -> Option<ReplayRecord> {
         let key = block_number.to_be_bytes();
         let (block_context, previous_block_timestamp) =
             if let Some(stored) = self.get_stored_context_v2(&key) {
-                let (block_hashes, previous_block_timestamp) =
-                    self.resolve_window_and_previous_timestamp(block_number, stored.parent_hash);
+                let (block_hashes, previous_block_timestamp) = match last_archived {
+                    Some(previous) if previous.block_number + 1 == block_number => {
+                        (previous.window.push(previous.hash), previous.timestamp)
+                    }
+                    _ => (
+                        self.read_block_hashes(block_number),
+                        self.previous_timestamp_from_canonical(block_number),
+                    ),
+                };
                 (
                     stored.into_context(self.chain_id, block_hashes),
                     previous_block_timestamp,
@@ -779,8 +729,9 @@ impl WriteReplay for BlockReplayStorage {
 
         if block_context.block_number <= current_latest_record {
             let block_number = block_context.block_number;
+            let mut last_archived = self.last_archived.lock().unwrap();
             let old_record = self
-                .get_replay_record_with_original_parent(block_number)
+                .get_replay_record_for_archival(block_number, &last_archived)
                 .expect("Old record must exist");
             if &old_record != block_record {
                 let old_record_hash = self.get_canonical_block_hash(block_number);
@@ -790,11 +741,23 @@ impl WriteReplay for BlockReplayStorage {
                     old_record_hash_hex,
                     "Overriding existing block replay record",
                 );
+                let window = old_record.block_context.block_hashes;
+                let timestamp = old_record.block_context.timestamp;
                 self.write_replay_unchecked(
                     Sealed::new_unchecked(old_record, old_record_hash),
                     WriteKind::Archived,
                 );
+                *last_archived = Some(LastArchived {
+                    block_number,
+                    hash: old_record_hash,
+                    window,
+                    timestamp,
+                });
             }
+        } else {
+            // A plain append ends any override wave in progress: without this, a stale entry
+            // could be mistaken later for an adjacent but unrelated override.
+            *self.last_archived.lock().unwrap() = None;
         }
 
         self.write_replay_unchecked(sealed_record, WriteKind::Canonical);
@@ -958,19 +921,10 @@ impl Migration<BlockReplayColumnFamily> for ContractBlockContexts {
     }
 }
 
-/// [`BlockContext`] as persisted in the `ContextV2` and `ArchivedContext` CFs: without the 256
-/// previous block hashes, and without the chain id (shared by all blocks, known from
-/// configuration / L1, not persisted at all — supplied by [`BlockReplayStorage`]'s in-memory
-/// `chain_id` field on read). In their place, this row's own immediate parent hash — fixed when
-/// the row was (last) written, independent of whatever `CanonicalHash` currently says.
-///
-/// For a canonical row, this is redundant with `CanonicalHash[block_number - 1]` in the common
-/// case, but it's what lets an override archive the row it's about to replace correctly without
-/// tracking any override-wave state: block `N`'s current row always has the parent hash it was
-/// actually built on, even if `N - 1`'s own canonical entry has since moved on to a different
-/// chain. For an archived row, it's the only copy of that fact, and lets the window and
-/// `previous_block_timestamp` be reconstructed later by walking a chain of these (see
-/// [`BlockReplayStorage::resolve_window_and_previous_timestamp`]).
+/// [`BlockContext`] as persisted in the `ContextV2` CF: without the 256 previous block hashes
+/// (reconstructed on read from `CanonicalHash`, see [`BlockReplayStorage::read_block_hashes`])
+/// and without the chain id (shared by all blocks, known from configuration / L1, not persisted
+/// at all — supplied by [`BlockReplayStorage`]'s in-memory `chain_id` field on read).
 ///
 /// The exhaustive destructuring in the conversions below keeps this struct in sync with
 /// [`BlockContext`]: a field added there fails compilation here, prompting a decision on whether
@@ -994,8 +948,6 @@ struct StoredBlockContextV2 {
     execution_version: u32,
     #[bincode(with_serde)]
     blob_fee: U256,
-    #[bincode(with_serde)]
-    parent_hash: BlockHash,
 }
 
 impl StoredBlockContextV2 {
@@ -1003,7 +955,7 @@ impl StoredBlockContextV2 {
         let BlockContext {
             chain_id: _,
             block_number,
-            block_hashes,
+            block_hashes: _,
             timestamp,
             eip1559_basefee,
             pubdata_price,
@@ -1027,7 +979,6 @@ impl StoredBlockContextV2 {
             mix_hash,
             execution_version,
             blob_fee,
-            parent_hash: BlockHash::from(block_hashes.0[255]),
         }
     }
 
@@ -1044,7 +995,6 @@ impl StoredBlockContextV2 {
             mix_hash,
             execution_version,
             blob_fee,
-            parent_hash: _,
         } = self;
         BlockContext {
             chain_id,
@@ -1409,28 +1359,38 @@ mod tests {
         let (old3, old4) = (&chain[3], &chain[4]);
         let (new3, new4) = override_blocks_3_and_4(&storage, &chain).await;
 
-        // The archived copies are byte-correct: old block 4's window ends with old block 3's
-        // hash (not the replacement's), and its `previous_block_timestamp` is old block 3's
-        // timestamp (not new block 3's) — both resolved by walking `parent_hash` pointers
-        // through `ArchivedContext`, not by any in-memory wave state.
-        assert_eq!(
-            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
-            Some(old4.as_ref().clone())
-        );
+        // Old block 3's archived copy is fully correct: its own parent (block 2) was never
+        // touched.
         assert_eq!(
             storage.get_replay_record_by_key(3, Some(old3.hash().0.to_vec())),
             Some(old3.as_ref().clone())
         );
+
+        // Old block 4's `block_context` — in particular its window, which ends with old block
+        // 3's hash, not the replacement's — is byte-correct too: `last_archived` still held old
+        // block 3's original data when block 4 was archived right after, in the same process.
+        // `previous_block_timestamp` isn't part of that fix (see `previous_timestamp_from_canonical`):
+        // it's re-derived live on every read, so it reflects new block 3, not old block 3.
+        let archived_old4 = storage
+            .get_replay_record_by_key(4, Some(old4.hash().0.to_vec()))
+            .unwrap();
+        assert_eq!(archived_old4.block_context, old4.block_context);
+        assert_eq!(
+            archived_old4.previous_block_timestamp,
+            new3.block_context.timestamp
+        );
+
         // The new canonical rows reconstruct against the repointed index.
         assert_eq!(storage.get_replay_record(3), Some(new3));
         assert_eq!(storage.get_replay_record(4), Some(new4));
     }
 
     #[tokio::test]
-    async fn override_wave_survives_reopening_storage_mid_wave() {
-        // Each row's own `parent_hash` is what it was built on, full stop — nothing needs to be
-        // remembered in memory across writes, not even within a single wave. Reopening storage
-        // between overriding block 3 and block 4 must not change block 4's archival outcome.
+    async fn override_wave_across_restart_has_known_imprecision() {
+        // `last_archived` lives in memory only: a restart between overriding block 3 and block 4
+        // loses it, so block 4's archival falls back to a live reconstruction against
+        // `CanonicalHash[3]` — which by then points at new block 3, not the old one this row was
+        // actually built on. This test documents that accepted gap, not a desired outcome.
         let dir = tempfile::tempdir().unwrap();
         let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
         let chain = make_chain(5);
@@ -1458,49 +1418,25 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
-            Some(old4.as_ref().clone())
-        );
+        // The new canonical chain is unaffected: it's written explicitly, never derived from
+        // `last_archived`.
         assert_eq!(storage.get_replay_record(4), Some(new4));
-    }
 
-    #[tokio::test]
-    async fn archived_rows_read_correctly_after_wave_state_is_gone() {
-        // The whole point of resolving archived rows by walking `parent_hash` pointers instead
-        // of an in-memory wave cache: they must read back correctly even after that cache is
-        // long gone — e.g. a fresh process, reading via `en_replay_record_overrides` well after
-        // the override happened.
-        let dir = tempfile::tempdir().unwrap();
-        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
-        let chain = make_chain(5);
-        for sealed in &chain {
-            storage.write(sealed.clone(), false).await.unwrap();
-        }
-        let (old3, old4) = (&chain[3], &chain[4]);
-        let (_, new4) = override_blocks_3_and_4(&storage, &chain).await;
-
-        // A plain append ends the wave, clearing any in-memory state.
-        let mut new5 = new4.clone();
-        new5.block_context.block_number = 5;
-        new5.block_context.block_hashes = new4.block_context.block_hashes.push(fake_hash(104));
-        new5.previous_block_timestamp = new4.block_context.timestamp;
-        storage
-            .write(Sealed::new_unchecked(new5, fake_hash(5)), false)
-            .await
+        // Old block 4's archived copy now has the wrong tail hash too — on top of the
+        // `previous_block_timestamp` quirk every archived row already has regardless of any
+        // restart (see `previous_timestamp_from_canonical`), losing `last_archived` mid-wave also
+        // corrupts the one thing it otherwise guarantees: the embedded window itself.
+        let archived_old4 = storage
+            .get_replay_record_by_key(4, Some(old4.hash().0.to_vec()))
             .unwrap();
-
-        // Reopening drops any remaining in-memory state outright.
-        drop(storage);
-        let storage = BlockReplayStorage::new_without_genesis(dir.path(), 270);
-
+        assert_ne!(archived_old4.block_context, old4.block_context);
         assert_eq!(
-            storage.get_replay_record_by_key(4, Some(old4.hash().0.to_vec())),
-            Some(old4.as_ref().clone())
+            archived_old4.block_context.block_hashes.0[255],
+            U256::from_be_bytes(new3_hash.0)
         );
         assert_eq!(
-            storage.get_replay_record_by_key(3, Some(old3.hash().0.to_vec())),
-            Some(old3.as_ref().clone())
+            archived_old4.previous_block_timestamp,
+            new3.block_context.timestamp
         );
     }
 }


### PR DESCRIPTION
## Summary

Retargeted to `main` now that #1458 (expand phase) has landed and soaked.

Step 2 of the replay WAL cleanup: the contract phase that reclaims the redundant persisted block hashes (measured against the real testnet WAL: ~16.7M blocks, ~146 GiB total, ~137 GiB of which is this redundancy), plus the schema-migration machinery it runs on.

### Migration runner (`lib/rocksdb`)

- `Migration<CF>` trait + `RocksDB::run_migrations`: ordered, idempotent, blocking migrations executed at open, before the database serves anything.
- Schema version stamped in a reserved `__schema_meta` CF managed by the wrapper, outside each database's CF enum — any database adopts the runner with zero schema changes and an empty migration list, gaining a clean refuse-to-start error (instead of a decode panic) when opened by a binary that doesn't know its version.
- Blocking only for now — see "Step 3" below for why background/resumable mode isn't needed yet.

### Contract migration (`contract_block_contexts`, WAL schema v1)

Per canonical row, in atomic 1000-row chunks: ensure the `CanonicalHash` entry (pre-#867 entries recovered from the successor's embedded hashes), ensure the stripped `ContextV2` row, delete the legacy ~8 KiB row; final `compact_range` reclaims the space. Idempotent and crash-resumable — each chunk is one atomic write, so a crash leaves every row either fully migrated or fully untouched; a restart safely reruns the whole scan from block 0, at the cost of cheaply re-verifying already-done rows rather than skipping them.

Timed end-to-end against a real copy of the testnet WAL (16,791,125 blocks, 148 GiB on disk): **~144 seconds** (open + migration, single pass) — ~142s for the per-row conversion loop (~8.5 µs/row) plus ~1.9s for the final compaction. Reclaimed 134 GiB on disk (148 GiB → 14 GiB), matching the ~137 GiB estimate. Comfortably fast enough that this phase stays blocking-only — see "Step 3" for the migration that will actually need background mode.

### Write/read paths after contraction

- Canonical rows are written stripped-only; the dual write from the expand phase is gone.
- Archived rows (a block displaced by an override) stay fully embedded, exactly as before this PR. Stripping them too was tried during review — a `parent_hash`-per-row scheme with a dedicated `ArchivedContext` CF, reconstructing the window by walking a chain of these on read — and dropped: overrides are rare enough that the extra CF and read-path complexity wasn't worth it.
- The one thing full embedding still needs help with: correctly archiving a block that was already displaced earlier in the same override wave (by the time it's block N+1's turn, the live canonical chain has moved on, so it no longer has the parent block N+1 was actually built on). Solved with a single in-memory `last_archived` cache — the most recently archived row, reused via the same shift-and-append the sequencer already does to build any new block's window, if the next override turns out to continue the same wave; cleared on any plain append. Not a durability mechanism: a restart landing between two overrides of the same wave loses it, and the next override's archived window ends up wrong at exactly the position the earlier override already repointed — accepted, since overrides are already very rare, multi-block waves rarer still, and a restart hitting the middle of one rarer still than that (see `override_wave_across_restart_has_known_imprecision`).
- `previous_block_timestamp` isn't persisted for any row, canonical or archived — it's always recomputed live from the current canonical neighbor on read. Correct by construction for canonical rows; for an archived row it's a pre-existing quirk (predates this PR), wrong whenever the block at its parent height has since been overridden — independent of the above, wave or no wave, restart or no restart.

## Breaking Changes

- Who is affected: node operators (main nodes and ENs).
- What breaks: after the migration runs, legacy canonical context rows are gone; binaries older than the expand phase (#1458) cannot read the database. The expand-phase binary remains a safe rollback target.
- Migration: automatic at first start, blocking. See "Step 3" for the downtime discussion.

## Rollout Instructions

- #1458 is already deployed and soaked; this lands on top of it.
- Each node (main node / EN) migrates its own WAL independently at startup; order doesn't matter.
- Watch startup logs for `running schema migration` / `schema migration finished` and the reclaimed-space compaction; alert on `schema migration failed`.
- Rollback: to the expand-phase binary at any time, including mid-migration. Rolling back further is refused explicitly by stamped databases.

## Step 3 (unification) — plan, not part of this PR

This PR is deliberately blocking-only; see the timing above for why that's fine for the contract phase. Step 3 is a different kind of migration: not a bounded delete + index-backfill, but a full re-key of *every* row under a composite key (old key tombstoned, new key inserted, for the whole history) — meaningfully more write-amplified, and the place the roadmap always expected to need background execution.

What's left for it:
- Composite `number ++ hash` key (preserves append locality vs. a pure hash key).
- Fold `NodeVersion` / `ProtocolVersion` / `BlockOutputHash` / the four `Starting*` cursors into one per-row metadata blob — 13 CFs → ~5.
- Make `previous_block_timestamp` a genuinely stored field for every row for the first time — closes the pre-existing archived-row quirk above for good.
- With composite keys, "revert" becomes a pure index repoint: the old row simply stays at its own key, never touched, forever fully correct — no separate archived-row write path, no wave-tracking cache, none of the quirks above.
- Needs: a background/resumable migration mode in the runner (not built yet — it only supports blocking today), given the re-key touches the whole history rather than a bounded set of rows.

## Testing

- Runner: version stamping, pending-only execution, refuse-on-future, failed-migration rerun, contiguity validation.
- Contract: legacy-only + pre-`CanonicalHash` history conversion (incl. successor-recovery), idempotent double-run, archived rows untouched, unrecoverable-tip error path.
- Override correctness: multi-block override wave archives the original window correctly via `last_archived` (`previous_block_timestamp`'s pre-existing quirk is asserted as such, not conflated with a regression); a restart between two overrides of the same wave is asserted to lose exactly that precision, not silently produce something worse.
- Integration (local, re-run against this design): all 9 `rebuild`/`revert_l1` tests (incl. a multi-block override via L1 revert), plus `external_node` (incl. transaction replay), `restart` (incl. recovery from an L1 batch revert), and `replay_archive` (encrypted recovery) — 23 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
