### PR TITLE
fix(l1_watcher): recognize pre-v31 supplier getter reverts

### DIFF
--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -903,13 +903,23 @@ impl<P: Provider> ZkChain<P> {
     }
 }
 
-/// Returns `true` if the error came from the contract itself (empty return data or a revert),
-/// which is how an EVM reports a call to a function selector that the deployed code does not
-/// implement. Network / transport failures return `false` so they can be propagated.
+/// Returns `true` for an empty contract response or empty EVM revert.
 pub fn is_method_missing(err: &alloy::contract::Error) -> bool {
     match err {
         alloy::contract::Error::ZeroData(..) => true,
-        alloy::contract::Error::TransportError(te) => te.as_error_resp().is_some(),
+        alloy::contract::Error::TransportError(te) => {
+            let Some(response) = te.as_error_resp() else {
+                return false;
+            };
+            // Geth-compatible RPCs report EVM execution reverts with code 3.
+            if response.code != 3 || !response.message.to_ascii_lowercase().contains("revert") {
+                return false;
+            }
+
+            response
+                .as_revert_data()
+                .is_some_and(|data| data.is_empty())
+        }
         _ => false,
     }
 }
@@ -937,5 +947,65 @@ impl<T> Enrich for alloy::contract::Result<T> {
             None => Error::Call(Box::new(e), function_name.to_string()),
             Some(block_id) => Error::CallAtBlock(Box::new(e), function_name.to_string(), block_id),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_method_missing;
+    use alloy::rpc::json_rpc::{ErrorPayload, RpcSend};
+    use alloy::transports::TransportError;
+    use serde::Serialize;
+
+    #[derive(Clone, Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct NestedRevert {
+        original_error: RevertData,
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    struct RevertData {
+        data: &'static str,
+    }
+
+    fn rpc_error<T: RpcSend>(
+        code: i64,
+        message: &'static str,
+        data: Option<T>,
+    ) -> alloy::contract::Error {
+        let payload = ErrorPayload {
+            code,
+            message: message.into(),
+            data,
+        }
+        .serialize_payload()
+        .unwrap();
+        alloy::contract::Error::TransportError(TransportError::ErrorResp(payload))
+    }
+
+    #[test]
+    fn method_missing_requires_an_empty_revert() {
+        assert!(is_method_missing(&rpc_error(
+            3,
+            "execution reverted",
+            Some("0x"),
+        )));
+        assert!(is_method_missing(&rpc_error(
+            3,
+            "execution reverted",
+            Some(NestedRevert {
+                original_error: RevertData { data: "0x" },
+            }),
+        )));
+        assert!(!is_method_missing(&rpc_error(
+            3,
+            "execution reverted",
+            Some("0xdeadbeef"),
+        )));
+        assert!(!is_method_missing(&rpc_error(
+            -32603,
+            "execution reverted",
+            Option::<&str>::None,
+        )));
     }
 }

--- a/lib/l1_watcher/src/upgrade_tx_watcher.rs
+++ b/lib/l1_watcher/src/upgrade_tx_watcher.rs
@@ -565,12 +565,7 @@ impl L1UpgradeTxWatcher {
                     self.ctm_l1
                 );
             }
-            Err(e) => {
-                // Transport errors (503, timeout, etc.) should propagate.
-                // Contract-level reverts (function not found) are expected on pre-v31 CTMs.
-                if matches!(e, alloy::contract::Error::TransportError(_)) {
-                    return Err(e.into());
-                }
+            Err(e) if is_method_missing(&e) => {
                 tracing::info!(
                     configured_supplier = ?self.bytecode_supplier_address,
                     ctm = ?self.ctm_l1,
@@ -578,6 +573,7 @@ impl L1UpgradeTxWatcher {
                 );
                 Ok(self.bytecode_supplier_address)
             }
+            Err(e) => Err(e.into()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- fall back to the configured bytecode supplier for the exact pre-v31 empty-revert response
- propagate non-empty reverts, internal RPC errors, and transport failures
- tighten the shared missing-method classifier used by compatibility call sites

## Why

Pre-v31 CTMs do not expose the supplier getter, but unrelated RPC failures must still surface.