### PR TITLE
ci: fix release-please workflow secrets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,11 +24,12 @@ concurrency:
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@d4361aa05b16f3e6253cbd012925369a5514c2b0 # main
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@57573036416cd30e5a06f91b35717414775bc730 # main
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications
-      # Org-level secret; the App ID comes from the org-level MATTERLABS_BOTS_APP_ID
-      # variable, resolved by the reusable workflow itself. API commits are auto-signed.
+      # Org-level secrets of the GitHub App used to mint installation tokens.
+      # API commits are auto-signed.
+      MATTERLABS_BOTS_APP_ID: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
       MATTERLABS_BOTS_PRIVATE_KEY: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
     with:
       config: '.github/release-please/config.json'          # Path to the configuration file


### PR DESCRIPTION
## What

- Bumps the `matter-labs/zksync-ci-common` release-please reusable workflow to [`5757303`](https://github.com/matter-labs/zksync-ci-common/commit/57573036416cd30e5a06f91b35717414775bc730) (matter-labs/zksync-ci-common#55).
- The reusable workflow now reads `MATTERLABS_BOTS_APP_ID` from **secrets** (org-level secret) instead of `vars`, and uses the `client-id` input of `actions/create-github-app-token` (fixes the `app-id` deprecation warning). Since this caller passes secrets explicitly rather than via `secrets: inherit`, the new required secret is added to the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)