### PR TITLE
ci: ignore RUSTSEC-2026-0235 (unused rkyv) in cargo-audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '.github/workflows/cargo-audit.yml'
+      - 'deny.toml'
   schedule:
     # Run every Monday-Friday at 8:30 AM UTC.
     - cron: "30 8 * * 1-5"
@@ -41,7 +43,10 @@ jobs:
           # 'RUSTSEC-2023-0071': Marvin timing sidechannel in `rsa` private-key operations. Production code only
           # performs public-key RSA-OAEP encryption (wrapping the age file key to the GCP KMS public key);
           # private-key decryption happens inside GCP KMS, never locally. No patched version exists yet.
-          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2023-0071'
+          # 'RUSTSEC-2026-0235': out-of-bounds read in `rkyv` < 0.8.17 when validating untrusted archives.
+          # `rkyv` 0.7.46 is only in Cargo.lock as an unused optional dependency of `rust_decimal` (via
+          # `byte-unit` <- `openraft`); no feature combination in this workspace enables it, so it is never compiled.
+          ignore: 'RUSTSEC-2025-0055,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2023-0071,RUSTSEC-2026-0235'
   cargo-deny:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

Adds `RUSTSEC-2026-0235` (out-of-bounds read in `rkyv` < 0.8.17 when validating untrusted archives) to the cargo-audit ignore list.

## Why

The advisory landed in the RustSec database today and now fails every `Security audit` run (e.g. [this one](https://github.com/matter-labs/zksync-os-server/actions/runs/30904616191/job/91976731454)).

The vulnerable code is never compiled in this workspace:
- `rkyv 0.7.46` appears in `Cargo.lock` only as an **optional** dependency of `rust_decimal` (via `byte-unit` <- `openraft`), and no feature combination enables it — `cargo tree -i rkyv@0.7.46 --all-features --target all --edges all` prints nothing.
- No upgrade path exists on the 0.7 line anyway: the fix is only in `rkyv 0.8.17+`, and `rust_decimal` still pins 0.7.

`deny.toml` intentionally does **not** get the ignore: cargo-deny resolves features and already knows `rkyv` is never built (adding the ignore produces an `advisory-not-detected` warning, and would mask the advisory if the feature were ever enabled). Verified locally that `cargo deny check --allow unmaintained` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)