### PR TITLE
perf(l1_watcher): prefetch commit data concurrently during batch backfill

### DIFF
--- a/lib/l1_watcher/src/persist_batch_watcher.rs
+++ b/lib/l1_watcher/src/persist_batch_watcher.rs
@@ -29,6 +29,58 @@ pub struct L1PersistBatchWatcher<BatchStorage> {
     committed_batches: HashMap<u64, DiscoveredCommittedBatch>,
     last_processed_commit_batch: u64,
     last_persisted_batch_on_start: u64,
+    /// Commit data prefetched for the current polling window, keyed by commit log identity.
+    prefetched: HashMap<LogKey, DiscoveredCommittedBatch>,
+}
+
+/// Identifies a log within its settlement layer: (L1 block number, log index).
+type LogKey = (u64, u64);
+
+/// Max concurrent L1 fetches when prefetching a window's commit data.
+const PREFETCH_CONCURRENCY: usize = 32;
+
+fn log_key(log: &Log) -> Result<LogKey, L1WatcherError> {
+    let block_number = log.block_number.ok_or_else(|| {
+        L1WatcherError::Other(anyhow::anyhow!("indexed log without block number"))
+    })?;
+    let log_index = log
+        .log_index
+        .ok_or_else(|| L1WatcherError::Other(anyhow::anyhow!("indexed log without log index")))?;
+    Ok((block_number, log_index))
+}
+
+/// Fetches the full committed-batch data for one commit event from the settlement layer.
+async fn fetch_discovered_batch(
+    provider: NodeProvider,
+    report: ReportCommittedBatchRangeZKsyncOS,
+    log: Log,
+) -> Result<DiscoveredCommittedBatch, L1WatcherError> {
+    let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
+    let l1_block_number = log.block_number.expect("indexed log without block number");
+    let zk_chain = ZkChain::new(log.address(), provider);
+    let batch_info =
+        util::fetch_committed_batch_data(&zk_chain, tx_hash, l1_block_number, report.batchNumber)
+            .await?
+            .into_stored();
+
+    Ok(DiscoveredCommittedBatch {
+        batch_info,
+        block_range: report.firstBlockNumber..=report.lastBlockNumber,
+    })
+}
+
+/// Extracts the decoded commit-range reports from a window's logs, keyed by log identity.
+fn commit_reports(
+    events: &[Log],
+) -> Result<Vec<(LogKey, ReportCommittedBatchRangeZKsyncOS, Log)>, L1WatcherError> {
+    events
+        .iter()
+        .filter(|log| log.topics()[0] == ReportCommittedBatchRangeZKsyncOS::SIGNATURE_HASH)
+        .map(|log| {
+            let report = ReportCommittedBatchRangeZKsyncOS::decode_log(&log.inner)?.data;
+            Ok((log_key(log)?, report, log.clone()))
+        })
+        .collect()
 }
 
 impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
@@ -70,6 +122,7 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
                 committed_batches: HashMap::new(),
                 last_processed_commit_batch: last_persisted_batch,
                 last_persisted_batch_on_start: last_persisted_batch,
+                prefetched: HashMap::new(),
             };
             Ok((start_block, processor))
         };
@@ -78,27 +131,16 @@ impl<BatchStorage: WriteBatch> L1PersistBatchWatcher<BatchStorage> {
     }
 
     async fn parse_committed_batch(
-        &self,
+        &mut self,
         provider: &NodeProvider,
         report: ReportCommittedBatchRangeZKsyncOS,
         log: Log,
     ) -> Result<DiscoveredCommittedBatch, L1WatcherError> {
-        let tx_hash = log.transaction_hash.expect("indexed log without tx hash");
-        let l1_block_number = log.block_number.expect("indexed log without block number");
-        let zk_chain = ZkChain::new(log.address(), provider.clone());
-        let batch_info = util::fetch_committed_batch_data(
-            &zk_chain,
-            tx_hash,
-            l1_block_number,
-            report.batchNumber,
-        )
-        .await?
-        .into_stored();
-
-        Ok(DiscoveredCommittedBatch {
-            batch_info,
-            block_range: report.firstBlockNumber..=report.lastBlockNumber,
-        })
+        // Misses (logs outside the prefetched window) fall back to a direct fetch.
+        if let Some(batch) = self.prefetched.remove(&log_key(&log)?) {
+            return Ok(batch);
+        }
+        fetch_discovered_batch(provider.clone(), report, log).await
     }
 
     async fn process_commit(
@@ -186,6 +228,26 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
         logs
     }
 
