### PR TITLE
fix(sequencer): update default values for gas rate limiter

### DIFF
--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1155,7 +1155,7 @@ pub struct TxGasRateLimitConfig {
     pub enabled: bool,
 
     /// Target sustained executed-gas throughput, in gas per second.
-    #[config(default_t = NonZeroU64::new(72_000_000).unwrap())]
+    #[config(default_t = NonZeroU64::new(35_000_000).unwrap())]
     pub gas_per_second: NonZeroU64,
 
     /// Bank capacity (idle burst headroom), in seconds' worth of `gas_per_second`. Sized to


### PR DESCRIPTION
## Summary

Update default `rpc.tx_gas_rate_limit.gas_per_second` config value to 0.8x of the lowest saturation plateau seen under loadtest.