### PR TITLE
feat: Expose protocol version filtering for prover

### DIFF
--- a/node/bin/src/prover_api/fake_fri_provers_pool.rs
+++ b/node/bin/src/prover_api/fake_fri_provers_pool.rs
@@ -50,7 +50,10 @@ impl FakeFriProversPool {
             runtime.spawn_critical_task("fake fri prover", async move {
                 loop {
                     // Only take inbound items whose age >= min_age.
-                    match jm.pick_next_job(min_age, "fake_prover".to_string()).await {
+                    match jm
+                        .pick_next_job(min_age, "fake_prover".to_string(), None)
+                        .await
+                    {
                         Some((fri_job, _prover_input)) => {
                             // Emulate proving work.
                             let start = Instant::now();

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -131,12 +131,21 @@ impl FriJobManager {
     ///
     /// `min_age` is used for fake provers to avoid taking fresh items,
     /// letting real provers race first.
+    ///
+    /// `supported_proving_versions` restricts assignment to batches of these versions;
+    /// `None` means the prover declared nothing and any batch qualifies.
     pub async fn pick_next_job(
         &self,
         min_age: Duration,
         prover_id: String,
+        supported_proving_versions: Option<&[ProvingVersion]>,
     ) -> Option<(FriJob, ProverInput)> {
-        self.jobs.pick_job(min_age, &prover_id).await
+        self.jobs
+            .pick_job(min_age, &prover_id, |job| {
+                supported_proving_versions
+                    .is_none_or(|versions| versions.contains(&job.metadata.proving_version))
+            })
+            .await
     }
 
     /// Submit a **real** proof provided by an external prover.

--- a/node/bin/src/prover_api/prover_job_map/map.rs
+++ b/node/bin/src/prover_api/prover_job_map/map.rs
@@ -102,20 +102,28 @@ impl<T: Clone> ProverJobMap<T> {
         );
     }
 
-    /// Picks the first job (lowest batch number) that is either:
+    /// Picks the first job (lowest batch number) that passes `predicate` and is either:
     /// - Pending and older than min_age (fake provers use non-empty min_age)
     /// - Assigned and timed out
     ///
     /// Returns None if no eligible job is found.
     ///
     /// Used for FRI jobs (one batch == one job)
-    pub async fn pick_job(&self, min_age: Duration, prover_id: &str) -> Option<(FriJob, T)> {
+    pub async fn pick_job<F>(
+        &self,
+        min_age: Duration,
+        prover_id: &str,
+        mut predicate: F,
+    ) -> Option<(FriJob, T)>
+    where
+        F: FnMut(&JobEntry<T>) -> bool,
+    {
         let now = Instant::now();
         let mut result = self
             .pick_jobs_while_with_limit(1, prover_id, |entry| {
                 // min_age is non-zero only for fake provers
                 // for real provers this is no-op - that is, we always take the oldest eligible job
-                now.duration_since(entry.metadata.added_at) >= min_age
+                now.duration_since(entry.metadata.added_at) >= min_age && predicate(entry)
             })
             .await;
 
@@ -471,9 +479,19 @@ mod tests {
     use zksync_os_contract_interface::models::{
         CommitBatchInfo, DACommitmentScheme, StoredBatchInfo,
     };
-    use zksync_os_types::{ProtocolSemanticVersion, PubdataMode};
+    use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion, PubdataMode};
 
     fn create_test_batch_envelope(batch_number: u64) -> SignedBatchEnvelope<Vec<u8>> {
+        create_test_batch_envelope_with_protocol_version(
+            batch_number,
+            ProtocolSemanticVersion::legacy_genesis_version(),
+        )
+    }
+
+    fn create_test_batch_envelope_with_protocol_version(
+        batch_number: u64,
+        protocol_version: ProtocolSemanticVersion,
+    ) -> SignedBatchEnvelope<Vec<u8>> {
         let batch = BatchMetadata {
             previous_stored_batch_info: StoredBatchInfo {
                 batch_number: batch_number.saturating_sub(1),
@@ -505,7 +523,7 @@ mod tests {
                     operator_da_input: vec![],
                     sl_chain_id: 2,
                 },
-                protocol_version: ProtocolSemanticVersion::legacy_genesis_version(),
+                protocol_version,
                 upgrade_tx_hash: None,
             },
             chain_address: Address::ZERO,
@@ -554,20 +572,52 @@ mod tests {
         map.add_job(create_test_batch_envelope(1)).await;
         map.add_job(create_test_batch_envelope(2)).await;
 
-        let job = map.pick_job(Duration::ZERO, "prover-1").await;
+        let job = map.pick_job(Duration::ZERO, "prover-1", |_| true).await;
         assert!(job.is_some());
         let (fri_job, _data) = job.unwrap();
         assert_eq!(fri_job.batch_number, 1);
 
         // Job 1 is now assigned, should pick job 2
-        let job = map.pick_job(Duration::ZERO, "prover-2").await;
+        let job = map.pick_job(Duration::ZERO, "prover-2", |_| true).await;
         assert!(job.is_some());
         let (fri_job, _data) = job.unwrap();
         assert_eq!(fri_job.batch_number, 2);
 
         // All jobs assigned, should return None
-        let job = map.pick_job(Duration::ZERO, "prover-3").await;
+        let job = map.pick_job(Duration::ZERO, "prover-3", |_| true).await;
         assert!(job.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_pick_job_with_proving_version_filter() {
+        let map = ProverJobMap::new(Duration::from_secs(60), 100, ProverStage::Fri);
+
+        map.add_job(create_test_batch_envelope(1)).await;
+        map.add_job(create_test_batch_envelope_with_protocol_version(
+            2,
+            ProtocolSemanticVersion::new(0, 31, 0),
+        ))
+        .await;
+
+        let job = map
+            .pick_job(Duration::ZERO, "prover-v7", |job| {
+                job.metadata.proving_version == ProvingVersion::V7
+            })
+            .await;
+
+        assert!(job.is_some());
+        let (fri_job, _data) = job.unwrap();
+        assert_eq!(fri_job.batch_number, 2);
+        assert_eq!(fri_job.vk_hash, ProvingVersion::V7.vk_hash());
+
+        let status = map.status().await;
+        assert_eq!(status[0].fri_job.batch_number, 1);
+        assert_eq!(status[0].assigned_to_prover_id, None);
+        assert_eq!(status[1].fri_job.batch_number, 2);
+        assert_eq!(
+            status[1].assigned_to_prover_id,
+            Some("prover-v7".to_string())
+        );
     }
 
     #[tokio::test]
@@ -576,18 +626,18 @@ mod tests {
 
         map.add_job(create_test_batch_envelope(1)).await;
 
-        let job = map.pick_job(Duration::ZERO, "prover-1").await;
+        let job = map.pick_job(Duration::ZERO, "prover-1", |_| true).await;
         assert!(job.is_some());
 
         // Try to pick again immediately - should return None (still assigned)
-        let job = map.pick_job(Duration::ZERO, "prover-2").await;
+        let job = map.pick_job(Duration::ZERO, "prover-2", |_| true).await;
         assert!(job.is_none());
 
         // Wait for timeout
         tokio::time::sleep(Duration::from_millis(150)).await;
 
         // Should be able to pick again after timeout
-        let job = map.pick_job(Duration::ZERO, "prover-2").await;
+        let job = map.pick_job(Duration::ZERO, "prover-2", |_| true).await;
         assert!(job.is_some());
         let (fri_job, _data) = job.unwrap();
         assert_eq!(fri_job.batch_number, 1);
@@ -622,6 +672,49 @@ mod tests {
             .await;
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].0.batch_number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_pick_multiple_jobs_with_proving_version_filter() {
+        let map = ProverJobMap::new(Duration::from_secs(60), 100, ProverStage::Snark);
+
+        map.add_job(create_test_batch_envelope(1)).await;
+        map.add_job(create_test_batch_envelope_with_protocol_version(
+            2,
+            ProtocolSemanticVersion::new(0, 31, 0),
+        ))
+        .await;
+        map.add_job(create_test_batch_envelope_with_protocol_version(
+            3,
+            ProtocolSemanticVersion::new(0, 31, 0),
+        ))
+        .await;
+
+        let jobs = map
+            .pick_jobs_while_with_limit(5, "prover-v7", |job| {
+                job.metadata.proving_version == ProvingVersion::V7
+            })
+            .await;
+
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0].0.batch_number, 2);
+        assert_eq!(jobs[1].0.batch_number, 3);
+        assert!(
+            jobs.iter()
+                .all(|(fri_job, _)| fri_job.vk_hash == ProvingVersion::V7.vk_hash())
+        );
+
+        let status = map.status().await;
+        assert_eq!(status[0].fri_job.batch_number, 1);
+        assert_eq!(status[0].assigned_to_prover_id, None);
+        assert_eq!(
+            status[1].assigned_to_prover_id,
+            Some("prover-v7".to_string())
+        );
+        assert_eq!(
+            status[2].assigned_to_prover_id,
+            Some("prover-v7".to_string())
+        );
     }
 
     #[tokio::test]
@@ -717,7 +810,7 @@ mod tests {
         map.add_job(create_test_batch_envelope(1)).await;
         map.add_job(create_test_batch_envelope(2)).await;
 
-        let _ = map.pick_job(Duration::ZERO, "prover-1").await;
+        let _ = map.pick_job(Duration::ZERO, "prover-1", |_| true).await;
 
         let status = map.status().await;
         assert_eq!(status.len(), 2);

--- a/node/bin/src/prover_api/prover_server/v1/handlers.rs
+++ b/node/bin/src/prover_api/prover_server/v1/handlers.rs
@@ -80,11 +80,16 @@ pub(super) async fn pick_fri_job(
         "Received FRI job pick request from prover with ID: {}",
         query.id
     );
+    let supported_proving_versions = query.supported_proving_versions();
     // for real provers, we return the next job immediately -
     // see `FakeProversPool` for fake provers implementation
     match state
         .fri_job_manager
-        .pick_next_job(std::time::Duration::from_secs(0), query.id)
+        .pick_next_job(
+            std::time::Duration::from_secs(0),
+            query.id,
+            supported_proving_versions.as_deref(),
+        )
         .await
     {
         Some((fri_job, input)) => {
@@ -179,7 +184,12 @@ pub(super) async fn pick_snark_job(
         "Received SNARK job pick request from prover with ID: {}",
         query.id
     );
-    match state.snark_job_manager.pick_real_job(query.id).await {
+    let supported_proving_versions = query.supported_proving_versions();
+    match state
+        .snark_job_manager
+        .pick_real_job(query.id, supported_proving_versions.as_deref())
+        .await
+    {
         Ok(Some(batches)) => {
             // Expect non-empty and all real FRI proofs
             let from = batches.first().unwrap().0.batch_number;

--- a/node/bin/src/prover_api/prover_server/v1/models.rs
+++ b/node/bin/src/prover_api/prover_server/v1/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use zksync_os_types::ProvingVersion;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct BatchDataPayload {
@@ -10,6 +11,57 @@ pub(super) struct BatchDataPayload {
 #[derive(Debug, Deserialize)]
 pub(super) struct ProverQuery {
     pub id: String,
+    /// Comma-separated vk_hashes of the proving versions this prover supports.
+    #[serde(default)]
+    pub supported_vk_hashes: Option<String>,
+}
+
+impl ProverQuery {
+    /// Proving versions this prover declared support for.
+    ///
+    /// `None` means no declaration and the caller must not filter jobs. This is a
+    /// backwards-compatibility layer: old provers don't send `supported_vk_hashes`
+    /// and must keep receiving jobs as before.
+    ///
+    /// Provers currently declare exactly one version; the list shape is for
+    /// multi-version provers, which become possible on the prover side with
+    /// airbender v2.
+    ///
+    /// A declared hash the server doesn't recognize is skipped with a warning: it's
+    /// most likely a proving version newer than this server, and the prover should
+    /// still be served the versions both sides know. If nothing in the declaration
+    /// is recognized, this returns `Some(vec![])` so that such a prover gets *no*
+    /// jobs rather than any jobs.
+    pub fn supported_proving_versions(&self) -> Option<Vec<ProvingVersion>> {
+        let hashes: Vec<&str> = self
+            .supported_vk_hashes
+            .iter()
+            .flat_map(|hashes| hashes.split(','))
+            .map(str::trim)
+            .filter(|hash| !hash.is_empty())
+            .collect();
+
+        if hashes.is_empty() {
+            return None;
+        }
+
+        let versions = hashes
+            .into_iter()
+            .filter_map(|hash| match ProvingVersion::try_from_vk_hash(hash) {
+                Ok(version) => Some(version),
+                Err(_) => {
+                    tracing::warn!(
+                        prover_id = self.id,
+                        vk_hash = hash,
+                        "prover declared a vk_hash unknown to this server; ignoring it"
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        Some(versions)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,4 +95,60 @@ pub(super) struct FailedProofResponse {
     pub proof_final_register_values: [u32; 16],
     pub vk_hash: String,
     pub proof: String, // base64‑encoded FRI proof (little‑endian u32 array)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProverQuery;
+    use zksync_os_types::ProvingVersion;
+
+    const UNKNOWN_VK_HASH: &str =
+        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    fn query(supported_vk_hashes: Option<&str>) -> ProverQuery {
+        ProverQuery {
+            id: "test_prover".to_string(),
+            supported_vk_hashes: supported_vk_hashes.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn no_declaration_means_no_filter() {
+        assert_eq!(query(None).supported_proving_versions(), None);
+        // Declared-but-blank is treated the same as absent
+        assert_eq!(query(Some("")).supported_proving_versions(), None);
+        assert_eq!(query(Some(" ,, ")).supported_proving_versions(), None);
+    }
+
+    #[test]
+    fn known_hashes_are_parsed() {
+        let q = query(Some(&format!(
+            "{}, {}",
+            ProvingVersion::V7.vk_hash(),
+            ProvingVersion::V6.vk_hash()
+        )));
+        assert_eq!(
+            q.supported_proving_versions(),
+            Some(vec![ProvingVersion::V7, ProvingVersion::V6])
+        );
+    }
+
+    #[test]
+    fn unknown_hash_is_skipped_keeping_known_ones() {
+        let q = query(Some(&format!(
+            "{},{}",
+            UNKNOWN_VK_HASH,
+            ProvingVersion::V7.vk_hash()
+        )));
+        assert_eq!(
+            q.supported_proving_versions(),
+            Some(vec![ProvingVersion::V7])
+        );
+    }
+
+    #[test]
+    fn all_unknown_hashes_mean_no_jobs_not_no_filter() {
+        let q = query(Some(UNKNOWN_VK_HASH));
+        assert_eq!(q.supported_proving_versions(), Some(vec![]));
+    }
 }

--- a/node/bin/src/prover_api/snark_job_manager.rs
+++ b/node/bin/src/prover_api/snark_job_manager.rs
@@ -59,6 +59,7 @@ impl SnarkJobManager {
     pub async fn pick_real_job(
         &self,
         prover_id: String,
+        supported_proving_versions: Option<&[ProvingVersion]>,
     ) -> anyhow::Result<Option<Vec<(FriJob, FriProof)>>> {
         // consume/remove all fake jobs that may be in the front of the queue
         self.process_pending_fake_fri_proofs().await?;
@@ -67,6 +68,8 @@ impl SnarkJobManager {
             .jobs
             .pick_jobs_while_with_limit(self.max_fris_per_snark, &prover_id, |job| {
                 !job.batch_envelope.data.is_fake()
+                    && supported_proving_versions
+                        .is_none_or(|versions| versions.contains(&job.metadata.proving_version))
             })
             .await;
 


### PR DESCRIPTION
Previously, provers could request any job and then they would be dropped if the prover was not capable to prove it. On the server side, we simply locked it until timeout (the server had no way to know whether the prover is processing or just dropped the job).

This PR adds job filters on server side. As such, the provers declare what jobs they can prove and server can filter for them (instead of providing any proof available).

This is great for protocol upgrades, when there are multiple versions of provers running at the same time. Previously, due to timing, the batches might get stuck (i.e. vX is available, but prover vX+1 keeps on getting the job, locking it on server and then dropping). With this change, job for vX will never be picked up by vX+1 prover.

Release notes: all changes are backwards compatible. If the server sees no protocol version provided, it behaves as it did previously (provide any job available). If the version is available, filter for it and it alone.

