### PR TITLE
fix(provider): retry header watcher poll when RPC returns no block

### DIFF
--- a/lib/provider/src/lib.rs
+++ b/lib/provider/src/lib.rs
@@ -341,10 +341,15 @@ impl NodeProvider {
                             continue;
                         }
                     };
-                let header = block_response
-                    .expect("header watcher RPC returned no block for a chain head")
-                    .header()
-                    .clone();
+                // A transient `null` for a chain-head tag is retried like any other poll failure.
+                let Some(block_response) = block_response else {
+                    tracing::warn!(
+                        ?block,
+                        "header watcher poll returned no block; retrying at next tick"
+                    );
+                    continue;
+                };
+                let header = block_response.header().clone();
                 tx.send_if_modified(|current: &mut <Ethereum as Network>::HeaderResponse| {
                     if current.hash() == header.hash() {
                         false


### PR DESCRIPTION
## Summary

Follow-up to #1490. That fix made the header watcher poll loop survive transport errors (`Err`), but an RPC that succeeds and returns `null` for a chain-head tag (`Ok(None)`) still panicked the poller task. With the channel-close semantics introduced in #1490, that panic closes the watch channel and crashes the whole node via the L1 watchers — so a single transient `null` from a load-balanced or lagging L1 endpoint caused a full process restart.

Treat `Ok(None)` the same as a transport error: log a warning and retry at the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)