### PR TITLE
fix(sequencer): improve default config values

### DIFF
--- a/integration-tests/tests/rpc/gas_rate_limit.rs
+++ b/integration-tests/tests/rpc/gas_rate_limit.rs
@@ -133,13 +133,14 @@ async fn gas_rate_limiter_closes_gate_and_recovers() -> Result<()> {
 
     let env = CURRENT_TO_L1.environment().await?;
     let mut config = env.default_config().await?;
-    config.rpc_config.tx_gas_rate_limit = Some(TxGasRateLimitConfig {
+    config.rpc_config.tx_gas_rate_limit = TxGasRateLimitConfig {
+        enabled: true,
         gas_per_second: NonZeroU64::new(GAS_PER_SECOND).unwrap(),
         max_credit_seconds: MAX_CREDIT_SECONDS,
         reopen_credit_seconds: 1.0,
         deficit_floor_seconds: 2.0,
         exempt_senders: [rich].into_iter().collect(),
-    });
+    };
     let mut tester = env.launch(config).await?;
     tester
         .l2_provider

--- a/lib/l1_sender/src/config.rs
+++ b/lib/l1_sender/src/config.rs
@@ -6,7 +6,7 @@ use zksync_os_operator_signer::SignerConfig;
 pub const DEFAULT_REQUIRED_CONFIRMATIONS_L1: u64 = 3;
 /// Default max submission attempts per L1 transaction when the node rejects it with a
 /// nonce-class error.
-pub const DEFAULT_NONCE_ERROR_MAX_ATTEMPTS: usize = 5;
+pub const DEFAULT_NONCE_ERROR_MAX_ATTEMPTS: usize = 10;
 /// Default backoff between attempts after a nonce-class rejection.
 pub const DEFAULT_NONCE_ERROR_RETRY_BACKOFF: Duration = Duration::from_secs(2);
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1072,9 +1072,9 @@ pub struct RpcConfig {
     pub rate_limits: RpcRateLimitsConfig,
 
     /// Rate limiter for incoming L2 transactions based on executed gas throughput.
-    /// Absent = disabled.
-    #[config(nest)]
-    pub tx_gas_rate_limit: Option<TxGasRateLimitConfig>,
+    /// Disabled by default; set `enabled = true` to turn it on.
+    #[config(nest, default)]
+    pub tx_gas_rate_limit: TxGasRateLimitConfig,
 
     /// List of disabled methods.
     /// Some stateful methods like `eth_newFilter` don't make sense when running in a cluster behind a load-balancer.
@@ -1126,12 +1126,18 @@ impl From<RpcRateLimitsConfig> for zksync_os_rpc::RateLimits {
 /// toward it too, even though only L2 admission is ever actually gated. Only effective on
 /// the main node.
 #[derive(Clone, Debug, DescribeConfig, DeserializeConfig, ConfigValidate)]
+#[config(derive(Default))]
 #[config(validate(
     Self::check_credit_windows,
     "max_credit_seconds must be positive, other windows non-negative, and reopen_credit_seconds must not exceed max_credit_seconds"
 ))]
 pub struct TxGasRateLimitConfig {
+    /// Whether the gas rate limiter is enabled. Only effective on the main node.
+    #[config(default_t = false)]
+    pub enabled: bool,
+
     /// Target sustained executed-gas throughput, in gas per second.
+    #[config(default_t = NonZeroU64::new(72_000_000).unwrap())]
     pub gas_per_second: NonZeroU64,
 
     /// Bank capacity (idle burst headroom), in seconds' worth of `gas_per_second`. Sized to

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -28,8 +28,8 @@ use crate::command_source::{
     ConsensusNodeCommandSource, ExternalNodeCommandSource, RebuildOptions,
 };
 use crate::config::{
-    Config, ProverApiConfig, RebuildConfig, TxGasRateLimitConfig, base_token_price_updater_config,
-    gas_adjuster_config, report_static_config_metrics,
+    Config, ProverApiConfig, RebuildConfig, base_token_price_updater_config, gas_adjuster_config,
+    report_static_config_metrics,
 };
 use crate::en_remote_config::load_remote_config;
 use crate::init_tx_forwarder::{build_consensus_tx_forwarder, build_static_tx_forwarder};
@@ -342,14 +342,10 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     // The gas rate limiter models sequencer capacity, which only the main node owns: other
     // roles forward txs to the main node, whose limiter is authoritative and whose rejections
     // (incl. `retryAfterMs`) propagate back to the caller.
-    let gas_rate_limit = if node_role.is_main() {
-        config
-            .rpc_config
-            .tx_gas_rate_limit
-            .clone()
-            .map(TxGasRateLimitConfig::into_lib)
+    let gas_rate_limit = if node_role.is_main() && config.rpc_config.tx_gas_rate_limit.enabled {
+        Some(config.rpc_config.tx_gas_rate_limit.clone().into_lib())
     } else {
-        if config.rpc_config.tx_gas_rate_limit.is_some() {
+        if !node_role.is_main() && config.rpc_config.tx_gas_rate_limit.enabled {
             tracing::warn!(
                 "rpc.tx_gas_rate_limit is ignored on non-main nodes; the executed-gas \
                  rate limiter runs on the main node only"


### PR DESCRIPTION
## Summary

- **l1_sender:** increase the default max attempts for nonce-class retry from 5 to 10 (`DEFAULT_NONCE_ERROR_MAX_ATTEMPTS`). With the default 2s backoff, this extends the worst-case backoff window from 8s to 18s before giving up on a transaction (this covers one Ehereum block timespan - 12s).
- **rpc gas rate limiter:** make the executed-gas rate limiter opt-in via a new `enabled` flag instead of `Option`-wrapping the whole config section, and bump the default `gas_per_second` to 72 Mgas/s. `rpc.tx_gas_rate_limit` is now a required (always-present, fully-defaulted) nested config instead of `Option<TxGasRateLimitConfig>`, so it no longer needs to be omitted to disable the limiter — set `enabled: false` (the default) instead.

## Test plan

- [x] `cargo build` / `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features --workspace --exclude zksync_os_integration_tests -- -D warnings`
- [x] `cargo nextest run --workspace --exclude zksync_os_integration_tests` (config + mempool rate-limiter unit tests pass)
- [x] `cargo nextest run -p zksync_os_integration_tests --profile no-pig gas_rate_limit` (`gas_rate_limiter_closes_gate_and_recovers` passes)
