### PR TITLE
fix(config): refuse local block rebuilds under consensus

### DIFF
--- a/integration-tests/src/test_config.rs
+++ b/integration-tests/src/test_config.rs
@@ -43,6 +43,14 @@ pub(crate) async fn build_node_config(
     // blocks): existing scenarios time their waits around continuous block
     // production. Dedicated idle-policy tests opt into heartbeats explicitly.
     config.consensus_config.idle_heartbeat = std::time::Duration::ZERO;
+    // `local_dev.yaml` arms the REVM auto-revert, which repairs a divergence by rewriting the
+    // offending block — refused under consensus, where the block carries a finalization
+    // certificate. Off for every test rather than per consensus scenario: the config validator
+    // that enforces this cannot catch a regression here, since tests never call `validate()`.
+    // Detection is untouched, so a divergence still logs and bumps `revm_divergences_detected`.
+    config
+        .sequencer_config
+        .revm_consistency_checker_revert_on_divergence = false;
     config.l1_provider_config =
         ProviderConfig::new(l1.address.clone(), TEST_PROVIDER_POLL_INTERVAL);
     if let Some(gateway_provider_config) = &mut config.gateway_provider_config {

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1270,11 +1270,38 @@ pub struct SequencerConfig {
     #[config(default_t = true)]
     pub revm_consistency_checker_enabled: bool,
     /// If enabled, node will revert block with divergence detected by REVM consistency checker.
+    ///
+    /// The revert works by re-running the chain with the offending block emptied, which rewrites
+    /// that block's hash and every descendant — impossible under consensus, where the block
+    /// carries a finalization certificate from the committee. Detection stays on either way;
+    /// only the automatic local repair is refused.
     #[config(default_t = false)]
+    #[config_validate(custom(
+        |root: &Config, value: &bool| !*value || !root.consensus_config.enabled,
+        "cannot be combined with `consensus.enabled=true`: rewriting a finalized block forks \
+         this node off the committee instead of healing it. Leave \
+         `sequencer.revm_consistency_checker_enabled` on for detection and recover a diverged \
+         validator through the disaster-fork runbook"
+    ))]
     pub revm_consistency_checker_revert_on_divergence: bool,
 
     /// Block rebuild / L1 revert options. See [`RebuildConfig`] for the three modes.
+    ///
+    /// The two local-block modes are refused under consensus; `L1Revert` touches only L1 and
+    /// stays available, since the disaster-fork runbook depends on it.
     #[config(nest)]
+    #[config_validate(custom(
+        |root: &Config, value: &Option<RebuildConfig>| {
+            !root.consensus_config.enabled
+                || value.as_ref().is_none_or(|rebuild| rebuild.bounds().is_none())
+        },
+        "must not rebuild local blocks when `consensus.enabled=true`: rebuilding rewrites them \
+         (emptied transactions, reset timestamps), and they were finalized by the committee — so \
+         this node forks off the chain instead of recovering. Faithful WAL replay on startup is \
+         unaffected. Use `L1Revert` (L1 only) or the disaster-fork runbook. This also rejects a \
+         rebuild synthesized from `failing_block` in `internal_config.json` — clear it by hand \
+         after resolving the divergence"
+    ))]
     pub rebuild: Option<RebuildConfig>,
 
     /// If set, external node will sync up to and including this block number and then stop processing blocks.
