### PR TITLE
test: kill leaked anvil/prover processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16188,6 +16188,7 @@ dependencies = [
  "flate2",
  "futures",
  "httpmock",
+ "libc",
  "regex",
  "reqwest 0.12.28",
  "reth-tasks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ k256 = { version = "0.13.4", default-features = false, features = [
     "pem",
     "std",
 ] }
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_with = "3.14.0"
 serde_json = "1"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -36,6 +36,7 @@ reth-tasks.workspace = true
 alloy = { workspace = true, default-features = false, features = ["provider-anvil-node", "rand", "json-rpc", "pubsub", "provider-ws"] }
 anyhow.workspace = true
 flate2.workspace = true
+libc.workspace = true
 reqwest.workspace = true
 tar.workspace = true
 tokio.workspace = true

--- a/integration-tests/src/bin/leash.rs
+++ b/integration-tests/src/bin/leash.rs
@@ -9,6 +9,10 @@
 //! On EOF: verify the target is still the process we were asked to kill (guards against
 //! PID reuse), send SIGTERM, wait up to `grace_secs`, then SIGKILL.
 //!
+//! This is intentionally a Rust binary rather than a shell script. Prover test artifacts are
+//! built on a non-GPU machine and transferred to a GPU runner, so keeping the watchdog in the
+//! Cargo build makes the transferred test archive self-contained.
+//!
 //! See `src/leash.rs` for the spawning side.
 
 fn main() {

--- a/integration-tests/src/bin/leash.rs
+++ b/integration-tests/src/bin/leash.rs
@@ -11,125 +11,122 @@
 //!
 //! See `src/leash.rs` for the spawning side.
 
-#[cfg(unix)]
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let (pid, grace_secs, expected_name) = match &args[..] {
-        [_, pid, grace, name] => (
-            parse_pid(pid).expect("pid must be a positive process ID"),
-            grace.parse::<u64>().expect("grace_secs must be an integer"),
-            name.clone(),
-        ),
-        _ => {
-            eprintln!("usage: leash <pid> <grace_secs> <expected_name>");
-            std::process::exit(2);
-        }
-    };
+    #[cfg(unix)]
+    unix::run();
+    #[cfg(not(unix))]
+    panic!("leash is only supported on Unix");
+}
 
