### PR TITLE
feat(l1_sender)!: pipelined sending with a bounded in-flight window

### DIFF
--- a/integration-tests/src/l1_helpers.rs
+++ b/integration-tests/src/l1_helpers.rs
@@ -1,7 +1,6 @@
 use crate::Tester;
 use crate::assert_traits::{DEFAULT_TIMEOUT, POLL_INTERVAL};
 use alloy::providers::Provider;
-use backon::{ConstantBuilder, Retryable};
 use zksync_os_alloy_ext::provider::ZksyncApi;
 use zksync_os_contract_interface::l1_discovery::L1State;
 
@@ -20,19 +19,24 @@ pub async fn wait_for_l1_state(
     description: &str,
     predicate: impl Fn(&L1State) -> bool,
 ) -> anyhow::Result<L1State> {
-    let max_times = DEFAULT_TIMEOUT.div_duration_f64(POLL_INTERVAL).floor() as usize;
-    (|| async {
-        let state = fetch_l1_state(tester).await?;
-        if predicate(&state) {
-            Ok(state)
-        } else {
-            anyhow::bail!("waiting for L1 state: {description}")
+    let deadline = std::time::Instant::now() + DEFAULT_TIMEOUT;
+    let mut last_err: Option<anyhow::Error> = None;
+    loop {
+        // The L1 state lives on anvil, so a dead node would otherwise burn the whole timeout
+        // and report an unhelpful "waiting for ..." error; fail fast with the real cause.
+        anyhow::ensure!(
+            !tester.has_crashed(),
+            "node crashed while waiting for L1 state: {description}",
+        );
+        match fetch_l1_state(tester).await {
+            Ok(state) if predicate(&state) => return Ok(state),
+            Ok(_) => {}
+            Err(err) => last_err = Some(err),
         }
-    })
-    .retry(
-        ConstantBuilder::default()
-            .with_delay(POLL_INTERVAL)
-            .with_max_times(max_times),
-    )
-    .await
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for L1 state: {description} (last fetch error: {last_err:?})",
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -142,6 +142,11 @@ impl TestEnvironment {
         })
     }
 
+    /// Anvil's direct RPC endpoint, e.g. to put a fault-injecting proxy in front of it.
+    pub fn l1_rpc_url(&self) -> &str {
+        &self.l1.address
+    }
+
     pub async fn default_config(&self) -> anyhow::Result<Config> {
         let mut config = build_node_config(&self.l1, self.chain_layout, false).await?;
         Tester::bind_runtime_config(
@@ -155,6 +160,34 @@ impl TestEnvironment {
     pub async fn launch_default(self) -> anyhow::Result<Tester> {
         let config = self.default_config().await?;
         self.launch(config).await
+    }
+
+    /// Launches the node with its L1 RPC routed through `l1_rpc_url` (e.g. a fault-injecting
+    /// proxy in front of anvil) instead of anvil's direct endpoint. Test-side helpers
+    /// (`Tester::l1_provider()` etc.) still talk to anvil directly.
+    pub async fn launch_with_l1_rpc(
+        self,
+        mut config: Config,
+        l1_rpc_url: String,
+    ) -> anyhow::Result<Tester> {
+        if !prover_input_generation_enabled() {
+            disable_prover_input_generation(&mut config);
+        }
+        Tester::bind_runtime_config(
+            &self.l1,
+            self.prepared_runtime.tempdir.as_ref(),
+            &mut config,
+        );
+        config.l1_provider_config.rpc_url = l1_rpc_url;
+        Tester::launch_node_inner(
+            self.l1,
+            config,
+            self.prepared_runtime.tempdir,
+            self.chain_layout,
+            None,
+            true,
+        )
+        .await
     }
 
     pub async fn launch(self, mut config: Config) -> anyhow::Result<Tester> {

--- a/integration-tests/src/test_config.rs
+++ b/integration-tests/src/test_config.rs
@@ -41,6 +41,9 @@ pub(crate) async fn build_node_config(
     let mut config = load_chain_config(chain_layout).await;
     config.l1_provider_config =
         ProviderConfig::new(l1.address.clone(), TEST_PROVIDER_POLL_INTERVAL);
+    // The L1 senders poll receipts on their own cadence (1s default) — keep tests fast
+    // against anvil's 0.25s blocks.
+    config.l1_sender_config.poll_interval = TEST_PROVIDER_POLL_INTERVAL;
     config.sequencer_config.fee_collector_address = Address::random();
     config.rpc_config.send_raw_transaction_sync_timeout = Duration::from_secs(10);
     config.prover_api_config.fake_fri_provers.enabled = !with_proofs;

--- a/integration-tests/tests/node/l1_sender.rs
+++ b/integration-tests/tests/node/l1_sender.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, POLL_INTERVAL, ReceiptAssert};
 use zksync_os_integration_tests::l1_helpers::{fetch_l1_state, wait_for_l1_state};
+use zksync_os_integration_tests::provider::ZksyncTestingProvider;
 use zksync_os_integration_tests::test_config::make_full_pipeline_config;
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
 use zksync_os_provider::{EthWalletProvider, NodeProvider};
@@ -716,6 +717,7 @@ async fn missing_sender_nonce_rpc_stalls_sender_until_in_flight_txs_settle(
     .await?;
 
     let committed_before_restart = fetch_l1_state(&tester).await?.last_committed_batch;
+    let l2_tip_before_restart = tester.l2_provider.get_block_number().await?;
     let stopped = tester.stop().await?;
     // Every operator account must be settled before mining stops: a leftover pooled
     // commit/prove/execute tx would keep startup L1-state discovery from completing.
@@ -750,6 +752,12 @@ async fn missing_sender_nonce_rpc_stalls_sender_until_in_flight_txs_settle(
     );
 
     let restarted = stopped.start().await?;
+    // The restarted RPC comes up while WAL replay is still running; new txs are validated
+    // against the mid-replay state (test wallet not yet funded), so wait out the replay.
+    restarted
+        .l2_zk_provider
+        .wait_for_block(l2_tip_before_restart)
+        .await?;
 
     // New L2 traffic seals new batches (2s batch timeout), so commit commands are queued
     // while the sender is still waiting out the unsettled account.

--- a/integration-tests/tests/node/l1_sender.rs
+++ b/integration-tests/tests/node/l1_sender.rs
@@ -1,0 +1,557 @@
+//! L1 sender behavior under load and adverse L1 conditions: pipelined-vs-stop-and-wait
+//! throughput, base/priority fee spikes, inclusion stalls, restarts mid-window,
+//! forced resubmission and L1 connection loss.
+
+use alloy::consensus::Transaction as ConsensusTransaction;
+use alloy::network::TransactionBuilder;
+use alloy::primitives::{Address, U256};
+use alloy::providers::Provider;
+use alloy::providers::ext::AnvilApi;
+use alloy::rpc::types::TransactionRequest;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, POLL_INTERVAL, ReceiptAssert};
+use zksync_os_integration_tests::l1_helpers::{fetch_l1_state, wait_for_l1_state};
+use zksync_os_integration_tests::test_config::make_full_pipeline_config;
+use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
+use zksync_os_provider::NodeProvider;
+use zksync_os_server::config::Config;
+
+/// Seals a batch roughly every two L2 transactions (and every 2s by timeout), so a burst of
+/// transactions turns into a stream of batches — i.e. of L1 commit transactions.
+fn fast_batches_config(config: &mut Config) {
+    make_full_pipeline_config(config);
+    config.prover_api_config.fake_fri_provers.compute_time = Duration::ZERO;
+    // Both prover stages are faked, so prover inputs may be faked too (independent of the
+    // NEXTEST_PROFILE the suite happens to run under).
+    config.prover_input_generator_config.enable_input_generation = false;
+    config.sequencer_config.block_time = Duration::from_millis(50);
+    config.batcher_config.tx_per_batch_limit = 1;
+    config.batcher_config.batch_timeout = Duration::from_secs(2);
+}
+
+async fn send_l2_txs(tester: &Tester, count: usize) -> anyhow::Result<()> {
+    for _ in 0..count {
+        tester
+            .l2_provider
+            .send_transaction(
+                TransactionRequest::default()
+                    .with_to(Address::random())
+                    .with_value(U256::from(1u64)),
+            )
+            .await?
+            .expect_successful_receipt()
+            .await?;
+    }
+    Ok(())
+}
+
+async fn commit_operator_address(config: &Config) -> anyhow::Result<Address> {
+    config
+        .l1_sender_config
+        .operator_commit_sk
+        .as_ref()
+        .expect("test config carries a commit operator key")
+        .address()
+        .await
+}
+
+/// (latest, pending) nonces of `address`; `pending - latest` = txs in the anvil mempool.
+async fn operator_nonces(l1: &NodeProvider, address: Address) -> anyhow::Result<(u64, u64)> {
+    let latest = l1.get_transaction_count(address).await?;
+    let pending = l1.get_transaction_count(address).pending().await?;
+    Ok((latest, pending))
+}
+
+/// Fully stops anvil block production (both tx-triggered and interval mining).
+async fn stop_l1_mining(l1: &NodeProvider) -> anyhow::Result<()> {
+    l1.anvil_set_auto_mine(false).await?;
+    l1.anvil_set_interval_mining(0).await?;
+    Ok(())
+}
+
+/// Resumes anvil block production and immediately mines a burst so pooled transactions land
+/// and confirmation depths advance.
+async fn resume_l1_mining(l1: &NodeProvider) -> anyhow::Result<()> {
+    l1.anvil_set_auto_mine(true).await?;
+    l1.anvil_set_interval_mining(1).await?;
+    l1.anvil_mine(Some(50), None).await?;
+    Ok(())
+}
+
+/// Waits until the commit operator has exactly `expected` transactions pooled on L1.
+async fn wait_for_pooled_commits(
+    l1: &NodeProvider,
+    operator: Address,
+    expected: u64,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + DEFAULT_TIMEOUT;
+    loop {
+        let (latest, pending) = operator_nonces(l1, operator).await?;
+        if pending - latest == expected {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected} pooled commit txs; have {}",
+            pending - latest,
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// The core throughput claim: with everything else equal, the pipelined sender drains a batch
+/// backlog to L1 several times faster than the stop-and-wait sender, because it never spends
+/// the inclusion + `required_confirmations` wait doing nothing.
+///
+/// Construction: the backlog is built while L1 mining is stopped, then the measurement covers
+/// only the drain after mining resumes at ~1s blocks. `required_confirmations = 24` makes the
+/// per-cycle dead time the stop-and-wait design pays (~24s per cycle at 1s blocks) dominate,
+/// mimicking the mainnet ratio of confirmation-wait to batch demand; the pipelined sender only
+/// pays that wait once, off the submission path.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn pipelined_commit_sender_outpaces_stop_and_wait(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    const TXS: usize = 60;
+    const TARGET_NEW_BATCHES: u64 = 24;
+    const CONFIRMATIONS: u64 = 24;
+
+    async fn run_variant(env: TestEnvironment, pipelined: bool) -> anyhow::Result<Duration> {
+        let mut config = env.default_config().await?;
+        fast_batches_config(&mut config);
+        config.l1_sender_config.required_confirmations = CONFIRMATIONS;
+        config.l1_sender_config.pipelining_enabled = pipelined;
+        let tester = env.launch(config).await?;
+        let l1 = tester.l1_provider().clone();
+
+        let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+
+        // Build the backlog with L1 inclusion stalled, so the measurement below captures
+        // sender throughput rather than L2 batch production.
+        stop_l1_mining(&l1).await?;
+        send_l2_txs(&tester, TXS).await?;
+        tokio::time::sleep(Duration::from_secs(8)).await;
+
+        let started = Instant::now();
+        // Resume without a catch-up burst: confirmations must accrue at the real block
+        // cadence for the comparison to be meaningful.
+        l1.anvil_set_auto_mine(true).await?;
+        l1.anvil_set_interval_mining(1).await?;
+        let target = initial + TARGET_NEW_BATCHES;
+        wait_for_l1_state(&tester, "backlog drained to L1", |state| {
+            state.last_committed_batch >= target
+        })
+        .await?;
+        let elapsed = started.elapsed();
+        anyhow::ensure!(!tester.has_crashed(), "node crashed during the benchmark");
+        tester.shutdown().await?;
+        Ok(elapsed)
+    }
+
+    let legacy_env = CURRENT_TO_L1.environment().await?;
+    let pipelined_elapsed = run_variant(env, true).await?;
+    let legacy_elapsed = run_variant(legacy_env, false).await?;
+
+    let speedup = legacy_elapsed.as_secs_f64() / pipelined_elapsed.as_secs_f64();
+    println!(
+        "L1 commit throughput ({TARGET_NEW_BATCHES}-batch backlog drained): \
+         pipelined {pipelined_elapsed:.2?} vs stop-and-wait {legacy_elapsed:.2?} \
+         => {speedup:.2}x speedup"
+    );
+    assert!(
+        speedup >= 2.5,
+        "expected the pipelined sender to be at least 2.5x faster \
+         (pipelined {pipelined_elapsed:?}, stop-and-wait {legacy_elapsed:?}, {speedup:.2}x)",
+    );
+    Ok(())
+}
+
+/// A base-fee spike above the operator's configured `max_fee_per_gas` cap must stall the
+/// sender (retry-and-wait), not crash the node; once the fee market decays back under the
+/// cap, commits resume on their own.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn base_fee_spike_stalls_sender_without_crashing(env: TestEnvironment) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    let tester = env.launch(config).await?;
+    let l1 = tester.l1_provider().clone();
+
+    // Baseline: commits flow.
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 6).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch >= initial + 2
+    })
+    .await?;
+
+    // Spike the base fee to 5000 gwei — far above the 200 gwei default cap. Anvil rejects
+    // under-priced submissions outright, so the sender must enter its fee-wait loop.
+    // Empty blocks decay the base fee by 12.5% each, so at 0.25s blocks the market comes
+    // back under the cap in roughly 25 blocks (~7s).
+    l1.anvil_set_next_block_base_fee_per_gas(5_000_000_000_000u128)
+        .await?;
+    let spiked = fetch_l1_state(&tester).await?.last_committed_batch;
+
+    // The node keeps accepting L2 traffic and stays alive through the spike.
+    send_l2_txs(&tester, 10).await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !tester.has_crashed(),
+        "node crashed during a base-fee spike; the sender should stall and retry instead",
+    );
+
+    // After the decay, everything produced during the spike settles.
+    wait_for_l1_state(&tester, "commits resumed after the spike", |state| {
+        state.last_committed_batch >= spiked + 6
+    })
+    .await?;
+    assert!(!tester.has_crashed());
+    Ok(())
+}
+
+/// When L1 stops including transactions entirely (mining halt — the extreme version of blob
+/// space exhaustion), the sender must fill its in-flight window up to exactly
+/// `command_limit` pooled transactions, never exceed it (the L1 per-account pool cap), stay
+/// alive, and drain everything once inclusion resumes.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn inclusion_stall_bounds_in_flight_window_and_recovers(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    const WINDOW: u64 = 8;
+
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    config.l1_sender_config.command_limit = WINDOW as usize;
+    let tester = env.launch(config).await?;
+    let l1 = tester.l1_provider().clone();
+    let operator = commit_operator_address(tester.config()).await?;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 4).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch > initial
+    })
+    .await?;
+
+    stop_l1_mining(&l1).await?;
+    send_l2_txs(&tester, 30).await?;
+
+    // The window must fill to the cap...
+    wait_for_pooled_commits(&l1, operator, WINDOW).await?;
+    // ...and never exceed it while inclusion is stalled.
+    for _ in 0..15 {
+        let (latest, pending) = operator_nonces(&l1, operator).await?;
+        assert!(
+            pending - latest <= WINDOW,
+            "in-flight window exceeded the per-account cap: {} > {WINDOW}",
+            pending - latest,
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        !tester.has_crashed(),
+        "node crashed during an L1 inclusion stall"
+    );
+
+    resume_l1_mining(&l1).await?;
+    wait_for_l1_state(&tester, "stalled batches drained", |state| {
+        state.last_committed_batch >= initial + 12
+    })
+    .await?;
+    assert!(!tester.has_crashed());
+    Ok(())
+}
+
+/// Crash-with-full-window is the common failure mode of a pipelined sender. The node is
+/// stopped while `command_limit` commit transactions sit unmined in the L1 mempool; mining
+/// resumes while the node is starting back up, so the in-flight commits land mid-startup —
+/// exactly the window in which a commit event must not trip the `UnexpectedCommit` guard —
+/// and every batch must settle exactly once (a duplicate commit would revert on L1 and crash
+/// the node).
+///
+/// (Startup L1-state discovery deliberately waits for pool-driven contract-state changes to
+/// land, so mining must resume for the node to boot at all — anvil cannot hold a
+/// "pooled txs + progressing chain" state that would exercise in-pool pairing.)
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn restart_mid_window_settles_in_flight_batches_exactly_once(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    const WINDOW: u64 = 8;
+
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    config.l1_sender_config.command_limit = WINDOW as usize;
+    let tester = env.launch(config).await?;
+    let l1 = tester.l1_provider().clone();
+    let operator = commit_operator_address(tester.config()).await?;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 4).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch > initial
+    })
+    .await?;
+
+    // Fill the in-flight window with pooled (unmined) commit txs, then stop the node while
+    // they are still pending.
+    stop_l1_mining(&l1).await?;
+    send_l2_txs(&tester, 24).await?;
+    wait_for_pooled_commits(&l1, operator, WINDOW).await?;
+    let stopped = tester.stop().await?;
+
+    // Resume mining while the node is starting: the pooled commits mine mid-startup, after
+    // the commit watcher is armed but before the sender's recovery runs.
+    let resume_l1 = l1.clone();
+    let resume = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        resume_l1_mining(&resume_l1).await
+    });
+    let restarted = stopped.start().await?;
+    resume
+        .await
+        .expect("resume task panicked")
+        .expect("failed to resume L1 mining");
+
+    wait_for_l1_state(&restarted, "in-flight batches settled", |state| {
+        state.last_committed_batch >= initial + 10
+    })
+    .await?;
+    // Still alive: no duplicate commit reverted on L1 and the UnexpectedCommit guard did not
+    // fire for transactions the previous session left in flight.
+    assert!(!restarted.has_crashed());
+    let (latest, pending) = operator_nonces(&l1, operator).await?;
+    assert!(
+        pending - latest <= WINDOW,
+        "in-flight window exceeded after restart: {} > {WINDOW}",
+        pending - latest,
+    );
+    Ok(())
+}
+
+/// The operator escape hatch for transactions dropped from the L1 mempool: a base-fee spike
+/// evicts the pooled (cap-priced) commit txs from anvil's pool; a restart with
+/// `force_transaction_resubmission` must resubmit the queued commands from the confirmed
+/// nonce with replacement fees and settle every batch exactly once.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn force_resubmission_resends_dropped_transactions(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    const WINDOW: u64 = 8;
+
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    config.l1_sender_config.command_limit = WINDOW as usize;
+    let tester = env.launch(config).await?;
+    let l1 = tester.l1_provider().clone();
+    let operator = commit_operator_address(tester.config()).await?;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 4).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch > initial
+    })
+    .await?;
+
+    stop_l1_mining(&l1).await?;
+    send_l2_txs(&tester, 24).await?;
+    wait_for_pooled_commits(&l1, operator, WINDOW).await?;
+    let (latest_before, _) = operator_nonces(&l1, operator).await?;
+    let stopped = tester.stop().await?;
+
+    // A base-fee spike above the txs' 200 gwei cap makes anvil evict them from the pool once
+    // mining resumes ("dropped from the mempool"). 2000 gwei decays below the 400 gwei
+    // replacement cap in ~12 blocks.
+    l1.anvil_set_next_block_base_fee_per_gas(2_000_000_000_000u128)
+        .await?;
+    l1.anvil_set_auto_mine(true).await?;
+    l1.anvil_set_interval_mining(1).await?;
+    let deadline = Instant::now() + DEFAULT_TIMEOUT;
+    loop {
+        let (latest, pending) = operator_nonces(&l1, operator).await?;
+        if pending == latest {
+            assert_eq!(
+                latest, latest_before,
+                "cap-priced txs should be evicted, not mined, under the spiked base fee",
+            );
+            break;
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for the pool to evict under-priced commit txs"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    let mut config = stopped.config().clone();
+    config
+        .l1_sender_config
+        .force_transaction_resubmission
+        .enabled = true;
+    let restarted = stopped.start_with_config(config).await?;
+
+    wait_for_l1_state(
+        &restarted,
+        "dropped batches resubmitted and settled",
+        |state| state.last_committed_batch >= initial + 10,
+    )
+    .await?;
+    assert!(!restarted.has_crashed());
+    Ok(())
+}
+
+/// A priority-fee spike on L1 (other actors bidding high tips) must never push the sender's
+/// bids above its configured priority-fee cap, and commits keep flowing.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn priority_fee_spike_is_capped_and_commits_continue(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    let tester = env.launch(config).await?;
+    let l1 = tester.l1_provider().clone();
+    let operator = commit_operator_address(tester.config()).await?;
+    let priority_fee_cap = tester.config().l1_sender_config.max_priority_fee_per_gas.0;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+
+    // Skew the fee-history percentiles with high-tip L1 transactions while the sender works.
+    for _ in 0..20 {
+        l1.send_transaction(
+            TransactionRequest::default()
+                .with_to(Address::random())
+                .with_value(U256::from(1u64))
+                .with_max_fee_per_gas(300_000_000_000u128)
+                .with_max_priority_fee_per_gas(100_000_000_000u128),
+        )
+        .await?
+        .get_receipt()
+        .await?;
+    }
+    send_l2_txs(&tester, 10).await?;
+    wait_for_l1_state(&tester, "commits during tip spike", |state| {
+        state.last_committed_batch >= initial + 4
+    })
+    .await?;
+
+    // The last mined commit tx must have honored the configured cap despite the spiked
+    // fee-history estimate.
+    let (latest, _) = operator_nonces(&l1, operator).await?;
+    anyhow::ensure!(latest > 0, "no commit txs mined");
+    let last_commit_tx = l1
+        .get_transaction_by_sender_nonce(operator, latest - 1)
+        .await?
+        .expect("mined commit tx must be retrievable");
+    let tip = ConsensusTransaction::max_priority_fee_per_gas(&last_commit_tx).unwrap_or_default();
+    assert!(
+        tip <= priority_fee_cap,
+        "commit tx bid a priority fee above the configured cap: {tip} > {priority_fee_cap}",
+    );
+    assert!(!tester.has_crashed());
+    Ok(())
+}
+
+/// A TCP proxy in front of anvil that can be "unplugged": while paused it kills active
+/// connections and refuses new ones, producing the same transport errors as a flaky L1 RPC.
+struct FlakyL1Proxy {
+    url: String,
+    paused: Arc<AtomicBool>,
+    epoch_tx: Arc<tokio::sync::watch::Sender<u64>>,
+}
+
+impl FlakyL1Proxy {
+    async fn start(target_url: &str) -> anyhow::Result<Self> {
+        let target = target_url
+            .strip_prefix("http://")
+            .unwrap_or(target_url)
+            .trim_end_matches('/')
+            .to_string();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let url = format!("http://{}", listener.local_addr()?);
+        let paused = Arc::new(AtomicBool::new(false));
+        let (epoch_tx, _) = tokio::sync::watch::channel(0u64);
+        let epoch_tx = Arc::new(epoch_tx);
+
+        let accept_paused = Arc::clone(&paused);
+        let accept_epoch = Arc::clone(&epoch_tx);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut inbound, _)) = listener.accept().await else {
+                    return;
+                };
+                if accept_paused.load(Ordering::SeqCst) {
+                    // Refuse service while "unplugged".
+                    continue;
+                }
+                let target = target.clone();
+                let mut epoch_rx = accept_epoch.subscribe();
+                tokio::spawn(async move {
+                    let Ok(mut outbound) = tokio::net::TcpStream::connect(&target).await else {
+                        return;
+                    };
+                    tokio::select! {
+                        _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound) => {}
+                        // A pause bump severs live connections mid-flight.
+                        _ = epoch_rx.changed() => {}
+                    }
+                });
+            }
+        });
+
+        Ok(Self {
+            url,
+            paused,
+            epoch_tx,
+        })
+    }
+
+    fn pause(&self) {
+        self.paused.store(true, Ordering::SeqCst);
+        self.epoch_tx.send_modify(|epoch| *epoch += 1);
+    }
+
+    fn resume(&self) {
+        self.paused.store(false, Ordering::SeqCst);
+    }
+}
+
+/// A short L1 connection outage (dropped and refused connections) must be absorbed by the
+/// provider's transport retries: no crash, and settlement resumes once connectivity is back.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn l1_connection_blip_is_absorbed(env: TestEnvironment) -> anyhow::Result<()> {
+    let proxy = FlakyL1Proxy::start(env.l1_rpc_url()).await?;
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    let tester = env.launch_with_l1_rpc(config, proxy.url.clone()).await?;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 6).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch >= initial + 2
+    })
+    .await?;
+
+    // 2s outage: within the transport retry budget (5 retries, 1s backoff).
+    proxy.pause();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    proxy.resume();
+
+    send_l2_txs(&tester, 6).await?;
+    wait_for_l1_state(&tester, "commits after the connection blip", |state| {
+        state.last_committed_batch >= initial + 5
+    })
+    .await?;
+    assert!(
+        !tester.has_crashed(),
+        "node crashed on a short L1 connection blip that transport retries should absorb",
+    );
+    Ok(())
+}

