### PR TITLE
ci: bump zksync-ci-common release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@57573036416cd30e5a06f91b35717414775bc730 # main
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@fcfe16cdf551d9a6b99d9e28d4c705faf0f4c27e # main
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for release notifications
       # Org-level secrets of the GitHub App used to mint installation tokens.


### PR DESCRIPTION
## Summary

Pins the reusable release-please workflow from `matter-labs/zksync-ci-common` to the latest commit, which sets explicit owner/repositories for the repo-scoped app token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)