### PR TITLE
fix(provider): fail hung L1 RPC requests with a retryable timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16507,7 +16507,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.22",
  "vise",
  "zksync_os_api",
  "zksync_os_base_token_adjuster",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16507,6 +16507,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber 0.3.22",
  "vise",
  "zksync_os_api",
  "zksync_os_base_token_adjuster",

--- a/lib/mempool/src/subpools/l1.rs
+++ b/lib/mempool/src/subpools/l1.rs
@@ -3,9 +3,13 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::sync::{Notify, RwLock, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use zksync_os_types::{L1PriorityEnvelope, L1TxSerialId, ZkTransaction};
+
+/// How often `pop_wait` warns while blocked on a priority transaction missing from the pool.
+const EMPTY_POOL_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct L1Subpool {
@@ -57,6 +61,7 @@ impl L1Subpool {
     }
 
     async fn pop_wait(&self) -> Arc<L1PriorityEnvelope> {
+        let started_at = tokio::time::Instant::now();
         loop {
             let notified = self.notify.notified();
             {
@@ -65,7 +70,17 @@ impl L1Subpool {
                     return pending_tx;
                 }
             }
-            notified.await;
+            // A long wait means the L1 watcher stopped delivering priority transactions
+            // and the calling replay/execution pipeline is blocked on it.
+            if tokio::time::timeout(EMPTY_POOL_WARN_INTERVAL, notified)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    waited = ?started_at.elapsed(),
+                    "L1 subpool has no pending priority transaction; blocked waiting for the L1 watcher to deliver it"
+                );
+            }
         }
     }
 

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -474,6 +474,11 @@ pub struct ProviderConfig {
     /// Backoff used between retry attempts.
     #[config(default_t = Duration::from_millis(1000))]
     pub retry_backoff: Duration,
+
+    /// Per-attempt timeout for every L1 RPC request. Must comfortably exceed the slowest
+    /// legitimate request (e.g. `eth_getLogs` over `l1_watcher.max_blocks_to_process` blocks).
+    #[config(default_t = 30 * TimeUnit::Seconds)]
+    pub request_timeout: Duration,
 }
 
 impl ProviderConfig {

--- a/node/bin/src/provider/mod.rs
+++ b/node/bin/src/provider/mod.rs
@@ -1,6 +1,7 @@
 mod latency;
 mod metrics;
 mod retry;
+mod timeout;
 
 use crate::config::ProviderConfig;
 use alloy::network::EthereumWallet;
@@ -27,6 +28,8 @@ pub(crate) async fn build_node_provider(
 ) -> NodeProvider {
     let max_retries = config.max_retries;
     let retry_backoff = config.retry_backoff;
+    let request_timeout = config.request_timeout;
+    // Timeout is the innermost layer so that each retry attempt gets its own timeout.
     let provider_layers = ServiceBuilder::new()
         .layer_fn(move |inner| latency::LatencyService { inner, provider })
         .layer_fn(move |inner| retry::RetryService {
@@ -34,6 +37,10 @@ pub(crate) async fn build_node_provider(
             provider,
             max_retries,
             backoff: retry_backoff,
+        })
+        .layer_fn(move |inner| timeout::TimeoutService {
+            inner,
+            timeout: request_timeout,
         });
 
     let client = RpcClient::builder()

--- a/node/bin/src/provider/retry.rs
+++ b/node/bin/src/provider/retry.rs
@@ -30,9 +30,9 @@ impl<S> RetryService<S> {
             }
             TransportError::Transport(TransportErrorKind::Custom(e)) => {
                 let msg = e.to_string();
-                // Internal `reqwest` error that can occur when node experiences intermittent
-                // networking issues.
-                msg.contains("error sending request")
+                // Intermittent `reqwest` networking error, or our timeout layer firing —
+                // a hung request on a dead connection succeeds on retry over a fresh one.
+                msg.contains("error sending request") || msg.contains(super::timeout::TIMED_OUT_MSG)
             }
             TransportError::ErrorResp(e) => {
                 // Internal error as observed on Infura

--- a/node/bin/src/provider/timeout.rs
+++ b/node/bin/src/provider/timeout.rs
@@ -1,0 +1,47 @@
+use alloy::rpc::json_rpc::{RequestPacket, ResponsePacket};
+use alloy::transports::{TransportError, TransportErrorKind, TransportFut};
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tower::Service;
+
+/// Matched by `retry::RetryService` to treat timed-out requests as retryable.
+pub(super) const TIMED_OUT_MSG: &str = "L1 RPC request timed out";
+
+/// Fails L1 RPC requests that receive no response within the configured timeout; without it,
+/// a request hanging on a half-dead connection never returns and freezes its caller forever.
+#[derive(Debug, Clone)]
+pub(super) struct TimeoutService<S> {
+    pub(super) inner: S,
+    pub(super) timeout: Duration,
+}
+
+impl<S> Service<RequestPacket> for TimeoutService<S>
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>
+        + Send
+        + 'static
+        + Clone,
+    S::Future: Send + 'static,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: RequestPacket) -> Self::Future {
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+        let timeout = self.timeout;
+        Box::pin(async move {
+            match tokio::time::timeout(timeout, inner.call(request)).await {
+                Ok(result) => result,
+                Err(_) => Err(TransportErrorKind::custom_str(&format!(
+                    "{TIMED_OUT_MSG} after {timeout:?}"
+                ))),
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a silent external-node replay stall caused by hung L1 RPC requests.

**Root cause:** an L1 RPC request can hang forever on a half-dead connection (e.g. dropped by an intermediary without a RST). The RPC client stack has no request timeout, and `RetryService` only engages on errors it observes — a request that never returns is never retried. A hung call freezes the `priority_tx` watcher inside `process_event`, so the priority transaction is never inserted into the L1 subpool; when replay reaches the first block consuming it, `L1Subpool::pop_wait` blocks forever with zero log output, backpressure halts the whole pipeline, and the node keeps reporting `healthy: true` indefinitely.

**Changes:**

- `TimeoutService`: new innermost RPC client layer that fails any L1 request receiving no response within `l1_provider.request_timeout` (default 30s, per retry attempt). Timeout errors are classified retryable, so the retry lands on a fresh connection.
- `L1Subpool::pop_wait`: warns every 30s with the accumulated wait time while blocked on a missing priority transaction, so a stalled replay pipeline is visible in logs instead of silent. The periodic re-check also closes the lost-notification race between the queue check and `notified`.

**Note:** if all retry attempts time out, the error propagates to `Watcher::run`, which panics and restarts the node — loud and self-healing, versus an indefinite silent stall.

Validated during development with unit tests (hung request → timeout error → retryable classification; `pop_wait` warn cadence and wakeup semantics); tests were dropped from the final diff to keep it minimal, consistent with the rest of `provider/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