+    async fn prefetch_events(
+        &mut self,
+        provider: &NodeProvider,
+        events: &[Log],
+    ) -> Result<(), L1WatcherError> {
+        // Drop leftovers from the previous window.
+        self.prefetched.clear();
+        let reports = commit_reports(events)?;
+        self.prefetched = util::prefetch_bounded(
+            reports,
+            PREFETCH_CONCURRENCY,
+            |(key, report, log)| async move {
+                let batch = fetch_discovered_batch(provider.clone(), report, log).await?;
+                Ok((key, batch))
+            },
+        )
+        .await?;
+        Ok(())
+    }
+
     async fn process_raw_event(
         &mut self,
         provider: &NodeProvider,
@@ -233,5 +295,56 @@ impl<BatchStorage: WriteBatch> ProcessRawEvents for L1PersistBatchWatcher<BatchS
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, B256, U256};
+    use alloy::sol_types::SolEvent;
+
+    fn rpc_log(data: alloy::primitives::LogData, block_number: u64, log_index: u64) -> Log {
+        Log {
+            inner: alloy::primitives::Log {
+                address: Address::repeat_byte(0xAA),
+                data,
+            },
+            block_hash: Some(B256::repeat_byte(1)),
+            block_number: Some(block_number),
+            block_timestamp: None,
+            transaction_hash: Some(B256::repeat_byte(2)),
+            transaction_index: Some(0),
+            log_index: Some(log_index),
+            removed: false,
+        }
+    }
+
+    #[test]
+    fn commit_reports_selects_only_commit_events_keyed_by_log_identity() {
+        let commit = ReportCommittedBatchRangeZKsyncOS {
+            batchNumber: 7,
+            firstBlockNumber: 100,
+            lastBlockNumber: 110,
+        };
+        let execute = BlockExecution {
+            batchNumber: U256::from(7),
+            batchHash: B256::repeat_byte(3),
+            commitment: B256::repeat_byte(4),
+        };
+        let logs = vec![
+            rpc_log(commit.encode_log_data(), 5, 2),
+            rpc_log(execute.encode_log_data(), 5, 3),
+        ];
+
+        let reports = commit_reports(&logs).unwrap();
+
+        assert_eq!(reports.len(), 1);
+        let (key, report, log) = &reports[0];
+        assert_eq!(*key, (5, 2));
+        assert_eq!(report.batchNumber, 7);
+        assert_eq!(report.firstBlockNumber, 100);
+        assert_eq!(report.lastBlockNumber, 110);
+        assert_eq!(log.log_index, Some(2));
     }
 }

--- a/lib/l1_watcher/src/traits.rs
+++ b/lib/l1_watcher/src/traits.rs
@@ -32,6 +32,16 @@ pub trait ProcessRawEvents: Send + Sync + 'static {
         None
     }
 
+    /// Invoked once per polling window before the ordered per-event processing, letting
+    /// processors fetch auxiliary data for many events concurrently. Defaults to a no-op.
+    async fn prefetch_events(
+        &mut self,
+        _provider: &NodeProvider,
+        _events: &[Log],
+    ) -> Result<(), L1WatcherError> {
+        Ok(())
+    }
+
     /// Invoked each time a new log matching the filter is found.
     ///
     /// `provider` is the settlement-layer provider the [`L1Watcher`](crate::L1Watcher) used to

--- a/lib/l1_watcher/src/util.rs
+++ b/lib/l1_watcher/src/util.rs
@@ -5,6 +5,9 @@ use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
 use backon::{ConstantBuilder, Retryable};
+use futures::{StreamExt, TryStreamExt};
+use std::collections::HashMap;
+use std::future::Future;
 use std::time::Duration;
 use zksync_os_batch_types::{CommittedBatchInfo, DiscoveredCommittedBatch};
 use zksync_os_contract_interface::IExecutor::ReportCommittedBatchRangeZKsyncOS;
@@ -18,6 +21,24 @@ use zksync_os_provider::NodeProvider;
 const COMMIT_DATA_RETRY_POLICY: ConstantBuilder = ConstantBuilder::new()
     .with_delay(Duration::from_millis(200))
     .with_max_times(50);
