### PR TITLE
fix: shutdown teardown, L1 watcher revert classification and fake-SNARK lease return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17201,6 +17201,7 @@ dependencies = [
  "futures",
  "rangemap",
  "reth-tasks",
+ "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/lib/l1_sender/src/commands/prove.rs
+++ b/lib/l1_sender/src/commands/prove.rs
@@ -27,6 +27,11 @@ impl ProofCommand {
         );
         Self { batches, proof }
     }
+
+    /// The batches this command settles, in range order.
+    pub fn batches(&self) -> &[SignedBatchEnvelope<FriProof>] {
+        &self.batches
+    }
 }
 
 impl SendToL1 for ProofCommand {

--- a/lib/l1_watcher/Cargo.toml
+++ b/lib/l1_watcher/Cargo.toml
@@ -31,5 +31,6 @@ backon.workspace = true
 rangemap.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 zk_os_api.workspace = true
 zk_os_basic_system.workspace = true

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -566,9 +566,15 @@ impl L1UpgradeTxWatcher {
                 );
             }
             Err(e) => {
-                // Transport errors (503, timeout, etc.) should propagate.
-                // Contract-level reverts (function not found) are expected on pre-v31 CTMs.
-                if matches!(e, alloy::contract::Error::TransportError(_)) {
+                // A pre-v31 CTM has no `L1_BYTECODES_SUPPLIER()` at all, so the
+                // call reverts on an unknown selector — which providers report
+                // as a JSON-RPC error response, not a transport failure. That
+                // one shape takes the configured fallback. Everything else
+                // (transport failures, rate limits, provider internal errors,
+                // bad params) propagates: they say nothing about which
+                // supplier is canonical, and silently falling back on a
+                // transient provider hiccup would pin the wrong one.
+                if !is_revert_response(&e) {
                     return Err(e.into());
                 }
                 tracing::info!(
@@ -580,6 +586,42 @@ impl L1UpgradeTxWatcher {
             }
         }
     }
+}
+
+/// Whether a contract-call error is the chain saying "this function reverted",
+/// as opposed to the provider failing to answer. A revert on a call with no
+/// return data is how an unknown selector surfaces.
+///
+/// Deliberately stricter than the shared [`is_method_missing`], which treats
+/// every JSON-RPC error response as a missing method. That is tolerable where a
+/// wrong answer only costs a retry; here it decides which bytecode supplier the
+/// node treats as canonical, so a rate limit or a paused contract must surface
+/// instead of silently selecting the configured fallback.
+fn is_revert_response(error: &alloy::contract::Error) -> bool {
+    let alloy::contract::Error::TransportError(transport) = error else {
+        return false;
+    };
+    let Some(payload) = transport.as_error_resp() else {
+        return false;
+    };
+    // JSON-RPC 3 is the de-facto "execution reverted" code; some providers only
+    // set the message. Rate limiting (-32005/429) and internal errors (-32603)
+    // never match either test.
+    let reverted = payload.code == 3
+        || payload
+            .message
+            .to_ascii_lowercase()
+            .contains("execution reverted");
+    // An unknown selector reverts with no return data. A revert that carries a
+    // reason is the contract deliberately refusing — a paused or misconfigured
+    // CTM — and answering that by pinning the configured supplier would hide a
+    // real fault behind a fallback. Read the raw `data`: alloy's
+    // `as_revert_data` only spelunks the payload shapes it recognises.
+    let carries_reason = payload.data.as_ref().is_some_and(|data| {
+        let raw = data.get().trim().trim_matches('"');
+        !(raw.is_empty() || raw == "null" || raw == "0x")
+    });
+    reverted && !carries_reason
 }
 
 #[async_trait::async_trait]
