### PR TITLE
chore(deps): bump h2 to 0.4.16 to fix RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6652,9 +6652,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

Bumps `h2` from 0.4.15 to 0.4.16 in `Cargo.lock` to clear [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258), which was failing the security audit job on `main`.

`h2` (pulled in transitively via `hyper`) accepted and queued empty DATA frames without limit. If streams are not actively drained, this can grow memory unboundedly, or panic if the length overflows. Low severity; patched in 0.4.16.

Lockfile-only change — the `h2` version and checksum are the only lines touched, no other dependency versions move.

Verified locally:
- `cargo metadata --locked` succeeds (lockfile is consistent, no further resolution needed)
- `cargo check --locked --workspace --exclude zksync_os_integration_tests` builds clean
- `cargo deny --manifest-path ./Cargo.toml check --allow unmaintained --hide-inclusion-graph` (same arguments as CI) reports `advisories ok, bans ok, licenses ok, sources ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)