### PR TITLE
feat: derive pubdata content from L1 state

### DIFF
--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -127,6 +127,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory + Clone>
             let read_state = self.read_state.clone();
             let merkle_tree = self.merkle_tree.clone();
             let pubdata_mode = request.pubdata_mode;
+            let pubdata_content = self.l1_state.pubdata_content;
             let native_batch_run = tokio::task::spawn_blocking(move || {
                 let native_blocks = native_run_blocks
                     .iter()
@@ -141,6 +142,7 @@ impl<Finality: ReadFinality, ReadState: ReadStateHistory + Clone>
                     &read_state,
                     merkle_tree,
                     pubdata_mode,
+                    pubdata_content,
                 )
             })
             .await
@@ -322,7 +324,7 @@ mod tests {
     };
     use zksync_os_types::{
         BlockOutput, BlockPubdata, BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion,
-        PubdataMode, SystemTxEnvelope, ZkTransaction,
+        PubdataContent, PubdataMode, SystemTxEnvelope, ZkTransaction,
     };
 
     const CHAIN_ID: u64 = 270;
@@ -488,6 +490,7 @@ mod tests {
             &read_state,
             tree.clone(),
             PubdataMode::Calldata,
+            PubdataContent::FullPubdata,
         )
         .unwrap();
 
@@ -499,8 +502,11 @@ mod tests {
         )
         .unwrap();
 
-        let chain_config_hash =
-            zksync_os_native_pig::v32_chain_config_hash(batch_info.commit_info.chain_id).unwrap();
+        let chain_config_hash = zksync_os_native_pig::v32_chain_config_hash(
+            batch_info.commit_info.chain_id,
+            PubdataContent::FullPubdata,
+        )
+        .unwrap();
         let reconstructed = keccak256(
             [
                 native_batch_run.previous_state_commitment.0,
@@ -546,6 +552,7 @@ mod tests {
             &read_state,
             tree.clone(),
             PubdataMode::Calldata,
+            PubdataContent::FullPubdata,
         )
         .expect("V8 native batch run failed");
 
@@ -598,6 +605,7 @@ mod tests {
             read_state,
             tree.clone(),
             PubdataMode::Calldata,
+            PubdataContent::FullPubdata,
         )
         .unwrap();
         let (batch_info, blob_sidecar) = PendingBatchInfo::build_from_canonical_output(
@@ -743,6 +751,7 @@ mod tests {
             l1_block_number: 0,
             finalized_l1_block_number: 0,
             da_input_mode: BatchDaInputMode::Rollup,
+            pubdata_content: PubdataContent::FullPubdata,
             l1_chain_id: SL_CHAIN_ID,
         }
     }

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -1,6 +1,6 @@
 use crate::metrics::L1_STATE_METRICS;
-use crate::models::BatchDaInputMode;
-use crate::{Bridgehub, MultisigCommitter, PubdataPricingMode, ZkChain};
+use crate::models::{BatchDaInputMode, PubdataContent as ChainPubdataContent};
+use crate::{Bridgehub, MultisigCommitter, PubdataContent, PubdataPricingMode, ZkChain};
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
@@ -37,6 +37,7 @@ pub struct L1State {
     /// Finalized L1 block number that was used to query `last_finalized_executed_batch`.
     pub finalized_l1_block_number: u64,
     pub da_input_mode: BatchDaInputMode,
+    pub pubdata_content: ChainPubdataContent,
     pub l1_chain_id: u64,
 }
 
@@ -125,6 +126,19 @@ impl L1State {
             PubdataPricingMode::Validium => BatchDaInputMode::Validium,
             v => panic!("unexpected pubdata pricing mode: {}", v as u8),
         };
+        let pubdata_content = match diamond_proxy_l1.get_pubdata_content().await {
+            Ok(PubdataContent::FullPubdata) => ChainPubdataContent::FullPubdata,
+            Ok(PubdataContent::LogsOnly) => ChainPubdataContent::LogsOnly,
+            Ok(v) => panic!("unexpected pubdata content: {}", v as u8),
+            // Pre-v32 diamonds have no getter; their pricing mode implies the same content choice.
+            Err(crate::Error::Call(err, _)) if crate::is_method_missing(&err) => {
+                match da_input_mode {
+                    BatchDaInputMode::Rollup => ChainPubdataContent::FullPubdata,
+                    BatchDaInputMode::Validium => ChainPubdataContent::LogsOnly,
+                }
+            }
+            Err(err) => return Err(err.into()),
+        };
 
         let batch_verification = match MultisigCommitter::try_new(
             validator_timelock,
@@ -163,6 +177,7 @@ impl L1State {
             l1_block_number: latest_l1_block_number,
             finalized_l1_block_number,
             da_input_mode,
+            pubdata_content,
             l1_chain_id,
         })
     }
@@ -217,6 +232,7 @@ impl L1State {
             l1_block_number,
             finalized_l1_block_number,
             da_input_mode: this.da_input_mode,
+            pubdata_content: this.pubdata_content,
             l1_chain_id: this.l1_chain_id,
         })
     }

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -118,6 +118,11 @@ alloy::sol! {
         Validium
     }
 
