### PR TITLE
ci: resolve spec-test chain ID from the node, pin geth install

### DIFF
--- a/.github/workflows/spec-tests.yaml
+++ b/.github/workflows/spec-tests.yaml
@@ -74,10 +74,19 @@ jobs:
         run: pip install -r ./python-scripts/requirements.txt
 
       - name: Install gETH node
+        env:
+          # The Launchpad PPA needs a live GPG key lookup on every run and periodically answers
+          # with `GPGKeyTemporarilyNotFoundError`, failing the job before any test runs.
+          # The official tarball has no such dependency and pins an exact build.
+          GETH_VERSION: 1.17.4-36a7dc72
         run: |
-          sudo add-apt-repository -y ppa:ethereum/ethereum
-          sudo apt-get update
-          sudo apt-get install ethereum --yes
+          curl -fsSL --retry 3 --retry-all-errors \
+            "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-${GETH_VERSION}.tar.gz" \
+            -o geth.tar.gz
+          tar -xzf geth.tar.gz
+          sudo install -m 0755 "geth-linux-amd64-${GETH_VERSION}/geth" /usr/local/bin/geth
+          rm -rf geth.tar.gz "geth-linux-amd64-${GETH_VERSION}"
+          geth version
 
       - name: Install yq
         env:
@@ -171,7 +180,8 @@ jobs:
     runs-on: matterlabs-ci-runner-high-performance
     env:
       RPC_URL: http://localhost:3050
-      CHAIN_ID: 6565
+      # CHAIN_ID is deliberately absent: it is read off the running node below. Declaring it
+      # here would shadow the value exported to GITHUB_ENV.
       # Use hardcoded rich wallet
       WALLET_ADDRESS: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049"
       PRIVATE_KEY: "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110"
@@ -218,6 +228,14 @@ jobs:
             sleep $INTERVAL
           done
           echo "Sequencer is up and running."
+
+      # The chain ID comes from the local chain state the server boots from, so it changes
+      # whenever that state is regenerated. Reading it from the node keeps the tests in sync.
+      - name: Resolve L2 chain ID
+        run: |
+          CHAIN_ID=$(cast chain-id --rpc-url "${RPC_URL}")
+          echo "Node reports L2 chain ID ${CHAIN_ID}"
+          echo "CHAIN_ID=${CHAIN_ID}" >> "${GITHUB_ENV}"
 
       - name: Checkout solidity tests
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Fixes both failures in the scheduled `Eth spec tests` workflow ([latest run](https://github.com/matter-labs/zksync-os-server/actions/runs/32725278797)).

**`zk-os-tests` — chain-ID mismatch.** All four hardhat projects fail with

```
HardhatError HHE708/HH101: Hardhat was set to use chain id 6565,
but connected to a chain with id 506.
```

The node boots `./local-chains/v31.0/default/config.yaml` (the default for the current `PROTOCOL_VERSION`), whose `chain_id` is 506, but the job declared `CHAIN_ID: 6565`. That has been true since the local chain state was regenerated, so the job has failed on every scheduled run since. The stale value also went into `--rpc-chain-id` for the eth-spec-tests step, which never got to run.

The ID is now read off the running node with `cast chain-id`, so it cannot drift again when the local chain state changes. The job-level `env` entry is removed because it would shadow the value exported to `GITHUB_ENV`.

Note: this is only half the fix. `antonbaliasnikov/solidity-tester` (checked out at `main`) hardcodes the chain ID in `src/constants.rs` and force-sets it on every hardhat command, so the workflow's value does not reach Hardhat yet. A companion change making it env-overridable is needed there before the hardhat step goes green.

**`geth-tests` — Launchpad outage.** `add-apt-repository ppa:ethereum/ethereum` failed with `HTTP Error 500 ... GPGKeyTemporarilyNotFoundError`. This job normally passes, but the PPA requires a live GPG key lookup on every run. Replaced with the official tarball, pinned to `1.17.4-36a7dc72` — the exact version the PPA installed in the last passing run.