### PR TITLE
fix(batch_verification): bound cache eviction to cached blocks

### DIFF
--- a/lib/batch_verification/src/verifier/block_cache.rs
+++ b/lib/batch_verification/src/verifier/block_cache.rs
@@ -55,18 +55,22 @@ impl<Finality: ReadFinality, Data> BlockCache<Finality, Data> {
 
     /// Removes all blocks lower than the given block number
     pub fn remove_lower_then(&mut self, block_number: u64) {
-        if let Some((low, high)) = self.range {
-            for num in low..block_number {
-                self.data.remove(&num);
-            }
-            let new_range = (block_number, high);
-
-            if new_range.0 > new_range.1 {
-                self.range = None;
-            } else {
-                self.range = Some(new_range);
-            }
+        let Some((low, high)) = self.range else {
+            return;
+        };
+        if block_number <= low {
+            return;
         }
+        if block_number > high {
+            // A syncing verifier may be far behind L1 finality. Iterating across that
+            // height gap for an otherwise tiny cache would stall replay ingestion.
+            self.data.clear();
+            self.range = None;
+            return;
+        }
+
+        self.data.retain(|number, _| *number >= block_number);
+        self.range = Some((block_number, high));
     }
 }
 
@@ -145,5 +149,33 @@ mod tests {
         cache.remove_lower_then(6);
         assert!(cache.data.is_empty());
         assert_eq!(cache.range, None);
+    }
+
+    #[test]
+    fn removing_to_a_height_far_above_the_cache_clears_it() {
+        let mut cache = BlockCache::<_, u64>::new(DummyFinality::zero());
+
+        for n in 1u64..=5 {
+            cache.insert(n, n).unwrap();
+        }
+
+        cache.remove_lower_then(1_000_000);
+
+        assert!(cache.data.is_empty());
+        assert_eq!(cache.range, None);
+    }
+
+    #[test]
+    fn removing_below_the_cached_range_does_not_expand_it() {
+        let mut cache = BlockCache::<_, u64>::new(DummyFinality::zero());
+
+        cache.insert(10, 10).unwrap();
+        cache.insert(11, 11).unwrap();
+
+        cache.remove_lower_then(5);
+
+        assert_eq!(cache.range, Some((10, 11)));
+        assert_eq!(cache.get(10), Some(&10));
+        assert_eq!(cache.get(11), Some(&11));
     }
 }


### PR DESCRIPTION
## Summary

Without this fix, `tree_manager` can stall on a node that started catching up but already has a lot of entries in its tree

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