+    enum PubdataContent {
+        FullPubdata,
+        LogsOnly
+    }
+
     // `IMailbox.sol`
     interface IMailbox {
         event NewPriorityRequest(
@@ -275,6 +280,7 @@ alloy::sol! {
         function getTotalBatchesExecuted() external view returns (uint256);
         function getTotalPriorityTxs() external view returns (uint256);
         function getPubdataPricingMode() external view returns (PubdataPricingMode);
+        function getPubdataContent() external view returns (PubdataContent);
         function getAdmin() external view returns (address);
         function getChainTypeManager() external view returns (address);
         function getProtocolVersion() external view returns (uint256);
@@ -817,6 +823,14 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("getPubdataPricingMode", None)
+    }
+
+    pub async fn get_pubdata_content(&self) -> Result<PubdataContent> {
+        self.instance
+            .getPubdataContent()
+            .call()
+            .await
+            .enrich("getPubdataContent", None)
     }
 
     /// Returns true iff the contract has non-empty code at `block_id`.

--- a/lib/contract_interface/src/models.rs
+++ b/lib/contract_interface/src/models.rs
@@ -53,6 +53,13 @@ pub enum BatchDaInputMode {
     Validium,
 }
 
+/// Which part of a batch's pubdata is committed on L1.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PubdataContent {
+    FullPubdata,
+    LogsOnly,
+}
+
 /// User-friendly version of [`IExecutor::StoredBatchInfo`] containing
 /// fields that are relevant for ZKsync OS.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/multivm/src/lib.rs
+++ b/lib/multivm/src/lib.rs
@@ -20,7 +20,7 @@ mod adapter;
 pub mod apps;
 
 pub use adapter::AbiTxSource;
-use zksync_os_types::{BlockOutput, BlockPubdata, ExecutionVersion};
+use zksync_os_types::{BlockOutput, BlockPubdata, ExecutionVersion, PubdataContent};
 macro_rules! into_legacy_block_output {
     ($o:expr) => {{
         let output = $o;
@@ -51,6 +51,7 @@ macro_rules! into_pubdata_used_block_output {
     }};
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_block<
     Storage: ReadStorage,
     PreimgSrc: PreimageSource,
@@ -60,6 +61,7 @@ pub fn run_block<
     Validator: AnyTxValidator,
 >(
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     storage: Storage,
     preimage_source: PreimgSrc,
     tx_source: TrSrc,
@@ -141,7 +143,8 @@ pub fn run_block<
                 .map(|o| into_legacy_block_output!(o))
         }
         ExecutionVersion::V7 => {
-            let chain_config = zksync_os_native_pig::v32_chain_config(block_context.chain_id)?;
+            let chain_config =
+                zksync_os_native_pig::v32_chain_config(block_context.chain_id, pubdata_content)?;
             let object = RunBlockForwardV7 {
                 fri_verifier_artifacts: None,
             };
@@ -173,6 +176,7 @@ pub fn simulate_tx<
 >(
     transaction: EncodedTx,
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     storage: Storage,
     preimage_source: PreimgSrc,
     tracer: &mut Tracer,
@@ -240,7 +244,8 @@ pub fn simulate_tx<
                 .map_err(|err| anyhow::anyhow!(err))
         }
         ExecutionVersion::V7 => {
-            let chain_config = zksync_os_native_pig::v32_chain_config(block_context.chain_id)?;
+            let chain_config =
+                zksync_os_native_pig::v32_chain_config(block_context.chain_id, pubdata_content)?;
             let object = RunBlockForwardV7 {
                 fri_verifier_artifacts: None,
             };

--- a/lib/native_pig/src/lib.rs
+++ b/lib/native_pig/src/lib.rs
@@ -8,7 +8,7 @@ use alloy::primitives::{B256, keccak256};
 use zksync_os_batch_types::{BlockMerkleTreeData, CanonicalBatchCommitData, PendingBatchInfo};
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord};
-use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion, PubdataMode};
+use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion, PubdataContent, PubdataMode};
 
 pub mod tree;
 mod v32;
@@ -43,6 +43,7 @@ pub struct NativeBatchRunOutput {
     pub last_block_timestamp: u64,
     pub chain_id: u64,
     pub sl_chain_id: u64,
+    pub pubdata_content: PubdataContent,
     pub upgrade_tx_hash: Option<B256>,
 }
 
@@ -105,7 +106,7 @@ impl NativeBatchRunOutput {
 
         // Reconstruct the batch public input exactly as `verify_fri_proof_v8` will and compare
         // it with the value the batch program computed; catches batch-output layout drift.
-        let chain_config_hash = v32::chain_config_hash(chain_id)?;
+        let chain_config_hash = v32::chain_config_hash(chain_id, self.pubdata_content)?;
         let reconstructed_public_input_hash = keccak256(
             [
                 self.previous_state_commitment.0,
@@ -129,13 +130,17 @@ impl NativeBatchRunOutput {
 /// the v32 batch public input, so every construction site must go through this function.
 pub fn v32_chain_config(
     chain_id: u64,
+    pubdata_content: PubdataContent,
 ) -> anyhow::Result<zk_ee_0_4_0::system::metadata::chain_config::ChainConfig> {
-    v32::chain_config(chain_id)
+    v32::chain_config(chain_id, pubdata_content)
 }
 
 /// keccak256 commitment of [`v32_chain_config`], as committed to in the v32 batch public input.
-pub fn v32_chain_config_hash(chain_id: u64) -> anyhow::Result<B256> {
-    v32::chain_config_hash(chain_id)
+pub fn v32_chain_config_hash(
+    chain_id: u64,
+    pubdata_content: PubdataContent,
+) -> anyhow::Result<B256> {
+    v32::chain_config_hash(chain_id, pubdata_content)
 }
 
 pub fn generate_batch_run<ReadState: ReadStateHistory>(
@@ -144,11 +149,16 @@ pub fn generate_batch_run<ReadState: ReadStateHistory>(
     read_state: &ReadState,
     merkle_tree: MerkleTree<RocksDBWrapper>,
     pubdata_mode: PubdataMode,
+    pubdata_content: PubdataContent,
 ) -> anyhow::Result<NativeBatchRunOutput> {
     match proving_version {
-        ProvingVersion::V8 => {
-            v32::generate_batch_run(blocks, read_state, merkle_tree, pubdata_mode)
-        }
+        ProvingVersion::V8 => v32::generate_batch_run(
+            blocks,
+            read_state,
+            merkle_tree,
+            pubdata_mode,
+            pubdata_content,
+        ),
         ProvingVersion::V6 | ProvingVersion::V7 => {
             anyhow::bail!("native batch proving is unsupported for {proving_version:?}")
         }
@@ -177,6 +187,7 @@ mod tests {
             last_block_timestamp: 200,
             chain_id: 270,
             sl_chain_id: 123,
+            pubdata_content: PubdataContent::FullPubdata,
             upgrade_tx_hash: Some(B256::repeat_byte(0x66)),
         };
 

--- a/lib/native_pig/src/v32.rs
+++ b/lib/native_pig/src/v32.rs
@@ -3,7 +3,10 @@ use crate::{NativeBatchBlock, NativeBatchRunOutput};
 use alloy::primitives::{B256, ruint::aliases::B160};
 use anyhow::Context as _;
 use std::collections::VecDeque;
-use zk_ee_0_4_0::common_structs::{ProofData, da_commitment_scheme::DACommitmentScheme};
+use zk_ee_0_4_0::common_structs::{
+    ProofData,
+    da_commitment_scheme::{DACommitmentScheme, PubdataContent as ZkEePubdataContent},
+};
 use zk_ee_0_4_0::system::metadata::chain_config::{ChainConfig, DEFAULT_MAX_TX_GAS_LIMIT};
 use zk_ee_0_4_0::system::metadata::zk_metadata::{BlockHashes, BlockMetadataFromOracle};
 use zk_ee_0_4_0::utils::Bytes32;
@@ -16,17 +19,28 @@ use zk_os_forward_system_0_4_0::run::{
 use zksync_os_interface::traits::TxListSource;
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord, ViewState};
-use zksync_os_types::{PubdataMode, ZksyncOsEncode};
+use zksync_os_types::{PubdataContent, PubdataMode, ZksyncOsEncode};
 
 /// The chain config all v32 native batch runs are executed with. Its hash is part of the batch
 /// public input, so proof verification must reconstruct it identically.
-pub(crate) fn chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
+pub(crate) fn chain_config(
+    chain_id: u64,
+    pubdata_content: PubdataContent,
+) -> anyhow::Result<ChainConfig> {
+    let pubdata_content = match pubdata_content {
+        PubdataContent::FullPubdata => ZkEePubdataContent::FullPubdata,
+        PubdataContent::LogsOnly => ZkEePubdataContent::LogsOnly,
+    };
     ChainConfig::new(chain_id, false, DEFAULT_MAX_TX_GAS_LIMIT)
+        .map(|config| config.with_pubdata_content(pubdata_content))
         .map_err(|err| anyhow::anyhow!("invalid chain config: {err:?}"))
 }
 
-pub(crate) fn chain_config_hash(chain_id: u64) -> anyhow::Result<B256> {
-    Ok(B256::from(chain_config(chain_id)?.hash()))
+pub(crate) fn chain_config_hash(
+    chain_id: u64,
+    pubdata_content: PubdataContent,
+) -> anyhow::Result<B256> {
+    Ok(B256::from(chain_config(chain_id, pubdata_content)?.hash()))
 }
 
 pub(crate) fn generate_batch_run<ReadState: ReadStateHistory>(
@@ -34,6 +48,7 @@ pub(crate) fn generate_batch_run<ReadState: ReadStateHistory>(
     read_state: &ReadState,
     merkle_tree: MerkleTree<RocksDBWrapper>,
     pubdata_mode: PubdataMode,
+    pubdata_content: PubdataContent,
 ) -> anyhow::Result<NativeBatchRunOutput> {
     anyhow::ensure!(
         !blocks.is_empty(),
@@ -44,7 +59,7 @@ pub(crate) fn generate_batch_run<ReadState: ReadStateHistory>(
     // The chain config is frozen for the whole batch; chain id lives there now rather than in
     // per-block metadata. All blocks in a batch share the same chain.
     let chain_id = first_replay_record.block_context.chain_id;
-    let chain_config = chain_config(chain_id)?;
+    let chain_config = chain_config(chain_id, pubdata_content)?;
     let first_state_version = first_replay_record
         .block_context
         .block_number
@@ -139,6 +154,7 @@ pub(crate) fn generate_batch_run<ReadState: ReadStateHistory>(
             "batch_output.settlement_layer_chain_id",
             batch_output.settlement_layer_chain_id,
         )?,
+        pubdata_content,
         upgrade_tx_hash,
     })
 }
@@ -259,5 +275,23 @@ impl<SV: ViewState> ForwardBatchState for HistoricalBatchState<SV> {
         if self.cursor + 1 < self.state_views.len() {
             self.cursor += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_config_uses_l1_pubdata_content() {
+        let full_pubdata = chain_config(270, PubdataContent::FullPubdata).unwrap();
+        let logs_only = chain_config(270, PubdataContent::LogsOnly).unwrap();
+
+        assert_eq!(
+            full_pubdata.pubdata_content(),
+            ZkEePubdataContent::FullPubdata
+        );
+        assert_eq!(logs_only.pubdata_content(), ZkEePubdataContent::LogsOnly);
+        assert_ne!(full_pubdata.hash(), logs_only.hash());
     }
 }

--- a/lib/rpc/src/debug_impl.rs
+++ b/lib/rpc/src/debug_impl.rs
@@ -76,7 +76,13 @@ impl<RpcStorage: ReadRpcStorage> DebugNamespace<RpcStorage> {
                     .into_call_config()
                     .map_err(|_| DebugError::InvalidTracerConfig)?;
 
-                match sandbox::call_trace(txs, block_context, prev_state_view, call_config) {
+                match sandbox::call_trace(
+                    txs,
+                    block_context,
+                    self.eth_call_handler.pubdata_content,
+                    prev_state_view,
+                    call_config,
+                ) {
                     Ok(calls) => Ok(calls
                         .into_iter()
                         .zip(&block.body.transactions)
@@ -97,6 +103,7 @@ impl<RpcStorage: ReadRpcStorage> DebugNamespace<RpcStorage> {
                 match crate::js_tracer::tracer::trace_block(
                     txs,
                     block_context,
+                    self.eth_call_handler.pubdata_content,
                     prev_state_view,
                     js,
                     limits,

--- a/lib/rpc/src/eth_call_handler.rs
+++ b/lib/rpc/src/eth_call_handler.rs
@@ -31,8 +31,8 @@ use zksync_os_tx_validators::policy_client::{AccessType, PolicyClient, PolicySes
 use zksync_os_types::ZksyncOsEncode;
 use zksync_os_types::{
     L1_TX_MINIMAL_GAS_LIMIT, L1Envelope, L1PriorityTxType, L1Tx, L1TxType, L2Envelope,
-    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType, ZkEnvelope,
-    ZkTransaction, ZkTxType,
+    PubdataContent, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, SYSTEM_TX_TYPE_ID, UpgradeTxType,
+    ZkEnvelope, ZkTransaction, ZkTxType,
 };
 
 #[derive(Clone, Debug)]
@@ -40,6 +40,7 @@ pub struct EthCallHandler<RpcStorage> {
     pub(crate) config: RpcConfig,
     pub(crate) storage: RpcStorage,
     pub(crate) chain_id: u64,
+    pub(crate) pubdata_content: PubdataContent,
     /// Last block context constructed by sequencer but not necessarily executed yet.
     last_constructed_block_context: watch::Receiver<Option<BlockContext>>,
     /// Optional policy client. When set, `eth_call` and `eth_estimateGas`
@@ -109,6 +110,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         config: RpcConfig,
         storage: RpcStorage,
         chain_id: u64,
+        pubdata_content: PubdataContent,
         last_constructed_block_context: watch::Receiver<Option<BlockContext>>,
         policy_client: Option<PolicyClient>,
     ) -> Self {
@@ -116,6 +118,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             config,
             storage,
             chain_id,
+            pubdata_content,
             last_constructed_block_context,
             policy_client,
         }
@@ -341,6 +344,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let res = simulate_with_optional_policy(
             execution_env.transaction,
             execution_env.block_context,
+            self.pubdata_content,
             state_view,
             policy_session.as_mut(),
         )
@@ -377,12 +381,14 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             Some(overrides) => call_trace_simulate(
                 execution_env.transaction,
                 execution_env.block_context,
+                self.pubdata_content,
                 OverriddenStateView::with_state_overrides(storage_view, overrides),
                 call_config,
             ),
             None => call_trace_simulate(
                 execution_env.transaction,
                 execution_env.block_context,
+                self.pubdata_content,
                 storage_view,
                 call_config,
             ),
@@ -414,6 +420,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 zksync_os_multivm::simulate_tx(
                     execution_env.transaction.encode(),
                     execution_env.block_context,
+                    self.pubdata_content,
                     view.clone(),
                     view,
                     &mut tracer,
@@ -432,6 +439,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
                 zksync_os_multivm::simulate_tx(
                     execution_env.transaction.encode(),
                     execution_env.block_context,
+                    self.pubdata_content,
                     storage_view.clone(),
                     storage_view,
                     &mut tracer,
@@ -518,8 +526,13 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
         let run_at = |gas_limit: u64| {
             let mut attempt = tx.clone();
             set_gas_limit(&mut attempt, gas_limit);
-            execute(attempt, block_context, storage_view.clone())
-                .map_err(EthCallError::ForwardSubsystemError)
+            execute(
+                attempt,
+                block_context,
+                self.pubdata_content,
+                storage_view.clone(),
+            )
+            .map_err(EthCallError::ForwardSubsystemError)
         };
 
         // Execute the transaction with the highest possible gas limit.
@@ -576,6 +589,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             simulate_with_optional_policy(
                 judged_tx,
                 block_context,
+                self.pubdata_content,
                 storage_view,
                 Some(&mut policy_session),
             )
@@ -597,14 +611,22 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
 fn simulate_with_optional_policy<V: ViewState>(
     tx: ZkTransaction,
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     view: V,
     policy: Option<&mut PolicySession>,
 ) -> anyhow::Result<Result<TxOutput, InvalidTransaction>> {
     if let Some(policy) = policy {
         let mut tracer = policy.paired_tracer();
-        execute_with(tx, block_context, view, &mut tracer, policy)
+        execute_with(
+            tx,
+            block_context,
+            pubdata_content,
+            view,
+            &mut tracer,
+            policy,
+        )
     } else {
-        execute(tx, block_context, view)
+        execute(tx, block_context, pubdata_content, view)
     }
 }
 

--- a/lib/rpc/src/eth_impl.rs
+++ b/lib/rpc/src/eth_impl.rs
@@ -66,6 +66,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> EthNamespace<RpcStorage, Me
             config.clone(),
             storage.clone(),
             chain_id,
+            eth_call_handler.pubdata_content,
             mempool.clone(),
             acceptance_state,
             tx_forwarder,

--- a/lib/rpc/src/js_tracer/tracer.rs
+++ b/lib/rpc/src/js_tracer/tracer.rs
@@ -1058,6 +1058,7 @@ impl EvmTracer for JsTracer {
 pub fn trace_block<V: ViewState + 'static>(
     txs: Vec<ZkTransaction>,
     block_context: zksync_os_storage_api::BlockContext,
+    pubdata_content: zksync_os_types::PubdataContent,
     state_view: V,
     js_tracer_config: String,
     limits: JsTracerLimits,
@@ -1069,6 +1070,7 @@ pub fn trace_block<V: ViewState + 'static>(
     };
     let _ = zksync_os_multivm::run_block(
         block_context,
+        pubdata_content,
         state_view.clone(),
         state_view,
         tx_source,

--- a/lib/rpc/src/lib.rs
+++ b/lib/rpc/src/lib.rs
@@ -78,13 +78,14 @@ use zksync_os_rpc_api::web3::Web3ApiServer;
 use zksync_os_rpc_api::zks::ZksApiServer;
 use zksync_os_storage_api::BlockContext;
 use zksync_os_tx_validators::policy_client::PolicyClient;
-use zksync_os_types::TransactionAcceptanceState;
+use zksync_os_types::{PubdataContent, TransactionAcceptanceState};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
     config: RpcConfig,
     listener: tokio::net::TcpListener,
     chain_id: u64,
+    pubdata_content: PubdataContent,
     bridgehub_address: Address,
     bytecode_supplier_address: Address,
     storage: RpcStorage,
@@ -105,6 +106,7 @@ pub async fn spawn<RpcStorage: ReadRpcStorage, Mempool: L2Subpool>(
         config.clone(),
         storage.clone(),
         chain_id,
+        pubdata_content,
         last_constructed_block_context.clone(),
         policy_client.clone(),
     );

--- a/lib/rpc/src/sandbox.rs
+++ b/lib/rpc/src/sandbox.rs
@@ -12,7 +12,7 @@ use zksync_os_interface::traits::{NoopTxCallback, TxListSource};
 use zksync_os_interface::types::{ExecutionResult, TxOutput};
 use zksync_os_multivm::{run_block, simulate_tx};
 use zksync_os_storage_api::{BlockContext, ViewState};
-use zksync_os_types::{ZkTransaction, ZksyncOsEncode};
+use zksync_os_types::{PubdataContent, ZkTransaction, ZksyncOsEncode};
 
 /// EVM max stack size.
 pub const STACK_SIZE: usize = 1024;
@@ -34,11 +34,13 @@ pub(crate) const POST_EXECUTION_PUBDATA_ERROR: &str =
 pub fn execute(
     tx: ZkTransaction,
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     state_view: impl ViewState,
 ) -> anyhow::Result<Result<TxOutput, InvalidTransaction>> {
     execute_with(
         tx,
         block_context,
+        pubdata_content,
         state_view,
         &mut NopTracer,
         &mut NopValidator,
@@ -51,6 +53,7 @@ pub fn execute(
 pub fn execute_with<T: AnyTracer, V: AnyTxValidator>(
     tx: ZkTransaction,
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     state_view: impl ViewState,
     tracer: &mut T,
     validator: &mut V,
@@ -60,6 +63,7 @@ pub fn execute_with<T: AnyTracer, V: AnyTxValidator>(
     simulate_tx(
         encoded_tx,
         block_context,
+        pubdata_content,
         state_view.clone(),
         state_view,
         tracer,
@@ -70,6 +74,7 @@ pub fn execute_with<T: AnyTracer, V: AnyTxValidator>(
 pub fn call_trace_simulate(
     tx: ZkTransaction,
     mut block_context: BlockContext,
+    pubdata_content: PubdataContent,
     state_view: impl ViewState,
     call_config: CallConfig,
 ) -> anyhow::Result<CallFrame> {
@@ -85,6 +90,7 @@ pub fn call_trace_simulate(
     let tx_result = simulate_tx(
         encoded_tx,
         block_context,
+        pubdata_content,
         state_view.clone(),
         state_view,
         &mut tracer,
@@ -110,6 +116,7 @@ pub fn call_trace_simulate(
 pub fn call_trace(
     txs: Vec<ZkTransaction>,
     block_context: BlockContext,
+    pubdata_content: PubdataContent,
     state_view: impl ViewState,
     call_config: CallConfig,
 ) -> anyhow::Result<Vec<CallFrame>> {
@@ -124,6 +131,7 @@ pub fn call_trace(
     };
     let block_output = run_block(
         block_context,
+        pubdata_content,
         state_view.clone(),
         state_view,
         tx_source,

--- a/lib/rpc/src/simulate.rs
+++ b/lib/rpc/src/simulate.rs
@@ -136,6 +136,7 @@ impl<RpcStorage: ReadRpcStorage> EthCallHandler<RpcStorage> {
             };
             let block_output = run_block(
                 block_context,
+                self.pubdata_content,
                 overridden_view.clone(),
                 overridden_view,
                 tx_source,

--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -17,7 +17,8 @@ use zksync_os_rpc_api::types::ZkTransactionReceipt;
 use zksync_os_storage_api::BlockContext;
 use zksync_os_tx_validators::policy_client::{AccessType, PolicyClient};
 use zksync_os_types::{
-    L2Envelope, L2Transaction, NotAcceptingReason, TransactionAcceptanceState, ZkTransaction,
+    L2Envelope, L2Transaction, NotAcceptingReason, PubdataContent, TransactionAcceptanceState,
+    ZkTransaction,
 };
 
 /// Maximum user provided timeout for `eth_sendRawTransactionSync`. Chosen liberally as waiting is
@@ -32,6 +33,7 @@ pub struct TxHandler<RpcStorage, Mempool> {
     config: RpcConfig,
     storage: RpcStorage,
     chain_id: u64,
+    pubdata_content: PubdataContent,
     mempool: Mempool,
     acceptance_state: watch::Receiver<TransactionAcceptanceState>,
     tx_forwarder: Option<TxForwarder>,
@@ -52,6 +54,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
         config: RpcConfig,
         storage: RpcStorage,
         chain_id: u64,
+        pubdata_content: PubdataContent,
         mempool: Mempool,
         acceptance_state: watch::Receiver<TransactionAcceptanceState>,
         tx_forwarder: Option<TxForwarder>,
@@ -62,6 +65,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
             config,
             storage,
             chain_id,
+            pubdata_content,
             mempool,
             acceptance_state,
             tx_forwarder,
@@ -101,6 +105,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
             let last_block_ctx = *self.last_constructed_block_context.borrow();
             let storage = self.storage.clone();
             let chain_id = self.chain_id;
+            let pubdata_content = self.pubdata_content;
             let zk_tx: ZkTransaction = l2_tx.clone().into();
             let policy_client = policy_client.clone();
             // `spawn_blocking`: the body has blocking I/O and VM execution.
@@ -122,6 +127,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
                 crate::sandbox::execute_with(
                     zk_tx,
                     block_context,
+                    pubdata_content,
                     storage_view,
                     &mut tracer,
                     &mut policy_session,

--- a/lib/sequencer/src/execution/block_executor.rs
+++ b/lib/sequencer/src/execution/block_executor.rs
@@ -17,7 +17,7 @@ use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
 use zksync_os_storage_api::{OverlayBuffer, ReadStateHistory, WriteState};
 use zksync_os_tx_validators::deployment_filter;
 use zksync_os_tx_validators::policy_client::AccessType;
-use zksync_os_types::{NotAcceptingReason, TransactionAcceptanceState};
+use zksync_os_types::{NotAcceptingReason, PubdataContent, TransactionAcceptanceState};
 
 /// Executes blocks, while only updating local in-memory state (mempool, block context).
 /// Does not persist anything to disk.
@@ -30,6 +30,7 @@ where
     pub block_context_provider: BlockContextProvider<Subpool>,
     pub state: State,
     pub config: SequencerConfig,
+    pub pubdata_content: PubdataContent,
     /// Controls transaction acceptance state.
     /// When max_blocks_to_produce limit is reached, sequencer sends NotAccepting to stop RPC from accepting new txs.
     pub tx_acceptance_state_sender: watch::Sender<TransactionAcceptanceState>,
@@ -145,6 +146,7 @@ where
                 let policy_tracer = policy_session.paired_tracer();
                 execute_block_in_vm(
                     prepared_command,
+                    self.pubdata_content,
                     exec_view,
                     &state_reporter,
                     policy_tracer,
@@ -156,6 +158,7 @@ where
                     make_deployment_filter(is_produce, &self.config.tx_validator.deployment_filter);
                 execute_block_in_vm(
                     prepared_command,
+                    self.pubdata_content,
                     exec_view,
                     &state_reporter,
                     tracer,

--- a/lib/sequencer/src/execution/execute_block_in_vm.rs
+++ b/lib/sequencer/src/execution/execute_block_in_vm.rs
@@ -19,7 +19,7 @@ use zksync_os_observability::ComponentStateReporter;
 use zksync_os_storage_api::{
     BlockContext, MeteredViewState, OverriddenStateView, ReplayRecord, ViewState,
 };
-use zksync_os_types::{SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
+use zksync_os_types::{PubdataContent, SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
 // Note that this is a pure function without a container struct (e.g. `struct BlockExecutor`)
 // MAINTAIN this to ensure the function is completely stateless - explicit or implicit.
 
@@ -28,6 +28,7 @@ use zksync_os_types::{SystemTxType, ZkTransaction, ZkTxType, ZksyncOsEncode};
 
 pub async fn execute_block_in_vm<V: ViewState>(
     mut command: PreparedBlockCommand<'_>,
+    pubdata_content: PubdataContent,
     state_view: V,
     latency_tracker: &ComponentStateReporter,
     tracer: impl AnyTracer + Send + 'static,
@@ -54,7 +55,7 @@ pub async fn execute_block_in_vm<V: ViewState>(
         latency_tracker.clone(),
         state_view_with_force_preimages,
     );
-    let mut runner = VmWrapper::new(ctx, metered_state_view, tracer, validator);
+    let mut runner = VmWrapper::new(ctx, pubdata_content, metered_state_view, tracer, validator);
 
     let mut executed_txs = Vec::<ZkTransaction>::new();
     let mut cumulative_gas_used = 0u64;

--- a/lib/sequencer/src/execution/vm_wrapper.rs
+++ b/lib/sequencer/src/execution/vm_wrapper.rs
@@ -12,6 +12,7 @@ use zksync_os_interface::tracing::{AnyTracer, AnyTxValidator};
 use zksync_os_interface::traits::{EncodedTx, NextTxResponse, TxResultCallback, TxSource};
 use zksync_os_interface::types::TxProcessingOutputOwned;
 use zksync_os_storage_api::{BlockContext, ViewState};
+use zksync_os_types::PubdataContent;
 
 /// A one‐by‐one driver around `run_block`, enabling `execute_next_tx` interface
 /// (as opposed to pull interface of `run_block` in zksync-os)
@@ -26,6 +27,7 @@ impl VmWrapper {
     /// Spawn the VM runner in a blocking task.
     pub fn new(
         context: BlockContext,
+        pubdata_content: PubdataContent,
         state_view: impl ViewState,
         mut tracer: impl AnyTracer + Send + 'static,
         mut validator: impl AnyTxValidator + Send + 'static,
@@ -44,6 +46,7 @@ impl VmWrapper {
             let (recording_state, recording_handle) = ReadRecordingState::new(state_view.clone());
             let block_output = zksync_os_multivm::run_block(
                 context,
+                pubdata_content,
                 recording_state,
                 state_view,
                 tx_source,

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -31,6 +31,7 @@ pub use zksync_os_contract_interface::InteropRoot;
 
 mod pubdata_mode;
 pub use pubdata_mode::PubdataMode;
+pub use zksync_os_contract_interface::models::PubdataContent;
 
 mod node;
 pub use node::NodeRole;

--- a/node/bin/src/batcher/batch_builder.rs
+++ b/node/bin/src/batcher/batch_builder.rs
@@ -12,7 +12,7 @@ use zksync_os_contract_interface::models::{L2Log, StoredBatchInfo};
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_native_pig::{NativeBatchBlock, NativeBatchRunOutput, generate_batch_run};
 use zksync_os_storage_api::{ReadStateHistory, read_multichain_root};
-use zksync_os_types::{ProvingVersion, PubdataMode, SystemTxType, ZkEnvelope};
+use zksync_os_types::{ProvingVersion, PubdataContent, PubdataMode, SystemTxType, ZkEnvelope};
 
 #[derive(Debug, Clone, Copy)]
 struct BatchPigMeasurement {
@@ -30,6 +30,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
     chain_id: u64,
     chain_address: Address,
     pubdata_mode: PubdataMode,
+    pubdata_content: PubdataContent,
     sl_chain_id: u64,
     read_state: &ReadState,
     merkle_tree: &MerkleTree<RocksDBWrapper>,
@@ -67,6 +68,7 @@ pub(crate) fn seal_batch<ReadState: ReadStateHistory>(
             read_state,
             merkle_tree.clone(),
             pubdata_mode,
+            pubdata_content,
         )?;
         let measurement = BatchPigMeasurement {
             mode: BatchPigMode::NativeBatch,
@@ -324,7 +326,7 @@ mod tests {
     use zksync_os_storage_api::{BlockContext, BlockHashes, ReplayRecord};
     use zksync_os_types::{
         BlockOutput, BlockPubdata, BlockStartCursors, ExecutionVersion, ProtocolSemanticVersion,
-        ProvingVersion, PubdataMode,
+        ProvingVersion, PubdataContent, PubdataMode,
     };
 
     fn dummy_block_output() -> BlockOutput {
@@ -400,6 +402,7 @@ mod tests {
                 last_block_timestamp: 0,
                 chain_id: 0,
                 sl_chain_id: 0,
+                pubdata_content: PubdataContent::FullPubdata,
                 upgrade_tx_hash: None,
             }),
         )

--- a/node/bin/src/batcher/mod.rs
+++ b/node/bin/src/batcher/mod.rs
@@ -20,7 +20,7 @@ use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_observability::{ComponentStateReporter, GenericComponentState};
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
 use zksync_os_storage_api::ReadStateHistory;
-use zksync_os_types::PubdataMode;
+use zksync_os_types::{PubdataContent, PubdataMode};
 
 pub mod batch_builder;
 mod batch_deadline_policy;
@@ -49,6 +49,7 @@ pub struct Batcher<ReadState> {
     pub pubdata_limit_bytes: u64,
     pub batcher_config: BatcherConfig,
     pub pubdata_mode: PubdataMode,
+    pub pubdata_content: PubdataContent,
     pub sidecar_sender: mpsc::Sender<BlobTransactionSidecar>,
     pub committed_batch_provider: CommittedBatchProvider,
     pub read_state: ReadState,
@@ -351,6 +352,7 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> Batcher<ReadState> {
         let chain_id = self.chain_id;
         let chain_address = self.chain_address;
         let sl_chain_id = self.sl_chain_id;
+        let pubdata_content = self.pubdata_content;
         let read_state = self.read_state.clone();
         let merkle_tree = self.merkle_tree.clone();
         tokio::task::spawn_blocking(move || {
@@ -361,6 +363,7 @@ impl<ReadState: ReadStateHistory + Clone + Send + 'static> Batcher<ReadState> {
                 chain_id,
                 chain_address,
                 pubdata_mode,
+                pubdata_content,
                 sl_chain_id,
                 &read_state,
                 &merkle_tree,

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -994,6 +994,7 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         config.rpc_config.into(),
         rpc_listener,
         chain_id,
+        l1_state.pubdata_content,
         bridgehub_address,
         bytecode_supplier_address,
         rpc_storage,
@@ -1176,6 +1177,7 @@ async fn run_main_node_pipeline(
             block_context_provider,
             state: state.clone(),
             config: config.into(),
+            pubdata_content: node_state_on_startup.l1_state.pubdata_content,
             tx_acceptance_state_sender,
             applied_block_number_receiver,
         })
@@ -1235,6 +1237,7 @@ async fn run_main_node_pipeline(
 
     let (fri_proving_step, fri_job_manager) = FriProvingPipelineStep::new(
         proof_storage.clone(),
+        node_state_on_startup.l1_state.pubdata_content,
         node_state_on_startup.l1_state.last_proved_batch,
         config.prover_api_config.fri_job_timeout,
         config.prover_api_config.max_assigned_batch_range,
@@ -1242,6 +1245,7 @@ async fn run_main_node_pipeline(
 
     let (snark_proving_step, snark_job_manager) = SnarkProvingPipelineStep::new(
         config.prover_api_config.max_fris_per_snark,
+        node_state_on_startup.l1_state.pubdata_content,
         node_state_on_startup.l1_state.last_proved_batch,
         config.prover_api_config.snark_job_timeout,
         config.prover_api_config.max_assigned_batch_range,
@@ -1319,6 +1323,7 @@ async fn run_main_node_pipeline(
             pubdata_limit_bytes: config.sequencer_config.block_pubdata_limit_bytes,
             batcher_config: config.batcher_config.clone(),
             pubdata_mode,
+            pubdata_content: node_state_on_startup.l1_state.pubdata_content,
             sidecar_sender,
             committed_batch_provider: committed_batch_provider.clone(),
             read_state: state.clone(),
@@ -1434,6 +1439,7 @@ async fn run_en_pipeline(
             block_context_provider,
             state: state.clone(),
             config: config.into(),
+            pubdata_content: node_state_on_startup.l1_state.pubdata_content,
             tx_acceptance_state_sender,
             applied_block_number_receiver,
         })

--- a/node/bin/src/prover_api/fri_job_manager.rs
+++ b/node/bin/src/prover_api/fri_job_manager.rs
@@ -27,7 +27,7 @@ use zksync_os_batch_types::batcher_model::{
     BatchMetadata, FriProof, ProverInput, RealFriProof, SignedBatchEnvelope,
 };
 use zksync_os_batcher_metrics::BatchExecutionStage;
-use zksync_os_types::ProvingVersion;
+use zksync_os_types::{ProvingVersion, PubdataContent};
 
 #[derive(Error, Debug)]
 pub enum SubmitError {
@@ -83,12 +83,14 @@ pub struct FriJobManager {
     batches_with_proof_sender: mpsc::Sender<SignedBatchEnvelope<FriProof>>,
     // == storage ==
     proof_storage: ProofStorage,
+    pubdata_content: PubdataContent,
 }
 
 impl FriJobManager {
     pub fn new(
         batches_with_proof_sender: mpsc::Sender<SignedBatchEnvelope<FriProof>>,
         proof_storage: ProofStorage,
+        pubdata_content: PubdataContent,
         assignment_timeout: Duration,
         max_assigned_batch_range: usize,
     ) -> Self {
@@ -101,6 +103,7 @@ impl FriJobManager {
             jobs,
             batches_with_proof_sender,
             proof_storage,
+            pubdata_content,
         }
     }
 
@@ -240,6 +243,7 @@ impl FriJobManager {
         // Deserialization + cryptographic verification are CPU-heavy (seconds of work) -
         // run them on a blocking thread so prover API requests don't stall the runtime.
         // `spawn_blocking` also catches panics that escape the verifiers' own `catch_unwind`.
+        let pubdata_content = self.pubdata_content;
         let verify_result = tokio::task::spawn_blocking({
             let batch_metadata = batch_metadata.clone();
             let proof_bytes = proof_bytes.clone();
@@ -249,6 +253,7 @@ impl FriJobManager {
                     &batch_metadata,
                     &proof_bytes,
                     batch_number,
+                    pubdata_content,
                 )
             }
         })
@@ -268,6 +273,7 @@ impl FriJobManager {
                 let expected_hash_u32s = fri_proof_verifier::expected_public_input_registers(
                     proving_version,
                     batch_metadata,
+                    self.pubdata_content,
                 )
                 .unwrap_or([0u32; 8]);
                 Err(SubmitError::FriProofVerificationError {
@@ -339,9 +345,13 @@ impl FriJobManager {
         batch_metadata: &BatchMetadata,
         proof_bytes: &Bytes,
         batch_number: u64,
+        pubdata_content: PubdataContent,
     ) -> Result<(), SubmitError> {
-        let expected_hash_u32s =
-            fri_proof_verifier::expected_public_input_registers(proving_version, batch_metadata)?;
+        let expected_hash_u32s = fri_proof_verifier::expected_public_input_registers(
+            proving_version,
+            batch_metadata,
+            pubdata_content,
+        )?;
         // TODO: This match is needed for the transition period.
         // Protocol 0.30/0.31 proofs use the Airbender 0.5.2 `ProgramProof` format, while
         // protocol 0.32 proofs use the unified stack's `UnrolledProgramProof`. All these

--- a/node/bin/src/prover_api/fri_proof_verifier.rs
+++ b/node/bin/src/prover_api/fri_proof_verifier.rs
@@ -1,7 +1,7 @@
 use crate::prover_api::fri_job_manager::SubmitError;
 use alloy::primitives::{B256, keccak256};
 use zksync_os_batch_types::batcher_model::BatchMetadata;
-use zksync_os_types::ProvingVersion;
+use zksync_os_types::{ProvingVersion, PubdataContent};
 
 /// Expected batch public-input hash, as the final register values a valid FRI proof of this
 /// batch must expose.
@@ -14,16 +14,19 @@ use zksync_os_types::ProvingVersion;
 pub fn expected_public_input_registers(
     proving_version: ProvingVersion,
     batch_metadata: &BatchMetadata,
+    pubdata_content: PubdataContent,
 ) -> Result<[u32; 8], SubmitError> {
     let state_before = batch_metadata.previous_stored_batch_info.state_commitment;
     let hash = match proving_version {
         ProvingVersion::V8 => {
             let batch_info = &batch_metadata.batch_info;
-            let chain_config_hash =
-                zksync_os_native_pig::v32_chain_config_hash(batch_info.commit_info.chain_id)
-                    .map_err(|err| {
-                        SubmitError::Other(format!("cannot compute V8 chain config hash: {err:#}"))
-                    })?;
+            let chain_config_hash = zksync_os_native_pig::v32_chain_config_hash(
+                batch_info.commit_info.chain_id,
+                pubdata_content,
+            )
+            .map_err(|err| {
+                SubmitError::Other(format!("cannot compute V8 chain config hash: {err:#}"))
+            })?;
             keccak256(
                 [
                     state_before.0,

--- a/node/bin/src/prover_api/fri_proving_pipeline_step.rs
+++ b/node/bin/src/prover_api/fri_proving_pipeline_step.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use zksync_os_batch_types::batcher_model::{FriProof, ProverInput, SignedBatchEnvelope};
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
+use zksync_os_types::PubdataContent;
 
 /// Pipeline step that waits for batches to be FRI proved.
 ///
@@ -29,6 +30,7 @@ pub struct FriProvingPipelineStep {
 impl FriProvingPipelineStep {
     pub fn new(
         proof_storage: ProofStorage,
+        pubdata_content: PubdataContent,
         last_proved_batch_number: u64,
         assignment_timeout: Duration,
         max_assigned_batch_range: usize,
@@ -40,6 +42,7 @@ impl FriProvingPipelineStep {
         let fri_job_manager = Arc::new(FriJobManager::new(
             batches_with_proof_sender,
             proof_storage,
+            pubdata_content,
             assignment_timeout,
             max_assigned_batch_range,
         ));

--- a/node/bin/src/prover_api/snark_job_manager.rs
+++ b/node/bin/src/prover_api/snark_job_manager.rs
@@ -11,7 +11,7 @@ use zksync_os_batch_types::batcher_model::{
 };
 use zksync_os_batcher_metrics::BatchExecutionStage;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
-use zksync_os_types::ProvingVersion;
+use zksync_os_types::{ProvingVersion, PubdataContent};
 
 /// Job manager for SNARK proving.
 ///
@@ -30,12 +30,14 @@ pub struct SnarkJobManager {
     prove_batches_sender: mpsc::Sender<ProofCommand>,
     // config
     max_fris_per_snark: usize,
+    pubdata_content: PubdataContent,
 }
 
 impl SnarkJobManager {
     pub fn new(
         prove_batches_sender: mpsc::Sender<ProofCommand>,
         max_fris_per_snark: usize,
+        pubdata_content: PubdataContent,
         assignment_timeout: Duration,
         max_assigned_batch_range: usize,
     ) -> Self {
@@ -48,6 +50,7 @@ impl SnarkJobManager {
             jobs,
             prove_batches_sender,
             max_fris_per_snark,
+            pubdata_content,
         }
     }
 
@@ -152,7 +155,8 @@ impl SnarkJobManager {
             .map(|batch| batch.with_stage(BatchExecutionStage::SnarkProvedReal))
             .collect();
 
-        let chain_config_hash = proof_chain_config_hash(&consumed_batches_proven)?;
+        let chain_config_hash =
+            proof_chain_config_hash(&consumed_batches_proven, self.pubdata_content)?;
         permit.send(ProofCommand::new(
             consumed_batches_proven,
             SnarkProof::Real(RealSnarkProof::V2 {
@@ -234,7 +238,8 @@ impl SnarkJobManager {
                 .map(|batch| batch.with_stage(BatchExecutionStage::SnarkProvedFake))
                 .collect();
 
-            let chain_config_hash = proof_chain_config_hash(&batches_with_fake_proofs)?;
+            let chain_config_hash =
+                proof_chain_config_hash(&batches_with_fake_proofs, self.pubdata_content)?;
             permit.send(ProofCommand::new(
                 batches_with_fake_proofs,
                 SnarkProof::Fake,
@@ -296,6 +301,7 @@ fn proof_chain_config_hash(
     batches: &[zksync_os_batch_types::batcher_model::SignedBatchEnvelope<
         zksync_os_batch_types::batcher_model::FriProof,
     >],
+    pubdata_content: PubdataContent,
 ) -> anyhow::Result<Option<alloy::primitives::B256>> {
     let batch_info = &batches
         .last()
@@ -305,6 +311,7 @@ fn proof_chain_config_hash(
     if batch_info.protocol_version.supports_l1_interop() {
         Ok(Some(zksync_os_native_pig::v32_chain_config_hash(
             batch_info.chain_id,
+            pubdata_content,
         )?))
     } else {
         Ok(None)

--- a/node/bin/src/prover_api/snark_proving_pipeline_step.rs
+++ b/node/bin/src/prover_api/snark_proving_pipeline_step.rs
@@ -8,6 +8,7 @@ use zksync_os_l1_sender::commands::L1SenderCommand;
 use zksync_os_l1_sender::commands::prove::ProofCommand;
 use zksync_os_observability::ComponentStateReporter;
 use zksync_os_pipeline::{PeekableReceiver, PipelineComponent, SendAndRecordExt};
+use zksync_os_types::PubdataContent;
 
 /// Pipeline step that waits for batches to be SNARK proved.
 ///
@@ -29,6 +30,7 @@ pub struct SnarkProvingPipelineStep {
 impl SnarkProvingPipelineStep {
     pub fn new(
         max_fris_per_snark: usize,
+        pubdata_content: PubdataContent,
         last_proved_batch_number: u64,
         assignment_timeout: Duration,
         max_assigned_batch_range: usize,
@@ -38,6 +40,7 @@ impl SnarkProvingPipelineStep {
         let snark_job_manager = Arc::new(SnarkJobManager::new(
             proof_commands_sender,
             max_fris_per_snark,
+            pubdata_content,
             assignment_timeout,
             max_assigned_batch_range,
         ));


### PR DESCRIPTION
## Summary

Pubdata content is a new concept orthogonal to DA commitment scheme. Now validium chains should use blobs/calldata DA and LogsOnly pubdata content. Still, we leave an option to do no DA for validiums if they wish to opt-in.

<!-- Briefly explain what this PR does. What problem does it solve? -->

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

