### PR TITLE
test: kill leaked anvil/prover processes when the test process dies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16188,6 +16188,7 @@ dependencies = [
  "flate2",
  "futures",
  "httpmock",
+ "libc",
  "regex",
  "reqwest 0.12.28",
  "reth-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ k256 = { version = "0.13.4", default-features = false, features = [
     "pem",
     "std",
 ] }
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"
 serde_json = "1"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -36,6 +36,7 @@ reth-tasks.workspace = true
 alloy = { workspace = true, default-features = false, features = ["provider-anvil-node", "rand", "json-rpc", "pubsub", "provider-ws"] }
 anyhow.workspace = true
 flate2.workspace = true
+libc.workspace = true
 reqwest.workspace = true
 tar.workspace = true
 tokio.workspace = true

--- a/integration-tests/src/bin/leash.rs
+++ b/integration-tests/src/bin/leash.rs
@@ -9,7 +9,7 @@
 //! On EOF: verify the target is still the process we were asked to kill (guards against
 //! PID reuse), send SIGTERM, wait up to `grace_secs`, then SIGKILL.
 //!
-//! See `crate::leash` for the spawning side.
+//! See `src/leash.rs` for the spawning side.
 
 #[cfg(unix)]
 fn main() {
@@ -75,9 +75,9 @@ fn name_matches(pid: i32, expected: &str) -> bool {
         Some(observed) => {
             observed == expected || (observed.len() == 15 && expected.starts_with(&observed))
         }
-        // Can't tell (no /proc on this platform, or the process is already gone). Signal
-        // anyway: `kill` of a dead PID is a no-op, and the caller attached us to this PID
-        // moments after spawning it, so a mid-run reuse race is vanishingly unlikely.
+        // The name is unobservable (`/proc/<pid>/comm` gone, `ps` found nothing), which in
+        // practice means the process is already dead — a reused PID would be observable and
+        // hit the mismatch arm above. Signalling a dead PID is a harmless no-op.
         None => true,
     }
 }

