### PR TITLE
fix(merkle_tree): handle empty batch proofs

### DIFF
--- a/lib/merkle_tree_api/src/flat.rs
+++ b/lib/merkle_tree_api/src/flat.rs
@@ -140,15 +140,19 @@ impl BatchTreeProof {
         leaf_count_before_update: u64,
     ) -> impl Iterator<Item = ((u8, u64), B256)> {
         let mut sibling_hashes = vec![];
-        Self::zip_leaves(
-            &Blake2Hasher,
-            tree_depth,
-            leaf_count_before_update,
-            self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
-            self.hashes.iter(),
-            Some(&mut sibling_hashes),
-        )
-        .expect("invalid batch tree proof");
+        // A proof with no touched leaves has no Merkle paths to fill, and the
+        // fold below cannot reconstruct a root without leaves.
+        if !self.sorted_leaves.is_empty() {
+            Self::zip_leaves(
+                &Blake2Hasher,
+                tree_depth,
+                leaf_count_before_update,
+                self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
+                self.hashes.iter(),
+                Some(&mut sibling_hashes),
+            )
+            .expect("invalid batch tree proof");
+        }
 
         sibling_hashes
             .into_iter()
@@ -169,15 +173,17 @@ impl BatchTreeProof {
         // in the same way they will be queried below; the order correctness is asserted
         // (see the `get_sibling_hash` closure).
         let mut sibling_hashes = vec![];
-        Self::zip_leaves(
-            &Blake2Hasher,
-            tree_depth,
-            leaf_count,
-            self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
-            self.hashes.iter(),
-            Some(&mut sibling_hashes),
-        )
-        .expect("invalid batch tree proof");
+        if !self.sorted_leaves.is_empty() {
+            Self::zip_leaves(
+                &Blake2Hasher,
+                tree_depth,
+                leaf_count,
+                self.sorted_leaves.iter().map(|(idx, leaf)| (*idx, leaf)),
+                self.hashes.iter(),
+                Some(&mut sibling_hashes),
+            )
+            .expect("invalid batch tree proof");
+        }
 
         let proof_entries = self.sorted_leaves.iter().map(|(&index, leaf)| {
             let proof_entry = StorageSlotProofEntry {
@@ -283,6 +289,18 @@ mod tests {
                 .map(|_| B256::random_with(rng))
                 .collect(),
         }
+    }
+
+    #[test]
+    fn empty_batch_proof_yields_no_paths() {
+        let proof = BatchTreeProof {
+            operations: vec![],
+            read_operations: vec![],
+            sorted_leaves: BTreeMap::new(),
+            hashes: vec![],
+        };
+        assert_eq!(proof.sibling_hashes(64, 1_000).count(), 0);
+        assert_eq!(proof.to_flat(64, 1_000).count(), 0);
     }
 
     #[test]

--- a/lib/merkle_tree_api/src/proofs.rs
+++ b/lib/merkle_tree_api/src/proofs.rs
@@ -337,6 +337,12 @@ impl BatchTreeProof {
         let mut node_hashes: Vec<_> = sorted_leaves
             .map(|(idx, leaf)| (idx, hasher.hash_leaf(leaf)))
             .collect();
+        // This fold reconstructs the root from touched leaves; callers with
+        // an empty proof must handle it before folding.
+        anyhow::ensure!(
+            !node_hashes.is_empty(),
+            "cannot fold zero leaves; an empty batch proof must be handled by the caller"
+        );
         let mut last_idx_on_level = leaf_count - 1;
 
         for depth in 0..tree_depth {


### PR DESCRIPTION
## Summary

Backport the non-consensus parts needed to keep prover input generation alive for batches without touched leaves.

<!--
If your change is *breaking* (semver-major), please UNCOMMENT and fill out the
sections below. These are required for PRs whose title is marked as breaking
via conventional commits (e.g. `feat!: ...`, `fix!: ...`).

Make sure that the contents are _actually_ helpful for people who can be self-hosting
our software.
-->

<!--
## Breaking Changes

- Who is affected? (e.g. protocol in general, EN users, main node)
- What exactly is breaking? (changed DB schema or wiring protocol, added configs)
- Are there migration steps required for consumers?
- Links to any related docs / migration guides.

## Rollout Instructions

- Order of operations (deploy backend, then clients, etc).
- Monitoring / alerting to watch during rollout.
- Rollback plan (what to revert, how to mitigate if things go wrong).
-->

