### PR TITLE
feat(node): refuse main-node startup when replay WAL is behind L1

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -404,14 +404,6 @@ pub struct GeneralConfig {
     #[config(default_t = None)]
     pub force_starting_block_number: Option<u64>,
 
-    /// UNSAFE. By default the main node refuses to start when its local replay WAL is behind the
-    /// last L1-committed block: producing new blocks on top of a stale WAL re-sequences block
-    /// numbers already committed to L1 and diverges the chain. The intended fix is restoring the
-    /// WAL via the replay archive recovery tool. Set to `true` to bypass the check and start
-    /// anyway (divergence).
-    #[config(default_t = false)]
-    pub allow_wal_behind_l1: bool,
-
     /// Path to the directory for persistence (eg RocksDB) - will contain both state and repositories' DBs
     #[config(default_t = DEFAULT_ROCKS_DB_PATH.into())]
     pub rocks_db_path: PathBuf,

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -404,6 +404,14 @@ pub struct GeneralConfig {
     #[config(default_t = None)]
     pub force_starting_block_number: Option<u64>,
 
+    /// UNSAFE. By default the main node refuses to start when its local replay WAL is behind the
+    /// last L1-committed block: producing new blocks on top of a stale WAL re-sequences block
+    /// numbers already committed to L1 and diverges the chain. The intended fix is restoring the
+    /// WAL via the replay archive recovery tool. Set to `true` to bypass the check and start
+    /// anyway (divergence).
+    #[config(default_t = false)]
+    pub allow_wal_behind_l1: bool,
+
     /// Path to the directory for persistence (eg RocksDB) - will contain both state and repositories' DBs
     #[config(default_t = DEFAULT_ROCKS_DB_PATH.into())]
     pub rocks_db_path: PathBuf,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -382,7 +382,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         last_l1_executed_block,
     };
 
-    node_startup_state.check_wal_not_behind_l1(&config);
+    node_startup_state.assert_consistency();
 
     if let Some(from_block_number) = rebuild_options.as_ref().map(|o| o.from_block_number)
         && node_role.is_main()
@@ -443,8 +443,6 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         blocks_to_replay = node_startup_state.block_replay_storage_last_block + 1 - starting_block,
         "Node state on startup"
     );
-
-    node_startup_state.assert_consistency();
 
     // MN sends `VerifyBatch` requests to the network and receives `PeerVerifyBatchResult`s back.
     let (verify_request_tx, verify_request_rx) = tokio::sync::mpsc::channel::<VerifyBatch>(16);

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -382,6 +382,8 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         last_l1_executed_block,
     };
 
+    node_startup_state.check_wal_not_behind_l1(&config);
+
     if let Some(from_block_number) = rebuild_options.as_ref().map(|o| o.from_block_number)
         && node_role.is_main()
     {

--- a/node/bin/src/node_state_on_startup.rs
+++ b/node/bin/src/node_state_on_startup.rs
@@ -1,4 +1,3 @@
-use crate::config::Config;
 use std::ops::RangeInclusive;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_types::NodeRole;
@@ -31,37 +30,13 @@ impl NodeStateOnStartup {
             self.last_l1_proved_block,
             self.last_l1_executed_block,
         );
-    }
-
-    /// Main-node-only guard against starting from a stale replay WAL.
-    ///
-    /// If the local WAL head is behind the last L1-committed block, the WAL is missing records
-    /// for blocks that are already committed on L1. Starting the sequencer in this state makes it
-    /// produce fresh blocks at WAL head + 1, re-sequencing block numbers L1 already knows —
-    /// guaranteed divergence, followed by batcher/commit-watcher crashes. The replay archive is
-    /// guaranteed complete up to the last L1-committed block (the archive gate blocks L1 commits
-    /// until all blocks of the batch are archived), so the correct fix is offline recovery.
-    ///
-    /// Panics with a pointer to the recovery docs unless `general.allow_wal_behind_l1` is set.
-    pub fn check_wal_not_behind_l1(&self, config: &Config) {
-        if !self.node_role.is_main() {
-            return;
-        }
-        if self.block_replay_storage_last_block >= self.last_l1_committed_block {
-            return;
-        }
-
-        let msg = "local replay WAL is behind the last L1-committed block. Restore the WAL from the replay archive first, see https://github.com/matter-labs/zksync-os-server/blob/main/lib/replay_archive/README.md";
-
-        if config.general_config.allow_wal_behind_l1 {
-            tracing::warn!(
-                "`general.allow_wal_behind_l1` is set - starting anyway and DIVERGING from L1. {msg}"
-            );
-        } else {
-            panic!(
-                "{msg}. To bypass this check and start anyway (divergence!), set \
-                 `general.allow_wal_behind_l1=true` (env: `ALLOW_WAL_BEHIND_L1=true`)."
-            );
-        }
+        assert!(
+            !self.node_role.is_main()
+                || self.block_replay_storage_last_block >= self.last_l1_committed_block,
+            "Block replay WAL head ({}) is behind the last L1-committed block ({}); \
+             check DB consistency and restore the WAL from a replay archive if available",
+            self.block_replay_storage_last_block,
+            self.last_l1_committed_block,
+        );
     }
 }

