### PR TITLE
feat(prover): drop pre-0.3 proving support

### DIFF
--- a/lib/l1_sender/src/commands/prove.rs
+++ b/lib/l1_sender/src/commands/prove.rs
@@ -141,9 +141,6 @@ impl ProofCommand {
         let verifier_version = match self.proof.proving_execution_version() {
             // Use default verifier for fake proofs.
             None => 0,
-            Some(4) => 4,
-            Some(5) => 5,
-            Some(6) => 6,
             Some(7) => 0,
             // Switch to 0 once the L1 default verifier becomes the V8 one (as done for V7).
             Some(8) => 8,

--- a/lib/native_pig/src/lib.rs
+++ b/lib/native_pig/src/lib.rs
@@ -149,7 +149,9 @@ pub fn generate_batch_run<ReadState: ReadStateHistory>(
         ProvingVersion::V8 => {
             v32::generate_batch_run(blocks, read_state, merkle_tree, pubdata_mode)
         }
-        _ => anyhow::bail!("native batch proving is unsupported for {proving_version:?}"),
+        ProvingVersion::V7 => {
+            anyhow::bail!("native batch proving is unsupported for {proving_version:?}")
+        }
     }
 }
 

--- a/lib/types/src/protocol/mod.rs
+++ b/lib/types/src/protocol/mod.rs
@@ -68,7 +68,7 @@ impl ProtocolSemanticVersion {
         // A patch version can change the proving harness, so a version is only live once it
         // maps to a `ProvingVersion` known to this server release.
         match self.minor {
-            30..=32 => ProvingVersion::try_from(self.clone()).is_ok(),
+            31..=32 => ProvingVersion::try_from(self.clone()).is_ok(),
             // When updating this function, make sure to insert the new non-live version here.
             _ => false,
         }
@@ -243,10 +243,9 @@ mod tests {
     fn test_protocol_semantic_version_is_live() {
         let test_vector = [
             ((0, 29, 5), false),
-            ((0, 30, 0), true),
-            ((0, 30, 1), true),
-            ((0, 30, 2), true),
-            // Patch versions without a known proving version are not live.
+            ((0, 30, 0), false),
+            ((0, 30, 1), false),
+            ((0, 30, 2), false),
             ((0, 30, 99), false),
             ((0, 31, 0), true),
             ((0, 32, 0), true),

--- a/lib/types/src/protocol/proving_version.rs
+++ b/lib/types/src/protocol/proving_version.rs
@@ -10,12 +10,6 @@ use super::ProtocolSemanticVersion;
 #[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ProvingVersion {
-    V1 = 1,
-    V2 = 2,
-    V3 = 3,
-    V4 = 4,
-    V5 = 5,
-    V6 = 6,
     V7 = 7,
     V8 = 8,
 }
@@ -24,48 +18,15 @@ impl TryFrom<ProtocolSemanticVersion> for ProvingVersion {
     type Error = ProvingVersionError;
 
     fn try_from(version: ProtocolSemanticVersion) -> Result<Self, Self::Error> {
-        // Prior to v30 release, updates happened without proper protocol upgrades, so it's
-        // impossible to determine an early version by the protocol version alone. However,
-        // the precise execution version is stored in the block context, so it can be loaded
-        // from there.
-        match (version.minor, version.patch) {
-            (29, 0) | (29, 1) => Ok(ProvingVersion::V4),
-            (30, 0) => Ok(ProvingVersion::V5),
-            (30, 1) => Ok(ProvingVersion::V6),
-            (30, 2) => Ok(ProvingVersion::V6),
-            (31, 0) => Ok(ProvingVersion::V7),
-            (31, 1) => Ok(ProvingVersion::V7),
-            (32, 0) => Ok(ProvingVersion::V8),
+        match (version.major, version.minor, version.patch) {
+            (0, 31, 0) | (0, 31, 1) => Ok(ProvingVersion::V7),
+            (0, 32, 0) => Ok(ProvingVersion::V8),
             _ => Err(ProvingVersionError::UnsupportedVersion(version)),
         }
     }
 }
 
 impl ProvingVersion {
-    // NOTE: V1 and V2 have a slight chance of being off as they've been backfilled.
-    // If you find a divergence in what you expect and the actual value, most likely a bug.
-
-    /// verification key hash generated from zksync-os v0.0.21, zksync-airbender v0.4.4 and zkos-wrapper v0.4.3
-    const V1_VK_HASH: &'static str =
-        "0x80a72fbdf9d6ab299fb5dfc2bcc807cfc7be38c9cfb0bc9b1ce6f9510fb110ea";
-    /// verification key hash generated from zksync-os v0.0.25, zksync-airbender v0.4.5 and zkos-wrapper v0.4.6
-    const V2_VK_HASH: &'static str =
-        "0x83d49897775e6c1f1d7247ec228e18158e8e3accda545c604de4c44eee1a9845";
-    /// verification key hash generated from zksync-os v0.0.26, zksync-airbender v0.5.0 and zkos-wrapper v0.5.0
-    const V3_VK_HASH: &'static str =
-        "0x6a4509801ec284b8921c63dc6aaba668a0d71382d87ae4095ffc2235154e9fa3";
-    /// verification key hash generated from zksync-os v0.1.0, zksync-airbender v0.5.1 and zkos-wrapper v0.5.3
-    const V4_VK_HASH: &'static str =
-        "0xa385a997a63cc78e724451dca8b044b5ef29fcdc9d8b6ced33d9f58de531faa5";
-
-    /// verification key hash generated from zksync-os v0.2.4, zksync-airbender v0.5.1 and zkos-wrapper v0.5.3
-    const V5_VK_HASH: &'static str =
-        "0x996b02b1d0420e997b4dc0d629a3a1bba93ed3185ac463f17b02ff83be139581";
-
-    /// verification key hash generated from zksync-os v0.2.5, zksync-airbender v0.5.2 and zkos-wrapper v0.5.4
-    const V6_VK_HASH: &'static str =
-        "0x124ebcd537a1e1c152774dd18f67660e35625bba0b669bf3b4836d636b105337";
-
     /// verification key hash generated from zksync-os v0.3.0, zksync-airbender v0.5.2 and zkos-wrapper v0.5.5
     const V7_VK_HASH: &'static str =
         "0x23156cf220288cd1e436dccfc09aa4883ea8288da61aa69e2c7251b0c0c44ccd";
@@ -80,12 +41,6 @@ impl ProvingVersion {
     /// Get the verification key hash associated with this execution version.
     pub fn vk_hash(&self) -> &'static str {
         match self {
-            Self::V1 => Self::V1_VK_HASH,
-            Self::V2 => Self::V2_VK_HASH,
-            Self::V3 => Self::V3_VK_HASH,
-            Self::V4 => Self::V4_VK_HASH,
-            Self::V5 => Self::V5_VK_HASH,
-            Self::V6 => Self::V6_VK_HASH,
             Self::V7 => Self::V7_VK_HASH,
             Self::V8 => Self::V8_VK_HASH,
         }
@@ -94,12 +49,6 @@ impl ProvingVersion {
     /// Try to get ExecutionVersion from verification key hash.
     pub fn try_from_vk_hash(vk_hash: &str) -> Result<Self, ProvingVersionError> {
         match vk_hash {
-            Self::V1_VK_HASH => Ok(Self::V1),
-            Self::V2_VK_HASH => Ok(Self::V2),
-            Self::V3_VK_HASH => Ok(Self::V3),
-            Self::V4_VK_HASH => Ok(Self::V4),
-            Self::V5_VK_HASH => Ok(Self::V5),
-            Self::V6_VK_HASH => Ok(Self::V6),
             Self::V7_VK_HASH => Ok(Self::V7),
             Self::V8_VK_HASH => Ok(Self::V8),
             val => Err(ProvingVersionError::UnsupportedVkHash(val.to_string())),
@@ -122,13 +71,7 @@ mod tests {
 
     #[test]
     fn version_mapping() {
-        // When adding new versions here, make sure to also update `unknown_versions` so that it makes sure
-        // that the (new) next protocol version is unknown.
         let test_vector = [
-            ((0, 29, 0), ProvingVersion::V4),
-            ((0, 29, 1), ProvingVersion::V4),
-            ((0, 30, 0), ProvingVersion::V5),
-            ((0, 30, 1), ProvingVersion::V6),
             ((0, 31, 0), ProvingVersion::V7),
             ((0, 31, 1), ProvingVersion::V7),
             ((0, 32, 0), ProvingVersion::V8),
@@ -141,7 +84,15 @@ mod tests {
             assert_eq!(&proving_version, expected);
         }
 
-        let unknown_versions = [(0, 27, 10), (0, 28, 5), (0, 30, 3), (0, 32, 1), (0, 33, 0)];
+        let unknown_versions = [
+            (0, 29, 1),
+            (0, 30, 0),
+            (0, 30, 1),
+            (0, 30, 2),
+            (0, 32, 1),
+            (0, 33, 0),
+            (1, 31, 0),
+        ];
 
         for (major, minor, patch) in unknown_versions.iter() {
             let version = ProtocolSemanticVersion::new(*major, *minor, *patch);
@@ -156,12 +107,6 @@ mod tests {
     #[test]
     fn vk_hash_mapping() {
         let test_vector = [
-            (ProvingVersion::V1, ProvingVersion::V1_VK_HASH),
-            (ProvingVersion::V2, ProvingVersion::V2_VK_HASH),
-            (ProvingVersion::V3, ProvingVersion::V3_VK_HASH),
-            (ProvingVersion::V4, ProvingVersion::V4_VK_HASH),
-            (ProvingVersion::V5, ProvingVersion::V5_VK_HASH),
-            (ProvingVersion::V6, ProvingVersion::V6_VK_HASH),
             (ProvingVersion::V7, ProvingVersion::V7_VK_HASH),
             (ProvingVersion::V8, ProvingVersion::V8_VK_HASH),
         ];

--- a/local-chains/v30.2/versions.yaml
+++ b/local-chains/v30.2/versions.yaml
@@ -1,5 +1,6 @@
 general:
   protocol_version: "v30.2"
+  # Historical fixture provenance only; the server no longer supports real proving for v30.2.
   verification_key: "0x124ebcd537a1e1c152774dd18f67660e35625bba0b669bf3b4836d636b105337"
 
 era-contracts:

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -241,14 +241,6 @@ fn compute_batch_prover_input(
     }
 
     Ok(match proving_version {
-        ProvingVersion::V1
-        | ProvingVersion::V2
-        | ProvingVersion::V3
-        | ProvingVersion::V4
-        | ProvingVersion::V5
-        | ProvingVersion::V6 => {
-            panic!("sealing batch with prover version v1-v6 is not supported");
-        }
         ProvingVersion::V7 => {
             // TODO: in the long-term we should generate proof input per batch
             let started_at = std::time::Instant::now();

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -343,17 +343,11 @@ impl FriJobManager {
         let expected_hash_u32s =
             fri_proof_verifier::expected_public_input_registers(proving_version, batch_metadata)?;
         // TODO: This match is needed for the transition period.
-        // v0.5.2 airbender cannot verify proofs generated with v0.5.1.
-        // Once all networks are protocol upgraded, the code below can be removed.
+        // Protocol 0.31 proofs use the Airbender 0.5.2 `ProgramProof` format, while protocol
+        // 0.32 proofs use the unified stack's `UnrolledProgramProof`. Both protocols remain
+        // supported, so their incompatible encodings require separate verifier backends.
         match proving_version {
-            ProvingVersion::V1
-            | ProvingVersion::V2
-            | ProvingVersion::V3
-            | ProvingVersion::V4
-            | ProvingVersion::V5 => Err(SubmitError::Other(
-                "proof verification for v1-v5 is not supported".to_string(),
-            )),
-            ProvingVersion::V6 | ProvingVersion::V7 => {
+            ProvingVersion::V7 => {
                 tracing::debug!("Using 0.5.2 proof verifier for batch {}", batch_number);
                 let program_proof =
                     bincode::serde::decode_from_slice(proof_bytes, bincode::config::standard())

--- a/node/bin/src/prover_api/fri_proof_verifier.rs
+++ b/node/bin/src/prover_api/fri_proof_verifier.rs
@@ -34,7 +34,7 @@ pub fn expected_public_input_registers(
                 .concat(),
             )
         }
-        _ => {
+        ProvingVersion::V7 => {
             let stored = batch_metadata.batch_info.clone().into_stored();
             keccak256(
                 [

--- a/node/bin/src/prover_api/prover_job_map/map.rs
+++ b/node/bin/src/prover_api/prover_job_map/map.rs
@@ -503,7 +503,7 @@ mod tests {
     fn create_test_batch_envelope(batch_number: u64) -> SignedBatchEnvelope<Vec<u8>> {
         create_test_batch_envelope_with_protocol_version(
             batch_number,
-            ProtocolSemanticVersion::legacy_genesis_version(),
+            ProtocolSemanticVersion::new(0, 32, 0),
         )
     }
 

--- a/node/bin/src/prover_api/prover_server/v1/models.rs
+++ b/node/bin/src/prover_api/prover_server/v1/models.rs
@@ -125,11 +125,11 @@ mod tests {
         let q = query(Some(&format!(
             "{}, {}",
             ProvingVersion::V7.vk_hash(),
-            ProvingVersion::V6.vk_hash()
+            ProvingVersion::V8.vk_hash()
         )));
         assert_eq!(
             q.supported_proving_versions(),
-            Some(vec![ProvingVersion::V7, ProvingVersion::V6])
+            Some(vec![ProvingVersion::V7, ProvingVersion::V8])
         );
     }
 

--- a/node/bin/src/prover_input_generator/mod.rs
+++ b/node/bin/src/prover_input_generator/mod.rs
@@ -255,14 +255,6 @@ fn compute_prover_input(
     let proving_version = ProvingVersion::try_from(replay_record.protocol_version.clone())
         .expect("invalid protocol version");
     let prover_input = match proving_version {
-        ProvingVersion::V1
-        | ProvingVersion::V2
-        | ProvingVersion::V3
-        | ProvingVersion::V4
-        | ProvingVersion::V5
-        | ProvingVersion::V6 => {
-            panic!("computing prover input for batch with prover version v1-v6 is not supported");
-        }
         ProvingVersion::V7 => {
             use zk_ee_prev::{
                 common_structs::ProofData, system::metadata::zk_metadata::BlockMetadataFromOracle,


### PR DESCRIPTION
## Summary

This PR removes real proving support for protocols backed by ZKsync OS versions older than 0.3.x. It:
- Removes `ProvingVersion::V1` through `V6`, while preserving the numeric values of `V7` and `V8`.
- Removes legacy VK hashes and protocol-to-proving mappings.
- Removes pre-0.3 branches from prover-input generation, batch construction, FRI verification, prover job handling, and L1 verifier selection.

This is the first step toward replacing the independent `ProvingVersion` domain with an authoritative registry keyed by exact protocol versions.

## Backwards Compatibility

This change is backwards compatible under the assumption that no pre-0.3 batches still require proving or L1 submission. The intentional compatibility break is limited to real proving for pre-0.3 protocols. Such batches can no longer enter the proving pipeline, have their proofs verified, or select their former L1 verifier.

## Rollout Instructions

No coordinated prover-client deployment or data migration is required because the Prover API remains unchanged. Existing provers supporting the retained `V7` and `V8` VK hashes can continue operating normally.