--- a/integration-tests/tests/node/l1_sender.rs
+++ b/integration-tests/tests/node/l1_sender.rs
@@ -1,6 +1,7 @@
 //! L1 sender behavior under load and adverse L1 conditions: pipelined-vs-stop-and-wait
 //! throughput, base/priority fee spikes, inclusion stalls, restarts mid-window,
-//! forced resubmission and L1 connection loss.
+//! forced resubmission, L1 connection loss and an L1 RPC lacking
+//! `eth_getTransactionBySenderAndNonce`.
 
 use alloy::consensus::Transaction as ConsensusTransaction;
 use alloy::network::TransactionBuilder;
@@ -8,14 +9,16 @@ use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
 use alloy::providers::ext::AnvilApi;
 use alloy::rpc::types::TransactionRequest;
+use serde_json::{Value, json};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use zksync_os_integration_tests::assert_traits::{DEFAULT_TIMEOUT, POLL_INTERVAL, ReceiptAssert};
 use zksync_os_integration_tests::l1_helpers::{fetch_l1_state, wait_for_l1_state};
 use zksync_os_integration_tests::test_config::make_full_pipeline_config;
 use zksync_os_integration_tests::{CURRENT_TO_L1, TestEnvironment, Tester, test_multisetup};
-use zksync_os_provider::NodeProvider;
+use zksync_os_provider::{EthWalletProvider, NodeProvider};
 use zksync_os_server::config::Config;
 
 /// Seals a batch roughly every two L2 transactions (and every 2s by timeout), so a burst of
@@ -99,6 +102,32 @@ async fn wait_for_pooled_commits(
         );
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+/// Waits until no configured operator account has transactions pooled on L1.
+async fn wait_for_operators_to_settle(l1: &NodeProvider, config: &Config) -> anyhow::Result<()> {
+    let operator_keys = [
+        &config.l1_sender_config.operator_commit_sk,
+        &config.l1_sender_config.operator_prove_sk,
+        &config.l1_sender_config.operator_execute_sk,
+    ];
+    let deadline = Instant::now() + DEFAULT_TIMEOUT;
+    for key in operator_keys.into_iter().flatten() {
+        let address = key.address().await?;
+        loop {
+            let (latest, pending) = operator_nonces(l1, address).await?;
+            if pending == latest {
+                break;
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "timed out waiting for operator {address} to settle; {} txs still pooled",
+                pending - latest,
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+    Ok(())
 }
 
 /// The core throughput claim: with everything else equal, the pipelined sender drains a batch
@@ -553,5 +582,200 @@ async fn l1_connection_blip_is_absorbed(env: TestEnvironment) -> anyhow::Result<
         !tester.has_crashed(),
         "node crashed on a short L1 connection blip that transport retries should absorb",
     );
+    Ok(())
+}
+
+/// A JSON-RPC proxy in front of anvil that rejects a single method with the JSON-RPC
+/// "method not found" error (-32601) and transparently forwards everything else — emulating an
+/// L1 provider that does not implement the method (e.g. the geth family, which lacks
+/// `eth_getTransactionBySenderAndNonce`).
+struct MethodNotFoundL1Proxy {
+    url: String,
+}
+
+impl MethodNotFoundL1Proxy {
+    async fn start(target_url: &str, missing_method: &'static str) -> anyhow::Result<Self> {
+        let target = target_url.to_string();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let url = format!("http://{}", listener.local_addr()?);
+        tokio::spawn(async move {
+            let client = reqwest::Client::new();
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let client = client.clone();
+                let target = target.clone();
+                tokio::spawn(async move {
+                    let _ = Self::serve_connection(stream, client, target, missing_method).await;
+                });
+            }
+        });
+        Ok(Self { url })
+    }
+
+    async fn serve_connection(
+        stream: tokio::net::TcpStream,
+        client: reqwest::Client,
+        target: String,
+        missing_method: &str,
+    ) -> anyhow::Result<()> {
+        let (read_half, mut write_half) = stream.into_split();
+        let mut reader = tokio::io::BufReader::new(read_half);
+        loop {
+            // Minimal HTTP/1.1 handling suffices: alloy's HTTP transport always POSTs a
+            // single JSON-RPC object with an explicit Content-Length.
+            let mut request_line = String::new();
+            if reader.read_line(&mut request_line).await? == 0 {
+                return Ok(()); // connection closed between keep-alive requests
+            }
+            let mut content_length = 0usize;
+            loop {
+                let mut header = String::new();
+                anyhow::ensure!(
+                    reader.read_line(&mut header).await? > 0,
+                    "truncated request"
+                );
+                let header = header.trim();
+                if header.is_empty() {
+                    break;
+                }
+                if let Some((name, value)) = header.split_once(':')
+                    && name.eq_ignore_ascii_case("content-length")
+                {
+                    content_length = value.trim().parse()?;
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            reader.read_exact(&mut body).await?;
+
+            let request: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+            let (status, response_body) =
+                if request.get("method").and_then(Value::as_str) == Some(missing_method) {
+                    let error = json!({
+                        "jsonrpc": "2.0",
+                        "id": request.get("id").cloned().unwrap_or(Value::Null),
+                        "error": {
+                            "code": -32601,
+                            "message": format!(
+                                "the method {missing_method} does not exist/is not available"
+                            ),
+                        },
+                    });
+                    (reqwest::StatusCode::OK, serde_json::to_vec(&error)?)
+                } else {
+                    let response = client
+                        .post(&target)
+                        .header("content-type", "application/json")
+                        .body(body)
+                        .send()
+                        .await?;
+                    (response.status(), response.bytes().await?.to_vec())
+                };
+            let head = format!(
+                "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("OK"),
+                response_body.len(),
+            );
+            write_half.write_all(head.as_bytes()).await?;
+            write_half.write_all(&response_body).await?;
+        }
+    }
+}
+
+/// An L1 RPC without `eth_getTransactionBySenderAndNonce` (geth family) cannot pair a previous
+/// session's in-flight transactions with queued commands. Restarted with an unsettled operator
+/// account, the pipelined sender must fall back to waiting for the account to settle —
+/// submitting nothing in the meantime — and resume sending once the leftover transaction mines.
+///
+/// The leftover in-flight transaction is a plain transfer from the commit operator rather than
+/// a real commit: startup L1-state discovery waits for pool-driven *contract-state* changes to
+/// land before the node boots (see `restart_mid_window_settles_in_flight_batches_exactly_once`),
+/// so a pooled commit cannot survive into the sender's recovery under anvil, while a transfer —
+/// which leaves contract state untouched — can.
+#[test_multisetup([CURRENT_TO_L1])]
+#[test_runtime(flavor = "multi_thread")]
+async fn missing_sender_nonce_rpc_stalls_sender_until_in_flight_txs_settle(
+    env: TestEnvironment,
+) -> anyhow::Result<()> {
+    let proxy =
+        MethodNotFoundL1Proxy::start(env.l1_rpc_url(), "eth_getTransactionBySenderAndNonce")
+            .await?;
+    let mut config = env.default_config().await?;
+    fast_batches_config(&mut config);
+    let tester = env.launch_with_l1_rpc(config, proxy.url.clone()).await?;
+    let l1 = tester.l1_provider().clone();
+    let operator = commit_operator_address(tester.config()).await?;
+
+    let initial = fetch_l1_state(&tester).await?.last_committed_batch;
+    send_l2_txs(&tester, 4).await?;
+    wait_for_l1_state(&tester, "baseline commits", |state| {
+        state.last_committed_batch > initial
+    })
+    .await?;
+
+    let committed_before_restart = fetch_l1_state(&tester).await?.last_committed_batch;
+    let stopped = tester.stop().await?;
+    // Every operator account must be settled before mining stops: a leftover pooled
+    // commit/prove/execute tx would keep startup L1-state discovery from completing.
+    wait_for_operators_to_settle(&l1, stopped.config()).await?;
+    stop_l1_mining(&l1).await?;
+
+    // Leave a pooled transfer from the commit operator: the restarted sender sees
+    // pending > latest but cannot inspect the transaction through the filtered RPC.
+    let mut operator_l1 = l1.clone();
+    stopped
+        .config()
+        .l1_sender_config
+        .operator_commit_sk
+        .as_ref()
+        .expect("test config carries a commit operator key")
+        .register_with_wallet(operator_l1.wallet_mut())
+        .await?;
+    // Deliberately not awaiting a receipt — mining is stopped, so there is none.
+    let _pooled_transfer = operator_l1
+        .send_transaction(
+            TransactionRequest::default()
+                .with_from(operator)
+                .with_to(Address::random())
+                .with_value(U256::from(1u64)),
+        )
+        .await?;
+    let (latest_nonce, pending_nonce) = operator_nonces(&l1, operator).await?;
+    assert_eq!(
+        pending_nonce,
+        latest_nonce + 1,
+        "the transfer must be pooled"
+    );
+
+    let restarted = stopped.start().await?;
+
+    // New L2 traffic seals new batches (2s batch timeout), so commit commands are queued
+    // while the sender is still waiting out the unsettled account.
+    send_l2_txs(&restarted, 4).await?;
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    for _ in 0..10 {
+        let nonces = operator_nonces(&l1, operator).await?;
+        assert_eq!(
+            nonces,
+            (latest_nonce, pending_nonce),
+            "the sender must not submit anything while the account has an unpairable \
+             in-flight transaction",
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(
+        !restarted.has_crashed(),
+        "node crashed while waiting for the operator account to settle",
+    );
+
+    // Once the stray transfer mines, the sender settles and drains the queued commits.
+    resume_l1_mining(&l1).await?;
+    wait_for_l1_state(&restarted, "commits resumed after settling", |state| {
+        state.last_committed_batch >= committed_before_restart + 2
+    })
+    .await?;
+    assert!(!restarted.has_crashed());
     Ok(())
 }

--- a/integration-tests/tests/node/mod.rs
+++ b/integration-tests/tests/node/mod.rs
@@ -1,5 +1,6 @@
 mod batcher;
 mod external_node;
+mod l1_sender;
 mod mempool;
 mod rebuild;
 mod replay_archive;

--- a/integration-tests/tests/node/rebuild.rs
+++ b/integration-tests/tests/node/rebuild.rs
@@ -497,13 +497,15 @@ async fn rebuild_after_l1_revert_starts_successfully(env: TestEnvironment) -> an
     // Confirm the node is alive and accepting new L2 transactions after rebuild.
     send_throwaway_tx(&restarted).await?;
 
-    // Verify the server commits a new batch on L1 with the same number as the reverted one.
-    // After the revert, last_committed_batch on L1 is 0; reaching committed_state.last_committed_batch
-    // again proves the node rebuilt and committed a distinct batch with the same number.
+    // Verify the server commits a new batch on L1 with the same number as a reverted one.
+    // After the revert, last_committed_batch on L1 is 0, so any nonzero value proves a
+    // distinct batch 1 was committed. The pre-revert batch COUNT is not a valid target: the
+    // rebuild re-batches the replayed blocks with fresh deadline timing, so the same blocks
+    // can legitimately pack into fewer batches than the original run committed.
     wait_for_l1_state(
         &restarted,
         "server commits a new batch on L1 after rebuild",
-        |state| state.last_committed_batch >= committed_state.last_committed_batch,
+        |state| state.last_committed_batch >= 1,
     )
     .await?;
 

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -286,10 +286,13 @@ async fn wait_to_finalize<T: Debug + PartialEq, Fut: Future<Output = crate::Resu
     f: impl Fn(BlockId) -> Fut,
 ) -> anyhow::Result<(u64, T)> {
     /// Ethereum blocks are mined every ~12 seconds on average, but we wait in 1-second intervals
-    /// optimistically to save time on startup.
+    /// optimistically to save time on startup. The budget must cover several block intervals:
+    /// the L1 sender routinely leaves in-flight transactions in the mempool on shutdown, so a
+    /// restart legitimately waits for them to mine (≥1 block each on mainnet, longer under fee
+    /// pressure or an overloaded CI host).
     const RETRY_BUILDER: ConstantBuilder = ConstantBuilder::new()
         .with_delay(Duration::from_secs(1))
-        .with_max_times(10);
+        .with_max_times(90);
 
     let pending_value = f(BlockId::pending())
         .await

--- a/lib/l1_sender/src/commands/commit.rs
+++ b/lib/l1_sender/src/commands/commit.rs
@@ -80,6 +80,7 @@ impl SendToL1 for CommitCommand {
     const SENT_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1TxSent;
     const MINED_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1TxMined;
     const PASSTHROUGH_STAGE: BatchExecutionStage = BatchExecutionStage::CommitL1Passthrough;
+    const MAY_SEND_BLOBS: bool = true;
 
     fn solidity_call(&self, _operator: &Address) -> Bytes {
         if let Some(signatures_set) = &self.signatures {

--- a/lib/l1_sender/src/commands/mod.rs
+++ b/lib/l1_sender/src/commands/mod.rs
@@ -80,6 +80,10 @@ pub trait SendToL1:
     const SENT_STAGE: BatchExecutionStage;
     const MINED_STAGE: BatchExecutionStage;
     const PASSTHROUGH_STAGE: BatchExecutionStage;
+    /// Whether this command type can produce blob-carrying transactions. Replacing a blob
+    /// transaction in the pool requires a 100% fee bump (vs 10% for regular transactions),
+    /// so blob-capable senders enforce higher replacement-fee minimums.
+    const MAY_SEND_BLOBS: bool = false;
     /// We use `Bytes` instead of `SolCall`, because SolCall is a trait that cannot be dyn
     fn solidity_call(&self, operator: &Address) -> Bytes;
 

--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -25,9 +25,18 @@ pub struct L1SenderConfig<Input> {
     pub force_transaction_resubmission: bool,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
+    /// In pipelined mode this is the in-flight window size: the max number of
+    /// submitted-but-not-yet-mined L1 transactions. Must not exceed the L1 node's
+    /// per-account pool cap (16 for both geth's blobpool and reth's default account slots).
     pub command_limit: usize,
 
-    /// How often to poll L1 for new blocks.
+    /// When true (default), transactions are submitted through a bounded in-flight window and
+    /// confirmations are tracked by a separate task, so submission never waits for inclusion.
+    /// When false, falls back to stop-and-wait: drain up to `command_limit` commands, send,
+    /// wait for all receipts + confirmations, repeat. Kill switch for the pipelined sender.
+    pub pipelining_enabled: bool,
+
+    /// Receipt/inclusion polling cadence.
     pub poll_interval: Duration,
 
     /// Maximum time to wait for a transaction to be included on L1.

--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -32,8 +32,8 @@ pub struct L1SenderConfig<Input> {
 
     /// When true (default), transactions are submitted through a bounded in-flight window and
     /// confirmations are tracked by a separate task, so submission never waits for inclusion.
-    /// When false, falls back to stop-and-wait: drain up to `command_limit` commands, send,
-    /// wait for all receipts + confirmations, repeat. Kill switch for the pipelined sender.
+    /// When false, commands are processed in synchronous cycles instead: drain up to
+    /// `command_limit` commands, send, wait for all receipts + confirmations, repeat.
     pub pipelining_enabled: bool,
 
     /// Receipt/inclusion polling cadence.

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -94,6 +94,16 @@ impl FeeParams {
             max_fee_per_blob_gas: self.max_fee_per_blob_gas.max(other.max_fee_per_blob_gas),
         }
     }
+
+    /// Fee floor for replacing this transaction in the pool: geth and reth both require a
+    /// 100% bump on tip, fee cap AND blob fee cap to replace a blob transaction.
+    pub(crate) fn doubled(self) -> FeeParams {
+        FeeParams {
+            max_fee_per_gas: self.max_fee_per_gas.saturating_mul(2),
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas.saturating_mul(2),
+            max_fee_per_blob_gas: self.max_fee_per_blob_gas.saturating_mul(2),
+        }
+    }
 }
 
 /// A blob sidecar converted once into the wire format the chain accepts.
@@ -146,6 +156,9 @@ pub(crate) struct SimPrefixEntry {
     pub(crate) calldata: Bytes,
     pub(crate) sidecar: Option<Arc<PreparedSidecar>>,
     pub(crate) fee_params: FeeParams,
+    /// Gas limit the transaction was sent with; reused when the transaction is evicted from
+    /// the pool and must be resent at the same nonce.
+    pub(crate) gas_limit: u64,
 }
 
 fn build_l1_simulation_request(
@@ -556,10 +569,27 @@ where
         loop {
             match self.provider.send_transaction(tx_request.clone()).await {
                 Ok(pending_tx) => return Ok(pending_tx),
-                Err(err)
-                    if is_nonce_error(&err)
-                        && nonce_error_attempt < self.config.nonce_error_max_attempts =>
-                {
+                Err(err) if is_nonce_error(&err) || is_already_known_error(&err) => {
+                    // The transport layer retries dropped connections, so a send whose
+                    // response was lost may have been accepted (and mined) on the first
+                    // attempt — the retry then reports "nonce too low"/"already known" even
+                    // though our transaction landed. Adopt it if it is on chain or in the
+                    // pool at our nonce.
+                    if let Some(pending_tx) = self.find_landed_tx(&tx_request).await {
+                        tracing::info!(
+                            command_name,
+                            range,
+                            tx_hash = ?pending_tx.tx_hash(),
+                            "transaction already landed at its nonce (transport-level retry \
+                             double-send); adopting it"
+                        );
+                        return Ok(pending_tx);
+                    }
+                    if !is_nonce_error(&err)
+                        || nonce_error_attempt >= self.config.nonce_error_max_attempts
+                    {
+                        return Err(err.into());
+                    }
                     tracing::warn!(
                         command_name,
                         range,
@@ -584,6 +614,16 @@ where
                     );
                     tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
                     pool_capacity_attempt += 1;
+                }
+                Err(err) if is_replacement_underpriced_error(&err) => {
+                    // Notably hit when `force_transaction_resubmission` is re-run against
+                    // transactions a previous force run already priced at the configured
+                    // replacement fees — those fees are absolute, so no further bump happens.
+                    return Err(anyhow::Error::from(err).context(
+                        "replacement fees did not outbid the transaction already pooled at \
+                         this nonce; if this repeats, raise the \
+                         `force_transaction_resubmission` multipliers or the fee caps",
+                    ));
                 }
                 Err(err) if is_fee_too_low_error(&err) => {
                     let elapsed = started_at.elapsed();
@@ -656,6 +696,38 @@ where
                     }
                 }
                 Err(err) => return Err(err.into()),
+            }
+        }
+    }
+
+    /// Checks whether a transaction with this request's calldata already sits at its nonce —
+    /// on chain or in the pool — and returns a pending-transaction handle for it if so. Used
+    /// to disambiguate nonce/already-known send rejections. Returns `None` (never an error)
+    /// when the provider cannot answer; the caller falls back to its retry policy.
+    async fn find_landed_tx(
+        &self,
+        tx_request: &TransactionRequest,
+    ) -> Option<alloy::providers::PendingTransactionBuilder<alloy::network::Ethereum>> {
+        let from = tx_request.from?;
+        let nonce = tx_request.nonce?;
+        match self
+            .provider
+            .get_transaction_by_sender_nonce(from, nonce)
+            .await
+        {
+            Ok(Some(tx)) if Some(ConsensusTransaction::input(&tx)) == tx_request.input.input() => {
+                Some(alloy::providers::PendingTransactionBuilder::new(
+                    self.provider.root().clone(),
+                    tx.tx_hash(),
+                ))
+            }
+            Ok(_) => None,
+            Err(err) => {
+                tracing::debug!(
+                    %err,
+                    "could not probe for a landed transaction at the send nonce"
+                );
+                None
             }
         }
     }
@@ -1276,6 +1348,35 @@ fn is_nonce_error(err: &TransportError) -> bool {
     }
 }
 
+/// Replacement-underpriced `eth_sendRawTransaction` rejections: the fee bump over the
+/// transaction already pooled at this nonce is below the node's price-bump requirement.
+/// Waiting never fixes an insufficient bump, so this class is fatal — restart recovery
+/// reprices from the pooled transaction's actual fees.
+fn is_replacement_underpriced_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ErrorResp(payload) => {
+            let message = payload.message.to_lowercase();
+            message.contains("replacement") && message.contains("underpriced")
+        }
+        _ => false,
+    }
+}
+
+/// `eth_sendRawTransaction` rejections reporting that the exact same transaction is already
+/// in the pool — the signature of a transport-level send retry whose first attempt was
+/// accepted but whose response was lost.
+fn is_already_known_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ErrorResp(payload) => {
+            let message = payload.message.to_lowercase();
+            message.contains("already known")
+                || message.contains("already imported")
+                || message.contains("already in the pool")
+        }
+        _ => false,
+    }
+}
+
 /// Max submission attempts when the L1 node rejects a transaction because the tx pool is at
 /// capacity. Sized to outlast several L1 slots — pool capacity frees as blocks mine, e.g.
 /// after a reorg briefly returns already-mined transactions to the pool while the in-flight
@@ -1424,6 +1525,32 @@ mod tests {
             "replacement transaction underpriced"
         )));
         assert!(!is_nonce_error(&TransportErrorKind::custom_str(
+            "error sending request"
+        )));
+    }
+
+    #[test]
+    fn already_known_classification() {
+        use alloy::rpc::json_rpc::ErrorPayload;
+        use alloy::transports::TransportErrorKind;
+
+        let resp = |message: &str| {
+            TransportError::ErrorResp(ErrorPayload {
+                code: -32000,
+                message: message.to_string().into(),
+                data: None,
+            })
+        };
+
+        // geth: "already known"; reth: "transaction already imported"; anvil: "already
+        // imported". All signal a transport-retry double-send of the same raw transaction.
+        assert!(is_already_known_error(&resp("already known")));
+        assert!(is_already_known_error(&resp(
+            "transaction already imported"
+        )));
+        assert!(is_already_known_error(&resp("ALREADY known")));
+        assert!(!is_already_known_error(&resp("nonce too low")));
+        assert!(!is_already_known_error(&TransportErrorKind::custom_str(
             "error sending request"
         )));
     }

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -95,8 +95,23 @@ impl FeeParams {
         }
     }
 
