### PR TITLE
ci(release-please): bumpo reusable CI version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
   release-please:
     uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
-      slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications  # Token for publishing to crates.io
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications
       gh_token: ${{ secrets.RELEASE_TOKEN }}                # GitHub token for creating PRs and releases
     with:
       config: '.github/release-please/config.json'          # Path to the configuration file

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,10 +24,9 @@ concurrency:
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1 # use v1 to get bugfixes here instead of SHA
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
-      slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications
-      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}  # Token for publishing to crates.io
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications  # Token for publishing to crates.io
       gh_token: ${{ secrets.RELEASE_TOKEN }}                # GitHub token for creating PRs and releases
     with:
       config: '.github/release-please/config.json'          # Path to the configuration file


### PR DESCRIPTION
## Summary

- update versions of reusable workflows used to publish crates to crates.io. New version of those workflows use trusted publishing instead of static API tokens
- due to the limitation of trusted publishing, new crates in crates.io will have to be initially created by DevOps:
> Your crate must already be published to crates.io (initial publish requires an API token)

---
reusable CI changes: https://github.com/matter-labs/zksync-ci-common/pull/51/changes