@@ -2976,6 +3003,97 @@ mod tests {
         let err = config.validate().await.unwrap_err().to_string();
 
         assert!(err.contains("cannot be enabled on a consensus observer"));
+    }
+
+    /// A committee validator whose config is otherwise complete, so these tests fail only on
+    /// what they are about.
+    fn consensus_validator_config() -> Config {
+        let mut config = base_config(NodeRole::MainNode);
+        config.consensus_config.enabled = true;
+        config.consensus_config.network_key = Some("00".repeat(32));
+        config.consensus_config.bls_key = Some("00".repeat(32));
+        config.consensus_config.validators = vec!["validator-a".into(), "validator-b".into()];
+        config
+    }
+
+    #[tokio::test]
+    async fn auto_revert_on_divergence_is_refused_under_consensus() {
+        let mut config = consensus_validator_config();
+        config
+            .sequencer_config
+            .revm_consistency_checker_revert_on_divergence = true;
+
+        let err = config.validate().await.unwrap_err().to_string();
+
+        assert!(
+            err.contains("`sequencer.revm_consistency_checker_revert_on_divergence`"),
+            "{err}"
+        );
+        assert!(
+            err.contains("cannot be combined with `consensus.enabled=true`"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detection_without_auto_revert_is_allowed_under_consensus() {
+        let mut config = consensus_validator_config();
+        config.sequencer_config.revm_consistency_checker_enabled = true;
+        config
+            .sequencer_config
+            .revm_consistency_checker_revert_on_divergence = false;
+
+        config.validate().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_block_rebuild_is_refused_under_consensus() {
+        let mut config = consensus_validator_config();
+        config.sequencer_config.rebuild = Some(RebuildConfig::BlockRebuild {
+            bounds: RebuildBounds {
+                from_block_number: 42,
+                from_block_hash: B256::repeat_byte(0x11),
+                blocks_to_empty: vec![42],
+                reset_timestamps: false,
+            },
+        });
+
+        let err = config.validate().await.unwrap_err().to_string();
+
+        assert!(err.contains("`sequencer.rebuild`"), "{err}");
+        assert!(
+            err.contains("must not rebuild local blocks when `consensus.enabled=true`"),
+            "{err}"
+        );
+    }
+
+    /// The disaster-fork runbook reverts committed batches on L1 while leaving local blocks
+    /// alone — that mode must survive the guard above.
+    #[tokio::test]
+    async fn l1_only_revert_is_allowed_under_consensus() {
+        let mut config = consensus_validator_config();
+        config.sequencer_config.rebuild = Some(RebuildConfig::L1Revert {
+            from_batch_number: NonZeroU64::new(7).unwrap(),
+            from_batch_commit_tx_hash: B256::repeat_byte(0x22),
+            l1_reverter_sk: local_signer(0x33),
+        });
+
+        config.validate().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_block_rebuild_is_still_allowed_without_consensus() {
+        let mut config = base_config(NodeRole::MainNode);
+        config.sequencer_config.rebuild = Some(RebuildConfig::BlockRebuild {
+            bounds: RebuildBounds {
+                from_block_number: 42,
+                from_block_hash: B256::repeat_byte(0x11),
+                blocks_to_empty: vec![42],
+                reset_timestamps: false,
+            },
+        });
+
+        config.validate().await.unwrap();
     }
 
     #[tokio::test]

--- a/tools/chaos/src/setup.rs
+++ b/tools/chaos/src/setup.rs
@@ -388,6 +388,9 @@ observability:
 sequencer:
   fee_collector_address: '{fee_collector}'
   block_dump_path: /db/block_dumps
+  # `local_dev.yaml` (the base layer) arms the REVM auto-revert, which rewrites a finalized
+  # block and is refused under consensus. Divergences still get detected and logged.
+  revm_consistency_checker_revert_on_divergence: false
 batcher:
   enabled: {batcher_enabled}
 prover_api:


### PR DESCRIPTION
## Summary

Two recovery paths repair a bad block by re-running the chain with it rewritten or emptied — `sequencer.revm_consistency_checker_revert_on_divergence` (automatic) and `sequencer.rebuild`'s `BlockRebuild` / `DangerBlockRebuildWithL1Revert` modes (manual). Both change the block's hash and every descendant. Fine for a single sequencer, impossible under consensus: the block already carries a finalization certificate, so the rewrite forks this node off the chain instead of healing it.

Nothing rejected the combination, and it failed silently. A divergence panics the node, restart synthesizes a `BlockRebuild` from `internal_config.json`'s `failing_block`, `starting_block` moves back to the divergent block — but `blocks_to_empty` is only consumed by `ConsensusNodeCommandSource`, which the consensus pipeline replaces. So the node re-executes the same block unchanged, re-detects the same deterministic divergence, and panics again.

Two declarative validators now refuse it at startup. `load_internal_config` runs before `validate()` (`main.rs:191-192`), so the `rebuild` guard covers the synthesized case as well as an operator-set one.

**Unaffected:** detection (`revm_consistency_checker_enabled`, `revm_divergences_detected`) still alerts. `L1Revert` stays allowed — it touches only L1, and the disaster-fork runbook needs it.

**Test fallout:** the chaos rig and the integration tests inherit the auto-revert from the `local_dev.yaml` base layer, so both were already running the forbidden combination. The rig's generated overlay sets it false; the tests turn it off in `build_node_config` next to the existing `idle_heartbeat` override. Test-wide rather than per consensus scenario, because tests never call `validate()` — the guard can't catch a regression there, so it has to be structural.

## Notes

- Rejects a previously-accepted config, but nothing working can depend on it. Say the word if you'd rather it warn for one release.
- Worth checking whether the deployed consensus env sets this flag.
- `truncate-to` runs after `validate()` (`main.rs:196`), so a node with a stale `failing_block` marker can't be truncated until it's cleared by hand — friction on the recovery path the error message points at. Happy to exempt the subcommand from the `rebuild` guard here or in a follow-up.
- Longer term this probably wants deleting rather than guarding: a REVM divergence is committee-wide by construction, so a per-node self-heal was never the right shape. The manual modes still have users on non-consensus chains, so this is the interim.
- Unrelated: `cargo fmt --all` touches six files this PR doesn't, so the base branch isn't `--check` clean. Left alone to keep the diff scoped.

## Testing

5 new unit tests (auto-revert refused, detection-only allowed, local rebuild refused, `L1Revert` allowed, local rebuild still allowed without consensus). `cargo test -p zksync_os_server --lib config::` 27 passed; `cargo test -p zksync_os_chaos` 32 passed; clippy clean on both; `cargo check -p zksync_os_integration_tests --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)