-    /// Fee floor for replacing this transaction in the pool: geth and reth both require a
-    /// 100% bump on tip, fee cap AND blob fee cap to replace a blob transaction.
+    /// Fee floor for replacing this transaction in the pool. Geth and reth require a 100%
+    /// bump on tip, fee cap AND blob fee cap to replace a blob transaction, but only a 10%
+    /// bump for regular transactions.
+    pub(crate) fn replacement_floor(self, carries_blobs: bool) -> FeeParams {
+        if carries_blobs {
+            self.doubled()
+        } else {
+            let bump = |fee: u128| fee.saturating_add(fee.div_ceil(10));
+            FeeParams {
+                max_fee_per_gas: bump(self.max_fee_per_gas),
+                max_priority_fee_per_gas: bump(self.max_priority_fee_per_gas),
+                max_fee_per_blob_gas: self.max_fee_per_blob_gas,
+            }
+        }
+    }
+
+    /// See [`Self::replacement_floor`] — the blob replacement bump.
     pub(crate) fn doubled(self) -> FeeParams {
         FeeParams {
             max_fee_per_gas: self.max_fee_per_gas.saturating_mul(2),
@@ -1031,7 +1046,14 @@ where
         force_transaction_resubmission: bool,
     ) -> anyhow::Result<FeeParams> {
         if force_transaction_resubmission {
-            return Ok(fee_config.replacement_fee_params());
+            let params = fee_config.replacement_fee_params();
+            // Blob-capable senders need a 100% bump to replace pooled blob transactions;
+            // the configured multipliers only have to satisfy the regular 10% bump rule.
+            return Ok(if Input::MAY_SEND_BLOBS {
+                params.max(fee_config.configured_fee_params().doubled())
+            } else {
+                params
+            });
         }
 
         let configured_params = fee_config.configured_fee_params();

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod config;
 mod metrics;
 pub mod pipeline_component;
+mod pipelined;
 pub mod upgrade_gatekeeper;
 
 use crate::commands::{L1SenderCommand, SendToL1};
@@ -26,6 +27,7 @@ use alloy::transports::TransportError;
 use anyhow::Context as _;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt, TryStreamExt};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
@@ -74,10 +76,76 @@ const L1_GAS_LIMIT_FALLBACK: u64 = 15_000_000;
 const L1_SIM_GAS_LIMIT: u64 = 30_000_000;
 
 #[derive(Debug, Clone, Copy)]
-struct FeeParams {
+pub(crate) struct FeeParams {
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
     max_fee_per_blob_gas: u128,
+}
+
+impl FeeParams {
+    /// Per-field maximum of two fee sets. Used to apply a replacement-fee floor on top of
+    /// the regularly resolved fees.
+    pub(crate) fn max(self, other: FeeParams) -> FeeParams {
+        FeeParams {
+            max_fee_per_gas: self.max_fee_per_gas.max(other.max_fee_per_gas),
+            max_priority_fee_per_gas: self
+                .max_priority_fee_per_gas
+                .max(other.max_priority_fee_per_gas),
+            max_fee_per_blob_gas: self.max_fee_per_blob_gas.max(other.max_fee_per_blob_gas),
+        }
+    }
+}
+
+/// A blob sidecar converted once into the wire format the chain accepts.
+///
+/// The EIP-7594 conversion computes 128 KZG cell proofs per blob (~200ms of CPU each), so it
+/// must happen exactly once per command — the result is shared between gas simulation, the
+/// send path, and in-flight simulation prefixes.
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedSidecar {
+    variant: BlobTransactionSidecarVariant,
+    blob_count: u64,
+}
+
+impl PreparedSidecar {
+    /// Converts `sidecar` into the format the chain's active fork accepts. The EIP-7594 cell
+    /// proof computation is CPU-heavy, so it runs on the blocking pool.
+    pub(crate) async fn prepare(
+        sidecar: alloy::consensus::BlobTransactionSidecar,
+        use_eip7594: bool,
+    ) -> anyhow::Result<Self> {
+        let blob_count = sidecar.blobs.len() as u64;
+        let variant = if use_eip7594 {
+            let converted = tokio::task::spawn_blocking(move || {
+                sidecar.try_into_7594(EnvKzgSettings::Default.get())
+            })
+            .await
+            .context("EIP-7594 sidecar conversion task panicked")??;
+            BlobTransactionSidecarVariant::Eip7594(converted)
+        } else {
+            BlobTransactionSidecarVariant::Eip4844(sidecar)
+        };
+        Ok(Self {
+            variant,
+            blob_count,
+        })
+    }
+
+    pub(crate) fn blob_count(&self) -> u64 {
+        self.blob_count
+    }
+}
+
+/// An in-flight (submitted, not yet observed mined) transaction mirrored into `eth_simulateV1`
+/// payloads so that gas estimates for chained commands (batch N+1 requires batch N committed)
+/// stay exact while predecessors are still in the mempool. On providers whose simulation base
+/// already includes pool transactions the prefix call simply reverts without applying state,
+/// which leaves the chained state intact either way; prefix results are always discarded.
+pub(crate) struct SimPrefixEntry {
+    pub(crate) nonce: u64,
+    pub(crate) calldata: Bytes,
+    pub(crate) sidecar: Option<Arc<PreparedSidecar>>,
+    pub(crate) fee_params: FeeParams,
 }
 
 fn build_l1_simulation_request(
@@ -86,9 +154,8 @@ fn build_l1_simulation_request(
     input: Bytes,
     nonce: u64,
     fee_params: FeeParams,
-    blob_sidecar: Option<alloy::consensus::BlobTransactionSidecar>,
-    use_eip7594_sidecar: bool,
-) -> anyhow::Result<TransactionRequest> {
+    prepared_sidecar: Option<&PreparedSidecar>,
+) -> TransactionRequest {
     // Mirror submission fees so providers (e.g. anvil) that parse the request
     // as a typed tx accept it.
     let mut req = TransactionRequest::default()
@@ -100,21 +167,15 @@ fn build_l1_simulation_request(
         .with_nonce(nonce)
         .with_gas_limit(L1_SIM_GAS_LIMIT);
 
-    if let Some(blob_sidecar) = blob_sidecar {
+    if let Some(prepared_sidecar) = prepared_sidecar {
         req.max_fee_per_blob_gas = Some(fee_params.max_fee_per_blob_gas);
-        if use_eip7594_sidecar {
-            req.set_blob_sidecar(BlobTransactionSidecarVariant::Eip7594(
-                blob_sidecar.try_into_7594(EnvKzgSettings::Default.get())?,
-            ));
-        } else {
-            req.set_blob_sidecar(BlobTransactionSidecarVariant::Eip4844(blob_sidecar));
-        }
+        req.set_blob_sidecar(prepared_sidecar.variant.clone());
         // Anvil routes blob requests through the EIP-4844 arm only when
         // `type=3` is set explicitly; otherwise it returns -32602.
         req.transaction_type = Some(3);
     }
 
-    Ok(req)
+    req
 }
 
 /// Process responsible for sending transactions to L1.
@@ -147,11 +208,6 @@ where
         outbound: mpsc::Sender<SignedBatchEnvelope<FriProof>>,
         state_reporter: ComponentStateReporter,
     ) -> anyhow::Result<()> {
-        let command_name = Input::COMPONENT_ID.as_str();
-        let fee_config = self.config.fee_config;
-        let force_transaction_resubmission = self.config.force_transaction_resubmission;
-
-        let mut cmd_buffer = Vec::with_capacity(self.config.command_limit);
         // Process all potential passthrough commands first
         if self
             .process_prepending_passthrough_commands(&mut inbound, &outbound, &state_reporter)
@@ -161,6 +217,39 @@ where
             tracing::info!("inbound channel closed");
             return Ok(());
         }
+
+        // The KZG trusted setup loads lazily on first use (~seconds); warm it up off the hot
+        // path so the first blob-carrying send doesn't stall the async executor.
+        if self.provider.capabilities().supports_eip7594 {
+            tokio::task::spawn_blocking(|| {
+                let _ = EnvKzgSettings::Default.get();
+            })
+            .await
+            .context("KZG trusted setup preload task panicked")?;
+        }
+
+        if self.config.pipelining_enabled {
+            self.run_pipelined(inbound, outbound, state_reporter).await
+        } else {
+            self.run_stop_and_wait(inbound, outbound, state_reporter)
+                .await
+        }
+    }
+
+    /// Legacy stop-and-wait sending: drain up to `command_limit` commands, send them, wait for
+    /// all receipts + confirmations, repeat. Kept verbatim as the kill-switch fallback for the
+    /// pipelined sender (`pipelining_enabled = false`).
+    async fn run_stop_and_wait(
+        &self,
+        mut inbound: PeekableReceiver<L1SenderCommand<Input>>,
+        outbound: mpsc::Sender<SignedBatchEnvelope<FriProof>>,
+        state_reporter: ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let command_name = Input::COMPONENT_ID.as_str();
+        let fee_config = self.config.fee_config;
+        let force_transaction_resubmission = self.config.force_transaction_resubmission;
+
+        let mut cmd_buffer = Vec::with_capacity(self.config.command_limit);
 
         // On startup, either recover submitted transactions from a previous session or, when
         // explicitly requested, skip recovery so the normal send path replaces them.
@@ -253,8 +342,16 @@ where
             let fee_params = self
                 .resolve_fee_params(fee_config, force_transaction_resubmission)
                 .await?;
+            let prepared_sidecars = self.prepare_sidecars(&commands).await?;
             let gas_limits = self
-                .estimate_gas_limits(&commands, operator_address, fee_params, base_nonce)
+                .estimate_gas_limits(
+                    &[],
+                    &commands,
+                    &prepared_sidecars,
+                    operator_address,
+                    fee_params,
+                    base_nonce,
+                )
                 .await?;
             tracing::info!(
                 command_name,
@@ -263,101 +360,39 @@ where
                 "estimated gas limits via eth_simulateV1",
             );
 
-            // Only blob-carrying commands (commit path) need the blob base fee, so fetch
-            // it once per cycle instead of paying an RPC round-trip per command.
-            let blob_base_fee = if commands.iter().any(|cmd| cmd.blob_sidecar().is_some()) {
-                let fee = self.provider.get_blob_base_fee().await?;
-                L1_SENDER_METRICS.report_blob_base_fee(fee)?;
-                Some(fee)
-            } else {
-                None
-            };
+            let blob_base_fee = self
+                .fetch_blob_base_fee_if_needed(&prepared_sidecars)
+                .await?;
 
             // It's important to preserve the order of commands -
             // so that we send them downstream also in order.
             // This holds true because l1 transactions are included in the order of sender nonce.
             // Keep this in mind if changing sending logic (that is, if adding `buffer` we'd need to set nonce manually)
-            let pending_txs: Vec<PendingTx<Input>> =
-            futures::stream::iter(commands.into_iter().zip(gas_limits).enumerate())
-                .then(|(nonce_offset, (mut cmd, gas_limit))| {
-                    let range = range.clone();
-                    async move {
-                    let mut tx_request = TransactionRequest::default()
-                        .with_from(operator_address)
-                        .with_nonce(base_nonce + nonce_offset as u64)
-                        .with_max_fee_per_gas(fee_params.max_fee_per_gas)
-                        .with_max_priority_fee_per_gas(fee_params.max_priority_fee_per_gas)
-                        .with_gas_limit(gas_limit)
-                        .with_to(self.to_address)
-                        .with_input(cmd.solidity_call(&operator_address));
+            let pending_txs: Vec<PendingTx<Input>> = futures::stream::iter(
+                commands
+                    .into_iter()
+                    .zip(gas_limits)
+                    .zip(prepared_sidecars)
+                    .enumerate(),
+            )
+            .then(|(nonce_offset, ((mut cmd, gas_limit), prepared_sidecar))| {
+                let range = range.clone();
+                async move {
+                    let tx_request = self.build_tx_request(
+                        cmd.solidity_call(&operator_address),
+                        operator_address,
+                        base_nonce + nonce_offset as u64,
+                        gas_limit,
+                        fee_params,
+                        prepared_sidecar.as_deref(),
+                        blob_base_fee,
+                    );
 
-                    let mut blob_gas_limit = 0;
-                    if let Some(blob_sidecar) = cmd.blob_sidecar() {
-                        blob_gas_limit = blob_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
-                        let fee_per_blob_gas = blob_base_fee
-                            .context("blob base fee not prefetched for a cycle with blob sidecars")?;
-                        let max_fee_per_blob_gas = fee_params.max_fee_per_blob_gas;
+                    // Notify CommitWatcher before the transaction can possibly land on L1:
+                    // this batch number is being submitted by this session.
+                    self.note_submitted_batches(&cmd);
 
-                        if fee_per_blob_gas > max_fee_per_blob_gas {
-                            tracing::warn!(
-                                max_fee_per_blob_gas,
-                                fee_per_blob_gas,
-                                "L1 sender's configured maxFeePerBlobGas is lower than the one estimated from network"
-                            );
-                        }
-                        tx_request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
-
-                        // Send the EIP-7594 blob format when the chain's active fork accepts it
-                        // (probed via `eth_config`, falling back to a chain-id heuristic — see
-                        // `ProviderCapabilities::supports_eip7594`). Pre-Fusaka chains and Anvil
-                        // get the legacy EIP-4844 format
-                        // (see https://github.com/foundry-rs/foundry/issues/12222).
-                        if self.provider.capabilities().supports_eip7594 {
-                            tx_request.set_blob_sidecar(BlobTransactionSidecarVariant::Eip7594(
-                                blob_sidecar.try_into_7594(EnvKzgSettings::Default.get())?,
-                            ));
-                        } else {
-                            tx_request.set_blob_sidecar(BlobTransactionSidecarVariant::Eip4844(blob_sidecar));
-                        }
-                    };
-
-                    let execution_balance_required = tx_request.max_fee_per_gas.unwrap_or_default()
-                        * u128::from(tx_request.gas.unwrap_or_default());
-                    let blob_balance_required = tx_request
-                        .max_fee_per_blob_gas
-                        .unwrap_or_default()
-                        * u128::from(blob_gas_limit);
-                    let balance_required = execution_balance_required
-                        .saturating_add(blob_balance_required)
-                        .min(u128::from(u64::MAX)) as u64;
-
-                    L1_SENDER_METRICS.balance_required_for_tx[&Input::COMPONENT_ID.as_str()]
-                        .set(balance_required);
-
-                    // A nonce-class rejection is a definitive refusal (tx not admitted), typically a
-                    // transient pool/state view inconsistency around a block import. The nonce is
-                    // fixed for this cycle, so re-sending it unchanged after a backoff self-heals.
-                    let mut send_attempt = 1;
-                    let pending_tx = loop {
-                        match self.provider.send_transaction(tx_request.clone()).await {
-                            Ok(pending_tx) => break pending_tx,
-                            Err(err)
-                                if is_nonce_error(&err)
-                                    && send_attempt < self.config.nonce_error_max_attempts =>
-                            {
-                                tracing::warn!(
-                                    command_name,
-                                    range,
-                                    send_attempt,
-                                    %err,
-                                    "L1 node rejected the transaction with a nonce error; retrying"
-                                );
-                                tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
-                                send_attempt += 1;
-                            }
-                            Err(err) => return Err(err.into()),
-                        }
-                    };
+                    let pending_tx = self.send_tx_with_retries(tx_request, &range).await?;
                     let submitted_at = Instant::now();
                     let tx_hash = *pending_tx.tx_hash();
                     let receipt_fut = self.wait_for_confirmed_receipt(tx_hash);
@@ -365,36 +400,219 @@ where
                         "{command_name}: L1 transaction submitted for {range}. Hash: {tx_hash:?} Waiting for inclusion...",
                     );
 
-                    // Notify CommitWatcher: this batch number has been submitted to L1.
-                    if let Some(sender) = &self.commit_submitted_tx {
-                        let batch_number = cmd
-                            .as_ref()
-                            .last()
-                            .expect("commands is non-empty after recv_many")
-                            .batch_number();
-                        sender.send_if_modified(|current| {
-                            if batch_number > *current {
-                                *current = batch_number;
-                                true
-                            } else {
-                                false
-                            }
-                        });
-                    }
-
                     cmd.as_mut()
                         .iter_mut()
                         .for_each(|envelope| envelope.set_stage(Input::SENT_STAGE));
                     anyhow::Ok((receipt_fut, cmd, submitted_at))
-                    }
-                })
-                // We could buffer the stream here to enable sending multiple batches of transactions in parallel,
-                // but this is not necessary for now - we wait for them to be included in parallel
-                .try_collect::<Vec<_>>()
-                .await?;
+                }
+            })
+            // We could buffer the stream here to enable sending multiple batches of transactions in parallel,
+            // but this is not necessary for now - the pipelined mode covers that; here we only
+            // wait for them to be included in parallel
+            .try_collect::<Vec<_>>()
+            .await?;
             tracing::info!(command_name, range, "sent to L1, waiting for inclusion");
             self.wait_for_txs_and_forward(pending_txs, &state_reporter, &outbound)
                 .await?;
+        }
+    }
+
+    /// Converts every blob-carrying command's sidecar into the chain's accepted wire format
+    /// exactly once. The result is shared between gas simulation, the send path and (in
+    /// pipelined mode) in-flight simulation prefixes; the EIP-7594 conversion computes KZG
+    /// cell proofs and must never run twice for the same sidecar.
+    pub(crate) async fn prepare_sidecars(
+        &self,
+        commands: &[Input],
+    ) -> anyhow::Result<Vec<Option<Arc<PreparedSidecar>>>> {
+        let use_eip7594 = self.provider.capabilities().supports_eip7594;
+        futures::future::try_join_all(commands.iter().map(|cmd| async move {
+            match cmd.blob_sidecar() {
+                Some(sidecar) => Ok(Some(Arc::new(
+                    PreparedSidecar::prepare(sidecar, use_eip7594).await?,
+                ))),
+                None => Ok(None),
+            }
+        }))
+        .await
+    }
+
+    /// Only blob-carrying commands (commit path) need the blob base fee, so fetch it once per
+    /// send wave instead of paying an RPC round-trip per command. Used for monitoring only —
+    /// the submitted cap always comes from the configured fee params.
+    pub(crate) async fn fetch_blob_base_fee_if_needed(
+        &self,
+        prepared_sidecars: &[Option<Arc<PreparedSidecar>>],
+    ) -> anyhow::Result<Option<u128>> {
+        if prepared_sidecars.iter().any(|sidecar| sidecar.is_some()) {
+            let fee = self.provider.get_blob_base_fee().await?;
+            L1_SENDER_METRICS.report_blob_base_fee(fee)?;
+            Ok(Some(fee))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Builds a submission-ready transaction request and reports the balance-required metric.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn build_tx_request(
+        &self,
+        calldata: Bytes,
+        operator_address: Address,
+        nonce: u64,
+        gas_limit: u64,
+        fee_params: FeeParams,
+        prepared_sidecar: Option<&PreparedSidecar>,
+        blob_base_fee: Option<u128>,
+    ) -> TransactionRequest {
+        let mut tx_request = TransactionRequest::default()
+            .with_from(operator_address)
+            .with_nonce(nonce)
+            .with_max_fee_per_gas(fee_params.max_fee_per_gas)
+            .with_max_priority_fee_per_gas(fee_params.max_priority_fee_per_gas)
+            .with_gas_limit(gas_limit)
+            .with_to(self.to_address)
+            .with_input(calldata);
+
+        let mut blob_gas_limit = 0;
+        if let Some(prepared_sidecar) = prepared_sidecar {
+            blob_gas_limit = prepared_sidecar.blob_count() * DATA_GAS_PER_BLOB;
+            let max_fee_per_blob_gas = fee_params.max_fee_per_blob_gas;
+            if let Some(fee_per_blob_gas) = blob_base_fee
+                && fee_per_blob_gas > max_fee_per_blob_gas
+            {
+                tracing::warn!(
+                    max_fee_per_blob_gas,
+                    fee_per_blob_gas,
+                    "L1 sender's configured maxFeePerBlobGas is lower than the one estimated from network"
+                );
+            }
+            tx_request.set_max_fee_per_blob_gas(max_fee_per_blob_gas);
+            // The sidecar already carries the EIP-7594 or EIP-4844 format matching the chain's
+            // active fork (probed via `eth_config`, falling back to a chain-id heuristic — see
+            // `ProviderCapabilities::supports_eip7594` and
+            // https://github.com/foundry-rs/foundry/issues/12222).
+            tx_request.set_blob_sidecar(prepared_sidecar.variant.clone());
+        }
+
+        let execution_balance_required =
+            tx_request.max_fee_per_gas.unwrap_or_default() * u128::from(gas_limit);
+        let blob_balance_required =
+            tx_request.max_fee_per_blob_gas.unwrap_or_default() * u128::from(blob_gas_limit);
+        let balance_required = execution_balance_required
+            .saturating_add(blob_balance_required)
+            .min(u128::from(u64::MAX)) as u64;
+        L1_SENDER_METRICS.balance_required_for_tx[&Input::COMPONENT_ID.as_str()]
+            .set(balance_required);
+
+        tx_request
+    }
+
+    /// Notifies the CommitWatcher which batch numbers this session has submitted (or is about
+    /// to submit) to L1, so a commit event for them is not mistaken for a leftover transaction
+    /// from a crashed session.
+    pub(crate) fn note_submitted_batches(&self, cmd: &Input) {
+        if let Some(sender) = &self.commit_submitted_tx {
+            let batch_number = cmd
+                .as_ref()
+                .last()
+                .expect("every command contains at least one envelope")
+                .batch_number();
+            sender.send_if_modified(|current| {
+                if batch_number > *current {
+                    *current = batch_number;
+                    true
+                } else {
+                    false
+                }
+            });
+        }
+    }
+
+    /// Submits a transaction, retrying rejections that are known to be transient:
+    ///
+    /// * nonce-class rejections — a definitive refusal (tx not admitted), typically a transient
+    ///   pool/state view inconsistency around a block import. The nonce is fixed, so re-sending
+    ///   unchanged after a backoff self-heals.
+    /// * pool-capacity rejections — the per-account or global pool limit is hit, e.g. when an
+    ///   L1 reorg briefly returns already-mined transactions to the pool while our in-flight
+    ///   window is full. Clears as blocks mine, so a longer retry budget applies.
+    /// * fee-too-low rejections — the L1 fee market moved above our configured caps. The caps
+    ///   are a deliberate operator bound, so the sender waits indefinitely (warning on the
+    ///   transaction-timeout cadence) instead of crash-looping for the duration of a fee spike;
+    ///   upstream backpressure engages while it waits.
+    ///
+    /// Everything else (including transport errors, where the tx may or may not have been
+    /// admitted) propagates as fatal: restart + in-flight recovery is the only safe way to
+    /// resolve the ambiguity without risking local nonce divergence.
+    pub(crate) async fn send_tx_with_retries(
+        &self,
+        tx_request: TransactionRequest,
+        range: &str,
+    ) -> anyhow::Result<alloy::providers::PendingTransactionBuilder<alloy::network::Ethereum>> {
+        let command_name = Input::COMPONENT_ID.as_str();
+        let started_at = Instant::now();
+        let mut nonce_error_attempt = 1;
+        let mut pool_capacity_attempt = 1;
+        let mut next_fee_warning_at = self.config.transaction_timeout;
+        loop {
+            match self.provider.send_transaction(tx_request.clone()).await {
+                Ok(pending_tx) => return Ok(pending_tx),
+                Err(err)
+                    if is_nonce_error(&err)
+                        && nonce_error_attempt < self.config.nonce_error_max_attempts =>
+                {
+                    tracing::warn!(
+                        command_name,
+                        range,
+                        nonce_error_attempt,
+                        %err,
+                        "L1 node rejected the transaction with a nonce error; retrying"
+                    );
+                    tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
+                    nonce_error_attempt += 1;
+                }
+                Err(err)
+                    if is_pool_capacity_error(&err)
+                        && pool_capacity_attempt < POOL_CAPACITY_ERROR_MAX_ATTEMPTS =>
+                {
+                    tracing::warn!(
+                        command_name,
+                        range,
+                        pool_capacity_attempt,
+                        %err,
+                        "L1 node rejected the transaction because the tx pool is at capacity; \
+                         waiting for L1 to mine before retrying"
+                    );
+                    tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
+                    pool_capacity_attempt += 1;
+                }
+                Err(err) if is_fee_too_low_error(&err) => {
+                    let elapsed = started_at.elapsed();
+                    if !self.config.transaction_timeout.is_zero() && elapsed >= next_fee_warning_at
+                    {
+                        next_fee_warning_at += self.config.transaction_timeout;
+                        tracing::warn!(
+                            command_name,
+                            range,
+                            waited_secs = elapsed.as_secs_f64(),
+                            %err,
+                            "L1 fee market is above the configured fee caps; the sender is \
+                             stalled until fees drop back under the caps (or the caps are \
+                             raised in `l1_sender` config)"
+                        );
+                    } else {
+                        tracing::info!(
+                            command_name,
+                            range,
+                            %err,
+                            "transaction priced below the current L1 fee market; retrying"
+                        );
+                    }
+                    tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
+                }
+                Err(err) => return Err(err.into()),
+            }
         }
     }
 
@@ -450,13 +668,13 @@ where
         Ok(())
     }
 
-    fn wait_for_confirmed_receipt(&self, tx_hash: B256) -> TransactionReceiptFuture {
+    pub(crate) fn wait_for_confirmed_receipt(&self, tx_hash: B256) -> TransactionReceiptFuture {
         let provider = self.provider.clone();
         let required_confirmations = self.config.required_confirmations;
         let timeout = self.config.transaction_timeout;
+        let poll_interval = self.config.poll_interval;
         async move {
             let started_at = Instant::now();
-            let poll_interval = provider.client().poll_interval();
             let mut next_warning_at = if timeout.is_zero() {
                 None
             } else {
@@ -691,7 +909,7 @@ where
         }
     }
 
-    async fn resolve_fee_params(
+    pub(crate) async fn resolve_fee_params(
         &self,
         fee_config: L1SenderFeeConfig,
         force_transaction_resubmission: bool,
@@ -718,15 +936,38 @@ where
     /// cumulative block-gas-limit constraints can't reject the batch, while writes from
     /// earlier blocks remain visible to later ones (spec-mandated overlay propagation).
     /// Falls back to [`L1_GAS_LIMIT_FALLBACK`] per tx on any simulate failure.
-    async fn estimate_gas_limits(
+    ///
+    /// `in_flight_prefix` mirrors already-submitted-but-unmined transactions ahead of
+    /// `commands` in the payload so chained calls (batch N+1 requires batch N committed) see
+    /// the right state on providers whose simulation base excludes pool transactions. On
+    /// providers whose base already includes them, the prefix call reverts without applying
+    /// state — harmless either way (see [`SimPrefixEntry`]); prefix results are discarded.
+    pub(crate) async fn estimate_gas_limits(
         &self,
+        in_flight_prefix: &[SimPrefixEntry],
         commands: &[Input],
+        prepared_sidecars: &[Option<Arc<PreparedSidecar>>],
         operator_address: Address,
         fee_params: FeeParams,
         // Sequential nonces start here — anvil's EIP-4844 parsing requires `nonce` and
         // `gas_limit` even with `validation=false`. Matches the send nonces.
         starting_nonce: u64,
     ) -> anyhow::Result<Vec<u64>> {
+        // eth_simulateV1 caps a payload at 256 blocks; with default configs
+        // prefix+commands is ≤ 32, so hitting this means a misconfiguration — degrade to
+        // un-prefixed estimation rather than fail.
+        let in_flight_prefix = if in_flight_prefix.len() + commands.len() > 256 {
+            tracing::warn!(
+                prefix_len = in_flight_prefix.len(),
+                commands_len = commands.len(),
+                "in-flight prefix + commands exceed the eth_simulateV1 256-block cap; \
+                 estimating without the in-flight prefix",
+            );
+            &[]
+        } else {
+            in_flight_prefix
+        };
+
         // Some L1 providers check sender balance even with `validation=false`; override
         // to bypass.
         let balance_override = StateOverridesBuilder::default()
@@ -739,30 +980,36 @@ where
             )
             .build();
 
-        // Mirror the submission path: EIP-7594 if the chain's active fork accepts it, EIP-4844
-        // otherwise. Only consumed by `build_l1_simulation_request` when a command actually
-        // carries a blob sidecar.
-        let use_eip7594_sidecar = self.provider.capabilities().supports_eip7594;
-
-        let block_state_calls = commands
-            .iter()
-            .enumerate()
-            .map(|(i, cmd)| {
-                let req = build_l1_simulation_request(
-                    operator_address,
-                    self.to_address,
-                    cmd.solidity_call(&operator_address),
-                    starting_nonce + i as u64,
-                    fee_params,
-                    cmd.blob_sidecar(),
-                    use_eip7594_sidecar,
-                )?;
+        let prefix_blocks = in_flight_prefix.iter().map(|entry| {
+            build_l1_simulation_request(
+                operator_address,
+                self.to_address,
+                entry.calldata.clone(),
+                entry.nonce,
+                entry.fee_params,
+                entry.sidecar.as_deref(),
+            )
+        });
+        let command_blocks = commands.iter().enumerate().map(|(i, cmd)| {
+            build_l1_simulation_request(
+                operator_address,
+                self.to_address,
+                cmd.solidity_call(&operator_address),
+                starting_nonce + i as u64,
+                fee_params,
+                prepared_sidecars[i].as_deref(),
+            )
+        });
+        let block_state_calls = prefix_blocks
+            .chain(command_blocks)
+            .map(|req| {
                 let mut sim_block = SimBlock::default().call(req);
                 sim_block.state_overrides = Some(balance_override.clone());
-                anyhow::Ok(sim_block)
+                sim_block
             })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+            .collect::<Vec<_>>();
 
+        let expected_blocks = block_state_calls.len();
         let payload = SimulatePayload {
             block_state_calls,
             ..Default::default()
@@ -771,11 +1018,11 @@ where
         // Top-level failures fall back across the batch; per-call reverts fall back only
         // for that tx.
         let blocks = match self.provider.simulate(&payload).pending().await {
-            Ok(blocks) if blocks.len() == commands.len() => blocks,
+            Ok(blocks) if blocks.len() == expected_blocks => blocks,
             Ok(blocks) => {
                 tracing::warn!(
                     returned = blocks.len(),
-                    expected = commands.len(),
+                    expected = expected_blocks,
                     "eth_simulateV1 returned mismatched block count, falling back to {L1_GAS_LIMIT_FALLBACK} per tx",
                 );
                 return Ok(vec![L1_GAS_LIMIT_FALLBACK; commands.len()]);
@@ -791,6 +1038,9 @@ where
 
         let gas_limits = blocks
             .iter()
+            // A prefix call reverting is expected on providers whose simulation base already
+            // includes pool transactions; only the trailing per-command results matter.
+            .skip(in_flight_prefix.len())
             .enumerate()
             .map(|(i, block)| match block.calls.first() {
                 Some(call) if call.status => call.gas_used.saturating_mul(2),
@@ -910,7 +1160,7 @@ where
         Ok(())
     }
 
-    async fn validate_tx_receipt(
+    pub(crate) async fn validate_tx_receipt(
         &self,
         command: &Input,
         receipt: TransactionReceipt,
@@ -977,6 +1227,51 @@ fn is_nonce_error(err: &TransportError) -> bool {
             message.contains("nonce too low")
                 || message.contains("nonce too high")
                 || message.contains("nonce gap")
+        }
+        _ => false,
+    }
+}
+
+/// Max submission attempts when the L1 node rejects a transaction because the tx pool is at
+/// capacity. Sized to outlast several L1 slots — pool capacity frees as blocks mine, e.g.
+/// after a reorg briefly returns already-mined transactions to the pool while the in-flight
+/// window is full.
+const POOL_CAPACITY_ERROR_MAX_ATTEMPTS: usize = 30;
+
+/// Fee-class `eth_sendRawTransaction` rejections: the transaction is priced below what the
+/// node currently accepts (base fee above our configured cap, or the pool's dynamic price
+/// floor rose). The fee caps are a deliberate operator bound, so the sender must WAIT for the
+/// market to come back under them — stalling (and letting backpressure engage) rather than
+/// crash-looping through restarts for the duration of a fee spike.
+///
+/// Replacement underpricing is deliberately NOT in this class: waiting never fixes an RBF
+/// bump that is too small, so it stays fatal.
+fn is_fee_too_low_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ErrorResp(payload) => {
+            let message = payload.message.to_lowercase();
+            message.contains("less than block base fee")
+                || message.contains("less than blob base fee")
+                || (message.contains("underpriced") && !message.contains("replacement"))
+        }
+        _ => false,
+    }
+}
+
+/// Pool-capacity-class `eth_sendRawTransaction` rejections: the sender's per-account slot
+/// limit (geth blobpool `maxTxsPerAccount`, reth `max-account-slots`) or the global pool
+/// capacity is exhausted. Unlike nonce errors these clear as L1 mines blocks, so they get a
+/// longer retry budget ([`POOL_CAPACITY_ERROR_MAX_ATTEMPTS`]).
+fn is_pool_capacity_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ErrorResp(payload) => {
+            let message = payload.message.to_lowercase();
+            message.contains("account limit exceeded")
+                || message.contains("account slots")
+                || message.contains("txpool is full")
+                || message.contains("pool is full")
+                || message.contains("in-flight transaction limit")
+                || message.contains("too many pending transactions")
         }
         _ => false,
     }
@@ -1122,19 +1417,91 @@ mod tests {
             "unexpected old request error: {old_err}",
         );
 
+        let prepared = PreparedSidecar {
+            blob_count: blob_sidecar.blobs.len() as u64,
+            variant: BlobTransactionSidecarVariant::Eip4844(blob_sidecar),
+        };
         let fixed_request = build_l1_simulation_request(
             operator_address,
             to_address,
             input,
             nonce,
             fee_params,
-            Some(blob_sidecar),
-            false,
-        )
-        .expect("sidecar-backed blob simulation request should be constructed");
+            Some(&prepared),
+        );
         fixed_request
             .build_typed_simulate_transaction()
             .expect("sidecar-backed blob simulation request should be buildable");
+    }
+
+    #[test]
+    fn pool_capacity_error_classification() {
+        use alloy::rpc::json_rpc::ErrorPayload;
+        use alloy::transports::TransportErrorKind;
+
+        let resp = |message: &str| {
+            TransportError::ErrorResp(ErrorPayload {
+                code: -32000,
+                message: message.to_string().into(),
+                data: None,
+            })
+        };
+
+        // geth blobpool per-account cap and legacy-pool global capacity.
+        assert!(is_pool_capacity_error(&resp(
+            "account limit exceeded: pooled 16 txs"
+        )));
+        assert!(is_pool_capacity_error(&resp("txpool is full")));
+        // reth per-account slot cap phrasing.
+        assert!(is_pool_capacity_error(&resp(
+            "rejected due to account slots limit"
+        )));
+        assert!(is_pool_capacity_error(&resp(
+            "Too many pending transactions for sender"
+        )));
+
+        // Not capacity-class: nonce errors, replacement pricing, transport failures.
+        assert!(!is_pool_capacity_error(&resp("nonce too high")));
+        assert!(!is_pool_capacity_error(&resp(
+            "replacement transaction underpriced"
+        )));
+        assert!(!is_pool_capacity_error(&resp("already known")));
+        assert!(!is_pool_capacity_error(&TransportErrorKind::custom_str(
+            "error sending request"
+        )));
+    }
+
+    #[test]
+    fn fee_too_low_error_classification() {
+        use alloy::rpc::json_rpc::ErrorPayload;
+        use alloy::transports::TransportErrorKind;
+
+        let resp = |message: &str| {
+            TransportError::ErrorResp(ErrorPayload {
+                code: -32003,
+                message: message.to_string().into(),
+                data: None,
+            })
+        };
+
+        // anvil rejects submissions priced under the next block's base fee outright; geth
+        // rejects under the pool's (dynamic) price floor with "transaction underpriced".
+        assert!(is_fee_too_low_error(&resp(
+            "max fee per gas less than block base fee"
+        )));
+        assert!(is_fee_too_low_error(&resp(
+            "max fee per blob gas less than blob base fee"
+        )));
+        assert!(is_fee_too_low_error(&resp("transaction underpriced")));
+
+        // An RBF bump that is too small never resolves by waiting — must stay fatal.
+        assert!(!is_fee_too_low_error(&resp(
+            "replacement transaction underpriced"
+        )));
+        assert!(!is_fee_too_low_error(&resp("nonce too low")));
+        assert!(!is_fee_too_low_error(&TransportErrorKind::custom_str(
+            "error sending request"
+        )));
     }
 
     /// `max_fee_per_gas` and `max_fee_per_blob_gas` are static caps set by

--- a/lib/l1_sender/src/lib.rs
+++ b/lib/l1_sender/src/lib.rs
@@ -180,9 +180,8 @@ fn build_l1_simulation_request(
 
 /// Process responsible for sending transactions to L1.
 /// Handles one type of l1 command (e.g. Commit or Prove).
-/// Loads up to `command_limit` commands from the channel and sends them to L1 in parallel.
-/// Waits for all transactions to be mined, sends them to the output channel
-/// and then starts with the next `command_limit` commands.
+/// Keeps up to `command_limit` transactions in flight, forwarding each command to the output
+/// channel once its transaction is confirmed — see `pipelined` for the send machinery.
 ///
 /// Important: the same provider (sender address) must not be used outside this process.
 ///     Otherwise, there will be a nonce conflict and a failed L1 transaction
@@ -228,17 +227,18 @@ where
             .context("KZG trusted setup preload task panicked")?;
         }
 
+        // Both send paths are large state machines; boxing keeps them out of this future
+        // (and of the component future moved by value at pipeline spawn), whose size is
+        // stack-critical — see the stack-overflow note in `pipelined.rs`.
         if self.config.pipelining_enabled {
-            self.run_pipelined(inbound, outbound, state_reporter).await
+            Box::pin(self.run_pipelined(inbound, outbound, state_reporter)).await
         } else {
-            self.run_stop_and_wait(inbound, outbound, state_reporter)
-                .await
+            Box::pin(self.run_stop_and_wait(inbound, outbound, state_reporter)).await
         }
     }
 
-    /// Legacy stop-and-wait sending: drain up to `command_limit` commands, send them, wait for
-    /// all receipts + confirmations, repeat. Kept verbatim as the kill-switch fallback for the
-    /// pipelined sender (`pipelining_enabled = false`).
+    /// Fallback send path (`pipelining_enabled = false`): drain up to `command_limit`
+    /// commands, send them, wait for all receipts + confirmations, repeat.
     async fn run_stop_and_wait(
         &self,
         mut inbound: PeekableReceiver<L1SenderCommand<Input>>,
@@ -406,9 +406,7 @@ where
                     anyhow::Ok((receipt_fut, cmd, submitted_at))
                 }
             })
-            // We could buffer the stream here to enable sending multiple batches of transactions in parallel,
-            // but this is not necessary for now - the pipelined mode covers that; here we only
-            // wait for them to be included in parallel
+            // Transactions are sent sequentially and only waited on in parallel.
             .try_collect::<Vec<_>>()
             .await?;
             tracing::info!(command_name, range, "sent to L1, waiting for inclusion");
@@ -418,9 +416,9 @@ where
     }
 
     /// Converts every blob-carrying command's sidecar into the chain's accepted wire format
-    /// exactly once. The result is shared between gas simulation, the send path and (in
-    /// pipelined mode) in-flight simulation prefixes; the EIP-7594 conversion computes KZG
-    /// cell proofs and must never run twice for the same sidecar.
+    /// exactly once. The result is shared between gas simulation, the send path and
+    /// in-flight simulation prefixes; the EIP-7594 conversion computes KZG cell proofs and
+    /// must never run twice for the same sidecar.
     pub(crate) async fn prepare_sidecars(
         &self,
         commands: &[Input],
@@ -547,7 +545,7 @@ where
     /// resolve the ambiguity without risking local nonce divergence.
     pub(crate) async fn send_tx_with_retries(
         &self,
-        tx_request: TransactionRequest,
+        mut tx_request: TransactionRequest,
         range: &str,
     ) -> anyhow::Result<alloy::providers::PendingTransactionBuilder<alloy::network::Ethereum>> {
         let command_name = Input::COMPONENT_ID.as_str();
@@ -610,6 +608,52 @@ where
                         );
                     }
                     tokio::time::sleep(self.config.nonce_error_retry_backoff).await;
+                    // Re-resolve fees before retrying: the market may have moved permanently
+                    // past this wave's estimate while still being below the configured caps —
+                    // retrying the stale estimate would stall until the market came back down.
+                    match self
+                        .resolve_fee_params(
+                            self.config.fee_config,
+                            self.config.force_transaction_resubmission,
+                        )
+                        .await
+                    {
+                        Ok(fresh) => {
+                            // Fees only ratchet up: EIP-1559 replacement rules reject
+                            // lowering, and the original fees may carry a replacement floor.
+                            let raised = FeeParams {
+                                max_fee_per_gas: tx_request
+                                    .max_fee_per_gas
+                                    .unwrap_or_default()
+                                    .max(fresh.max_fee_per_gas),
+                                max_priority_fee_per_gas: tx_request
+                                    .max_priority_fee_per_gas
+                                    .unwrap_or_default()
+                                    .max(fresh.max_priority_fee_per_gas),
+                                max_fee_per_blob_gas: tx_request
+                                    .max_fee_per_blob_gas
+                                    .unwrap_or_default()
+                                    .max(fresh.max_fee_per_blob_gas),
+                            };
+                            tx_request.max_fee_per_gas = Some(raised.max_fee_per_gas);
+                            tx_request.max_priority_fee_per_gas =
+                                Some(raised.max_priority_fee_per_gas);
+                            if tx_request.max_fee_per_blob_gas.is_some() {
+                                tx_request.max_fee_per_blob_gas = Some(raised.max_fee_per_blob_gas);
+                            }
+                        }
+                        Err(err) => {
+                            // Estimation hiccups must not kill the wait loop; the next
+                            // iteration retries with the current fees.
+                            tracing::warn!(
+                                command_name,
+                                range,
+                                %err,
+                                "failed to refresh fee estimate while waiting out the fee \
+                                 market; retrying with current fees"
+                            );
+                        }
+                    }
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/lib/l1_sender/src/metrics.rs
+++ b/lib/l1_sender/src/metrics.rs
@@ -37,6 +37,11 @@ pub struct L1SenderMetrics {
     #[metrics(labels = ["command"])]
     pub parallel_transactions: LabeledFamily<&'static str, Gauge<u64>>,
 
+    /// Occupancy of the pipelined sender's in-flight window: transactions submitted but not
+    /// yet observed mined. Bounded by `command_limit`.
+    #[metrics(labels = ["command"])]
+    pub txs_in_flight: LabeledFamily<&'static str, Gauge<u64>>,
+
     /// L1 Transaction fee in Ether (i.e. total cost of commit/prove/execute)
     #[metrics(labels = ["command"], buckets = Buckets::exponential(0.0001..=100.0, 3.0))]
     pub l1_transaction_fee_ether: LabeledFamily<&'static str, Histogram<f64>>,

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -1,8 +1,8 @@
 //! Pipelined ("two-watermark") L1 sending.
 //!
-//! The stop-and-wait sender ties up the whole cycle waiting for inclusion + confirmations
-//! (~40-70s on mainnet) during which nothing new is submitted. This module decouples the
-//! three phases into concurrently running tasks joined by bounded queues:
+//! Submission, inclusion tracking, and confirmation run as concurrent tasks joined by
+//! bounded queues, so new transactions go out while earlier ones are still waiting to be
+//! mined or confirmed:
 //!
 //! ```text
 //! submitter ──(submitted queue: entries hold an unmined-slot permit)──▶ inclusion watcher
@@ -16,8 +16,8 @@
 //!   observed mined. This matches the L1 pool's *per-account* cap (geth blobpool
 //!   `maxTxsPerAccount` = reth `max-account-slots` = 16), which counts pooled (unmined)
 //!   transactions only. Each submission takes a semaphore permit that the inclusion watcher
-//!   releases at the *first receipt sighting* — never at confirmation, which would waste
-//!   `(required_confirmations-1)` blocks of window budget per tx and cap throughput at ~2x.
+//!   releases at the *first receipt sighting* — never at confirmation, which would keep each
+//!   window slot occupied for `required_confirmations - 1` extra blocks per transaction.
 //! * **Confirmation depth** — downstream forwarding still waits for `required_confirmations`,
 //!   handled by a separate FIFO task so it delays forwarding by a constant without ever
 //!   blocking submission.
@@ -307,7 +307,15 @@ where
             anyhow::Ok(())
         };
 
-        tokio::try_join!(submitter, inclusion_watcher, confirmation_forwarder)?;
+        // Boxed for stack safety, not style: these three state machines (the submitter
+        // embeds the whole wave-submission and recovery-seeding machinery) otherwise live
+        // inline in this future, which itself is moved by value when the pipeline spawns the
+        // component — that spike overflowed an 8 MiB thread stack in debug builds.
+        tokio::try_join!(
+            Box::pin(submitter),
+            Box::pin(inclusion_watcher),
+            Box::pin(confirmation_forwarder)
+        )?;
         Ok(())
     }
 
@@ -500,7 +508,7 @@ where
     /// Polls until a receipt for `tx_hash` exists (any depth). Warns on the configured
     /// transaction-timeout cadence; like the confirmation poller, it never gives up —
     /// a permanently stuck transaction requires operator intervention
-    /// (`force_transaction_resubmission`) exactly as in stop-and-wait mode.
+    /// (`force_transaction_resubmission`).
     async fn wait_for_receipt_existence(&self, tx_hash: B256) -> anyhow::Result<()> {
         let timeout = self.config.transaction_timeout;
         let poll_interval = self.config.poll_interval;
@@ -543,11 +551,12 @@ where
     /// startup state: which transactions to track as already-submitted, which nonce to
     /// continue from, and whether a stale suffix must be replaced with bumped fees.
     ///
-    /// Pairing works like the stop-and-wait recovery: for each pending nonce the on-chain
-    /// transaction's calldata is compared against the next queued command (pinned to the same
-    /// L1 block at which the inbound queue was constructed — see `l1_block_number`). Unlike
-    /// stop-and-wait, a mismatch or dropped transaction produces a [`ReplacementPlan`] so the
-    /// stale suffix is replaced at its own nonces instead of appending duplicates behind it.
+    /// Pairing: for each pending nonce the on-chain transaction's calldata is compared
+    /// against the next queued command (pinned to the same L1 block at which the inbound
+    /// queue was constructed — see `l1_block_number`). A match is tracked as
+    /// already-submitted; a mismatch or dropped transaction produces a [`ReplacementPlan`] so
+    /// the stale suffix is replaced at its own nonces instead of appending duplicates behind
+    /// it.
     ///
     /// Returns `None` when the inbound channel closes mid-recovery.
     async fn plan_pipelined_recovery(

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -99,9 +99,9 @@ struct MinedTx<Input> {
 }
 
 /// Fee floor applying while the submitter replaces a stale in-flight suffix left by a previous
-/// session (recovery calldata mismatch or a dropped transaction). Blob-tx replacement requires
-/// a 100% bump on tip, fee cap AND blob fee cap in both geth and reth, so the floor is
-/// 2x the stale transactions' actual fees.
+/// session (recovery calldata mismatch or a dropped transaction). The floor is the stale
+/// transactions' actual fees bumped by the pool's price-bump rule: 100% on all three fields
+/// for blob transactions (geth and reth), 10% otherwise.
 #[derive(Clone, Copy, Debug)]
 struct ReplacementPlan {
     /// Nonces below this replace previously-submitted transactions.
@@ -701,8 +701,8 @@ where
     }
 
     /// Rebuilds and resends the transaction at `request.nonce` from its simulation-prefix
-    /// entry after a pool eviction. Fees are re-resolved and floored at 2x the original send
-    /// (the blob RBF bump rule) in case the evicted transaction resurfaces in the pool.
+    /// entry after a pool eviction. Fees are re-resolved and floored at the original send's
+    /// fees plus the pool's replacement bump, in case the evicted transaction resurfaces.
     async fn resend_evicted(
         &self,
         state: &mut SubmitterState,
@@ -726,7 +726,7 @@ where
                 self.config.force_transaction_resubmission,
             )
             .await?;
-        let fee_params = resolved.max(entry.fee_params.doubled());
+        let fee_params = resolved.max(entry.fee_params.replacement_floor(entry.sidecar.is_some()));
 
         let blob_base_fee = if entry.sidecar.is_some() {
             Some(self.provider.get_blob_base_fee().await?)
@@ -948,9 +948,10 @@ where
     }
 
     /// Computes the replacement-fee floor for a stale in-flight suffix `[from_nonce,
-    /// until_nonce)`: 2x the per-field maximum of every still-visible stale transaction, which
-    /// satisfies the 100% price-bump rule geth and reth apply to blob-transaction replacement.
-    /// Returns `None` when no stale transaction is visible anymore (nothing to outbid).
+    /// until_nonce)`: the per-field maximum of every still-visible stale transaction, bumped
+    /// by the pool's price-bump rule — 100% when any stale transaction carries blobs, 10%
+    /// otherwise. Returns `None` when no stale transaction is visible anymore (nothing to
+    /// outbid).
     async fn build_replacement_plan(
         &self,
         operator_address: Address,
@@ -959,8 +960,10 @@ where
         first_stale: Option<&L1TxResponse>,
     ) -> Option<ReplacementPlan> {
         let mut stale_fee_max: Option<FeeParams> = None;
+        let mut any_blobs = false;
         let mut fold = |tx: &L1TxResponse| {
             let fees = fee_params_of_tx(tx, self.config.fee_config);
+            any_blobs |= ConsensusTransaction::max_fee_per_blob_gas(tx).is_some();
             stale_fee_max = Some(match stale_fee_max {
                 Some(current) => current.max(fees),
                 None => fees,
@@ -994,7 +997,7 @@ where
 
         stale_fee_max.map(|fees| ReplacementPlan {
             until_nonce,
-            fee_floor: fees.doubled(),
+            fee_floor: fees.replacement_floor(any_blobs),
         })
     }
 

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -1,0 +1,841 @@
+//! Pipelined ("two-watermark") L1 sending.
+//!
+//! The stop-and-wait sender ties up the whole cycle waiting for inclusion + confirmations
+//! (~40-70s on mainnet) during which nothing new is submitted. This module decouples the
+//! three phases into concurrently running tasks joined by bounded queues:
+//!
+//! ```text
+//! submitter ──(submitted queue: entries hold an unmined-slot permit)──▶ inclusion watcher
+//! inclusion watcher ──(mined queue)──▶ confirmation forwarder ──▶ downstream
+//! inclusion watcher ──(watch: mined-nonce floor)──▶ submitter (sim-prefix pruning)
+//! ```
+//!
+//! The two watermarks:
+//!
+//! * **Unmined window** — at most `command_limit` transactions may be submitted but not yet
+//!   observed mined. This matches the L1 pool's *per-account* cap (geth blobpool
+//!   `maxTxsPerAccount` = reth `max-account-slots` = 16), which counts pooled (unmined)
+//!   transactions only. Each submission takes a semaphore permit that the inclusion watcher
+//!   releases at the *first receipt sighting* — never at confirmation, which would waste
+//!   `(required_confirmations-1)` blocks of window budget per tx and cap throughput at ~2x.
+//! * **Confirmation depth** — downstream forwarding still waits for `required_confirmations`,
+//!   handled by a separate FIFO task so it delays forwarding by a constant without ever
+//!   blocking submission.
+//!
+//! Invariants:
+//!
+//! * Nonces are assigned strictly sequentially by the single submitter; `next_nonce` advances
+//!   only on a successful send. Any ambiguous send outcome (transport error) is fatal —
+//!   restart + in-flight recovery is the only safe way to resolve it.
+//! * Downstream forwarding is strict FIFO = nonce order = batch order (same-sender L1
+//!   transactions are included in nonce order, so receipts appear in FIFO order too).
+//! * Transient window overshoot (an L1 reorg can briefly return "mined" transactions to the
+//!   pool after their permits were released) is absorbed by treating pool-capacity rejections
+//!   as retryable with a generous budget.
+
+use crate::commands::{L1SenderCommand, SendToL1};
+use crate::config::L1SenderFeeConfig;
+use crate::metrics::L1_SENDER_METRICS;
+use crate::pipeline_component::L1Sender;
+use crate::{FeeParams, L1SenderState, METHOD_NOT_FOUND_CODE, PreparedSidecar, SimPrefixEntry};
+use alloy::consensus::Transaction as ConsensusTransaction;
+use alloy::eips::BlockId;
+use alloy::network::{Ethereum, Network, TransactionResponse};
+use alloy::primitives::{Address, B256};
+use alloy::providers::Provider;
+use alloy::transports::TransportError;
+use anyhow::Context as _;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, watch};
+use zksync_os_batch_types::batcher_model::{FriProof, SignedBatchEnvelope};
+use zksync_os_observability::ComponentStateReporter;
+use zksync_os_pipeline::{PeekableReceiver, SendAndRecordExt};
+
+type L1TxResponse = <Ethereum as Network>::TransactionResponse;
+
+/// Sizing factor for the mined-but-unconfirmed queue. The physical population is bounded by
+/// (inclusion rate × confirmation window); the bound only exists to cap memory if the
+/// confirmation forwarder stalls, at which point permit starvation pauses submission.
+const MINED_QUEUE_CAPACITY_FACTOR: usize = 4;
+
+/// A transaction submitted to L1 but not yet observed mined. Holds one unmined-window permit,
+/// released by the inclusion watcher at the first receipt sighting.
+struct InFlightTx<Input> {
+    tx_hash: B256,
+    nonce: u64,
+    command: Input,
+    submitted_at: Instant,
+    permit: OwnedSemaphorePermit,
+}
+
+/// A transaction observed mined, awaiting `required_confirmations` before its command is
+/// forwarded downstream.
+struct MinedTx<Input> {
+    tx_hash: B256,
+    nonce: u64,
+    command: Input,
+    submitted_at: Instant,
+}
+
+/// Fee floor applying while the submitter replaces a stale in-flight suffix left by a previous
+/// session (recovery calldata mismatch or a dropped transaction). Blob-tx replacement requires
+/// a 100% bump on tip, fee cap AND blob fee cap in both geth and reth, so the floor is
+/// 2x the stale transactions' actual fees.
+#[derive(Clone, Copy, Debug)]
+struct ReplacementPlan {
+    /// Nonces below this replace previously-submitted transactions.
+    until_nonce: u64,
+    fee_floor: FeeParams,
+}
+
+/// A previous session's in-flight transaction paired with its queued command during recovery.
+struct RecoveredInFlight<Input> {
+    tx_hash: B256,
+    nonce: u64,
+    command: Input,
+    /// Fees the transaction was actually sent with — reused for its simulation-prefix entry.
+    fee_params: FeeParams,
+}
+
+/// Startup state for the pipelined sender, derived from in-flight transaction recovery.
+struct PipelinedStart<Input> {
+    /// Already-submitted transactions to track (nonce order). Their commands were consumed
+    /// from the inbound queue.
+    seeds: Vec<RecoveredInFlight<Input>>,
+    /// Nonce of the next new submission.
+    next_nonce: u64,
+    /// All nonces below this are known mined (confirmed-nonce baseline at startup).
+    mined_floor: u64,
+    replacement: Option<ReplacementPlan>,
+}
+
+/// Mutable submitter-side state threaded through send waves.
+struct SubmitterState {
+    next_nonce: u64,
+    /// Submitted-but-not-observed-mined transactions mirrored into `eth_simulateV1` payloads
+    /// (see [`SimPrefixEntry`]). Pruned against the inclusion watcher's mined-nonce floor.
+    in_flight_prefix: VecDeque<SimPrefixEntry>,
+    replacement: Option<ReplacementPlan>,
+}
+
+impl<Input> L1Sender<Input>
+where
+    Input: SendToL1 + Send + 'static,
+{
+    pub(crate) async fn run_pipelined(
+        &self,
+        mut inbound: PeekableReceiver<L1SenderCommand<Input>>,
+        outbound: mpsc::Sender<SignedBatchEnvelope<FriProof>>,
+        state_reporter: ComponentStateReporter,
+    ) -> anyhow::Result<()> {
+        let command_name = Input::COMPONENT_ID.as_str();
+        let operator_address = self.operator_address().await?;
+        let window = self.config.command_limit.max(1);
+
+        let start = self
+            .plan_pipelined_recovery(&mut inbound, &state_reporter, operator_address)
+            .await?
+            .context("inbound channel closed during in-flight recovery")?;
+
+        tracing::info!(
+            command_name,
+            window,
+            seeds = start.seeds.len(),
+            next_nonce = start.next_nonce,
+            replacement = ?start.replacement,
+            "starting pipelined L1 sender",
+        );
+
+        let slots = Arc::new(Semaphore::new(window));
+        // Entries hold an unmined-slot permit, so occupancy never exceeds `window`.
+        let (submitted_tx, mut submitted_rx) = mpsc::channel::<InFlightTx<Input>>(window);
+        let (mined_tx, mut mined_rx) =
+            mpsc::channel::<MinedTx<Input>>(MINED_QUEUE_CAPACITY_FACTOR * window + 64);
+        // "All nonces below this value have been observed mined."
+        let (mined_floor_tx, mined_floor_rx) = watch::channel(start.mined_floor);
+
+        let state_reporter = &state_reporter;
+
+        let submitter = {
+            let slots = Arc::clone(&slots);
+            let submitted_tx = submitted_tx;
+            async move {
+                let mut state = SubmitterState {
+                    next_nonce: start.next_nonce,
+                    in_flight_prefix: VecDeque::new(),
+                    replacement: start.replacement,
+                };
+                self.seed_recovered_txs(
+                    start.seeds,
+                    &mut state,
+                    &slots,
+                    &submitted_tx,
+                    operator_address,
+                )
+                .await?;
+
+                let mut raw_buffer: Vec<L1SenderCommand<Input>> = Vec::with_capacity(window);
+                loop {
+                    // Wait for window capacity first, then for commands: idle permits are
+                    // never contended, and this order keeps commands in the channel (visible
+                    // to backpressure) until they can actually be sent.
+                    state_reporter.enter_state(L1SenderState::WaitingL1Inclusion);
+                    let mut permits = vec![
+                        Arc::clone(&slots)
+                            .acquire_owned()
+                            .await
+                            .expect("in-flight window semaphore is never closed"),
+                    ];
+                    while permits.len() < window {
+                        match Arc::clone(&slots).try_acquire_owned() {
+                            Ok(permit) => permits.push(permit),
+                            Err(_) => break,
+                        }
+                    }
+
+                    state_reporter.enter_state(L1SenderState::Idle);
+                    let received = inbound.recv_many(&mut raw_buffer, permits.len()).await;
+                    if received == 0 {
+                        tracing::info!(command_name, "inbound channel closed");
+                        // Drop `submitted_tx` (by returning) so the inclusion watcher and the
+                        // confirmation forwarder drain their queues and exit.
+                        return anyhow::Ok(());
+                    }
+                    // Excess permits are released by dropping them.
+                    permits.truncate(received);
+
+                    let last = raw_buffer
+                        .last()
+                        .context("recv_many returned non-zero count but the buffer is empty")?;
+                    state_reporter.record_picked(
+                        last.last_block_number(),
+                        last.block_timestamp(),
+                        Some(last.last_batch_number()),
+                    );
+                    let commands = raw_buffer
+                        .drain(..)
+                        .map(|cmd| -> anyhow::Result<Input> {
+                            match cmd {
+                                L1SenderCommand::SendToL1(command) => Ok(command),
+                                L1SenderCommand::Passthrough(batch) => anyhow::bail!(
+                                    "Unexpected passthrough command for batch {:?}. \
+                                     No passthrough commands are expected after the first `SendToL1`.",
+                                    batch.batch_number()
+                                ),
+                            }
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()?;
+
+                    state_reporter.enter_state(L1SenderState::SendingToL1);
+                    self.submit_wave(
+                        &mut state,
+                        commands,
+                        permits,
+                        operator_address,
+                        &submitted_tx,
+                        &mined_floor_rx,
+                    )
+                    .await?;
+                    L1_SENDER_METRICS.txs_in_flight[&command_name]
+                        .set((window - slots.available_permits()) as u64);
+                }
+            }
+        };
+
+        let inclusion_watcher = {
+            let slots = Arc::clone(&slots);
+            let mined_tx = mined_tx;
+            async move {
+                while let Some(entry) = submitted_rx.recv().await {
+                    let InFlightTx {
+                        tx_hash,
+                        nonce,
+                        command,
+                        submitted_at,
+                        permit,
+                    } = entry;
+                    // Same-sender transactions mine in nonce order, so head-of-line sighting
+                    // is exhaustive: this receipt appearing implies nothing behind it is
+                    // mined-but-unobserved for long.
+                    self.wait_for_receipt_existence(tx_hash).await?;
+                    // First sighting frees an unmined-window slot; confirmation depth is the
+                    // forwarder's concern only.
+                    drop(permit);
+                    mined_floor_tx.send_replace(nonce + 1);
+                    L1_SENDER_METRICS.txs_in_flight[&command_name]
+                        .set((window - slots.available_permits()) as u64);
+                    if mined_tx
+                        .send(MinedTx {
+                            tx_hash,
+                            nonce,
+                            command,
+                            submitted_at,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        // The forwarder only stops on error; `try_join!` surfaces its error,
+                        // this just terminates the watcher promptly.
+                        anyhow::bail!("confirmation forwarder terminated");
+                    }
+                }
+                anyhow::Ok(())
+            }
+        };
+
+        let confirmation_forwarder = async move {
+            while let Some(mined) = mined_rx.recv().await {
+                let receipt = self.wait_for_confirmed_receipt(mined.tx_hash).await;
+                // Observe latency before propagating errors so timeout cases are recorded.
+                L1_SENDER_METRICS.tx_inclusion_latency_seconds[&command_name]
+                    .observe(mined.submitted_at.elapsed().as_secs_f64());
+                let receipt = receipt?;
+                self.validate_tx_receipt(&mined.command, receipt).await?;
+                tracing::info!(
+                    command_name,
+                    nonce = mined.nonce,
+                    tx_hash = ?mined.tx_hash,
+                    "L1 transaction confirmed, sending downstream",
+                );
+                for mut envelope in mined.command.into() {
+                    envelope.set_stage(Input::MINED_STAGE);
+                    outbound.send_and_record(envelope, state_reporter)?;
+                }
+            }
+            anyhow::Ok(())
+        };
+
+        tokio::try_join!(submitter, inclusion_watcher, confirmation_forwarder)?;
+        Ok(())
+    }
+
+    /// Hands a previous session's recovered in-flight transactions to the tracking tasks.
+    /// Each seed occupies an unmined-window permit (released as usual once observed mined) and
+    /// gets a simulation-prefix entry so gas estimation for new commands chains correctly.
+    async fn seed_recovered_txs(
+        &self,
+        seeds: Vec<RecoveredInFlight<Input>>,
+        state: &mut SubmitterState,
+        slots: &Arc<Semaphore>,
+        submitted_tx: &mpsc::Sender<InFlightTx<Input>>,
+        operator_address: Address,
+    ) -> anyhow::Result<()> {
+        let use_eip7594 = self.provider.capabilities().supports_eip7594;
+        for seed in seeds {
+            let sidecar = match seed.command.blob_sidecar() {
+                Some(sidecar) => Some(Arc::new(
+                    PreparedSidecar::prepare(sidecar, use_eip7594).await?,
+                )),
+                None => None,
+            };
+            state.in_flight_prefix.push_back(SimPrefixEntry {
+                nonce: seed.nonce,
+                calldata: seed.command.solidity_call(&operator_address),
+                sidecar,
+                fee_params: seed.fee_params,
+            });
+            self.note_submitted_batches(&seed.command);
+            // If there are more seeds than window slots (the window was larger in a previous
+            // session), this blocks until the inclusion watcher frees permits — it is already
+            // running and needs no permits itself.
+            let permit = Arc::clone(slots)
+                .acquire_owned()
+                .await
+                .expect("in-flight window semaphore is never closed");
+            submitted_tx
+                .send(InFlightTx {
+                    tx_hash: seed.tx_hash,
+                    nonce: seed.nonce,
+                    command: seed.command,
+                    submitted_at: Instant::now(),
+                    permit,
+                })
+                .await
+                .map_err(|_| anyhow::anyhow!("inclusion watcher terminated during seeding"))?;
+        }
+        Ok(())
+    }
+
+    /// Sends one wave of commands (bounded by the permits handed in), assigning sequential
+    /// nonces and pushing each transaction to the inclusion watcher.
+    async fn submit_wave(
+        &self,
+        state: &mut SubmitterState,
+        commands: Vec<Input>,
+        mut permits: Vec<OwnedSemaphorePermit>,
+        operator_address: Address,
+        submitted_tx: &mpsc::Sender<InFlightTx<Input>>,
+        mined_floor_rx: &watch::Receiver<u64>,
+    ) -> anyhow::Result<()> {
+        let command_name = Input::COMPONENT_ID.as_str();
+        let range = Input::display_range(&commands);
+        tracing::info!(command_name, range, "sending L1 transactions");
+        L1_SENDER_METRICS.parallel_transactions[&command_name].set(commands.len() as u64);
+
+        // Drop prefix entries for transactions the inclusion watcher has observed mined —
+        // their state is part of the provider's simulation base now.
+        let mined_floor = *mined_floor_rx.borrow();
+        while state
+            .in_flight_prefix
+            .front()
+            .is_some_and(|entry| entry.nonce < mined_floor)
+        {
+            state.in_flight_prefix.pop_front();
+        }
+
+        let fee_params = self
+            .resolve_fee_params(
+                self.config.fee_config,
+                self.config.force_transaction_resubmission,
+            )
+            .await?;
+        let fee_params = self.apply_replacement_floor(state, fee_params);
+
+        let prepared_sidecars = self.prepare_sidecars(&commands).await?;
+        let gas_limits = self
+            .estimate_gas_limits(
+                state.in_flight_prefix.make_contiguous(),
+                &commands,
+                &prepared_sidecars,
+                operator_address,
+                fee_params,
+                state.next_nonce,
+            )
+            .await?;
+        tracing::info!(
+            command_name,
+            range,
+            ?gas_limits,
+            "estimated gas limits via eth_simulateV1",
+        );
+        let blob_base_fee = self
+            .fetch_blob_base_fee_if_needed(&prepared_sidecars)
+            .await?;
+
+        for ((mut command, gas_limit), prepared_sidecar) in
+            commands.into_iter().zip(gas_limits).zip(prepared_sidecars)
+        {
+            let nonce = state.next_nonce;
+            let calldata = command.solidity_call(&operator_address);
+            let tx_request = self.build_tx_request(
+                calldata.clone(),
+                operator_address,
+                nonce,
+                gas_limit,
+                fee_params,
+                prepared_sidecar.as_deref(),
+                blob_base_fee,
+            );
+
+            // Notify CommitWatcher before the transaction can possibly land on L1:
+            // this batch number is being submitted by this session.
+            self.note_submitted_batches(&command);
+
+            let pending_tx = self.send_tx_with_retries(tx_request, &range).await?;
+            let tx_hash = *pending_tx.tx_hash();
+            state.next_nonce += 1;
+            tracing::info!(
+                "{command_name}: L1 transaction submitted for {range}. Hash: {tx_hash:?} (nonce {nonce})",
+            );
+
+            command
+                .as_mut()
+                .iter_mut()
+                .for_each(|envelope| envelope.set_stage(Input::SENT_STAGE));
+            state.in_flight_prefix.push_back(SimPrefixEntry {
+                nonce,
+                calldata,
+                sidecar: prepared_sidecar,
+                fee_params,
+            });
+
+            let permit = permits
+                .pop()
+                .context("fewer permits than commands in a wave")?;
+            submitted_tx
+                .send(InFlightTx {
+                    tx_hash,
+                    nonce,
+                    command,
+                    submitted_at: Instant::now(),
+                    permit,
+                })
+                .await
+                .map_err(|_| anyhow::anyhow!("inclusion watcher terminated"))?;
+        }
+        Ok(())
+    }
+
+    /// Applies (and expires) the recovery replacement-fee floor for the current wave. If any
+    /// nonce in the wave replaces a stale transaction, the whole wave gets the floor — a
+    /// bounded overpay that keeps fee resolution per-wave instead of per-tx.
+    fn apply_replacement_floor(
+        &self,
+        state: &mut SubmitterState,
+        fee_params: FeeParams,
+    ) -> FeeParams {
+        match state.replacement {
+            Some(plan) if state.next_nonce < plan.until_nonce => {
+                let raised = fee_params.max(plan.fee_floor);
+                tracing::warn!(
+                    command_name = Input::COMPONENT_ID.as_str(),
+                    until_nonce = plan.until_nonce,
+                    next_nonce = state.next_nonce,
+                    ?raised,
+                    "replacing stale in-flight transactions from a previous session; \
+                     applying a 2x replacement fee floor (may exceed configured fee caps)",
+                );
+                raised
+            }
+            Some(_) => {
+                state.replacement = None;
+                fee_params
+            }
+            None => fee_params,
+        }
+    }
+
+    /// Polls until a receipt for `tx_hash` exists (any depth). Warns on the configured
+    /// transaction-timeout cadence; like the confirmation poller, it never gives up —
+    /// a permanently stuck transaction requires operator intervention
+    /// (`force_transaction_resubmission`) exactly as in stop-and-wait mode.
+    async fn wait_for_receipt_existence(&self, tx_hash: B256) -> anyhow::Result<()> {
+        let timeout = self.config.transaction_timeout;
+        let poll_interval = self.config.poll_interval;
+        let started_at = Instant::now();
+        let mut next_warning_at = if timeout.is_zero() {
+            None
+        } else {
+            Some(timeout)
+        };
+        loop {
+            let receipt = self
+                .provider
+                .get_transaction_receipt(tx_hash)
+                .await
+                .with_context(|| {
+                    format!("fetch receipt while waiting for L1 inclusion of tx {tx_hash}")
+                })?;
+            if receipt.is_some() {
+                return Ok(());
+            }
+
+            let elapsed = started_at.elapsed();
+            if let Some(warning_at) = next_warning_at
+                && elapsed >= warning_at
+            {
+                tracing::warn!(
+                    command_name = Input::COMPONENT_ID.as_str(),
+                    ?tx_hash,
+                    waited_secs = elapsed.as_secs_f64(),
+                    "still waiting for L1 inclusion; if the transaction is stuck underpriced, \
+                     restart with `force_transaction_resubmission.enabled = true`",
+                );
+                next_warning_at = Some(warning_at + timeout);
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    /// Detects in-flight L1 transactions from a previous session and derives the pipelined
+    /// startup state: which transactions to track as already-submitted, which nonce to
+    /// continue from, and whether a stale suffix must be replaced with bumped fees.
+    ///
+    /// Pairing works like the stop-and-wait recovery: for each pending nonce the on-chain
+    /// transaction's calldata is compared against the next queued command (pinned to the same
+    /// L1 block at which the inbound queue was constructed — see `l1_block_number`). Unlike
+    /// stop-and-wait, a mismatch or dropped transaction produces a [`ReplacementPlan`] so the
+    /// stale suffix is replaced at its own nonces instead of appending duplicates behind it.
+    ///
+    /// Returns `None` when the inbound channel closes mid-recovery.
+    async fn plan_pipelined_recovery(
+        &self,
+        inbound: &mut PeekableReceiver<L1SenderCommand<Input>>,
+        state_reporter: &ComponentStateReporter,
+        operator_address: Address,
+    ) -> anyhow::Result<Option<PipelinedStart<Input>>> {
+        let command_name = Input::COMPONENT_ID.as_str();
+        let latest_nonce = self
+            .provider
+            .get_transaction_count(operator_address)
+            .block_id(BlockId::number(self.l1_block_number))
+            .await
+            .context("get confirmed transaction count")?;
+        let pending_nonce = self
+            .provider
+            .get_transaction_count(operator_address)
+            .pending()
+            .await
+            .context("get pending transaction count")?;
+
+        if self.config.force_transaction_resubmission {
+            if pending_nonce > latest_nonce {
+                tracing::warn!(
+                    command_name,
+                    latest_nonce,
+                    pending_nonce,
+                    "force resubmission: replacing {} in-flight transactions starting from the \
+                     confirmed nonce with replacement fees",
+                    pending_nonce - latest_nonce,
+                );
+            }
+            // Replacement fees are applied session-wide via `resolve_fee_params`; config
+            // validation guarantees the multipliers satisfy the 100% blob-RBF bump rule.
+            return Ok(Some(PipelinedStart {
+                seeds: vec![],
+                next_nonce: latest_nonce,
+                mined_floor: latest_nonce,
+                replacement: None,
+            }));
+        }
+
+        if pending_nonce <= latest_nonce {
+            return Ok(Some(PipelinedStart {
+                seeds: vec![],
+                next_nonce: pending_nonce.max(latest_nonce),
+                mined_floor: latest_nonce,
+                replacement: None,
+            }));
+        }
+
+        let in_flight_count = (pending_nonce - latest_nonce) as usize;
+        tracing::info!(
+            command_name,
+            l1_block_number = self.l1_block_number,
+            latest_nonce,
+            pending_nonce,
+            in_flight_count,
+            "Detected in-flight L1 transactions on startup, attempting recovery",
+        );
+
+        // Probe whether the provider supports `eth_getTransactionBySenderAndNonce` before
+        // iterating over all pending nonces.
+        if let Err(TransportError::ErrorResp(ref e)) = self
+            .provider
+            .get_transaction_by_sender_nonce(operator_address, latest_nonce)
+            .await
+        {
+            if e.code == METHOD_NOT_FOUND_CODE {
+                tracing::warn!(
+                    command_name,
+                    in_flight_count,
+                    "eth_getTransactionBySenderAndNonce is not supported by the current L1 \
+                     provider, so in-flight transactions cannot be paired with queued commands. \
+                     Waiting for them to settle before sending anything. For crash-tolerant \
+                     operation use a provider that supports the method (reth/Erigon family), or \
+                     restart with `force_transaction_resubmission.enabled = true` to replace \
+                     them.",
+                );
+                let settled_nonce = self.wait_for_account_quiescence(operator_address).await?;
+                return Ok(Some(PipelinedStart {
+                    seeds: vec![],
+                    next_nonce: settled_nonce,
+                    mined_floor: settled_nonce,
+                    replacement: None,
+                }));
+            }
+            anyhow::bail!("Error while probing eth_getTransactionBySenderAndNonce support: {e}");
+        }
+
+        let mut seeds: Vec<RecoveredInFlight<Input>> = Vec::with_capacity(in_flight_count);
+        let mut replacement = None;
+        for nonce in latest_nonce..pending_nonce {
+            let tx = match self
+                .provider
+                .get_transaction_by_sender_nonce(operator_address, nonce)
+                .await
+            {
+                Err(err) => {
+                    anyhow::bail!("Failed to fetch in-flight transaction at nonce {nonce}: {err}");
+                }
+                Ok(Some(tx)) => tx,
+                Ok(None) => {
+                    tracing::warn!(
+                        command_name,
+                        nonce,
+                        "In-flight transaction at nonce {nonce} was dropped from the mempool; \
+                         re-sending queued commands from that nonce",
+                    );
+                    replacement = self
+                        .build_replacement_plan(operator_address, nonce, pending_nonce, None)
+                        .await;
+                    break;
+                }
+            };
+
+            // Peek at the next command without consuming it so that a mismatch leaves
+            // `inbound` intact for the normal send path.
+            let matches = inbound
+                .peek_recv(|raw_cmd| {
+                    let L1SenderCommand::SendToL1(cmd) = raw_cmd else {
+                        return false;
+                    };
+                    cmd.solidity_call(&operator_address) == *tx.input()
+                })
+                .await;
+
+            match matches {
+                None => return Ok(None),
+                Some(false) => {
+                    tracing::warn!(
+                        command_name,
+                        nonce,
+                        "In-flight transaction calldata does not match the next queued command; \
+                         replacing in-flight transactions from nonce {nonce} with queued \
+                         commands at bumped fees",
+                    );
+                    replacement = self
+                        .build_replacement_plan(operator_address, nonce, pending_nonce, Some(&tx))
+                        .await;
+                    break;
+                }
+                Some(true) => {
+                    let Some(L1SenderCommand::SendToL1(cmd)) =
+                        inbound.recv_and_record_picked(state_reporter).await
+                    else {
+                        unreachable!("peek succeeded, recv must return the same item");
+                    };
+                    seeds.push(RecoveredInFlight {
+                        tx_hash: tx.tx_hash(),
+                        nonce,
+                        command: cmd,
+                        fee_params: fee_params_of_tx(&tx, self.config.fee_config),
+                    });
+                }
+            }
+        }
+
+        let next_nonce = latest_nonce + seeds.len() as u64;
+        tracing::info!(
+            command_name,
+            recovered = seeds.len(),
+            in_flight_count,
+            next_nonce,
+            replacement_active = replacement.is_some(),
+            "Recovered in-flight transactions; tracking their inclusion in the background",
+        );
+
+        Ok(Some(PipelinedStart {
+            seeds,
+            next_nonce,
+            mined_floor: latest_nonce,
+            replacement,
+        }))
+    }
+
+    /// Computes the replacement-fee floor for a stale in-flight suffix `[from_nonce,
+    /// until_nonce)`: 2x the per-field maximum of every still-visible stale transaction, which
+    /// satisfies the 100% price-bump rule geth and reth apply to blob-transaction replacement.
+    /// Returns `None` when no stale transaction is visible anymore (nothing to outbid).
+    async fn build_replacement_plan(
+        &self,
+        operator_address: Address,
+        from_nonce: u64,
+        until_nonce: u64,
+        first_stale: Option<&L1TxResponse>,
+    ) -> Option<ReplacementPlan> {
+        let mut stale_fee_max: Option<FeeParams> = None;
+        let mut fold = |tx: &L1TxResponse| {
+            let fees = fee_params_of_tx(tx, self.config.fee_config);
+            stale_fee_max = Some(match stale_fee_max {
+                Some(current) => current.max(fees),
+                None => fees,
+            });
+        };
+        if let Some(tx) = first_stale {
+            fold(tx);
+        }
+        let already_fetched = first_stale.is_some() as u64;
+        for nonce in (from_nonce + already_fetched)..until_nonce {
+            match self
+                .provider
+                .get_transaction_by_sender_nonce(operator_address, nonce)
+                .await
+            {
+                Ok(Some(tx)) => fold(&tx),
+                // A dropped tx needs no outbidding; an error here must not block startup —
+                // worst case the floor is too low and the send fails fatally with a clear
+                // "replacement transaction underpriced" error.
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::warn!(
+                        nonce,
+                        %err,
+                        "failed to fetch stale in-flight transaction while computing the \
+                         replacement fee floor",
+                    );
+                }
+            }
+        }
+
+        stale_fee_max.map(|fees| ReplacementPlan {
+            until_nonce,
+            fee_floor: FeeParams {
+                max_fee_per_gas: fees.max_fee_per_gas.saturating_mul(2),
+                max_priority_fee_per_gas: fees.max_priority_fee_per_gas.saturating_mul(2),
+                max_fee_per_blob_gas: fees.max_fee_per_blob_gas.saturating_mul(2),
+            },
+        })
+    }
+
+    /// Polls until the operator account has no pending transactions (pending nonce == latest
+    /// nonce). Used when in-flight transactions exist but cannot be paired with queued
+    /// commands because the provider lacks `eth_getTransactionBySenderAndNonce`.
+    async fn wait_for_account_quiescence(&self, operator_address: Address) -> anyhow::Result<u64> {
+        let timeout = self.config.transaction_timeout;
+        let poll_interval = self.config.poll_interval;
+        let started_at = Instant::now();
+        let mut next_warning_at = if timeout.is_zero() {
+            None
+        } else {
+            Some(timeout)
+        };
+        loop {
+            let latest_nonce = self
+                .provider
+                .get_transaction_count(operator_address)
+                .await
+                .context("get latest transaction count while waiting for quiescence")?;
+            let pending_nonce = self
+                .provider
+                .get_transaction_count(operator_address)
+                .pending()
+                .await
+                .context("get pending transaction count while waiting for quiescence")?;
+            if pending_nonce <= latest_nonce {
+                return Ok(latest_nonce);
+            }
+
+            let elapsed = started_at.elapsed();
+            if let Some(warning_at) = next_warning_at
+                && elapsed >= warning_at
+            {
+                tracing::warn!(
+                    command_name = Input::COMPONENT_ID.as_str(),
+                    latest_nonce,
+                    pending_nonce,
+                    waited_secs = elapsed.as_secs_f64(),
+                    "still waiting for previous-session in-flight transactions to settle; \
+                     restart with `force_transaction_resubmission.enabled = true` to replace \
+                     them instead",
+                );
+                next_warning_at = Some(warning_at + timeout);
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+}
+
+/// Extracts the fee parameters a transaction was actually sent with. The blob fee cap falls
+/// back to the configured cap for non-blob transactions (the value is then unused).
+fn fee_params_of_tx(tx: &L1TxResponse, fee_config: L1SenderFeeConfig) -> FeeParams {
+    FeeParams {
+        max_fee_per_gas: ConsensusTransaction::max_fee_per_gas(tx),
+        max_priority_fee_per_gas: ConsensusTransaction::max_priority_fee_per_gas(tx)
+            .unwrap_or_default(),
+        max_fee_per_blob_gas: ConsensusTransaction::max_fee_per_blob_gas(tx)
+            .unwrap_or(fee_config.max_fee_per_blob_gas_wei),
+    }
+}

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -849,7 +849,9 @@ where
                      restart with `force_transaction_resubmission.enabled = true` to replace \
                      them.",
                 );
-                let settled_nonce = self.wait_for_account_quiescence(operator_address).await?;
+                let settled_nonce = self
+                    .wait_for_in_flight_txs_to_settle(operator_address)
+                    .await?;
                 return Ok(Some(PipelinedStart {
                     seeds: vec![],
                     next_nonce: settled_nonce,
@@ -1004,7 +1006,10 @@ where
     /// Polls until the operator account has no pending transactions (pending nonce == latest
     /// nonce). Used when in-flight transactions exist but cannot be paired with queued
     /// commands because the provider lacks `eth_getTransactionBySenderAndNonce`.
-    async fn wait_for_account_quiescence(&self, operator_address: Address) -> anyhow::Result<u64> {
+    async fn wait_for_in_flight_txs_to_settle(
+        &self,
+        operator_address: Address,
+    ) -> anyhow::Result<u64> {
         let timeout = self.config.transaction_timeout;
         let poll_interval = self.config.poll_interval;
         let started_at = Instant::now();
@@ -1018,13 +1023,17 @@ where
                 .provider
                 .get_transaction_count(operator_address)
                 .await
-                .context("get latest transaction count while waiting for quiescence")?;
+                .context(
+                    "get latest transaction count while waiting for in-flight txs to settle",
+                )?;
             let pending_nonce = self
                 .provider
                 .get_transaction_count(operator_address)
                 .pending()
                 .await
-                .context("get pending transaction count while waiting for quiescence")?;
+                .context(
+                    "get pending transaction count while waiting for in-flight txs to settle",
+                )?;
             if pending_nonce <= latest_nonce {
                 return Ok(latest_nonce);
             }

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -35,6 +35,11 @@
 //! * A transaction evicted from the L1 pool (fee spike, pool pressure) is detected by the
 //!   inclusion watcher and resent at its nonce — waiting for its receipt would wedge the
 //!   window forever. The old hash stays tracked in case the evicted original still mines.
+//! * The L1 RPC endpoint is assumed to serve a single consistent view (one node, or sticky
+//!   routing to one): startup recovery trusts a single `pending` nonce read. A backend that
+//!   has not seen our pooled transactions makes the sender race its own earlier sends —
+//!   still safe (single-use nonces + the contract's batch-chain check revert anything
+//!   inconsistent), but each affected nonce costs wasted gas and a spurious restart.
 
 use crate::commands::{L1SenderCommand, SendToL1};
 use crate::config::L1SenderFeeConfig;

--- a/lib/l1_sender/src/pipelined.rs
+++ b/lib/l1_sender/src/pipelined.rs
@@ -32,6 +32,9 @@
 //! * Transient window overshoot (an L1 reorg can briefly return "mined" transactions to the
 //!   pool after their permits were released) is absorbed by treating pool-capacity rejections
 //!   as retryable with a generous budget.
+//! * A transaction evicted from the L1 pool (fee spike, pool pressure) is detected by the
+//!   inclusion watcher and resent at its nonce — waiting for its receipt would wedge the
+//!   window forever. The old hash stays tracked in case the evicted original still mines.
 
 use crate::commands::{L1SenderCommand, SendToL1};
 use crate::config::L1SenderFeeConfig;
@@ -63,11 +66,22 @@ const MINED_QUEUE_CAPACITY_FACTOR: usize = 4;
 /// A transaction submitted to L1 but not yet observed mined. Holds one unmined-window permit,
 /// released by the inclusion watcher at the first receipt sighting.
 struct InFlightTx<Input> {
-    tx_hash: B256,
+    /// Candidate hashes for this nonce, oldest first. Grows when a pool-evicted transaction
+    /// is resent: the old hash stays a candidate because eviction is observed remotely and
+    /// the original may still mine (e.g. it was propagated before the eviction).
+    tx_hashes: Vec<B256>,
     nonce: u64,
     command: Input,
     submitted_at: Instant,
     permit: OwnedSemaphorePermit,
+}
+
+/// Inclusion-watcher → submitter request to resend the transaction at `nonce` (its previous
+/// send was evicted from the L1 pool). The submitter rebuilds it from the nonce's
+/// simulation-prefix entry and replies with the new hash.
+struct ResendRequest {
+    nonce: u64,
+    reply: tokio::sync::oneshot::Sender<B256>,
 }
 
 /// A transaction observed mined, awaiting `required_confirmations` before its command is
@@ -97,6 +111,8 @@ struct RecoveredInFlight<Input> {
     command: Input,
     /// Fees the transaction was actually sent with — reused for its simulation-prefix entry.
     fee_params: FeeParams,
+    /// Gas limit the transaction was sent with — reused if it must be resent after eviction.
+    gas_limit: u64,
 }
 
 /// Startup state for the pipelined sender, derived from in-flight transaction recovery.
@@ -155,6 +171,9 @@ where
             mpsc::channel::<MinedTx<Input>>(MINED_QUEUE_CAPACITY_FACTOR * window + 64);
         // "All nonces below this value have been observed mined."
         let (mined_floor_tx, mined_floor_rx) = watch::channel(start.mined_floor);
+        // Inclusion watcher asks the submitter to resend pool-evicted transactions. The
+        // watcher requests resends one at a time (head of line), so capacity 1 suffices.
+        let (resend_tx, mut resend_rx) = mpsc::channel::<ResendRequest>(1);
 
         let state_reporter = &state_reporter;
 
@@ -180,14 +199,22 @@ where
                 loop {
                     // Wait for window capacity first, then for commands: idle permits are
                     // never contended, and this order keeps commands in the channel (visible
-                    // to backpressure) until they can actually be sent.
+                    // to backpressure) until they can actually be sent. Both waits service
+                    // resend requests: the watcher may need a resend precisely when the
+                    // window is full and no new sends can proceed.
                     state_reporter.enter_state(L1SenderState::WaitingL1Inclusion);
-                    let mut permits = vec![
-                        Arc::clone(&slots)
-                            .acquire_owned()
-                            .await
-                            .expect("in-flight window semaphore is never closed"),
-                    ];
+                    let first_permit = loop {
+                        tokio::select! {
+                            biased;
+                            Some(request) = resend_rx.recv() => {
+                                self.resend_evicted(&mut state, request, operator_address).await?;
+                            }
+                            permit = Arc::clone(&slots).acquire_owned() => {
+                                break permit.expect("in-flight window semaphore is never closed");
+                            }
+                        }
+                    };
+                    let mut permits = vec![first_permit];
                     while permits.len() < window {
                         match Arc::clone(&slots).try_acquire_owned() {
                             Ok(permit) => permits.push(permit),
@@ -196,7 +223,17 @@ where
                     }
 
                     state_reporter.enter_state(L1SenderState::Idle);
-                    let received = inbound.recv_many(&mut raw_buffer, permits.len()).await;
+                    let received = loop {
+                        tokio::select! {
+                            biased;
+                            Some(request) = resend_rx.recv() => {
+                                self.resend_evicted(&mut state, request, operator_address).await?;
+                            }
+                            received = inbound.recv_many(&mut raw_buffer, permits.len()) => {
+                                break received;
+                            }
+                        }
+                    };
                     if received == 0 {
                         tracing::info!(command_name, "inbound channel closed");
                         // Drop `submitted_tx` (by returning) so the inclusion watcher and the
@@ -247,19 +284,22 @@ where
         let inclusion_watcher = {
             let slots = Arc::clone(&slots);
             let mined_tx = mined_tx;
+            let resend_tx = resend_tx;
             async move {
-                while let Some(entry) = submitted_rx.recv().await {
+                while let Some(mut entry) = submitted_rx.recv().await {
+                    // Same-sender transactions mine in nonce order, so head-of-line sighting
+                    // is exhaustive: this receipt appearing implies nothing behind it is
+                    // mined-but-unobserved for long.
+                    let mined_hash = self
+                        .wait_for_inclusion(&mut entry, operator_address, &resend_tx)
+                        .await?;
                     let InFlightTx {
-                        tx_hash,
                         nonce,
                         command,
                         submitted_at,
                         permit,
+                        ..
                     } = entry;
-                    // Same-sender transactions mine in nonce order, so head-of-line sighting
-                    // is exhaustive: this receipt appearing implies nothing behind it is
-                    // mined-but-unobserved for long.
-                    self.wait_for_receipt_existence(tx_hash).await?;
                     // First sighting frees an unmined-window slot; confirmation depth is the
                     // forwarder's concern only.
                     drop(permit);
@@ -268,7 +308,7 @@ where
                         .set((window - slots.available_permits()) as u64);
                     if mined_tx
                         .send(MinedTx {
-                            tx_hash,
+                            tx_hash: mined_hash,
                             nonce,
                             command,
                             submitted_at,
@@ -343,6 +383,7 @@ where
                 calldata: seed.command.solidity_call(&operator_address),
                 sidecar,
                 fee_params: seed.fee_params,
+                gas_limit: seed.gas_limit,
             });
             self.note_submitted_batches(&seed.command);
             // If there are more seeds than window slots (the window was larger in a previous
@@ -354,7 +395,7 @@ where
                 .expect("in-flight window semaphore is never closed");
             submitted_tx
                 .send(InFlightTx {
-                    tx_hash: seed.tx_hash,
+                    tx_hashes: vec![seed.tx_hash],
                     nonce: seed.nonce,
                     command: seed.command,
                     submitted_at: Instant::now(),
@@ -457,6 +498,7 @@ where
                 calldata,
                 sidecar: prepared_sidecar,
                 fee_params,
+                gas_limit,
             });
 
             let permit = permits
@@ -464,7 +506,7 @@ where
                 .context("fewer permits than commands in a wave")?;
             submitted_tx
                 .send(InFlightTx {
-                    tx_hash,
+                    tx_hashes: vec![tx_hash],
                     nonce,
                     command,
                     submitted_at: Instant::now(),
@@ -505,11 +547,23 @@ where
         }
     }
 
-    /// Polls until a receipt for `tx_hash` exists (any depth). Warns on the configured
-    /// transaction-timeout cadence; like the confirmation poller, it never gives up —
-    /// a permanently stuck transaction requires operator intervention
-    /// (`force_transaction_resubmission`).
-    async fn wait_for_receipt_existence(&self, tx_hash: B256) -> anyhow::Result<()> {
+    /// Polls until one of the entry's candidate transactions has a receipt (any depth) and
+    /// returns that hash. Never gives up on a transaction that is merely unmined — but a
+    /// transaction *evicted from the pool* (fee spike, pool pressure) would otherwise be
+    /// waited on forever, wedging the whole window, so eviction is detected and the
+    /// transaction is resent at its nonce via the submitter.
+    async fn wait_for_inclusion(
+        &self,
+        entry: &mut InFlightTx<Input>,
+        operator_address: Address,
+        resend_tx: &mpsc::Sender<ResendRequest>,
+    ) -> anyhow::Result<B256> {
+        /// Pool presence is probed every N-th empty receipt poll (it costs one RPC per
+        /// candidate), and eviction is acted on only after two consecutive absent probes —
+        /// a just-submitted transaction can be transiently invisible.
+        const EVICTION_PROBE_EVERY: u32 = 5;
+        const EVICTION_PROBES_TO_CONFIRM: u32 = 2;
+
         let timeout = self.config.transaction_timeout;
         let poll_interval = self.config.poll_interval;
         let started_at = Instant::now();
@@ -518,16 +572,34 @@ where
         } else {
             Some(timeout)
         };
+        let mut polls: u32 = 0;
+        let mut consecutive_absent: u32 = 0;
         loop {
-            let receipt = self
-                .provider
-                .get_transaction_receipt(tx_hash)
-                .await
-                .with_context(|| {
-                    format!("fetch receipt while waiting for L1 inclusion of tx {tx_hash}")
-                })?;
-            if receipt.is_some() {
-                return Ok(());
+            for &tx_hash in &entry.tx_hashes {
+                let receipt = self
+                    .provider
+                    .get_transaction_receipt(tx_hash)
+                    .await
+                    .with_context(|| {
+                        format!("fetch receipt while waiting for L1 inclusion of tx {tx_hash}")
+                    })?;
+                if receipt.is_some() {
+                    return Ok(tx_hash);
+                }
+            }
+
+            polls += 1;
+            if polls.is_multiple_of(EVICTION_PROBE_EVERY) {
+                if self.all_candidates_absent(entry).await? {
+                    consecutive_absent += 1;
+                } else {
+                    consecutive_absent = 0;
+                }
+                if consecutive_absent >= EVICTION_PROBES_TO_CONFIRM {
+                    self.handle_evicted_entry(entry, operator_address, resend_tx)
+                        .await?;
+                    consecutive_absent = 0;
+                }
             }
 
             let elapsed = started_at.elapsed();
@@ -536,7 +608,8 @@ where
             {
                 tracing::warn!(
                     command_name = Input::COMPONENT_ID.as_str(),
-                    ?tx_hash,
+                    tx_hashes = ?entry.tx_hashes,
+                    nonce = entry.nonce,
                     waited_secs = elapsed.as_secs_f64(),
                     "still waiting for L1 inclusion; if the transaction is stuck underpriced, \
                      restart with `force_transaction_resubmission.enabled = true`",
@@ -545,6 +618,140 @@ where
             }
             tokio::time::sleep(poll_interval).await;
         }
+    }
+
+    /// True when none of the entry's candidate transactions are known to the L1 node —
+    /// neither pooled nor mined.
+    async fn all_candidates_absent(&self, entry: &InFlightTx<Input>) -> anyhow::Result<bool> {
+        for &tx_hash in &entry.tx_hashes {
+            let known = self
+                .provider
+                .get_transaction_by_hash(tx_hash)
+                .await
+                .with_context(|| format!("probe pool presence of tx {tx_hash}"))?
+                .is_some();
+            if known {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    /// All candidates for this nonce vanished from the pool. If the nonce was consumed by a
+    /// transaction that is none of ours, another sender is using the operator account — fatal.
+    /// Otherwise the transaction was evicted (fee spike, pool pressure): ask the submitter to
+    /// resend it at the same nonce and track the new hash alongside the old candidates (the
+    /// eviction is observed remotely, so an old candidate may still mine elsewhere).
+    async fn handle_evicted_entry(
+        &self,
+        entry: &mut InFlightTx<Input>,
+        operator_address: Address,
+        resend_tx: &mpsc::Sender<ResendRequest>,
+    ) -> anyhow::Result<()> {
+        let latest_nonce = self
+            .provider
+            .get_transaction_count(operator_address)
+            .await
+            .context("get confirmed nonce while handling a pool eviction")?;
+        if latest_nonce > entry.nonce {
+            // Give in-flight receipt propagation one more chance before declaring foul play.
+            for &tx_hash in &entry.tx_hashes {
+                if self
+                    .provider
+                    .get_transaction_receipt(tx_hash)
+                    .await?
+                    .is_some()
+                {
+                    return Ok(());
+                }
+            }
+            anyhow::bail!(
+                "nonce {} was consumed by a transaction that is not one of ours ({:?}); \
+                 the operator account is being used by another sender",
+                entry.nonce,
+                entry.tx_hashes,
+            );
+        }
+
+        tracing::warn!(
+            command_name = Input::COMPONENT_ID.as_str(),
+            nonce = entry.nonce,
+            tx_hashes = ?entry.tx_hashes,
+            "in-flight transaction was evicted from the L1 pool; resending at the same nonce",
+        );
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        resend_tx
+            .send(ResendRequest {
+                nonce: entry.nonce,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("submitter terminated during an eviction resend"))?;
+        let new_hash = reply_rx
+            .await
+            .context("submitter dropped an eviction resend request")?;
+        entry.tx_hashes.push(new_hash);
+        entry.submitted_at = Instant::now();
+        Ok(())
+    }
+
+    /// Rebuilds and resends the transaction at `request.nonce` from its simulation-prefix
+    /// entry after a pool eviction. Fees are re-resolved and floored at 2x the original send
+    /// (the blob RBF bump rule) in case the evicted transaction resurfaces in the pool.
+    async fn resend_evicted(
+        &self,
+        state: &mut SubmitterState,
+        request: ResendRequest,
+        operator_address: Address,
+    ) -> anyhow::Result<()> {
+        let entry = state
+            .in_flight_prefix
+            .iter_mut()
+            .find(|entry| entry.nonce == request.nonce)
+            .with_context(|| {
+                format!(
+                    "no in-flight prefix entry for evicted nonce {}",
+                    request.nonce
+                )
+            })?;
+
+        let resolved = self
+            .resolve_fee_params(
+                self.config.fee_config,
+                self.config.force_transaction_resubmission,
+            )
+            .await?;
+        let fee_params = resolved.max(entry.fee_params.doubled());
+
+        let blob_base_fee = if entry.sidecar.is_some() {
+            Some(self.provider.get_blob_base_fee().await?)
+        } else {
+            None
+        };
+        let tx_request = self.build_tx_request(
+            entry.calldata.clone(),
+            operator_address,
+            entry.nonce,
+            entry.gas_limit,
+            fee_params,
+            entry.sidecar.as_deref(),
+            blob_base_fee,
+        );
+        let pending_tx = self
+            .send_tx_with_retries(tx_request, &format!("resend of nonce {}", request.nonce))
+            .await?;
+        entry.fee_params = fee_params;
+
+        let new_hash = *pending_tx.tx_hash();
+        tracing::info!(
+            command_name = Input::COMPONENT_ID.as_str(),
+            nonce = request.nonce,
+            tx_hash = ?new_hash,
+            "resent evicted L1 transaction",
+        );
+        // The watcher owns the entry lifecycle; if it is gone the try_join surfaces its error.
+        let _ = request.reply.send(new_hash);
+        Ok(())
     }
 
     /// Detects in-flight L1 transactions from a previous session and derives the pipelined
@@ -711,6 +918,7 @@ where
                         nonce,
                         command: cmd,
                         fee_params: fee_params_of_tx(&tx, self.config.fee_config),
+                        gas_limit: ConsensusTransaction::gas_limit(&tx),
                     });
                 }
             }
@@ -781,11 +989,7 @@ where
 
         stale_fee_max.map(|fees| ReplacementPlan {
             until_nonce,
-            fee_floor: FeeParams {
-                max_fee_per_gas: fees.max_fee_per_gas.saturating_mul(2),
-                max_priority_fee_per_gas: fees.max_priority_fee_per_gas.saturating_mul(2),
-                max_fee_per_blob_gas: fees.max_fee_per_blob_gas.saturating_mul(2),
-            },
+            fee_floor: fees.doubled(),
         })
     }
 

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -245,11 +245,21 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> Batcher<ReadState> {
                 }) => {
                     state_reporter.enter_state(GenericComponentState::Active);
                     match should_seal {
-                        Some(true) => {
+                        Some(true) if !blocks.is_empty() => {
                             // some of the limits was reached, start sealing the batch
                             break;
                         }
-                        Some(false) => {
+                        Some(seal_after_adding) => {
+                            // `seal_after_adding` means the batch is still empty and the peeked
+                            // block alone exceeds a seal limit. A batch must contain at least
+                            // one block — refusing it would replay the same block forever — so
+                            // accept it as a single-block batch.
+                            if seal_after_adding {
+                                tracing::warn!(
+                                    batch_number,
+                                    "a single block exceeds batch seal limits; sealing it as its own batch"
+                                );
+                            }
                             let Some(ProverBlock { output: block_output, record: replay_record, prover_input, tree_output }) = block_receiver.pop_buffer() else {
                                 anyhow::bail!("No block received in buffer after peeking")
                             };
@@ -300,6 +310,10 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> Batcher<ReadState> {
                                 tree_output,
                                 prover_input,
                             ));
+
+                            if seal_after_adding {
+                                break;
+                            }
                         }
                         None => {
                             tracing::info!("inbound channel closed");

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1162,10 +1162,21 @@ pub struct L1SenderConfig {
     pub force_transaction_resubmission: ForceTransactionResubmissionConfig,
 
     /// Max number of commands (to commit/prove/execute one batch) to be processed at a time.
+    /// With pipelined sending this is the in-flight window size: the max number of
+    /// submitted-but-not-yet-mined L1 transactions. Must not exceed the L1 node's per-account
+    /// pool cap — 16 for both geth's blobpool (`maxTxsPerAccount`) and reth's default
+    /// `max-account-slots` — or sends are rejected until the pool drains.
     #[config(default_t = 16)]
     pub command_limit: usize,
 
-    /// How often to poll L1 for new blocks.
+    /// When true (default), L1 transactions are submitted through a bounded in-flight window
+    /// and confirmations are tracked separately, so submission never waits for inclusion.
+    /// When false, falls back to stop-and-wait: drain up to `command_limit` commands, send,
+    /// wait for all receipts + confirmations, repeat. Kill switch for the pipelined sender.
+    #[config(default_t = true)]
+    pub pipelining_enabled: bool,
+
+    /// Receipt/inclusion polling cadence of the L1 senders.
     #[config(default_t = 1 * TimeUnit::Seconds)]
     pub poll_interval: Duration,
 
@@ -1209,22 +1220,49 @@ pub struct L1SenderConfig {
 
 #[derive(Clone, Copy, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
 #[config(derive(Default))]
+#[config(validate(
+    Self::check_replacement_multipliers,
+    "replacement multipliers must be >= 2.0 while force resubmission is enabled: geth and reth \
+     only replace a blob transaction when tip, fee cap AND blob fee cap are all bumped by 100%"
+))]
 pub struct ForceTransactionResubmissionConfig {
     /// Skips startup in-flight recovery and resubmits queued L1 transactions with replacement fee caps.
     #[config(default_t = false)]
     pub enabled: bool,
 
     /// Multiplier applied to `max_fee_per_gas` when force transaction resubmission is enabled.
-    #[config(default_t = 1.1, validate(is_positive_f64, "must be positive"))]
+    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
+    #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_gas_replacement_multiplier: f64,
 
     /// Multiplier applied to `max_priority_fee_per_gas` when force transaction resubmission is enabled.
-    #[config(default_t = 1.1, validate(is_positive_f64, "must be positive"))]
+    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
+    #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_priority_fee_per_gas_replacement_multiplier: f64,
 
     /// Multiplier applied to `max_fee_per_blob_gas` when force transaction resubmission is enabled.
+    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
     #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
+}
+
+impl ForceTransactionResubmissionConfig {
+    /// Replacing an in-pool blob transaction requires >= 100% bump on tip, fee cap and blob
+    /// fee cap (geth blobpool and reth default price bump). Lower multipliers make every
+    /// forced resubmission fail as "replacement transaction underpriced" — a crash loop —
+    /// so they are rejected up front.
+    fn check_replacement_multipliers(&self) -> Result<(), ErrorWithOrigin> {
+        if self.enabled
+            && (self.max_fee_per_gas_replacement_multiplier < 2.0
+                || self.max_priority_fee_per_gas_replacement_multiplier < 2.0
+                || self.max_fee_per_blob_gas_replacement_multiplier < 2.0)
+        {
+            return Err(ErrorWithOrigin::custom(
+                "replacement multipliers must be >= 2.0 while force resubmission is enabled",
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn is_positive_f64(&val: &f64) -> bool {
@@ -2036,6 +2074,7 @@ impl L1SenderConfig {
             },
             force_transaction_resubmission: force_transaction_resubmission.enabled,
             command_limit: self.command_limit,
+            pipelining_enabled: self.pipelining_enabled,
             poll_interval: self.poll_interval,
             transaction_timeout: self.transaction_timeout,
             required_confirmations: self.required_confirmations,
@@ -2460,6 +2499,7 @@ mod tests {
                 max_fee_per_blob_gas: 2 * EtherUnit::Gwei,
                 force_transaction_resubmission: ForceTransactionResubmissionConfig::default(),
                 command_limit: 16,
+                pipelining_enabled: true,
                 poll_interval: Duration::from_millis(100),
                 transaction_timeout: Duration::from_secs(600),
                 required_confirmations: DEFAULT_REQUIRED_CONFIRMATIONS_L1,

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1171,8 +1171,8 @@ pub struct L1SenderConfig {
 
     /// When true (default), L1 transactions are submitted through a bounded in-flight window
     /// and confirmations are tracked separately, so submission never waits for inclusion.
-    /// When false, falls back to stop-and-wait: drain up to `command_limit` commands, send,
-    /// wait for all receipts + confirmations, repeat. Kill switch for the pipelined sender.
+    /// When false, commands are processed in synchronous cycles instead: drain up to
+    /// `command_limit` commands, send, wait for all receipts + confirmations, repeat.
     #[config(default_t = true)]
     pub pipelining_enabled: bool,
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1222,8 +1222,9 @@ pub struct L1SenderConfig {
 #[config(derive(Default))]
 #[config(validate(
     Self::check_replacement_multipliers,
-    "replacement multipliers must be >= 2.0 while force resubmission is enabled: geth and reth \
-     only replace a blob transaction when tip, fee cap AND blob fee cap are all bumped by 100%"
+    "replacement multipliers must be >= 1.1 (>= 2.0 for the blob fee) while force resubmission \
+     is enabled: geth and reth replace a pooled transaction only with a 10% fee bump (100% for \
+     blob transactions)"
 ))]
 pub struct ForceTransactionResubmissionConfig {
     /// Skips startup in-flight recovery and resubmits queued L1 transactions with replacement fee caps.
@@ -1231,34 +1232,39 @@ pub struct ForceTransactionResubmissionConfig {
     pub enabled: bool,
 
     /// Multiplier applied to `max_fee_per_gas` when force transaction resubmission is enabled.
-    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
-    #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
+    /// Must be >= 1.1 (the pool price-bump rule). The commit sender raises its effective
+    /// multipliers to 2.0 as needed — replacing a blob transaction requires a 100% bump.
+    #[config(default_t = 1.1, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_gas_replacement_multiplier: f64,
 
     /// Multiplier applied to `max_priority_fee_per_gas` when force transaction resubmission is enabled.
-    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
-    #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
+    /// Must be >= 1.1 (the pool price-bump rule). The commit sender raises its effective
+    /// multipliers to 2.0 as needed — replacing a blob transaction requires a 100% bump.
+    #[config(default_t = 1.1, validate(is_positive_f64, "must be positive"))]
     pub max_priority_fee_per_gas_replacement_multiplier: f64,
 
     /// Multiplier applied to `max_fee_per_blob_gas` when force transaction resubmission is enabled.
-    /// Must be >= 2.0: replacing a blob transaction requires a 100% bump on all three fee caps.
+    /// Must be >= 2.0: only blob transactions have a blob fee, and replacing one requires a
+    /// 100% bump on all three fee caps.
     #[config(default_t = 2.0, validate(is_positive_f64, "must be positive"))]
     pub max_fee_per_blob_gas_replacement_multiplier: f64,
 }
 
 impl ForceTransactionResubmissionConfig {
-    /// Replacing an in-pool blob transaction requires >= 100% bump on tip, fee cap and blob
-    /// fee cap (geth blobpool and reth default price bump). Lower multipliers make every
-    /// forced resubmission fail as "replacement transaction underpriced" — a crash loop —
-    /// so they are rejected up front.
+    /// Replacing a pooled transaction requires a >= 10% fee bump (geth/reth default price
+    /// bump); the blob fee cap only exists on blob transactions, whose replacement requires
+    /// 100% on every field — the commit sender enforces that 2.0 minimum itself. Lower
+    /// multipliers make every forced resubmission fail as "replacement transaction
+    /// underpriced" — a crash loop — so they are rejected up front.
     fn check_replacement_multipliers(&self) -> Result<(), ErrorWithOrigin> {
         if self.enabled
-            && (self.max_fee_per_gas_replacement_multiplier < 2.0
-                || self.max_priority_fee_per_gas_replacement_multiplier < 2.0
+            && (self.max_fee_per_gas_replacement_multiplier < 1.1
+                || self.max_priority_fee_per_gas_replacement_multiplier < 1.1
                 || self.max_fee_per_blob_gas_replacement_multiplier < 2.0)
         {
             return Err(ErrorWithOrigin::custom(
-                "replacement multipliers must be >= 2.0 while force resubmission is enabled",
+                "replacement multipliers must be >= 1.1 (>= 2.0 for the blob fee) while force \
+                 resubmission is enabled",
             ));
         }
         Ok(())

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -205,6 +205,14 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         ProviderKind::L1,
     )
     .await;
+    // Counted BEFORE the L1 state is read: an in-flight commit tx that mines in between is
+    // then reflected in both counts (over-approximating the UnexpectedCommit guard, which is
+    // safe); the reverse order could miss it in both.
+    let in_flight_commit_txs = if node_role.is_main() && config.batcher_config.enabled {
+        in_flight_commit_tx_count(&config, &l1_provider).await
+    } else {
+        0
+    };
     // Genesis and the repository manager are initialized here (before the startup revert) so
     // that the `from_block_hash` guard can read the current local block hash.
     let diamond_proxy_l1 =
@@ -549,10 +557,24 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     };
 
     // Channel from L1Sender<CommitCommand> to L1CommitWatcher.
-    // Initialized to startup's last_committed_batch so any commit above that value
-    // which the pipeline didn't submit in this session triggers a restart.
-    let (commit_submitted_tx, commit_submitted_rx) =
-        watch::channel(node_startup_state.l1_state.last_committed_batch);
+    // Initialized to startup's last_committed_batch plus any in-flight commit transactions a
+    // previous session left in the L1 mempool: the watcher starts processing L1 events before
+    // the pipeline's in-flight recovery seeds this watch, so a leftover tx mining in that gap
+    // must not trip the `UnexpectedCommit` guard. Each in-flight commit tx commits exactly one
+    // batch; if one never mines, the guard is merely that much more permissive until the
+    // pipeline overtakes it.
+    let commit_submitted_init = {
+        let base = node_startup_state.l1_state.last_committed_batch;
+        if in_flight_commit_txs > 0 {
+            tracing::info!(
+                base,
+                in_flight_commit_txs,
+                "arming the UnexpectedCommit guard above in-flight commit txs from a previous session"
+            );
+        }
+        base + in_flight_commit_txs
+    };
+    let (commit_submitted_tx, commit_submitted_rx) = watch::channel(commit_submitted_init);
 
     tracing::info!("Initializing L1 Watchers");
     runtime.spawn_critical_task(
@@ -1529,6 +1551,38 @@ fn effective_main_node_pubdata_mode(config: &Config) -> PubdataMode {
         .l1_sender_config
         .pubdata_mode
         .expect("`l1_sender.pubdata_mode` is required on the Main Node")
+}
+
+/// Counts commit transactions a previous session left in the L1 mempool (pending minus latest
+/// nonce of the commit operator). Used to arm the `UnexpectedCommit` guard above them: they may
+/// mine before the pipeline's in-flight recovery seeds the `commit_submitted` watch. Degrades
+/// to 0 (today's tighter guard) when the operator key is absent or L1 reads fail — the guard is
+/// an alarm, not a correctness mechanism, so startup must not depend on it.
+async fn in_flight_commit_tx_count(config: &Config, l1_provider: &NodeProvider) -> u64 {
+    let Some(signer) = &config.l1_sender_config.operator_commit_sk else {
+        return 0;
+    };
+    let count = async {
+        let operator_address = signer.address().await?;
+        let latest = l1_provider.get_transaction_count(operator_address).await?;
+        let pending = l1_provider
+            .get_transaction_count(operator_address)
+            .pending()
+            .await?;
+        anyhow::Ok(pending.saturating_sub(latest))
+    }
+    .await;
+    match count {
+        Ok(count) => count,
+        Err(err) => {
+            tracing::warn!(
+                %err,
+                "failed to count in-flight commit txs; arming the UnexpectedCommit guard at the \
+                 committed frontier"
+            );
+            0
+        }
+    }
 }
 
 /// Validates that the `l1_sender.operator_*_sk` keys required for the L1Sender pipeline are

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -1556,7 +1556,7 @@ fn effective_main_node_pubdata_mode(config: &Config) -> PubdataMode {
 /// Counts commit transactions a previous session left in the L1 mempool (pending minus latest
 /// nonce of the commit operator). Used to arm the `UnexpectedCommit` guard above them: they may
 /// mine before the pipeline's in-flight recovery seeds the `commit_submitted` watch. Degrades
-/// to 0 (today's tighter guard) when the operator key is absent or L1 reads fail — the guard is
+/// to 0 (the tightest guard) when the operator key is absent or L1 reads fail — the guard is
 /// an alarm, not a correctness mechanism, so startup must not depend on it.
 async fn in_flight_commit_tx_count(config: &Config, l1_provider: &NodeProvider) -> u64 {
     let Some(signer) = &config.l1_sender_config.operator_commit_sk else {


### PR DESCRIPTION
## Summary

  The L1 sender used to send a wave of transactions and idle until all of them were included and
  confirmed — capping settlement at ~890 batches/hour on mainnet. It now keeps up to command_limit (16,
  the L1 pool's per-account cap) transactions in flight and tracks confirmations in a separate task;
  downstream forwarding is still confirmation-gated in batch order. A/B benchmark: 4x faster
  settlement.

  The old behavior is still available: l1_sender.pipelining_enabled = false.
  
  Living with a window of unconfirmed transactions required handling what the pool does to them:
  fee-priced-out sends wait for the market instead of crashing, evicted transactions are resent at
  their nonce with a 2x bump, and restart recovery pairs pending transactions with re-queued commands —
  replacing mismatched or dropped ones at their own nonces. force_transaction_resubmission now
  replaces stuck transactions instead of appending behind them.

  New integration tests cover the benchmark plus fee spikes, eviction, inclusion stalls, restarts
  mid-window, forced resubmission, and L1 connection loss.

 ## Breaking Changes
  
  - Main-node operators only; no protocol, DB, or wire changes.
  - Shutdown leaves in-flight transactions in the mempool — recovery picks them up on restart. Recovery
  pairing needs eth_getTransactionBySenderAndNonce (reth-family) and a single consistent L1 RPC view.

## Rollout Instructions
  
  - Ensure the L1 node's per-account pool limits cover command_limit (geth blobpool maxTxsPerAccount,
  reth max-account-slots; both default 16).
  - Deploy normally, no migrations. Watch the new txs_in_flight gauge; fee-stall and eviction-resend
  warnings during L1 fee spikes are expected.
  - Rollback: l1_sender.pipelining_enabled = false (no redeploy). If mismatched transactions are pooled
  at that point, restart once with force_transaction_resubmission.enabled = true.