--- a/node/bin/src/node_state_on_startup.rs
+++ b/node/bin/src/node_state_on_startup.rs
@@ -76,30 +76,44 @@ impl NodeStateOnStartup {
              state would re-sequence committed block numbers and diverge from L1."
         )
         .unwrap();
-        writeln!(
-            msg,
-            "Restore the WAL from the replay archive (node must stay stopped):\n\
-             1. replay_archive_recovery download {source} --output-root <dir>\n\
-             2. replay_archive_recovery recover-rocksdb --input-root <dir> \\\n\
-             \x20      --replay-db-path {db} \\\n\
-             \x20      --anchor-block-number {anchor} --anchor-block-hash <hash>{decrypt}\n\
-             \x20  (`--replay-db-path` must point at an empty/absent dir - move the stale \
-             `{wal_name}` away first)",
-            source = replay_archive_source_args(&config.replay_archive_config),
-            db = replay_db_path.display(),
-            anchor = self.last_l1_committed_block,
-            decrypt = replay_archive_decrypt_args(&config.replay_archive_config),
-            wal_name = BLOCK_REPLAY_WAL_DB_NAME,
-        )
-        .unwrap();
-        writeln!(
-            msg,
-            "Anchor hash for block {anchor} is not known locally - take it from a healthy \
-             replica (`eth_getBlockByNumber`) or from the archive object listing under prefix \
-             `{anchor}/`.",
-            anchor = self.last_l1_committed_block,
-        )
-        .unwrap();
+        if matches!(config.replay_archive_config, ReplayArchiveConfig::Noop) {
+            writeln!(
+                msg,
+                "No replay archive is configured on this node (`replay_archive.type=Noop`), so \
+                 recovery commands cannot be suggested. Either restore from a replay archive of \
+                 another node in this chain (run `replay_archive_recovery` with that node's \
+                 bucket and decryption key against {db}), or copy a complete `{wal_name}` \
+                 directory from a healthy node.",
+                db = replay_db_path.display(),
+                wal_name = BLOCK_REPLAY_WAL_DB_NAME,
+            )
+            .unwrap();
+        } else {
+            writeln!(
+                msg,
+                "Restore the WAL from the replay archive (node must stay stopped):\n\
+                 1. replay_archive_recovery download {source} --output-root <dir>\n\
+                 2. replay_archive_recovery recover-rocksdb --input-root <dir> \\\n\
+                 \x20      --replay-db-path {db} \\\n\
+                 \x20      --anchor-block-number {anchor} --anchor-block-hash <hash>{decrypt}\n\
+                 \x20  (`--replay-db-path` must point at an empty/absent dir - move the stale \
+                 `{wal_name}` away first)",
+                source = replay_archive_source_args(&config.replay_archive_config),
+                db = replay_db_path.display(),
+                anchor = self.last_l1_committed_block,
+                decrypt = replay_archive_decrypt_args(&config.replay_archive_config),
+                wal_name = BLOCK_REPLAY_WAL_DB_NAME,
+            )
+            .unwrap();
+            writeln!(
+                msg,
+                "Anchor hash for block {anchor} is not known locally - take it from a healthy \
+                 replica (`eth_getBlockByNumber`) or from the archive object listing under prefix \
+                 `{anchor}/`.",
+                anchor = self.last_l1_committed_block,
+            )
+            .unwrap();
+        }
 
         if config.general_config.allow_wal_behind_l1 {
             tracing::warn!(
@@ -116,11 +130,7 @@ impl NodeStateOnStartup {
 
 fn replay_archive_source_args(config: &ReplayArchiveConfig) -> String {
     match config {
-        ReplayArchiveConfig::Noop => {
-            "<archive source args - replay archive is NOT configured on this node, \
-             take the bucket/root from the node that archives>"
-                .to_string()
-        }
+        ReplayArchiveConfig::Noop => unreachable!("Noop is handled before command generation"),
         ReplayArchiveConfig::FileSystem { root_path, .. } => {
             format!("--archive-root {}", root_path.display())
         }

--- a/node/bin/src/node_state_on_startup.rs
+++ b/node/bin/src/node_state_on_startup.rs
@@ -1,6 +1,4 @@
-use crate::BLOCK_REPLAY_WAL_DB_NAME;
-use crate::config::{Config, ReplayArchiveConfig, ReplayArchiveEncryptionConfig};
-use std::fmt::Write;
+use crate::config::Config;
 use std::ops::RangeInclusive;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_types::NodeRole;
@@ -44,7 +42,7 @@ impl NodeStateOnStartup {
     /// guaranteed complete up to the last L1-committed block (the archive gate blocks L1 commits
     /// until all blocks of the batch are archived), so the correct fix is offline recovery.
     ///
-    /// Panics with recovery instructions unless `general.allow_wal_behind_l1` is set.
+    /// Panics with a pointer to the recovery docs unless `general.allow_wal_behind_l1` is set.
     pub fn check_wal_not_behind_l1(&self, config: &Config) {
         if !self.node_role.is_main() {
             return;
@@ -53,129 +51,17 @@ impl NodeStateOnStartup {
             return;
         }
 
-        let gap = self.last_l1_committed_block - self.block_replay_storage_last_block;
-        let replay_db_path = config
-            .general_config
-            .rocks_db_path
-            .join(BLOCK_REPLAY_WAL_DB_NAME);
-
-        let mut msg = String::new();
-        writeln!(
-            msg,
-            "local replay WAL is behind L1: \
-             WAL head = block {wal}, last L1-committed block = {l1} \
-             (last committed batch = {batch}), missing {gap} block(s)",
-            wal = self.block_replay_storage_last_block,
-            l1 = self.last_l1_committed_block,
-            batch = self.l1_state.last_committed_batch,
-        )
-        .unwrap();
-        writeln!(
-            msg,
-            "The WAL is missing blocks already committed to L1. Producing new blocks from this \
-             state would re-sequence committed block numbers and diverge from L1."
-        )
-        .unwrap();
-        if matches!(config.replay_archive_config, ReplayArchiveConfig::Noop) {
-            writeln!(
-                msg,
-                "No replay archive is configured on this node (`replay_archive.type=Noop`), so \
-                 recovery commands cannot be suggested. Either restore from a replay archive of \
-                 another node in this chain (run `replay_archive_recovery` with that node's \
-                 bucket and decryption key against {db}), or copy a complete `{wal_name}` \
-                 directory from a healthy node.",
-                db = replay_db_path.display(),
-                wal_name = BLOCK_REPLAY_WAL_DB_NAME,
-            )
-            .unwrap();
-        } else {
-            writeln!(
-                msg,
-                "Restore the WAL from the replay archive (node must stay stopped):\n\
-                 1. replay_archive_recovery download {source} --output-root <dir>\n\
-                 2. replay_archive_recovery recover-rocksdb --input-root <dir> \\\n\
-                 \x20      --replay-db-path {db} \\\n\
-                 \x20      --anchor-block-number {anchor} --anchor-block-hash <hash>{decrypt}\n\
-                 \x20  (`--replay-db-path` must point at an empty/absent dir - move the stale \
-                 `{wal_name}` away first)",
-                source = replay_archive_source_args(&config.replay_archive_config),
-                db = replay_db_path.display(),
-                anchor = self.last_l1_committed_block,
-                decrypt = replay_archive_decrypt_args(&config.replay_archive_config),
-                wal_name = BLOCK_REPLAY_WAL_DB_NAME,
-            )
-            .unwrap();
-            writeln!(
-                msg,
-                "Anchor hash for block {anchor} is not known locally - take it from a healthy \
-                 replica (`eth_getBlockByNumber`) or from the archive object listing under prefix \
-                 `{anchor}/`.",
-                anchor = self.last_l1_committed_block,
-            )
-            .unwrap();
-        }
+        let msg = "local replay WAL is behind the last L1-committed block. Restore the WAL from the replay archive first, see https://github.com/matter-labs/zksync-os-server/blob/main/lib/replay_archive/README.md";
 
         if config.general_config.allow_wal_behind_l1 {
             tracing::warn!(
-                "`general.allow_wal_behind_l1` is set - starting anyway and DIVERGING from L1.\n{msg}"
+                "`general.allow_wal_behind_l1` is set - starting anyway and DIVERGING from L1. {msg}"
             );
         } else {
             panic!(
-                "{msg}To bypass this check and start anyway (divergence!), set \
+                "{msg}. To bypass this check and start anyway (divergence!), set \
                  `general.allow_wal_behind_l1=true` (env: `ALLOW_WAL_BEHIND_L1=true`)."
             );
-        }
-    }
-}
-
-fn replay_archive_source_args(config: &ReplayArchiveConfig) -> String {
-    match config {
-        ReplayArchiveConfig::Noop => unreachable!("Noop is handled before command generation"),
-        ReplayArchiveConfig::FileSystem { root_path, .. } => {
-            format!("--archive-root {}", root_path.display())
-        }
-        ReplayArchiveConfig::S3WithCredentialFile {
-            bucket_base_url,
-            s3_credential_file_path,
-            endpoint,
-            region,
-            ..
-        } => {
-            let mut args = format!(
-                "--s3-bucket-base-url {bucket_base_url} \
-                 --s3-credential-file-path {}",
-                s3_credential_file_path.display()
-            );
-            if let Some(endpoint) = endpoint {
-                write!(args, " --s3-endpoint {endpoint}").unwrap();
-            }
-            if let Some(region) = region {
-                write!(args, " --s3-region {region}").unwrap();
-            }
-            args
-        }
-        ReplayArchiveConfig::Gcs {
-            bucket_base_url, ..
-        } => format!("--gcs-bucket-base-url {bucket_base_url}"),
-    }
-}
-
-fn replay_archive_decrypt_args(config: &ReplayArchiveConfig) -> String {
-    let encryption = match config {
-        ReplayArchiveConfig::Noop => return String::new(),
-        ReplayArchiveConfig::FileSystem { encryption, .. }
-        | ReplayArchiveConfig::S3WithCredentialFile { encryption, .. }
-        | ReplayArchiveConfig::Gcs { encryption, .. } => encryption,
-    };
-    match encryption {
-        ReplayArchiveEncryptionConfig::Noop => String::new(),
-        ReplayArchiveEncryptionConfig::AgeX25519 { .. } => {
-            " \\\n\x20      --identity-file <age identity> (or --age-secret-key / \
-             env REPLAY_ARCHIVE_AGE_SECRET_KEY)"
-                .to_string()
-        }
-        ReplayArchiveEncryptionConfig::GcpKms { kms_key_version } => {
-            format!(" \\\n\x20      --kms-key-version {kms_key_version}")
         }
     }
 }

--- a/node/bin/src/node_state_on_startup.rs
+++ b/node/bin/src/node_state_on_startup.rs
@@ -1,3 +1,6 @@
+use crate::BLOCK_REPLAY_WAL_DB_NAME;
+use crate::config::{Config, ReplayArchiveConfig, ReplayArchiveEncryptionConfig};
+use std::fmt::Write;
 use std::ops::RangeInclusive;
 use zksync_os_contract_interface::l1_discovery::L1State;
 use zksync_os_types::NodeRole;
@@ -30,5 +33,139 @@ impl NodeStateOnStartup {
             self.last_l1_proved_block,
             self.last_l1_executed_block,
         );
+    }
+
+    /// Main-node-only guard against starting from a stale replay WAL.
+    ///
+    /// If the local WAL head is behind the last L1-committed block, the WAL is missing records
+    /// for blocks that are already committed on L1. Starting the sequencer in this state makes it
+    /// produce fresh blocks at WAL head + 1, re-sequencing block numbers L1 already knows —
+    /// guaranteed divergence, followed by batcher/commit-watcher crashes. The replay archive is
+    /// guaranteed complete up to the last L1-committed block (the archive gate blocks L1 commits
+    /// until all blocks of the batch are archived), so the correct fix is offline recovery.
+    ///
+    /// Panics with recovery instructions unless `general.allow_wal_behind_l1` is set.
+    pub fn check_wal_not_behind_l1(&self, config: &Config) {
+        if !self.node_role.is_main() {
+            return;
+        }
+        if self.block_replay_storage_last_block >= self.last_l1_committed_block {
+            return;
+        }
+
+        let gap = self.last_l1_committed_block - self.block_replay_storage_last_block;
+        let replay_db_path = config
+            .general_config
+            .rocks_db_path
+            .join(BLOCK_REPLAY_WAL_DB_NAME);
+
+        let mut msg = String::new();
+        writeln!(
+            msg,
+            "local replay WAL is behind L1: \
+             WAL head = block {wal}, last L1-committed block = {l1} \
+             (last committed batch = {batch}), missing {gap} block(s)",
+            wal = self.block_replay_storage_last_block,
+            l1 = self.last_l1_committed_block,
+            batch = self.l1_state.last_committed_batch,
+        )
+        .unwrap();
+        writeln!(
+            msg,
+            "The WAL is missing blocks already committed to L1. Producing new blocks from this \
+             state would re-sequence committed block numbers and diverge from L1."
+        )
+        .unwrap();
+        writeln!(
+            msg,
+            "Restore the WAL from the replay archive (node must stay stopped):\n\
+             1. replay_archive_recovery download {source} --output-root <dir>\n\
+             2. replay_archive_recovery recover-rocksdb --input-root <dir> \\\n\
+             \x20      --replay-db-path {db} \\\n\
+             \x20      --anchor-block-number {anchor} --anchor-block-hash <hash>{decrypt}\n\
+             \x20  (`--replay-db-path` must point at an empty/absent dir - move the stale \
+             `{wal_name}` away first)",
+            source = replay_archive_source_args(&config.replay_archive_config),
+            db = replay_db_path.display(),
+            anchor = self.last_l1_committed_block,
+            decrypt = replay_archive_decrypt_args(&config.replay_archive_config),
+            wal_name = BLOCK_REPLAY_WAL_DB_NAME,
+        )
+        .unwrap();
+        writeln!(
+            msg,
+            "Anchor hash for block {anchor} is not known locally - take it from a healthy \
+             replica (`eth_getBlockByNumber`) or from the archive object listing under prefix \
+             `{anchor}/`.",
+            anchor = self.last_l1_committed_block,
+        )
+        .unwrap();
+
+        if config.general_config.allow_wal_behind_l1 {
+            tracing::warn!(
+                "`general.allow_wal_behind_l1` is set - starting anyway and DIVERGING from L1.\n{msg}"
+            );
+        } else {
+            panic!(
+                "{msg}To bypass this check and start anyway (divergence!), set \
+                 `general.allow_wal_behind_l1=true` (env: `ALLOW_WAL_BEHIND_L1=true`)."
+            );
+        }
+    }
+}
+
+fn replay_archive_source_args(config: &ReplayArchiveConfig) -> String {
+    match config {
+        ReplayArchiveConfig::Noop => {
+            "<archive source args - replay archive is NOT configured on this node, \
+             take the bucket/root from the node that archives>"
+                .to_string()
+        }
+        ReplayArchiveConfig::FileSystem { root_path, .. } => {
+            format!("--archive-root {}", root_path.display())
+        }
+        ReplayArchiveConfig::S3WithCredentialFile {
+            bucket_base_url,
+            s3_credential_file_path,
+            endpoint,
+            region,
+            ..
+        } => {
+            let mut args = format!(
+                "--s3-bucket-base-url {bucket_base_url} \
+                 --s3-credential-file-path {}",
+                s3_credential_file_path.display()
+            );
+            if let Some(endpoint) = endpoint {
+                write!(args, " --s3-endpoint {endpoint}").unwrap();
+            }
+            if let Some(region) = region {
+                write!(args, " --s3-region {region}").unwrap();
+            }
+            args
+        }
+        ReplayArchiveConfig::Gcs {
+            bucket_base_url, ..
+        } => format!("--gcs-bucket-base-url {bucket_base_url}"),
+    }
+}
+
+fn replay_archive_decrypt_args(config: &ReplayArchiveConfig) -> String {
+    let encryption = match config {
+        ReplayArchiveConfig::Noop => return String::new(),
+        ReplayArchiveConfig::FileSystem { encryption, .. }
+        | ReplayArchiveConfig::S3WithCredentialFile { encryption, .. }
+        | ReplayArchiveConfig::Gcs { encryption, .. } => encryption,
+    };
+    match encryption {
+        ReplayArchiveEncryptionConfig::Noop => String::new(),
+        ReplayArchiveEncryptionConfig::AgeX25519 { .. } => {
+            " \\\n\x20      --identity-file <age identity> (or --age-secret-key / \
+             env REPLAY_ARCHIVE_AGE_SECRET_KEY)"
+                .to_string()
+        }
+        ReplayArchiveEncryptionConfig::GcpKms { kms_key_version } => {
+            format!(" \\\n\x20      --kms-key-version {kms_key_version}")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Guards the main node against starting from a stale replay WAL.

Previously, if the local `block_replay_wal` was missing blocks that were already committed to L1 (e.g. a main node brought up from an outdated disk after a full outage), the node would replay its WAL to the tip and start **producing new blocks at WAL head + 1** — re-sequencing block numbers L1 already knows.
The result was guaranteed divergence, surfacing later as confusing batcher / commit-watcher crashes (`Existing batch first block ... does not match`, `UnexpectedCommit` restart loops) instead of a clear error at startup.

### What this PR does

- Extends `NodeStateOnStartup::assert_consistency` with a new invariant: on the **main node**, the replay WAL head must not be behind the last L1-committed block. If it is, the node panics at startup with a message showing both block numbers and pointing at restoring the WAL from a replay archive. External nodes are exempt — they legitimately lag behind L1 and catch up over p2p.
- Moves the `assert_consistency()` call earlier in startup, right after the node state is assembled — so the check fires before the starting block is determined and before any rebuild logic runs.

Both values compared were already computed during startup, so the check adds no extra I/O.

### Behavior change note

Intentionally *not* marked breaking: the check only fires in a state that was already fatal (the node would diverge and crash shortly after startup). It converts a delayed, confusing failure into an immediate one. Correctly operated deployments see no change.