--- a/integration-tests/src/bin/leash.rs
+++ b/integration-tests/src/bin/leash.rs
@@ -1,0 +1,115 @@
+//! Watchdog that kills a target process when the process holding the other end of our
+//! stdin pipe dies — however it dies, including SIGKILL and OOM kills.
+//!
+//! Usage: `leash <pid> <grace_secs> <expected_name>`, with stdin connected to a pipe whose
+//! write end is held (and never written to) by the process whose lifetime we track. The
+//! kernel closes that pipe on any kind of process death, so reading EOF here is a reliable
+//! death signal that needs no polling and no cooperation from the tracked process.
+//!
+//! On EOF: verify the target is still the process we were asked to kill (guards against
+//! PID reuse), send SIGTERM, wait up to `grace_secs`, then SIGKILL.
+//!
+//! See `crate::leash` for the spawning side.
+
+#[cfg(unix)]
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (pid, grace_secs, expected_name) = match &args[..] {
+        [_, pid, grace, name] => (
+            pid.parse::<i32>().expect("pid must be an integer"),
+            grace.parse::<u64>().expect("grace_secs must be an integer"),
+            name.clone(),
+        ),
+        _ => {
+            eprintln!("usage: leash <pid> <grace_secs> <expected_name>");
+            std::process::exit(2);
+        }
+    };
+
+    wait_for_parent_death();
+
+    if !name_matches(pid, &expected_name) {
+        // Target is gone, or the PID has been reused by an unrelated process.
+        return;
+    }
+
+    unsafe {
+        if libc::kill(pid, libc::SIGTERM) != 0 {
+            return;
+        }
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
+    while std::time::Instant::now() < deadline {
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+}
+
+/// Blocks until every write end of our stdin pipe is closed.
+#[cfg(unix)]
+fn wait_for_parent_death() {
+    use std::io::Read;
+    let mut buf = [0u8; 64];
+    let mut stdin = std::io::stdin().lock();
+    loop {
+        match stdin.read(&mut buf) {
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return,
+        }
+    }
+}
+
+/// Best-effort check that `pid` still refers to the process we were told to kill.
+#[cfg(unix)]
+fn name_matches(pid: i32, expected: &str) -> bool {
+    match observed_name(pid) {
+        // The kernel truncates a process's `comm` to 15 bytes, so a truncated observed
+        // name is matched as a prefix of the expected one.
+        Some(observed) => {
+            observed == expected || (observed.len() == 15 && expected.starts_with(&observed))
+        }
+        // Can't tell (no /proc on this platform, or the process is already gone). Signal
+        // anyway: `kill` of a dead PID is a no-op, and the caller attached us to this PID
+        // moments after spawning it, so a mid-run reuse race is vanishingly unlikely.
+        None => true,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn observed_name(pid: i32) -> Option<String> {
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    Some(comm.trim_end().to_string())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn observed_name(pid: i32) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8(out.stdout).ok()?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    // macOS `ps` reports the full executable path.
+    Some(
+        std::path::Path::new(name)
+            .file_name()?
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+#[cfg(not(unix))]
+fn main() {}

--- a/integration-tests/src/leash.rs
+++ b/integration-tests/src/leash.rs
@@ -20,11 +20,12 @@ use std::process::{Command, Stdio};
 /// How long the sidecar waits after SIGTERM before escalating to SIGKILL.
 const GRACE_SECS: u64 = 5;
 
-/// Arranges for the process `pid` to be killed shortly after the current process dies —
-/// no matter how it dies — bounded by [`GRACE_SECS`] once the sidecar fires.
+/// Makes sure `pid` dies once the current process dies, no matter how the current process
+/// exits — including SIGKILL, where no `Drop` ever runs. The target first gets SIGTERM,
+/// then SIGKILL after [`GRACE_SECS`] if it did not shut down.
 ///
 /// `expected_name` is the target's executable name; the sidecar re-checks it before killing
-/// to avoid signalling an unrelated process if the PID has been reused by then.
+/// so that a PID reused by an unrelated process is left alone.
 pub(crate) fn attach(pid: u32, expected_name: &str) -> anyhow::Result<()> {
     let mut child = Command::new(leash_bin()?)
         .args([

--- a/integration-tests/src/leash.rs
+++ b/integration-tests/src/leash.rs
@@ -1,0 +1,70 @@
+//! Ties the lifetime of helper processes (anvil, the prover service) to the lifetime of the
+//! test process itself.
+//!
+//! `Drop`-based cleanup (`AnvilInstance::drop`, `kill_on_drop`) only runs while the process
+//! unwinds normally. It never runs when the test process is SIGKILLed (OOM killer, `kill -9`,
+//! IDE stop buttons) or aborts, and nextest only *detects* leaked grandchildren — it does not
+//! kill them. A leaked anvil mines a block every 250ms forever, growing without bound.
+//!
+//! [`attach`] spawns a tiny sidecar (see `src/bin/leash.rs`) that holds the read end of a
+//! pipe whose write end stays open in this process for its entire lifetime. The kernel
+//! closes that write end on *any* kind of process death, including SIGKILL, at which point
+//! the sidecar kills the target (SIGTERM, grace period, SIGKILL) and exits.
+
+use anyhow::Context;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// How long the sidecar waits after SIGTERM before escalating to SIGKILL.
+const GRACE_SECS: u64 = 5;
+
+/// Guarantees that the process `pid` does not outlive the current process.
+///
+/// `expected_name` is the target's executable name; the sidecar re-checks it before killing
+/// to avoid signalling an unrelated process if the PID has been reused by then.
+pub(crate) fn attach(pid: u32, expected_name: &str) -> anyhow::Result<()> {
+    let mut child = Command::new(leash_bin()?)
+        .args([
+            pid.to_string(),
+            GRACE_SECS.to_string(),
+            expected_name.to_string(),
+        ])
+        .stdin(Stdio::piped())
+        // The sidecar outlives the test process; if it inherited stdout/stderr, nextest
+        // would flag every test as leaky via the still-open handles.
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn leash sidecar")?;
+    // Keep the pipe's write end open until this process dies: its closure — performed by
+    // the kernel even on SIGKILL — is what tells the sidecar to fire. The leash is thus a
+    // pure backstop; regular shutdown paths stay in charge while the process is alive.
+    // (std spawns pipes with CLOEXEC, so no later child can inherit the write end and keep
+    // the sidecar armed past our death.)
+    std::mem::forget(child.stdin.take());
+    // The sidecar strictly outlives this process, so it can never become our zombie;
+    // dropping the handle without waiting is fine.
+    drop(child);
+    Ok(())
+}
+
+/// Path to the `leash` binary built alongside the integration tests.
+///
+/// Cargo only injects `CARGO_BIN_EXE_leash` into the package's test targets, not this
+/// library, so resolve it relative to the running test executable
+/// (`target/<profile>/deps/<test>` → `target/<profile>/leash`).
+pub fn leash_bin() -> anyhow::Result<PathBuf> {
+    let exe = std::env::current_exe().context("cannot determine current executable")?;
+    let exe_dir = exe
+        .parent()
+        .context("current executable has no parent directory")?;
+    let mut candidates = vec![exe_dir.join("leash")];
+    if let Some(target_dir) = exe_dir.parent() {
+        candidates.push(target_dir.join("leash"));
+    }
+    candidates
+        .iter()
+        .find(|path| path.is_file())
+        .cloned()
+        .with_context(|| format!("leash binary not found; tried {candidates:?}"))
+}

--- a/integration-tests/src/leash.rs
+++ b/integration-tests/src/leash.rs
@@ -3,8 +3,10 @@
 //!
 //! `Drop`-based cleanup (`AnvilInstance::drop`, `kill_on_drop`) only runs while the process
 //! unwinds normally. It never runs when the test process is SIGKILLed (OOM killer, `kill -9`,
-//! IDE stop buttons) or aborts, and nextest only *detects* leaked grandchildren — it does not
-//! kill them. A leaked anvil mines a block every 250ms forever, growing without bound.
+//! IDE stop buttons) or aborts. nextest kills the test's process group on timeouts and
+//! Ctrl-C, but children that outlive any other kind of test death are only *detected* as
+//! leaky, never killed. A leaked anvil mines a block every 250ms forever, growing without
+//! bound.
 //!
 //! [`attach`] spawns a tiny sidecar (see `src/bin/leash.rs`) that holds the read end of a
 //! pipe whose write end stays open in this process for its entire lifetime. The kernel
@@ -18,7 +20,8 @@ use std::process::{Command, Stdio};
 /// How long the sidecar waits after SIGTERM before escalating to SIGKILL.
 const GRACE_SECS: u64 = 5;
 
-/// Guarantees that the process `pid` does not outlive the current process.
+/// Arranges for the process `pid` to be killed shortly after the current process dies —
+/// no matter how it dies — bounded by [`GRACE_SECS`] once the sidecar fires.
 ///
 /// `expected_name` is the target's executable name; the sidecar re-checks it before killing
 /// to avoid signalling an unrelated process if the PID has been reused by then.
@@ -39,8 +42,8 @@ pub(crate) fn attach(pid: u32, expected_name: &str) -> anyhow::Result<()> {
     // Keep the pipe's write end open until this process dies: its closure — performed by
     // the kernel even on SIGKILL — is what tells the sidecar to fire. The leash is thus a
     // pure backstop; regular shutdown paths stay in charge while the process is alive.
-    // (std spawns pipes with CLOEXEC, so no later child can inherit the write end and keep
-    // the sidecar armed past our death.)
+    // (std spawns pipes with CLOEXEC, so no later child can inherit the write end and hold
+    // the pipe open past our death, which would stop the sidecar from ever firing.)
     std::mem::forget(child.stdin.take());
     // The sidecar strictly outlives this process, so it can never become our zombie;
     // dropping the handle without waiting is fine.

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -46,6 +46,7 @@ pub mod assert_traits;
 pub mod config;
 pub mod contracts;
 pub mod l1_helpers;
+pub mod leash;
 mod node_log;
 mod prover_tester;
 pub mod provider;
@@ -851,6 +852,11 @@ impl AnvilL1 {
         })?;
         let address = provider.inner().anvil().endpoint();
 
+        // `AnvilInstance`'s Drop never runs if the test process is SIGKILLed or aborts,
+        // which would orphan an anvil that mines (and allocates) forever. The leash kills
+        // it whenever this process dies, no matter how.
+        leash::attach(provider.inner().anvil().child().id(), "anvil")?;
+
         let wallet = provider.wallet().clone();
 
         (|| async {
@@ -921,7 +927,7 @@ async fn spawn_prover_service(tester: &Tester, sequencer_urls: &[String], iterat
     let path =
         download_prover_and_unpack(protocol_version, cfg!(feature = "gpu-prover-tests")).await;
 
-    let mut child = tokio::process::Command::new(path)
+    let mut child = tokio::process::Command::new(&path)
         .arg("--sequencer-urls")
         .arg(sequencer_urls.join(","))
         .arg("--app-bin-path")
@@ -937,8 +943,20 @@ async fn spawn_prover_service(tester: &Tester, sequencer_urls: &[String], iterat
         .arg("--max-fris-per-snark")
         .arg("1")
         .arg("--disable-zk")
+        // Without this the prover keeps running after a panic: the wait-task below is
+        // dropped on runtime shutdown without ever signalling the child.
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn prover service");
+    if let Some(pid) = child.id() {
+        let name = std::path::Path::new(&path)
+            .file_name()
+            .expect("prover binary path has no file name")
+            .to_string_lossy();
+        // Same rationale as for anvil: `kill_on_drop` never fires if the test process is
+        // SIGKILLed or aborts.
+        leash::attach(pid, &name).expect("failed to attach leash to prover service");
+    }
     tokio::task::spawn(async move {
         let code = child
             .wait()

--- a/integration-tests/tests/leash_sidecar.rs
+++ b/integration-tests/tests/leash_sidecar.rs
@@ -1,0 +1,128 @@
+//! End-to-end tests for the `leash` sidecar (see `src/bin/leash.rs` and `src/leash.rs`):
+//! the mechanism that guarantees anvil/prover children die with the test process even when
+//! it is SIGKILLed.
+#![cfg(unix)]
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use zksync_os_integration_tests::leash::leash_bin;
+
+/// `CARGO_BIN_EXE_leash` is only available here, in the package's test targets; the library
+/// resolves the binary from `current_exe()` instead. Pin the two to each other so the
+/// resolution logic can't silently rot.
+#[test]
+fn leash_bin_resolution_matches_cargo() {
+    let resolved = leash_bin().expect("failed to resolve leash binary");
+    let expected = std::path::Path::new(env!("CARGO_BIN_EXE_leash"));
+    assert_eq!(
+        resolved.canonicalize().unwrap(),
+        expected.canonicalize().unwrap(),
+    );
+}
+
+/// Emulates the real deployment: a "holder" process owns the write end of the leash's stdin
+/// pipe (like the test process does via the leaked `ChildStdin`), and gets SIGKILLed. The
+/// kernel closes the pipe, and the leash must take the victim down.
+#[test]
+fn kills_victim_when_holder_is_sigkilled() {
+    let mut victim = spawn_sleep();
+
+    let mut leash = leash_command(victim.id(), "sleep")
+        .spawn()
+        .expect("failed to spawn leash");
+    let pipe_write_end = leash.stdin.take().unwrap();
+
+    // Hand the pipe's write end off to the holder as its stdout; our own copy is closed
+    // when `spawn` returns, so the holder is then the sole owner.
+    let mut holder = Command::new("sleep")
+        .arg("300")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(pipe_write_end))
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn holder");
+
+    // Give the chain a moment to settle, then hard-kill the holder — the case Drop-based
+    // cleanup can never handle.
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        victim.try_wait().unwrap().is_none(),
+        "victim died too early"
+    );
+    holder.kill().unwrap();
+    holder.wait().unwrap();
+
+    assert_dies_within(&mut victim, Duration::from_secs(10));
+    let _ = leash.wait();
+}
+
+/// If the PID was reused by an unrelated process by the time the leash fires, it must not
+/// kill it. Emulated by giving the leash a wrong expected name from the start.
+#[test]
+fn spares_victim_on_name_mismatch() {
+    let mut victim = spawn_sleep();
+
+    let mut leash = leash_command(victim.id(), "definitely-not-sleep")
+        .spawn()
+        .expect("failed to spawn leash");
+    // Dropping the write end delivers EOF immediately.
+    drop(leash.stdin.take());
+    leash.wait().unwrap();
+
+    assert!(
+        victim.try_wait().unwrap().is_none(),
+        "leash killed a process whose name did not match"
+    );
+    victim.kill().unwrap();
+    victim.wait().unwrap();
+}
+
+/// EOF is also delivered when the write end is dropped without any process dying — the
+/// normal-teardown analogue (nothing holds the pipe anymore, target already gone or not).
+#[test]
+fn kills_victim_on_plain_eof() {
+    let mut victim = spawn_sleep();
+
+    let mut leash = leash_command(victim.id(), "sleep")
+        .spawn()
+        .expect("failed to spawn leash");
+    drop(leash.stdin.take());
+
+    assert_dies_within(&mut victim, Duration::from_secs(10));
+    let _ = leash.wait();
+}
+
+fn spawn_sleep() -> Child {
+    Command::new("sleep")
+        .arg("300")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn victim")
+}
+
+fn leash_command(victim_pid: u32, expected_name: &str) -> Command {
+    let mut cmd = Command::new(leash_bin().expect("failed to resolve leash binary"));
+    cmd.arg(victim_pid.to_string())
+        .arg("2")
+        .arg(expected_name)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd
+}
+
+fn assert_dies_within(victim: &mut Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if victim.try_wait().unwrap().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    victim.kill().unwrap();
+    victim.wait().unwrap();
+    panic!("victim was not killed by the leash within {timeout:?}");
+}

--- a/integration-tests/tests/leash_sidecar.rs
+++ b/integration-tests/tests/leash_sidecar.rs
@@ -78,8 +78,10 @@ fn spares_victim_on_name_mismatch() {
     victim.wait().unwrap();
 }
 
-/// EOF is also delivered when the write end is dropped without any process dying — the
-/// normal-teardown analogue (nothing holds the pipe anymore, target already gone or not).
+/// The kill path triggers on pipe EOF itself, not on holder death specifically: dropping
+/// the write end without any process dying must have the same effect. (Production never
+/// drops the write end early — `attach` leaks it until process death — so this pins the
+/// mechanism, not a real deployment scenario.)
 #[test]
 fn kills_victim_on_plain_eof() {
     let mut victim = spawn_sleep();

--- a/integration-tests/tests/leash_sidecar.rs
+++ b/integration-tests/tests/leash_sidecar.rs
@@ -1,6 +1,6 @@
 //! End-to-end tests for the `leash` sidecar (see `src/bin/leash.rs` and `src/leash.rs`):
-//! the mechanism that guarantees anvil/prover children die with the test process even when
-//! it is SIGKILLed.
+//! the mechanism that makes anvil/prover children die with the test process even when it
+//! is SIGKILLed.
 #![cfg(unix)]
 
 use std::process::{Child, Command, Stdio};
@@ -80,8 +80,8 @@ fn spares_victim_on_name_mismatch() {
 
 /// The kill path triggers on pipe EOF itself, not on holder death specifically: dropping
 /// the write end without any process dying must have the same effect. (Production never
-/// drops the write end early — `attach` leaks it until process death — so this pins the
-/// mechanism, not a real deployment scenario.)
+/// drops the write end early — `attach` leaks it until process death — so this checks the
+/// mechanism itself rather than a scenario production hits.)
 #[test]
 fn kills_victim_on_plain_eof() {
     let mut victim = spawn_sleep();


### PR DESCRIPTION
## What

Integration tests could leak anvil instances (and the prover-service child): shutdown only ran in `AnvilInstance::drop`, which never executes when the test process is SIGKILLed (OOM killer, `kill -9`, IDE stop buttons) or aborts. nextest group-kills on timeouts/Ctrl-C, but only *detects* processes leaked any other way — it never kills them. An orphaned anvil mines a block every 250ms forever (`--block-time 0.25`), growing without bound.

## How

Every spawned helper process now gets a small **leash sidecar** (`integration-tests/src/bin/leash.rs`):

- The sidecar holds the read end of a pipe whose write end stays open in the test process for its entire lifetime (deliberately leaked `ChildStdin`).
- The kernel closes that write end on *any* kind of process death — including SIGKILL — so pipe EOF is a reliable, poll-free death signal.
- On EOF the sidecar re-checks the target's process name (guards against PID reuse), then SIGTERM → 5s grace → SIGKILL, and exits.
- While the test process is alive the leash never fires, so the existing Drop-based shutdown paths stay in charge; the leash is a pure backstop.

Attached to anvil in `AnvilL1::start` and to the prover-service child in `spawn_prover_service` (which also gains `kill_on_drop(true)` — previously the prover kept running after a test panic).

## Verification

- New e2e tests in `tests/leash_sidecar.rs`: SIGKILLed pipe-holder → victim dies; plain EOF → victim dies; name mismatch → victim spared; and a test pinning the lib's `current_exe()`-based binary resolution to `CARGO_BIN_EXE_leash`.
- Manual experiment: ran a real integration test, `kill -9`'d the test process mid-run — 8s later `pgrep anvil` and the sidecar count were both 0.
- Sample of real integration tests (mempool, external-node forward_transactions) passes with no `LEAK` markers and nothing lingering afterwards.
- `cargo fmt`, `cargo clippy -p zksync_os_integration_tests --all-targets`, and a compile check with `--features prover-tests` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)