### PR TITLE
feat(zks): add stable getBatchByNumber and getLatestBatchNumber RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17133,6 +17133,7 @@ dependencies = [
  "zksync_os_server",
  "zksync_os_state_full_diffs",
  "zksync_os_status_server",
+ "zksync_os_storage_api",
  "zksync_os_tx_validators",
  "zksync_os_types",
  "zksync_os_verify_storage_proof",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -21,6 +21,7 @@ zksync_os_l1_watcher.workspace = true
 zksync_os_tx_validators.workspace = true
 zksync_os_types.workspace = true
 zksync_os_rpc_api.workspace = true
+zksync_os_storage_api.workspace = true
 zksync_os_merkle_tree_api.workspace = true
 zksync_os_state_full_diffs.workspace = true
 zksync_os_multivm.workspace = true

--- a/integration-tests/tests/rpc/batches.rs
+++ b/integration-tests/tests/rpc/batches.rs
@@ -1,0 +1,51 @@
+use alloy::providers::Provider;
+use zksync_os_alloy_ext::provider::ZksyncApi;
+use zksync_os_integration_tests::assert_traits::ReceiptAssert;
+use zksync_os_integration_tests::contracts::Counter;
+use zksync_os_integration_tests::{CURRENT_TO_L1, Tester, test_multisetup};
+use zksync_os_storage_api::PersistedBatch;
+
+#[test_multisetup([CURRENT_TO_L1])]
+async fn enumerate_batches(tester: Tester) -> anyhow::Result<()> {
+    let deploy_block_number = Counter::deploy_builder(tester.l2_provider.clone())
+        .send()
+        .await?
+        .expect_successful_receipt()
+        .await?
+        .block_number
+        .expect("no block for successful receipt");
+
+    // Resolves only once the batch containing the deploy block is finalized on L1.
+    let batch_number = tester
+        .l2_zk_provider
+        .wait_batch_number_by_block_number(deploy_block_number)
+        .await?;
+
+    let latest_batch_number = tester.l2_zk_provider.get_latest_batch_number().await?;
+    assert!(
+        latest_batch_number >= batch_number,
+        "latest batch {latest_batch_number} is behind finalized batch {batch_number}"
+    );
+
+    let batch: Option<PersistedBatch> = tester
+        .l2_zk_provider
+        .client()
+        .request("zks_getBatchByNumber", (batch_number,))
+        .await?;
+    let batch = batch.expect("batch should be available by its number");
+    assert_eq!(batch.number(), batch_number);
+    assert!(
+        batch.block_range.contains(&deploy_block_number),
+        "batch {batch_number} block range {:?} does not contain deploy block {deploy_block_number}",
+        batch.block_range
+    );
+
+    let missing: Option<PersistedBatch> = tester
+        .l2_zk_provider
+        .client()
+        .request("zks_getBatchByNumber", (latest_batch_number + 1_000_000,))
+        .await?;
+    assert!(missing.is_none(), "out-of-range batch should not exist");
+
+    Ok(())
+}

--- a/integration-tests/tests/rpc/batches.rs
+++ b/integration-tests/tests/rpc/batches.rs
@@ -21,7 +21,7 @@ async fn enumerate_batches(tester: Tester) -> anyhow::Result<()> {
         .wait_batch_number_by_block_number(deploy_block_number)
         .await?;
 
-    let latest_batch_number = tester.l2_zk_provider.get_latest_batch_number().await?;
+    let latest_batch_number = tester.l2_zk_provider.get_batch_number().await?;
     assert!(
         latest_batch_number >= batch_number,
         "latest batch {latest_batch_number} is behind finalized batch {batch_number}"

--- a/integration-tests/tests/rpc/mod.rs
+++ b/integration-tests/tests/rpc/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod batches;
 mod call;
 mod debug;
 mod deployment_filter;

--- a/lib/alloy_ext/src/provider.rs
+++ b/lib/alloy_ext/src/provider.rs
@@ -46,6 +46,10 @@ pub trait ZksyncApi: Provider<Zksync> {
             .await
     }
 
+    async fn get_latest_batch_number(&self) -> TransportResult<u64> {
+        self.client().request("zks_getLatestBatchNumber", ()).await
+    }
+
     async fn get_batch_number_by_block_number(
         &self,
         block_number: BlockNumber,

--- a/lib/alloy_ext/src/provider.rs
+++ b/lib/alloy_ext/src/provider.rs
@@ -46,25 +46,26 @@ pub trait ZksyncApi: Provider<Zksync> {
             .await
     }
 
-    async fn get_latest_batch_number(&self) -> TransportResult<u64> {
-        self.client().request("zks_getLatestBatchNumber", ()).await
+    async fn get_batch_number(&self) -> TransportResult<u64> {
+        self.client().request("zks_batchNumber", ()).await
     }
 
     async fn get_batch_number_by_block_number(
         &self,
         block_number: BlockNumber,
-    ) -> TransportResult<u64> {
+    ) -> TransportResult<Option<u64>> {
         #[derive(Debug, Deserialize)]
         struct CommittedBatchView {
             batch_info: StoredBatchInfo,
         }
 
-        let CommittedBatchView { batch_info } = self
+        let batch: Option<CommittedBatchView> = self
             .client()
-            .request("unstable_getBatchByBlockNumber", (block_number,))
+            .request("zks_getBatchByBlockNumber", (block_number,))
             .await?;
+        let batch_info = batch.map(|batch| batch.batch_info);
         tracing::debug!(block_number, ?batch_info, "got batch info for block");
-        Ok(batch_info.batch_number)
+        Ok(batch_info.map(|batch_info| batch_info.batch_number))
     }
 
     async fn wait_batch_number_by_block_number(
@@ -72,18 +73,14 @@ pub trait ZksyncApi: Provider<Zksync> {
         block_number: BlockNumber,
     ) -> TransportResult<u64> {
         loop {
-            match self.get_batch_number_by_block_number(block_number).await {
-                Ok(number) => return Ok(number),
-                Err(err)
-                    if err.as_error_resp().is_some_and(|err| {
-                        err.code == -32603 && err.message.contains("has not been finalized")
-                    }) =>
-                {
-                    tracing::info!(block_number, %err, "batch corresponding to block isn't finalized; waiting");
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                }
-                Err(err) => return Err(err),
+            if let Some(number) = self.get_batch_number_by_block_number(block_number).await? {
+                return Ok(number);
             }
+            tracing::info!(
+                block_number,
+                "batch corresponding to block isn't finalized; waiting"
+            );
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 }

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -24,7 +24,7 @@ use zksync_os_rpc_api::{
     },
     zks::ZksApiServer,
 };
-use zksync_os_storage_api::{RepositoryError, StateError, read_multichain_root};
+use zksync_os_storage_api::{PersistedBatch, RepositoryError, StateError, read_multichain_root};
 use zksync_os_types::{L2_TO_L1_TREE_SIZE, ProtocolSemanticVersion};
 
 pub struct ZksNamespace<RpcStorage> {
@@ -217,6 +217,16 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
 
     fn get_batch_by_number_impl(&self, batch_number: u64) -> ZksResult<Option<PersistedBatch>> {
         Ok(self.storage.batch().get_batch_by_number(batch_number)?)
+    }
+
+    fn get_batch_by_block_number_impl(
+        &self,
+        block_number: u64,
+    ) -> ZksResult<Option<PersistedBatch>> {
+        Ok(self
+            .storage
+            .batch()
+            .get_batch_by_block_number(block_number)?)
     }
 
     fn get_proof_impl(
@@ -420,7 +430,12 @@ impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
         self.get_batch_by_number_impl(batch_number).to_rpc_result()
     }
 
-    fn get_latest_batch_number(&self) -> RpcResult<u64> {
+    fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<Option<PersistedBatch>> {
+        self.get_batch_by_block_number_impl(block_number)
+            .to_rpc_result()
+    }
+
+    fn batch_number(&self) -> RpcResult<u64> {
         Ok(self.storage.batch().latest_batch())
     }
 

--- a/lib/rpc/src/zks_impl.rs
+++ b/lib/rpc/src/zks_impl.rs
@@ -215,6 +215,10 @@ impl<RpcStorage: ReadRpcStorage> ZksNamespace<RpcStorage> {
         }))
     }
 
+    fn get_batch_by_number_impl(&self, batch_number: u64) -> ZksResult<Option<PersistedBatch>> {
+        Ok(self.storage.batch().get_batch_by_number(batch_number)?)
+    }
+
     fn get_proof_impl(
         &self,
         address: Address,
@@ -410,6 +414,14 @@ impl<RpcStorage: ReadRpcStorage> ZksApiServer for ZksNamespace<RpcStorage> {
     fn get_block_metadata_by_number(&self, block_number: u64) -> RpcResult<Option<BlockMetadata>> {
         self.get_block_metadata_by_number_impl(block_number)
             .to_rpc_result()
+    }
+
+    fn get_batch_by_number(&self, batch_number: u64) -> RpcResult<Option<PersistedBatch>> {
+        self.get_batch_by_number_impl(batch_number).to_rpc_result()
+    }
+
+    fn get_latest_batch_number(&self) -> RpcResult<u64> {
+        Ok(self.storage.batch().latest_batch())
     }
 
     fn get_proof(

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -9,6 +9,7 @@ use alloy::rpc::types::Index;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use zksync_os_genesis::GenesisInput;
+use zksync_os_storage_api::PersistedBatch;
 
 #[cfg_attr(not(feature = "server"), rpc(client, namespace = "zks"))]
 #[cfg_attr(feature = "server", rpc(server, client, namespace = "zks"))]
@@ -63,6 +64,12 @@ pub trait ZksApi {
 
     #[method(name = "getBlockMetadataByNumber")]
     fn get_block_metadata_by_number(&self, block_number: u64) -> RpcResult<Option<BlockMetadata>>;
+
+    #[method(name = "getBatchByNumber")]
+    fn get_batch_by_number(&self, batch_number: u64) -> RpcResult<Option<PersistedBatch>>;
+
+    #[method(name = "getLatestBatchNumber")]
+    fn get_latest_batch_number(&self) -> RpcResult<u64>;
 
     #[method(name = "getProof", blocking)]
     fn get_proof(

--- a/lib/rpc_api/src/zks.rs
+++ b/lib/rpc_api/src/zks.rs
@@ -68,8 +68,12 @@ pub trait ZksApi {
     #[method(name = "getBatchByNumber")]
     fn get_batch_by_number(&self, batch_number: u64) -> RpcResult<Option<PersistedBatch>>;
 
-    #[method(name = "getLatestBatchNumber")]
-    fn get_latest_batch_number(&self) -> RpcResult<u64>;
+    /// Stable replacement for `unstable_getBatchByBlockNumber`, which stays supported for now.
+    #[method(name = "getBatchByBlockNumber")]
+    fn get_batch_by_block_number(&self, block_number: u64) -> RpcResult<Option<PersistedBatch>>;
+
+    #[method(name = "batchNumber")]
+    fn batch_number(&self) -> RpcResult<u64>;
 
     #[method(name = "getProof", blocking)]
     fn get_proof(


### PR DESCRIPTION
## Summary

Adds stable `zks_` RPC methods for enumerating batches:

- `zks_getBatchByNumber(batch_number) -> Option<PersistedBatch>`
- `zks_batchNumber() -> u64`
- `zks_getBatchByBlockNumber(block_number) -> Option<PersistedBatch>` — stable replacement for `unstable_getBatchByBlockNumber`, which keeps working for now

All three expose storage functions that already exist (`ReadBatch::get_batch_by_number`, `ReadBatch::latest_batch`, `ReadBatch::get_batch_by_block_number`) — no new indexing. This lets a consumer enumerate batches (latest number + fetch-by-number), unblocking re-adding a Batches page to the block explorer. Approved by protocol (Daniyar Itegulov).

`zks_batchNumber` mirrors `eth_blockNumber`. The batch getters reuse the existing `PersistedBatch` type (same one `unstable_getBatchByBlockNumber` returns) rather than introducing a new DTO, and return `Option` (`null` when absent) instead of erroring, so all three batch reads behave uniformly.

`ZksyncApi::wait_batch_number_by_block_number` now polls the stable `zks_getBatchByBlockNumber` and retries while it returns `null`, replacing the error-message string match against `unstable_`.

Includes an integration test (`rpc::batches::enumerate_batches`) covering: latest number covers a freshly finalized batch, fetch-by-number returns the expected batch, block-range membership, and out-of-range number → `None`.