@@ -791,5 +833,56 @@ mod tests {
         // The hash should be blake2s256 of the full preimage.
         let expected_hash = B256::from_slice(Blake2s256::digest(&full_preimage).as_slice());
         assert_eq!(hash, expected_hash);
+    }
+
+    /// Only a revert-shaped JSON-RPC error means "this CTM has no
+    /// `L1_BYTECODES_SUPPLIER()`". A provider that is rate limiting us, or one
+    /// that failed internally, says nothing about the chain, and taking the
+    /// configured fallback on those would pin the wrong supplier.
+    #[test]
+    fn only_reverts_select_the_configured_supplier() {
+        use alloy::transports::{RpcError, TransportErrorKind};
+
+        fn rpc_error(code: i64, message: &'static str) -> alloy::contract::Error {
+            alloy::contract::Error::TransportError(RpcError::ErrorResp(
+                alloy::rpc::json_rpc::ErrorPayload {
+                    code,
+                    message: message.into(),
+                    data: None,
+                },
+            ))
+        }
+
+        // Pre-v31 CTM: the call reverts on an unknown selector.
+        assert!(is_revert_response(&rpc_error(3, "execution reverted")));
+        assert!(is_revert_response(&rpc_error(-32000, "execution reverted")));
+
+        // A revert that carries a reason is a real refusal, not a missing
+        // method: a misconfigured or paused CTM must surface rather than
+        // silently pin the configured supplier.
+        let with_reason = alloy::contract::Error::TransportError(RpcError::ErrorResp(
+            alloy::rpc::json_rpc::ErrorPayload {
+                code: 3,
+                message: "execution reverted: paused".into(),
+                data: Some(
+                    serde_json::value::RawValue::from_string("\"0x08c379a0\"".into())
+                        .expect("raw value"),
+                ),
+            },
+        ));
+        assert!(!is_revert_response(&with_reason));
+
+        // Provider trouble, not chain state.
+        assert!(!is_revert_response(&rpc_error(
+            -32005,
+            "rate limit exceeded"
+        )));
+        assert!(!is_revert_response(&rpc_error(-32603, "internal error")));
+        assert!(!is_revert_response(&rpc_error(-32602, "invalid params")));
+        assert!(!is_revert_response(
+            &alloy::contract::Error::TransportError(RpcError::Transport(
+                TransportErrorKind::BackendGone
+            ))
+        ));
     }
 }

