### PR TITLE
fix(prover_api): reserve capacity before fake SNARK assignment

### DIFF
--- a/node/bin/src/prover_api/mod.rs
+++ b/node/bin/src/prover_api/mod.rs
@@ -10,3 +10,5 @@ mod prover_job_map;
 pub mod prover_server;
 pub mod snark_job_manager;
 pub mod snark_proving_pipeline_step;
+#[cfg(test)]
+mod test_util;

--- a/node/bin/src/prover_api/prover_job_map/map.rs
+++ b/node/bin/src/prover_api/prover_job_map/map.rs
@@ -197,6 +197,16 @@ impl<T: Clone> ProverJobMap<T> {
             .collect()
     }
 
+    pub async fn has_assignable_job<F>(&self, mut predicate: F) -> bool
+    where
+        F: FnMut(&JobEntry<T>) -> bool,
+    {
+        let now = Instant::now();
+        let jobs = self.lock_with_tracking(JobMapMethod::PickJobsWhile).await;
+        jobs.values()
+            .any(|entry| self.is_job_eligible(&[], entry, now, 1, &mut predicate))
+    }
+
     /// Checks if a job is eligible for assignment based on:
     /// - Not exceeding the limit of selected jobs
     /// - Being either pending or timed out
@@ -491,77 +501,11 @@ impl<T: Clone> ProverJobMap<T> {
 mod tests {
     use super::*;
     use crate::prover_api::metrics::ProverStage;
-    use alloy::primitives::{Address, B256};
-    use std::time::Duration;
-    use zksync_os_batch_types::PendingBatchInfo;
-    use zksync_os_batch_types::batcher_model::{BatchForSigning, BatchMetadata};
-    use zksync_os_contract_interface::models::{
-        CommitBatchInfo, DACommitmentScheme, StoredBatchInfo,
+    use crate::prover_api::test_util::{
+        create_test_batch_envelope, create_test_batch_envelope_with_protocol_version,
     };
-    use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion, PubdataMode};
-
-    fn create_test_batch_envelope(batch_number: u64) -> SignedBatchEnvelope<Vec<u8>> {
-        create_test_batch_envelope_with_protocol_version(
-            batch_number,
-            ProtocolSemanticVersion::new(0, 32, 0),
-        )
-    }
-
-    fn create_test_batch_envelope_with_protocol_version(
-        batch_number: u64,
-        protocol_version: ProtocolSemanticVersion,
-    ) -> SignedBatchEnvelope<Vec<u8>> {
-        let batch = BatchMetadata {
-            previous_stored_batch_info: StoredBatchInfo {
-                batch_number: batch_number.saturating_sub(1),
-                state_commitment: B256::ZERO,
-                number_of_layer1_txs: 0,
-                priority_operations_hash: B256::ZERO,
-                dependency_roots_rolling_hash: B256::ZERO,
-                l2_to_l1_logs_root_hash: B256::ZERO,
-                commitment: B256::ZERO,
-                // unused
-                last_block_timestamp: Some(0),
-            },
-            batch_info: PendingBatchInfo {
-                commit_info: CommitBatchInfo {
-                    batch_number,
-                    new_state_commitment: B256::ZERO,
-                    number_of_layer1_txs: 0,
-                    number_of_layer2_txs: 0,
-                    priority_operations_hash: B256::ZERO,
-                    dependency_roots_rolling_hash: B256::ZERO,
-                    l2_to_l1_logs_root_hash: B256::ZERO,
-                    l2_da_commitment_scheme: DACommitmentScheme::BlobsAndPubdataKeccak256,
-                    da_commitment: B256::ZERO,
-                    first_block_timestamp: 0,
-                    first_block_number: Some(batch_number),
-                    last_block_timestamp: 0,
-                    last_block_number: Some(batch_number),
-                    chain_id: 1,
-                    operator_da_input: vec![],
-                    sl_chain_id: 2,
-                },
-                protocol_version,
-                upgrade_tx_hash: None,
-            },
-            chain_address: Address::ZERO,
-            blob_sidecar: None,
-            first_block_number: batch_number,
-            last_block_number: batch_number,
-            last_block_hash: None,
-            pubdata_mode: PubdataMode::Calldata,
-            tx_count: 10,
-            computational_native_used: None,
-            logs: vec![],
-            messages: vec![],
-            multichain_root: Default::default(),
-            set_sl_chain_id_migration_number: None,
-        };
-
-        BatchForSigning::new(batch, vec![1, 2, 3])
-            .with_signatures(zksync_os_batch_types::batcher_model::BatchSignatureData::NotNeeded)
-    }
+    use std::time::Duration;
+    use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion};
 
     #[tokio::test]
     async fn test_add_and_complete_job() {

--- a/node/bin/src/prover_api/prover_job_map/mod.rs
+++ b/node/bin/src/prover_api/prover_job_map/mod.rs
@@ -3,3 +3,4 @@ mod models;
 mod tracked_lock;
 
 pub use map::ProverJobMap;
+pub(super) use models::JobEntry;

--- a/node/bin/src/prover_api/snark_job_manager.rs
+++ b/node/bin/src/prover_api/snark_job_manager.rs
@@ -1,6 +1,6 @@
 use crate::prover_api::fri_job_manager::FriJob;
 use crate::prover_api::metrics::{ProverStage, ProverType};
-use crate::prover_api::prover_job_map::ProverJobMap;
+use crate::prover_api::prover_job_map::{JobEntry, ProverJobMap};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -154,13 +154,23 @@ impl SnarkJobManager {
         timeout_for_real_fris: Option<Duration>,
     ) -> anyhow::Result<()> {
         loop {
+            let is_fake_or_timed_out = |job: &JobEntry<FriProof>| {
+                job.batch_envelope.data.is_fake()
+                    || timeout_for_real_fris
+                        .is_some_and(|timeout| job.metadata.added_at.elapsed() >= timeout)
+            };
+            if !self.jobs.has_assignable_job(is_fake_or_timed_out).await {
+                return Ok(());
+            }
+
+            let permit = self.try_reserve_permit_downstream()?;
             let assigned: Vec<(FriJob, FriProof)> = self
                 .jobs
-                .pick_jobs_while_with_limit(self.max_fris_per_snark, "fake_prover", |job| {
-                    job.batch_envelope.data.is_fake()
-                        || (timeout_for_real_fris.is_some()
-                            && job.metadata.added_at.elapsed() >= timeout_for_real_fris.unwrap())
-                })
+                .pick_jobs_while_with_limit(
+                    self.max_fris_per_snark,
+                    "fake_prover",
+                    is_fake_or_timed_out,
+                )
                 .await;
 
             if assigned.is_empty() {
@@ -180,7 +190,6 @@ impl SnarkJobManager {
 
             let batch_from = assigned.first().unwrap().0.batch_number;
             let batch_to = assigned.last().unwrap().0.batch_number;
-            let permit = self.try_reserve_permit_downstream()?;
             let Some(completed) = self
                 .jobs
                 .complete_many_jobs(batch_from, batch_to, ProverType::Fake, "fake_prover")
@@ -250,5 +259,50 @@ impl FakeSnarkProver {
                 tracing::info!("`FakeSnarkProver` iteration failed: {err}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prover_api::test_util::create_test_batch_envelope_with_data;
+    use zksync_os_types::ProtocolSemanticVersion;
+
+    #[tokio::test]
+    async fn backpressure_does_not_lease_fake_jobs() {
+        let protocol_version = ProtocolSemanticVersion::new(0, 32, 0);
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender
+            .try_send(ProofCommand::new(
+                vec![create_test_batch_envelope_with_data(
+                    100,
+                    protocol_version.clone(),
+                    FriProof::Fake,
+                )],
+                SnarkProof::Fake,
+            ))
+            .unwrap();
+
+        let manager = SnarkJobManager::new(sender, 1, Duration::from_secs(60), 100);
+        manager
+            .add_job(create_test_batch_envelope_with_data(
+                1,
+                protocol_version,
+                FriProof::Fake,
+            ))
+            .await;
+
+        let err = manager.process_pending_fake_fri_proofs().await.unwrap_err();
+        assert_eq!(err.to_string(), "downstream backpressure");
+        let status = manager.jobs.status().await;
+        assert_eq!(status[0].assigned_to_prover_id, None);
+        assert_eq!(status[0].current_attempt, 0);
+
+        receiver.recv().await.unwrap();
+        manager.process_pending_fake_fri_proofs().await.unwrap();
+
+        let command = receiver.recv().await.unwrap();
+        assert_eq!(command.as_ref()[0].batch_number(), 1);
+        assert!(manager.jobs.status().await.is_empty());
     }
 }

--- a/node/bin/src/prover_api/test_util.rs
+++ b/node/bin/src/prover_api/test_util.rs
@@ -1,0 +1,75 @@
+use alloy::primitives::{Address, B256};
+use zksync_os_batch_types::PendingBatchInfo;
+use zksync_os_batch_types::batcher_model::{BatchForSigning, BatchMetadata, SignedBatchEnvelope};
+use zksync_os_contract_interface::models::{CommitBatchInfo, DACommitmentScheme, StoredBatchInfo};
+use zksync_os_types::{ProtocolSemanticVersion, PubdataMode};
+
+pub(super) fn create_test_batch_envelope(batch_number: u64) -> SignedBatchEnvelope<Vec<u8>> {
+    create_test_batch_envelope_with_protocol_version(
+        batch_number,
+        ProtocolSemanticVersion::new(0, 32, 0),
+    )
+}
+
+pub(super) fn create_test_batch_envelope_with_protocol_version(
+    batch_number: u64,
+    protocol_version: ProtocolSemanticVersion,
+) -> SignedBatchEnvelope<Vec<u8>> {
+    create_test_batch_envelope_with_data(batch_number, protocol_version, vec![1, 2, 3])
+}
+
+pub(super) fn create_test_batch_envelope_with_data<T>(
+    batch_number: u64,
+    protocol_version: ProtocolSemanticVersion,
+    data: T,
+) -> SignedBatchEnvelope<T> {
+    let batch = BatchMetadata {
+        previous_stored_batch_info: StoredBatchInfo {
+            batch_number: batch_number.saturating_sub(1),
+            state_commitment: B256::ZERO,
+            number_of_layer1_txs: 0,
+            priority_operations_hash: B256::ZERO,
+            dependency_roots_rolling_hash: B256::ZERO,
+            l2_to_l1_logs_root_hash: B256::ZERO,
+            commitment: B256::ZERO,
+            last_block_timestamp: Some(0),
+        },
+        batch_info: PendingBatchInfo {
+            commit_info: CommitBatchInfo {
+                batch_number,
+                new_state_commitment: B256::ZERO,
+                number_of_layer1_txs: 0,
+                number_of_layer2_txs: 0,
+                priority_operations_hash: B256::ZERO,
+                dependency_roots_rolling_hash: B256::ZERO,
+                l2_to_l1_logs_root_hash: B256::ZERO,
+                l2_da_commitment_scheme: DACommitmentScheme::BlobsAndPubdataKeccak256,
+                da_commitment: B256::ZERO,
+                first_block_timestamp: 0,
+                first_block_number: Some(batch_number),
+                last_block_timestamp: 0,
+                last_block_number: Some(batch_number),
+                chain_id: 1,
+                operator_da_input: vec![],
+                sl_chain_id: 2,
+            },
+            protocol_version,
+            upgrade_tx_hash: None,
+        },
+        chain_address: Address::ZERO,
+        blob_sidecar: None,
+        first_block_number: batch_number,
+        last_block_number: batch_number,
+        last_block_hash: None,
+        pubdata_mode: PubdataMode::Calldata,
+        tx_count: 10,
+        computational_native_used: None,
+        logs: vec![],
+        messages: vec![],
+        multichain_root: Default::default(),
+        set_sl_chain_id_migration_number: None,
+    };
+
+    BatchForSigning::new(batch, data)
+        .with_signatures(zksync_os_batch_types::batcher_model::BatchSignatureData::NotNeeded)
+}


### PR DESCRIPTION
## Summary

- check for an eligible fake or timed-out FRI job without mutating the job map
- reserve downstream proof-command capacity before assigning the job
- keep backpressured jobs unassigned with their attempt counter unchanged

## Why

Assigning a job before reserving output capacity can strand it when the command channel is full.
