### PR TITLE
fix(prover_api): measure the payload transfer in pick_job_latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17786,6 +17786,7 @@ dependencies = [
  "full_statement_verifier 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2-2026-02-10)",
  "futures",
  "http 1.3.1",
+ "http-body 1.0.1",
  "jsonrpsee",
  "num",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,7 @@ tempfile = "3.0.2"
 base64 = "0.22.1"
 axum = "0.8.4"
 http = "1.3.1"
+http-body = "1.0.1"
 fs2 = "0.4.3"
 test-log = { version = "0.2.18", default-features = false }
 backon = "1.5.1"

--- a/node/bin/Cargo.toml
+++ b/node/bin/Cargo.toml
@@ -108,6 +108,7 @@ smart-config = { workspace = true, features = ["primitive-types", "alloy"] }
 smart-config-commands.workspace = true
 axum.workspace = true
 http.workspace = true
+http-body.workspace = true
 async-trait.workspace = true
 jsonrpsee = { workspace = true, default-features = false, features = [
     "client",

--- a/node/bin/src/prover_api/metrics.rs
+++ b/node/bin/src/prover_api/metrics.rs
@@ -53,17 +53,23 @@ pub struct ProverMetrics {
     pub computational_native_proven: LabeledFamily<ProverJobLabels, Histogram<u64>, 3>,
 }
 
+/// `Buckets::LATENCIES` lumps 5s-30s into one bucket, where a fat batch payload transfer lands.
+const PROVER_API_LATENCIES: Buckets = Buckets::values(&[
+    0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0,
+    200.0, 500.0,
+]);
+
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "prover_api")]
 pub struct ProverApiMetrics {
     /// Latency for job pick requests, including writing the payload to the prover.
-    #[metrics(unit = Unit::Seconds, labels = ["stage", "job_result"], buckets = Buckets::LATENCIES)]
+    #[metrics(unit = Unit::Seconds, labels = ["stage", "job_result"], buckets = PROVER_API_LATENCIES)]
     pub pick_job_latency: LabeledFamily<(ProverStage, PickJobResult), Histogram<Duration>, 2>,
     /// Time hyper spent writing the pick payload. Includes transfers the prover abandoned.
-    #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = Buckets::LATENCIES)]
+    #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = PROVER_API_LATENCIES)]
     pub pick_job_transfer_latency: LabeledFamily<ProverStage, Histogram<Duration>>,
     /// Latency for proof submission requests
-    #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = Buckets::LATENCIES)]
+    #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = PROVER_API_LATENCIES)]
     pub submit_proof_latency: LabeledFamily<ProverStage, Histogram<Duration>>,
     /// Counter for timed-out jobs that were reassigned to another prover
     #[metrics(labels = ["stage"])]

--- a/node/bin/src/prover_api/metrics.rs
+++ b/node/bin/src/prover_api/metrics.rs
@@ -56,7 +56,7 @@ pub struct ProverMetrics {
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "prover_api")]
 pub struct ProverApiMetrics {
-    /// Latency for job pick requests
+    /// Latency for job pick requests, including writing the payload to the prover.
     #[metrics(unit = Unit::Seconds, labels = ["stage", "job_result"], buckets = Buckets::LATENCIES)]
     pub pick_job_latency: LabeledFamily<(ProverStage, PickJobResult), Histogram<Duration>, 2>,
     /// Latency for proof submission requests
@@ -90,7 +90,8 @@ pub enum PickJobResult {
     NoJob,
     /// Request failed with error
     Error,
-    /// Client disconnected before the response was sent
+    /// Client disconnected while the request was being handled. A disconnect during the payload
+    /// transfer is reported as `new_job`.
     Cancelled,
 }
 

--- a/node/bin/src/prover_api/metrics.rs
+++ b/node/bin/src/prover_api/metrics.rs
@@ -59,6 +59,9 @@ pub struct ProverApiMetrics {
     /// Latency for job pick requests, including writing the payload to the prover.
     #[metrics(unit = Unit::Seconds, labels = ["stage", "job_result"], buckets = Buckets::LATENCIES)]
     pub pick_job_latency: LabeledFamily<(ProverStage, PickJobResult), Histogram<Duration>, 2>,
+    /// Time hyper spent writing the pick payload. Includes transfers the prover abandoned.
+    #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = Buckets::LATENCIES)]
+    pub pick_job_transfer_latency: LabeledFamily<ProverStage, Histogram<Duration>>,
     /// Latency for proof submission requests
     #[metrics(unit = Unit::Seconds, labels = ["stage"], buckets = Buckets::LATENCIES)]
     pub submit_proof_latency: LabeledFamily<ProverStage, Histogram<Duration>>,

--- a/node/bin/src/prover_api/prover_server/v1/handlers.rs
+++ b/node/bin/src/prover_api/prover_server/v1/handlers.rs
@@ -50,7 +50,8 @@ impl PickJobGuard {
         response.map(|inner| {
             Body::new(GuardedBody {
                 inner,
-                _guard: self,
+                payload_ready: Instant::now(),
+                guard: self,
             })
         })
     }
@@ -65,7 +66,15 @@ impl Drop for PickJobGuard {
 
 struct GuardedBody {
     inner: Body,
-    _guard: PickJobGuard,
+    payload_ready: Instant,
+    guard: PickJobGuard,
+}
+
+impl Drop for GuardedBody {
+    fn drop(&mut self) {
+        PROVER_API_METRICS.pick_job_transfer_latency[&self.guard.stage]
+            .observe(self.payload_ready.elapsed());
+    }
 }
 
 impl HttpBody for GuardedBody {

--- a/node/bin/src/prover_api/prover_server/v1/handlers.rs
+++ b/node/bin/src/prover_api/prover_server/v1/handlers.rs
@@ -1,12 +1,16 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
 use axum::{
     Json,
+    body::{Body, Bytes},
     extract::{Path, Query, State},
     response::{IntoResponse, Response},
 };
 use base64::{Engine, engine::general_purpose};
 use http::StatusCode;
+use http_body::{Body as HttpBody, Frame, SizeHint};
 use zksync_os_batch_types::batcher_model::{FriProof, ProverInput};
 use zksync_os_types::ProvingVersion;
 
@@ -41,12 +45,47 @@ impl PickJobGuard {
     fn finish(&mut self, result: PickJobResult) {
         self.result = Some(result);
     }
+
+    fn record_after_write(self, response: Response) -> Response {
+        response.map(|inner| {
+            Body::new(GuardedBody {
+                inner,
+                _guard: self,
+            })
+        })
+    }
 }
 
 impl Drop for PickJobGuard {
     fn drop(&mut self) {
         let result = self.result.unwrap_or(PickJobResult::Cancelled);
         PROVER_API_METRICS.pick_job_latency[&(self.stage, result)].observe(self.started.elapsed());
+    }
+}
+
+struct GuardedBody {
+    inner: Body,
+    _guard: PickJobGuard,
+}
+
+impl HttpBody for GuardedBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.inner).poll_frame(cx)
+    }
+
+    /// Never true: hyper releases a finished body once the last frame is buffered, before the write.
+    fn is_end_stream(&self) -> bool {
+        false
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
     }
 }
 
@@ -99,12 +138,14 @@ pub(super) async fn pick_fri_job(
             };
             let prover_input = general_purpose::STANDARD.encode(&bytes);
             guard.finish(PickJobResult::NewJob);
-            Json(BatchDataPayload {
-                batch_number: fri_job.batch_number,
-                vk_hash: fri_job.vk_hash,
-                prover_input,
-            })
-            .into_response()
+            guard.record_after_write(
+                Json(BatchDataPayload {
+                    batch_number: fri_job.batch_number,
+                    vk_hash: fri_job.vk_hash,
+                    prover_input,
+                })
+                .into_response(),
+            )
         }
         None => {
             guard.finish(PickJobResult::NoJob);
@@ -223,13 +264,15 @@ pub(super) async fn pick_snark_job(
                 .collect();
 
             guard.finish(PickJobResult::NewJob);
-            Json(NextSnarkProverJobPayload {
-                from_batch_number: from,
-                to_batch_number: to,
-                vk_hash,
-                fri_proofs,
-            })
-            .into_response()
+            guard.record_after_write(
+                Json(NextSnarkProverJobPayload {
+                    from_batch_number: from,
+                    to_batch_number: to,
+                    vk_hash,
+                    fri_proofs,
+                })
+                .into_response(),
+            )
         }
         Ok(None) => {
             guard.finish(PickJobResult::NoJob);


### PR DESCRIPTION
During INC-37 a 247MB prover input reported ~700ms of pick latency: the guard was dropped when the
handler returned, i.e. after serializing the payload but before hyper wrote a byte of it. The
transfer that blew the prover's request timeout was invisible on both sides.

The guard now moves into the response body, so it is dropped after the write, and
`pick_job_transfer_latency` isolates that write from the rest of the pick. Both, plus
`submit_proof_latency`, move onto a 1-2-5 ladder: `Buckets::LATENCIES` resolves 1s-30s with a single
edge, which is exactly where a fat batch lands.

[PLA-1228.](https://linear.app/matterlabs/issue/PLA-1228/investigate-http-connection-timeouts-on-fri-prover-commiunication)

Two limitations worth knowing:
- hyper buffers up to ~408KB (`DEFAULT_MAX_BUFFER_SIZE`) before flushing, so a pick response below
  that is fully buffered and released before it reaches the wire - the transfer reads ~0. The metric
  is meaningful for the fat payloads it exists for, not for small ones.
- The difference between the two metrics is not only serialization: it also covers `pick_next_job`,
  i.e. job-map lock acquisition and the prover-input clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