--- a/lib/pipeline/src/builder.rs
+++ b/lib/pipeline/src/builder.rs
@@ -49,6 +49,13 @@ impl Pipeline<()> {
         self.runtime.spawn_critical_with_graceful_shutdown_signal(
             "pipeline",
             |shutdown| async move {
+                // Keep the sender alive so `recv()` blocks (instead of returning
+                // `None`) when a segment is aborted before it can deregister.
+                // Without this, Rust 2024 edition closure capture rules would drop
+                // the sender when `spawn()` returns because the async block never
+                // references it directly.
+                let _sender_keepalive = self.shutdown_sender;
+
                 // Hold shutdown open until every spawned segment deregisters.
                 let _guard = shutdown.await;
 
@@ -99,13 +106,33 @@ impl<Output: Send + 'static> Pipeline<Output> {
         let shutdown_sender = self.shutdown_sender.clone();
         self.runtime
             .spawn_critical_with_graceful_shutdown_signal(name, |shutdown| async move {
+                let mut shutdown = std::pin::pin!(shutdown);
                 tokio::select! {
                     res = component.run(input_receiver, output_sender, reporter) => {
-                        res.expect("pipeline segment failed");
-                        tracing::debug!(name, "segment finished running");
+                        // Held until after the shutdown status is sent, exactly
+                        // like the guard the shutdown branch below binds.
+                        let mut _shutdown_guard = None;
+                        if let Err(err) = res {
+                            // A segment that fails once shutdown is under way has
+                            // almost certainly just lost a downstream receiver that
+                            // was dropped ahead of it — ordinary teardown, not a
+                            // fault. Panicking there reports a critical-task failure
+                            // and leaves the runtime unable to finish shutting down.
+                            // Both select branches can be ready at once, so this is
+                            // a coin flip rather than a rare interleaving.
+                            match futures::FutureExt::now_or_never(&mut shutdown) {
+                                Some(guard) => {
+                                    _shutdown_guard = Some(guard);
+                                    tracing::info!(name, "segment failed during shutdown: {err:#}");
+                                }
+                                None => panic!("pipeline segment failed: {err:#}"),
+                            }
+                        } else {
+                            tracing::debug!(name, "segment finished running");
+                        }
                         shutdown_sender.send(name).await.expect("failed to send shutdown status");
                     }
-                    _guard = shutdown => {
+                    _guard = &mut shutdown => {
                         tracing::debug!(name, "segment shutting down");
                         shutdown_sender.send(name).await.expect("failed to send shutdown status");
                     }

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -194,11 +194,16 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> PipelineComponent
                 "Batch da_input",
             );
 
-            if let Some(sidecar) = batch_envelope.batch.blob_sidecar.clone() {
-                self.sidecar_sender
-                    .send(sidecar)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to send sidecar: {e}"))?;
+            if let Some(sidecar) = batch_envelope.batch.blob_sidecar.clone()
+                && self.sidecar_sender.send(sidecar).await.is_err()
+            {
+                // The gas adjuster consumes these to estimate blob fill ratios.
+                // Losing a sample degrades a fee estimate; it is not a reason to
+                // fail the batcher. The channel closes when the adjuster's task
+                // is gone, which on shutdown happens while batches are still
+                // being sealed — failing here turns an ordinary shutdown into a
+                // critical-task panic.
+                tracing::debug!("blob fee sample dropped: gas adjuster is gone");
             }
             output.send_and_record(batch_envelope, &state_reporter)?;
         }

--- a/node/bin/src/prover_api/mod.rs
+++ b/node/bin/src/prover_api/mod.rs
@@ -10,3 +10,5 @@ mod prover_job_map;
 pub mod prover_server;
 pub mod snark_job_manager;
 pub mod snark_proving_pipeline_step;
+#[cfg(test)]
+pub(crate) mod test_util;

--- a/node/bin/src/prover_api/snark_job_manager.rs
+++ b/node/bin/src/prover_api/snark_job_manager.rs
@@ -180,7 +180,29 @@ impl SnarkJobManager {
 
             let batch_from = assigned.first().unwrap().0.batch_number;
             let batch_to = assigned.last().unwrap().0.batch_number;
-            let permit = self.try_reserve_permit_downstream()?;
+            let permit = match self.prove_batches_sender.try_reserve() {
+                Ok(permit) => permit,
+                Err(TrySendError::Full(_)) => {
+                    // Downstream is busy. The pick above already leased these
+                    // batches, so returning now without giving the lease back
+                    // would hold them until the assignment timeout — idle, and
+                    // invisible to every other prover — while the stage that
+                    // applied the backpressure drains in milliseconds.
+                    for (job, _) in &assigned {
+                        self.jobs
+                            .unassign_job(job.batch_number, "fake_prover")
+                            .await;
+                    }
+                    tracing::info!(
+                        batch_from,
+                        batch_to,
+                        "downstream is full; returned the fake-SNARK lease so the range stays \
+                         pickable"
+                    );
+                    return Ok(());
+                }
+                Err(TrySendError::Closed(_)) => anyhow::bail!("server is shutting down"),
+            };
             let Some(completed) = self
                 .jobs
                 .complete_many_jobs(batch_from, batch_to, ProverType::Fake, "fake_prover")
@@ -250,5 +272,47 @@ impl FakeSnarkProver {
                 tracing::info!("`FakeSnarkProver` iteration failed: {err}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prover_api::test_util::create_test_batch_envelope;
+
+    /// Downstream backpressure must not cost a lease. The fake prover picks
+    /// under the same assignment rules as a real one, so a pick it cannot use
+    /// has to be handed back: otherwise the range sits assigned for the whole
+    /// `assignment_timeout` (300s by default) while the stage that pushed back
+    /// drains in milliseconds — a stall no other prover can break.
+    #[tokio::test]
+    async fn backpressure_returns_the_fake_snark_lease() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let manager = SnarkJobManager::new(sender.clone(), 4, Duration::from_secs(300), 100);
+        manager
+            .add_job(create_test_batch_envelope(1, FriProof::Fake))
+            .await;
+
+        // Occupy the only downstream slot, then let the fake prover run.
+        let filler = create_test_batch_envelope(999, FriProof::Fake);
+        sender
+            .try_send(ProofCommand::new(vec![filler], SnarkProof::Fake))
+            .expect("the one slot starts free");
+        manager
+            .process_pending_fake_fri_proofs()
+            .await
+            .expect("backpressure is not an error");
+
+        // Capacity returns; the batch must be provable right away.
+        receiver.recv().await.expect("filler command");
+        manager
+            .process_pending_fake_fri_proofs()
+            .await
+            .expect("the second round proceeds");
+        let command = tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("batch 1 is still leased to the fake prover")
+            .expect("batch 1 is picked again once there is room");
+        assert_eq!(command.batches()[0].batch_number(), 1);
     }
 }

--- a/node/bin/src/prover_api/test_util.rs
+++ b/node/bin/src/prover_api/test_util.rs
@@ -1,0 +1,62 @@
+//! Shared fixtures for prover_api unit tests.
+
+use alloy::primitives::{Address, B256};
+use zksync_os_batch_types::PendingBatchInfo;
+use zksync_os_batch_types::batcher_model::{
+    BatchForSigning, BatchMetadata, BatchSignatureData, SignedBatchEnvelope,
+};
+use zksync_os_contract_interface::models::{CommitBatchInfo, DACommitmentScheme, StoredBatchInfo};
+use zksync_os_types::{ProtocolSemanticVersion, PubdataMode};
+
+/// A minimal all-zero batch envelope carrying `data` as its proof payload.
+pub(crate) fn create_test_batch_envelope<E>(batch_number: u64, data: E) -> SignedBatchEnvelope<E> {
+    let batch = BatchMetadata {
+        previous_stored_batch_info: StoredBatchInfo {
+            batch_number: batch_number.saturating_sub(1),
+            state_commitment: B256::ZERO,
+            number_of_layer1_txs: 0,
+            priority_operations_hash: B256::ZERO,
+            dependency_roots_rolling_hash: B256::ZERO,
+            l2_to_l1_logs_root_hash: B256::ZERO,
+            commitment: B256::ZERO,
+            // unused
+            last_block_timestamp: Some(0),
+        },
+        batch_info: PendingBatchInfo {
+            commit_info: CommitBatchInfo {
+                batch_number,
+                new_state_commitment: B256::ZERO,
+                number_of_layer1_txs: 0,
+                number_of_layer2_txs: 0,
+                priority_operations_hash: B256::ZERO,
+                dependency_roots_rolling_hash: B256::ZERO,
+                l2_to_l1_logs_root_hash: B256::ZERO,
+                l2_da_commitment_scheme: DACommitmentScheme::BlobsAndPubdataKeccak256,
+                da_commitment: B256::ZERO,
+                first_block_timestamp: 0,
+                first_block_number: Some(batch_number),
+                last_block_timestamp: 0,
+                last_block_number: Some(batch_number),
+                chain_id: 1,
+                operator_da_input: vec![],
+                sl_chain_id: 2,
+            },
+            protocol_version: ProtocolSemanticVersion::legacy_genesis_version(),
+            upgrade_tx_hash: None,
+        },
+        chain_address: Address::ZERO,
+        blob_sidecar: None,
+        first_block_number: batch_number,
+        last_block_number: batch_number,
+        last_block_hash: None,
+        pubdata_mode: PubdataMode::Calldata,
+        tx_count: 10,
+        computational_native_used: None,
+        logs: vec![],
+        messages: vec![],
+        multichain_root: Default::default(),
+        set_sl_chain_id_migration_number: None,
+    };
+
+    BatchForSigning::new(batch, data).with_signatures(BatchSignatureData::NotNeeded)
+}


### PR DESCRIPTION
## Summary

Three independent robustness fixes in different subsystems. None of them changes
behaviour on the happy path — each turns a case that currently reports a crash,
trusts a wrong answer, or idles on a stale lease into the correct outcome. They
are independently revertable and can be reviewed in any order.

### 1. `fix(pipeline,batcher)`: survive an ordinary shutdown

Two ways a clean stop was reported as a crash.

- A pipeline segment that fails once graceful shutdown is under way has almost
  certainly just lost a downstream receiver that was dropped ahead of it.
  Panicking there reported a critical-task failure and left the runtime unable
  to finish shutting down. Both `select!` branches are ready at that moment, so
  which one wins is a coin flip rather than a rare interleaving. A segment that
  fails while the node is still *running* keeps panicking — `now_or_never` on
  the shutdown future is what separates the two cases.
- The blob sidecars the batcher hands the gas adjuster are fee-estimation
  samples. Failing that send failed the whole batcher segment, and the channel
  closes whenever the adjuster's task is gone — always on an external node, and
  during shutdown while batches are still being sealed. A lost sample now
  degrades a fee estimate instead of killing the segment.

### 2. `fix(l1_watcher)`: only an empty revert selects the configured supplier

A pre-v31 CTM has no `L1_BYTECODES_SUPPLIER()`, so the call reverts on an
unknown selector — which providers report as a JSON-RPC error response, not a
transport failure. The previous check treated *every* error response as "method
missing", so a rate limit (`-32005`), a provider internal error (`-32603`), or a
deliberately paused contract silently pinned the configured supplier as
canonical.

`is_revert_response` now matches the revert shape specifically, and a revert
that carries return data — a real revert reason, i.e. a contract deliberately
refusing — is **not** treated as a missing method. This is stricter than the
shared `is_method_missing` on purpose: there a wrong answer costs a retry, here
it decides which bytecode supplier the node treats as canonical.

### 3. `fix(prover_api)`: return the fake-SNARK lease on downstream backpressure

`pick_jobs_while_with_limit` assigns jobs before the loop reserves downstream
capacity, so a full channel abandoned the pick with the range still leased to
`fake_prover` — invisible to every other prover until the 300 s assignment
timeout, while the stage that applied the backpressure drains in milliseconds.
The lease is handed back instead.

## Testing

New unit tests:

- `only_reverts_select_the_configured_supplier` — covers all five error shapes
  (revert with and without data, rate limit, internal error, invalid params, and
  a transport failure).
- `backpressure_returns_the_fake_snark_lease` — one-slot downstream channel; the
  range must become pickable as soon as capacity returns rather than after the
  assignment timeout.

Full workspace verification is listed in a comment below.

## Notes for the reviewer

- `node/bin/src/prover_api/test_util.rs` is new shared test scaffolding
  (`create_test_batch_envelope`). The `prover_job_map` tests previously built the
  same fixture inline and now call it.
- `lib/l1_sender/src/commands/prove.rs` gains a single read-only accessor
  (`batches()`) so the backpressure test can assert on the emitted command. No
  encoding behaviour changes.