+
+/// Runs `fetch` over `items` with at most `limit` fetches in flight, collecting the keyed
+/// results into a map. The first error aborts the whole run.
+pub(crate) async fn prefetch_bounded<T, K, V, F, Fut>(
+    items: Vec<T>,
+    limit: usize,
+    fetch: F,
+) -> Result<HashMap<K, V>, L1WatcherError>
+where
+    K: std::hash::Hash + Eq,
+    F: Fn(T) -> Fut,
+    Fut: Future<Output = Result<(K, V), L1WatcherError>>,
+{
+    futures::stream::iter(items.into_iter().map(fetch))
+        .buffer_unordered(limit.max(1))
+        .try_collect()
+        .await
+}
 
 /// Distance of the first downward gallop probe from the latest block.
 ///
@@ -323,7 +344,51 @@ pub(crate) async fn fetch_commit_batch_info(
 #[cfg(test)]
 mod tests {
     use super::find_first_true_block;
+    use super::prefetch_bounded;
+    use crate::watcher::L1WatcherError;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn prefetch_bounded_never_exceeds_limit_but_runs_concurrently() {
+        const LIMIT: usize = 4;
+        let in_flight = AtomicUsize::new(0);
+        let max_seen = AtomicUsize::new(0);
+        let items: Vec<u64> = (0..16).collect();
+        let in_flight = &in_flight;
+        let max_seen = &max_seen;
+        let map = prefetch_bounded(items, LIMIT, |i| async move {
+            let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            max_seen.fetch_max(now, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok::<_, L1WatcherError>((i, ()))
+        })
+        .await
+        .unwrap();
+        assert_eq!(map.len(), 16);
+        let max = max_seen.load(Ordering::SeqCst);
+        assert!(max <= LIMIT, "in-flight fetches exceeded limit: {max}");
+        assert!(max >= 2, "fetches ran serially (max in-flight {max})");
+    }
+
+    #[tokio::test]
+    async fn prefetch_bounded_is_actually_concurrent_within_limit() {
+        // All 8 fetches wait on one barrier: completes only if 8 run at once.
+        let barrier = tokio::sync::Barrier::new(8);
+        let barrier = &barrier;
+        let items: Vec<u64> = (0..8).collect();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            prefetch_bounded(items, 8, |i| async move {
+                barrier.wait().await;
+                Ok::<_, L1WatcherError>((i, ()))
+            }),
+        )
+        .await
+        .expect("deadlocked: fetches did not run concurrently");
+        assert_eq!(result.unwrap().len(), 8);
+    }
 
     /// Runs the search against a synthetic monotonic predicate (`block >= first_true`) and
     /// returns the result along with every probed block.

--- a/lib/l1_watcher/src/watcher.rs
+++ b/lib/l1_watcher/src/watcher.rs
@@ -219,6 +219,10 @@ impl<P: ProcessRawEvents> L1Watcher<P> {
             METRICS.events_loaded[&self.processor.name()].inc_by(events.len() as u64);
             METRICS.most_recently_scanned_l1_block[&self.processor.name()].set(to_block);
 
+            self.processor
+                .prefetch_events(&self.provider, &events)
+                .await?;
+
             for event in events {
                 self.processor
                     .process_raw_event(&self.provider, event)


### PR DESCRIPTION
## Summary

The `persist_batch` watcher fetched committed-batch data (commit tx calldata + `BlockCommit` event) one batch at a time, in event order. On a fresh-DB start this makes the full history backfill latency-bound: each commit costs a full RPC round trip (~150ms/event against a remote RPC), so historical 1000-block windows with hundreds of commits take minutes each — a full backfill of a long-lived chain takes many hours.

This PR adds a `prefetch_events` hook to `ProcessRawEvents`, invoked once per polling window before the ordered per-event processing (default no-op, so other watchers are unaffected). The `persist_batch` watcher uses it to fetch all of a window's commit data with up to 32 concurrent requests, keyed by log identity (`(block_number, log_index)`). The ordered commit/execute state machine is unchanged and consumes the prefetched results, falling back to a direct fetch on a miss. The first fetch error aborts the window, matching the previous serial semantics.

### Measured impact

Full backfill of a chain with ~286k batches (stage-rollup history against a remote Sepolia RPC):

- serial: ~145ms/event, ~60s per 1000-block window, ~20h projected total
- prefetched: ~1.4–8ms/event (cached / cold upstream), 0.7–3s per window, well under 1h total

### Testing

- Unit tests for the bounded-concurrency prefetch helper (respects the limit and is actually concurrent — both verified to catch mutations that serialize the fetches or drop the bound) and for commit-log selection keyed by log identity.
- Verified end-to-end on a full stage-rollup backfill in both cache-hit and cold-upstream regimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