-    wait_for_parent_death();
+#[cfg(unix)]
+mod unix {
+    pub(super) fn run() {
+        let args: Vec<String> = std::env::args().collect();
+        let (pid, grace_secs, expected_name) = match &args[..] {
+            [_, pid, grace, name] => (
+                parse_pid(pid).expect("pid must be a positive process ID"),
+                grace.parse::<u64>().expect("grace_secs must be an integer"),
+                name.clone(),
+            ),
+            _ => {
+                eprintln!("usage: leash <pid> <grace_secs> <expected_name>");
+                std::process::exit(2);
+            }
+        };
 
-    if !name_matches(pid, &expected_name) {
-        // Target is gone, or the PID has been reused by an unrelated process.
-        return;
-    }
+        wait_for_parent_death();
 
-    // SAFETY: `kill` only passes these integer values to the OS; it does not dereference
-    // memory owned by Rust. A nonzero return value reports an invalid or stale PID.
-    unsafe {
-        if libc::kill(pid, libc::SIGTERM) != 0 {
+        if !name_matches(pid, &expected_name) {
+            // Target is gone, or the PID has been reused by an unrelated process.
             return;
         }
-    }
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
-    while std::time::Instant::now() < deadline {
-        // SAFETY: Signal 0 only asks the OS whether `pid` can be signalled and does not
-        // dereference memory or deliver a signal.
-        if unsafe { libc::kill(pid, 0) } != 0 {
+
+        // SAFETY: `kill` only passes these integer values to the OS; it does not dereference
+        // memory owned by Rust. A nonzero return value reports an invalid or stale PID.
+        unsafe {
+            if libc::kill(pid, libc::SIGTERM) != 0 {
+                return;
+            }
+        }
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
+        while std::time::Instant::now() < deadline {
+            // SAFETY: Signal 0 only asks the OS whether `pid` can be signalled and does not
+            // dereference memory or deliver a signal.
+            if unsafe { libc::kill(pid, 0) } != 0 {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        if !name_matches(pid, &expected_name) {
+            // The target may have exited during the grace period and its PID may now belong
+            // to an unrelated process.
             return;
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-    if !name_matches(pid, &expected_name) {
-        // The target may have exited during the grace period and its PID may now belong
-        // to an unrelated process.
-        return;
-    }
-    // SAFETY: As above, `kill` only passes integer values to the OS. Failure is harmless
-    // here because SIGKILL is the final best-effort cleanup step.
-    unsafe {
-        libc::kill(pid, libc::SIGKILL);
-    }
-}
-
-/// Rejects values such as `0` and `-1`, which `kill` interprets as process selectors.
-#[cfg(unix)]
-fn parse_pid(raw: &str) -> Option<libc::pid_t> {
-    let pid = raw.parse::<u32>().ok()?;
-    let pid = libc::pid_t::try_from(pid).ok()?;
-    (pid > 0).then_some(pid)
-}
-
-/// Blocks until every write end of our stdin pipe is closed.
-#[cfg(unix)]
-fn wait_for_parent_death() {
-    use std::io::Read;
-    let mut buf = [0u8; 64];
-    let mut stdin = std::io::stdin().lock();
-    loop {
-        match stdin.read(&mut buf) {
-            Ok(0) => return,
-            Ok(_) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(_) => return,
+        // SAFETY: As above, `kill` only passes integer values to the OS. Failure is harmless
+        // here because SIGKILL is the final best-effort cleanup step.
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
         }
     }
-}
 
-/// Best-effort check that `pid` still refers to the process we were told to kill.
-#[cfg(unix)]
-fn name_matches(pid: libc::pid_t, expected: &str) -> bool {
-    observed_name_matches(observed_name(pid).as_deref(), expected)
-}
-
-/// Matches an observed process name without guessing when no name could be read.
-#[cfg(unix)]
-fn observed_name_matches(observed: Option<&str>, expected: &str) -> bool {
-    let Some(observed) = observed else {
-        return false;
-    };
-    // Linux truncates a process's `comm` to 15 bytes, so accept that exact-length
-    // prefix as well as an untruncated match.
-    observed == expected || (observed.len() == 15 && expected.starts_with(observed))
-}
-
-#[cfg(target_os = "linux")]
-fn observed_name(pid: libc::pid_t) -> Option<String> {
-    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
-    Some(comm.trim_end().to_string())
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-fn observed_name(pid: libc::pid_t) -> Option<String> {
-    let out = std::process::Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "comm="])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
+    /// Rejects values such as `0` and `-1`, which `kill` interprets as process selectors.
+    fn parse_pid(raw: &str) -> Option<libc::pid_t> {
+        let pid = raw.parse::<u32>().ok()?;
+        let pid = libc::pid_t::try_from(pid).ok()?;
+        (pid > 0).then_some(pid)
     }
-    let name = String::from_utf8(out.stdout).ok()?;
-    let name = name.trim();
-    if name.is_empty() {
-        return None;
-    }
-    // macOS `ps` reports the full executable path.
-    Some(
-        std::path::Path::new(name)
-            .file_name()?
-            .to_string_lossy()
-            .into_owned(),
-    )
-}
 
-#[cfg(not(unix))]
-fn main() {}
+    /// Blocks until every write end of our stdin pipe is closed.
+    fn wait_for_parent_death() {
+        use std::io::Read;
+        let mut buf = [0u8; 64];
+        let mut stdin = std::io::stdin().lock();
+        loop {
+            match stdin.read(&mut buf) {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(_) => return,
+            }
+        }
+    }
+
+    /// Best-effort check that `pid` still refers to the process we were told to kill.
+    fn name_matches(pid: libc::pid_t, expected: &str) -> bool {
+        let Some(observed) = observed_name(pid) else {
+            return false;
+        };
+        // Linux truncates a process's `comm` to 15 bytes, so accept that exact-length
+        // prefix as well as an untruncated match.
+        observed == expected || (observed.len() == 15 && expected.starts_with(&observed))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn observed_name(pid: libc::pid_t) -> Option<String> {
+        let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+        Some(comm.trim_end().to_string())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn observed_name(pid: libc::pid_t) -> Option<String> {
+        let out = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "comm="])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let name = String::from_utf8(out.stdout).ok()?;
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+        // macOS `ps` reports the full executable path.
+        Some(
+            std::path::Path::new(name)
+                .file_name()?
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}

--- a/integration-tests/src/bin/leash.rs
+++ b/integration-tests/src/bin/leash.rs
@@ -1,0 +1,135 @@
+//! Watchdog that kills a target process when the process holding the other end of our
+//! stdin pipe dies — however it dies, including SIGKILL and OOM kills.
+//!
+//! Usage: `leash <pid> <grace_secs> <expected_name>`, with stdin connected to a pipe whose
+//! write end is held (and never written to) by the process whose lifetime we track. The
+//! kernel closes that pipe on any kind of process death, so reading EOF here is a reliable
+//! death signal that needs no polling and no cooperation from the tracked process.
+//!
+//! On EOF: verify the target is still the process we were asked to kill (guards against
+//! PID reuse), send SIGTERM, wait up to `grace_secs`, then SIGKILL.
+//!
+//! See `src/leash.rs` for the spawning side.
+
+#[cfg(unix)]
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (pid, grace_secs, expected_name) = match &args[..] {
+        [_, pid, grace, name] => (
+            parse_pid(pid).expect("pid must be a positive process ID"),
+            grace.parse::<u64>().expect("grace_secs must be an integer"),
+            name.clone(),
+        ),
+        _ => {
+            eprintln!("usage: leash <pid> <grace_secs> <expected_name>");
+            std::process::exit(2);
+        }
+    };
+
+    wait_for_parent_death();
+
+    if !name_matches(pid, &expected_name) {
+        // Target is gone, or the PID has been reused by an unrelated process.
+        return;
+    }
+
+    // SAFETY: `kill` only passes these integer values to the OS; it does not dereference
+    // memory owned by Rust. A nonzero return value reports an invalid or stale PID.
+    unsafe {
+        if libc::kill(pid, libc::SIGTERM) != 0 {
+            return;
+        }
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(grace_secs);
+    while std::time::Instant::now() < deadline {
+        // SAFETY: Signal 0 only asks the OS whether `pid` can be signalled and does not
+        // dereference memory or deliver a signal.
+        if unsafe { libc::kill(pid, 0) } != 0 {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    if !name_matches(pid, &expected_name) {
+        // The target may have exited during the grace period and its PID may now belong
+        // to an unrelated process.
+        return;
+    }
+    // SAFETY: As above, `kill` only passes integer values to the OS. Failure is harmless
+    // here because SIGKILL is the final best-effort cleanup step.
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+    }
+}
+
+/// Rejects values such as `0` and `-1`, which `kill` interprets as process selectors.
+#[cfg(unix)]
+fn parse_pid(raw: &str) -> Option<libc::pid_t> {
+    let pid = raw.parse::<u32>().ok()?;
+    let pid = libc::pid_t::try_from(pid).ok()?;
+    (pid > 0).then_some(pid)
+}
+
+/// Blocks until every write end of our stdin pipe is closed.
+#[cfg(unix)]
+fn wait_for_parent_death() {
+    use std::io::Read;
+    let mut buf = [0u8; 64];
+    let mut stdin = std::io::stdin().lock();
+    loop {
+        match stdin.read(&mut buf) {
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(_) => return,
+        }
+    }
+}
+
+/// Best-effort check that `pid` still refers to the process we were told to kill.
+#[cfg(unix)]
+fn name_matches(pid: libc::pid_t, expected: &str) -> bool {
+    observed_name_matches(observed_name(pid).as_deref(), expected)
+}
+
+/// Matches an observed process name without guessing when no name could be read.
+#[cfg(unix)]
+fn observed_name_matches(observed: Option<&str>, expected: &str) -> bool {
+    let Some(observed) = observed else {
+        return false;
+    };
+    // Linux truncates a process's `comm` to 15 bytes, so accept that exact-length
+    // prefix as well as an untruncated match.
+    observed == expected || (observed.len() == 15 && expected.starts_with(observed))
+}
+
+#[cfg(target_os = "linux")]
+fn observed_name(pid: libc::pid_t) -> Option<String> {
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+    Some(comm.trim_end().to_string())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn observed_name(pid: libc::pid_t) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8(out.stdout).ok()?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    // macOS `ps` reports the full executable path.
+    Some(
+        std::path::Path::new(name)
+            .file_name()?
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+#[cfg(not(unix))]
+fn main() {}

--- a/integration-tests/src/leash.rs
+++ b/integration-tests/src/leash.rs
@@ -1,0 +1,77 @@
+//! Ties the lifetime of helper processes (anvil, the prover service) to the lifetime of the
+//! test process itself.
+//!
+//! `Drop`-based cleanup (`AnvilInstance::drop`, `kill_on_drop`) runs during ordinary teardown
+//! or unwinding. It never runs when the test process is SIGKILLed (OOM killer, `kill -9`, IDE
+//! stop buttons) or aborts. nextest kills the test's process group on timeouts and Ctrl-C,
+//! but children that outlive any other kind of test death are only *detected* as leaky, never
+//! killed. A leaked anvil mines a block every 250ms forever, growing without bound.
+//!
+//! [`attach`] spawns a tiny sidecar (see `src/bin/leash.rs`) that holds the read end of a
+//! pipe whose write end stays open in this process for its entire lifetime. The kernel
+//! closes that write end on *any* kind of process death, including SIGKILL, at which point
+//! the sidecar kills the target (SIGTERM, grace period, SIGKILL) and exits.
+
+use anyhow::Context;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// How long the sidecar waits after SIGTERM before escalating to SIGKILL.
+const GRACE_SECS: u64 = 5;
+
+/// Makes sure `pid` dies once the current process dies, no matter how the current process
+/// exits — including SIGKILL, where no `Drop` ever runs. The target first gets SIGTERM,
+/// then SIGKILL after [`GRACE_SECS`] if it did not shut down.
+///
+/// `expected_name` is the target's executable name; the sidecar re-checks it before killing
+/// so that a PID reused by an unrelated process is left alone.
+pub(crate) fn attach(pid: u32, expected_name: &str) -> anyhow::Result<()> {
+    let mut child = Command::new(leash_bin()?)
+        .args([
+            pid.to_string(),
+            GRACE_SECS.to_string(),
+            expected_name.to_string(),
+        ])
+        .stdin(Stdio::piped())
+        // The sidecar outlives the test process; if it inherited stdout/stderr, nextest
+        // would flag every test as leaky via the still-open handles.
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to spawn leash sidecar")?;
+    // Keep the pipe's write end open until this process dies: its closure — performed by
+    // the kernel even on SIGKILL — is what tells the sidecar to fire. The leash is thus a
+    // pure backstop; regular shutdown paths stay in charge while the process is alive.
+    // (std spawns pipes with CLOEXEC, so no later child can inherit the write end and hold
+    // the pipe open past our death, which would stop the sidecar from ever firing.)
+    let write_end = child
+        .stdin
+        .take()
+        .context("leash sidecar stdin was not piped")?;
+    std::mem::forget(write_end);
+    // The sidecar strictly outlives this process, so it can never become our zombie;
+    // dropping the handle without waiting is fine.
+    drop(child);
+    Ok(())
+}
+
+/// Path to the `leash` binary built alongside the integration tests.
+///
+/// Cargo only injects `CARGO_BIN_EXE_leash` into the package's test targets, not this
+/// library, so resolve it relative to the running test executable
+/// (`target/<profile>/deps/<test>` → `target/<profile>/leash`).
+fn leash_bin() -> anyhow::Result<PathBuf> {
+    let exe = std::env::current_exe().context("cannot determine current executable")?;
+    let exe_dir = exe
+        .parent()
+        .context("current executable has no parent directory")?;
+    let mut candidates = vec![exe_dir.join("leash")];
+    if let Some(target_dir) = exe_dir.parent() {
+        candidates.push(target_dir.join("leash"));
+    }
+    candidates
+        .iter()
+        .find(|path| path.is_file())
+        .cloned()
+        .with_context(|| format!("leash binary not found; tried {candidates:?}"))
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -46,6 +46,7 @@ pub mod assert_traits;
 pub mod config;
 pub mod contracts;
 pub mod l1_helpers;
+mod leash;
 mod node_log;
 mod prover_tester;
 pub mod provider;
@@ -851,6 +852,11 @@ impl AnvilL1 {
         })?;
         let address = provider.inner().anvil().endpoint();
 
+        // `AnvilInstance`'s Drop never runs if the test process is SIGKILLed or aborts,
+        // which would orphan an anvil that mines (and allocates) forever. The leash kills
+        // it whenever this process dies, no matter how.
+        leash::attach(provider.inner().anvil().child().id(), "anvil")?;
+
         let wallet = provider.wallet().clone();
 
         (|| async {
@@ -921,7 +927,7 @@ async fn spawn_prover_service(tester: &Tester, sequencer_urls: &[String], iterat
     let path =
         download_prover_and_unpack(protocol_version, cfg!(feature = "gpu-prover-tests")).await;
 
-    let mut child = tokio::process::Command::new(path)
+    let mut child = tokio::process::Command::new(&path)
         .arg("--sequencer-urls")
         .arg(sequencer_urls.join(","))
         .arg("--app-bin-path")
@@ -937,8 +943,21 @@ async fn spawn_prover_service(tester: &Tester, sequencer_urls: &[String], iterat
         .arg("--max-fris-per-snark")
         .arg("1")
         .arg("--disable-zk")
+        // Without this the prover keeps running after a panic: the wait-task below is
+        // dropped on runtime shutdown without ever signalling the child.
+        .kill_on_drop(true)
         .spawn()
         .expect("failed to spawn prover service");
+    let pid = child
+        .id()
+        .expect("newly spawned prover service has no process ID");
+    let name = std::path::Path::new(&path)
+        .file_name()
+        .expect("prover binary path has no file name")
+        .to_string_lossy();
+    // Same rationale as for anvil: `kill_on_drop` never fires if the test process is
+    // SIGKILLed or aborts.
+    leash::attach(pid, &name).expect("failed to attach leash to prover service");
     tokio::task::spawn(async move {
         let code = child
             .wait()


### PR DESCRIPTION
## Summary

Adds a helper process `leash` that ties the lifetime of a spawned process to the root process.

This should fix cases when anvil could leak and take a lot of RAM space just by continuously producing blocks every 250ms

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

