### PR TITLE
feat(v32): run the chain config with the pubdata content the chain holds on L1

### DIFF
--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -310,7 +310,9 @@ mod tests {
     use zksync_os_batch_types::BlockMerkleTreeData;
     use zksync_os_batch_types::PendingBatchInfo;
     use zksync_os_batch_types::batcher_model::{BatchEnvelope, BatchMetadata, ProverInput};
-    use zksync_os_contract_interface::models::{BatchDaInputMode, StoredBatchInfo};
+    use zksync_os_contract_interface::models::{
+        BatchDaInputMode, ChainPubdataContent, StoredBatchInfo,
+    };
     use zksync_os_contract_interface::{Bridgehub, ZkChain};
     use zksync_os_genesis::{FileGenesisInputSource, GenesisState, build_genesis};
     use zksync_os_interface::traits::{PreimageSource, ReadStorage};
@@ -743,6 +745,7 @@ mod tests {
             l1_block_number: 0,
             finalized_l1_block_number: 0,
             da_input_mode: BatchDaInputMode::Rollup,
+            pubdata_content: ChainPubdataContent::FullPubdata,
             l1_chain_id: SL_CHAIN_ID,
         }
     }

--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -311,7 +311,7 @@ mod tests {
     use zksync_os_batch_types::PendingBatchInfo;
     use zksync_os_batch_types::batcher_model::{BatchEnvelope, BatchMetadata, ProverInput};
     use zksync_os_contract_interface::models::{
-        BatchDaInputMode, ChainPubdataContent, StoredBatchInfo,
+        BatchDaInputMode, ChainPubdataContent, DACommitmentScheme, StoredBatchInfo,
     };
     use zksync_os_contract_interface::{Bridgehub, ZkChain};
     use zksync_os_genesis::{FileGenesisInputSource, GenesisState, build_genesis};
@@ -746,6 +746,7 @@ mod tests {
             finalized_l1_block_number: 0,
             da_input_mode: BatchDaInputMode::Rollup,
             pubdata_content: ChainPubdataContent::FullPubdata,
+            l2_da_commitment_scheme: DACommitmentScheme::BlobsZKsyncOS,
             l1_chain_id: SL_CHAIN_ID,
         }
     }

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -1,6 +1,6 @@
 use crate::metrics::L1_STATE_METRICS;
-use crate::models::BatchDaInputMode;
-use crate::{Bridgehub, MultisigCommitter, PubdataPricingMode, ZkChain};
+use crate::models::{BatchDaInputMode, ChainPubdataContent};
+use crate::{Bridgehub, MultisigCommitter, PubdataContent, PubdataPricingMode, ZkChain};
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
@@ -37,8 +37,14 @@ pub struct L1State {
     /// Finalized L1 block number that was used to query `last_finalized_executed_batch`.
     pub finalized_l1_block_number: u64,
     pub da_input_mode: BatchDaInputMode,
+    /// Which part of the pubdata this chain's batches commit to, read from the chain itself. Part of
+    /// the batch public input, so the node must execute and prove with exactly this value.
+    pub pubdata_content: ChainPubdataContent,
     pub l1_chain_id: u64,
 }
+
+/// First protocol minor version whose Getters facet exposes `getPubdataContent`.
+const FIRST_PUBDATA_CONTENT_MINOR_VERSION: u64 = 32;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct BatchFinality {
@@ -126,6 +132,9 @@ impl L1State {
             v => panic!("unexpected pubdata pricing mode: {}", v as u8),
         };
 
+        let pubdata_content =
+            Self::fetch_pubdata_content(&diamond_proxy_l1, latest_l1_block_number.into()).await?;
+
         let batch_verification = match MultisigCommitter::try_new(
             validator_timelock,
             diamond_proxy_l1.provider().clone(),
@@ -163,7 +172,31 @@ impl L1State {
             l1_block_number: latest_l1_block_number,
             finalized_l1_block_number,
             da_input_mode,
+            pubdata_content,
             l1_chain_id,
+        })
+    }
+
+    /// Reads the chain's pubdata content, defaulting to `FullPubdata` for chains that predate it.
+    ///
+    /// `getPubdataContent` was added to the Getters facet in v32; a v31 diamond has no such selector,
+    /// so the version is checked first rather than letting the call fail. `FullPubdata` is exactly
+    /// what a pre-v32 chain behaves as — its batch public input carries no chain config hash at all.
+    async fn fetch_pubdata_content(
+        diamond_proxy_l1: &ZkChain<NodeProvider>,
+        block_id: BlockId,
+    ) -> anyhow::Result<ChainPubdataContent> {
+        let raw_protocol_version = diamond_proxy_l1.get_raw_protocol_version(block_id).await?;
+        // Packed semver: `major << 64 | minor << 32 | patch`.
+        let minor: u64 = (raw_protocol_version >> 32u32).to::<u64>() & u64::from(u32::MAX);
+        if minor < FIRST_PUBDATA_CONTENT_MINOR_VERSION {
+            return Ok(ChainPubdataContent::FullPubdata);
+        }
+
+        Ok(match diamond_proxy_l1.get_pubdata_content().await? {
+            PubdataContent::FULL_PUBDATA => ChainPubdataContent::FullPubdata,
+            PubdataContent::LOGS_ONLY => ChainPubdataContent::LogsOnly,
+            v => panic!("unexpected pubdata content: {}", v as u8),
         })
     }
 
@@ -214,6 +247,7 @@ impl L1State {
             last_proved_batch: batch_finality.last_proved_batch,
             last_executed_batch: batch_finality.last_executed_batch,
             last_finalized_executed_batch,
+            pubdata_content: this.pubdata_content,
             l1_block_number,
             finalized_l1_block_number,
             da_input_mode: this.da_input_mode,

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -1,5 +1,5 @@
 use crate::metrics::L1_STATE_METRICS;
-use crate::models::{BatchDaInputMode, ChainPubdataContent};
+use crate::models::{BatchDaInputMode, ChainPubdataContent, DACommitmentScheme};
 use crate::{Bridgehub, MultisigCommitter, PubdataContent, PubdataPricingMode, ZkChain};
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256};
@@ -40,6 +40,9 @@ pub struct L1State {
     /// Which part of the pubdata this chain's batches commit to, read from the chain itself. Part of
     /// the batch public input, so the node must execute and prove with exactly this value.
     pub pubdata_content: ChainPubdataContent,
+    /// The mechanism this chain's batches publish pubdata with. Every committed batch has to declare
+    /// exactly this scheme, so the node's pubdata mode has to produce it.
+    pub l2_da_commitment_scheme: DACommitmentScheme,
     pub l1_chain_id: u64,
 }
 
@@ -134,6 +137,8 @@ impl L1State {
 
         let pubdata_content =
             Self::fetch_pubdata_content(&diamond_proxy_l1, latest_l1_block_number.into()).await?;
+        let l2_da_commitment_scheme: DACommitmentScheme =
+            diamond_proxy_l1.get_l2_da_commitment_scheme().await?.into();
 
         let batch_verification = match MultisigCommitter::try_new(
             validator_timelock,
@@ -173,6 +178,7 @@ impl L1State {
             finalized_l1_block_number,
             da_input_mode,
             pubdata_content,
+            l2_da_commitment_scheme,
             l1_chain_id,
         })
     }
@@ -248,6 +254,7 @@ impl L1State {
             last_executed_batch: batch_finality.last_executed_batch,
             last_finalized_executed_batch,
             pubdata_content: this.pubdata_content,
+            l2_da_commitment_scheme: this.l2_da_commitment_scheme,
             l1_block_number,
             finalized_l1_block_number,
             da_input_mode: this.da_input_mode,

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -275,6 +275,7 @@ alloy::sol! {
         function getTotalBatchesExecuted() external view returns (uint256);
         function getTotalPriorityTxs() external view returns (uint256);
         function getPubdataPricingMode() external view returns (PubdataPricingMode);
+        function getPubdataContent() external view returns (PubdataContent);
         function getAdmin() external view returns (address);
         function getChainTypeManager() external view returns (address);
         function getProtocolVersion() external view returns (uint256);
@@ -282,6 +283,14 @@ alloy::sol! {
         function baseTokenGasPriceMultiplierDenominator() external view returns (uint128);
         function getBaseToken() external view returns (address);
         function getSettlementLayer() external view returns (address);
+    }
+
+    // Taken from `system-contracts/contracts/Constants.sol`. Which *part* of the pubdata a batch
+    // commits to; orthogonal to the DA commitment scheme (the publishing mechanism). ZKsync OS only,
+    // and only present on v32+ diamonds.
+    enum PubdataContent {
+        FULL_PUBDATA,
+        LOGS_ONLY
     }
 
     // Taken from `common/Config.sol`
@@ -817,6 +826,16 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("getPubdataPricingMode", None)
+    }
+
+    /// The chain's pubdata content. Only exists on v32+ diamonds — callers must gate on the protocol
+    /// version, since on an older one this decodes an empty return and fails.
+    pub async fn get_pubdata_content(&self) -> Result<PubdataContent> {
+        self.instance
+            .getPubdataContent()
+            .call()
+            .await
+            .enrich("getPubdataContent", None)
     }
 
     /// Returns true iff the contract has non-empty code at `block_id`.

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -276,6 +276,7 @@ alloy::sol! {
         function getTotalPriorityTxs() external view returns (uint256);
         function getPubdataPricingMode() external view returns (PubdataPricingMode);
         function getPubdataContent() external view returns (PubdataContent);
+        function getDAValidatorPair() external view returns (address, L2DACommitmentScheme);
         function getAdmin() external view returns (address);
         function getChainTypeManager() external view returns (address);
         function getProtocolVersion() external view returns (uint256);
@@ -826,6 +827,17 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("getPubdataPricingMode", None)
+    }
+
+    /// The chain's L2 DA commitment scheme — the mechanism its batches publish pubdata with. The
+    /// `Committer` requires every committed batch to declare exactly this scheme.
+    pub async fn get_l2_da_commitment_scheme(&self) -> Result<L2DACommitmentScheme> {
+        self.instance
+            .getDAValidatorPair()
+            .call()
+            .await
+            .map(|pair| pair._1)
+            .enrich("getDAValidatorPair", None)
     }
 
     /// The chain's pubdata content. Only exists on v32+ diamonds — callers must gate on the protocol

--- a/lib/contract_interface/src/models.rs
+++ b/lib/contract_interface/src/models.rs
@@ -53,6 +53,22 @@ pub enum BatchDaInputMode {
     Validium,
 }
 
+/// User-friendly version of [`crate::PubdataContent`] with statically known possible variants.
+///
+/// Which part of the pubdata the chain's batches commit to. It is folded into every batch's public
+/// input through the ZKsync OS chain config hash, so the node must run with exactly the value the
+/// chain holds on L1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChainPubdataContent {
+    /// The whole pubdata is committed and published. Every pre-v32 chain, and every rollup.
+    FullPubdata,
+    /// Only the mandatory L2->L1 log region — which carries the interop commitment tree leaves — is
+    /// committed; state diffs and message preimages are published at the operator's discretion.
+    /// This is what a ZKsync OS validium runs with; it still publishes that region through the same
+    /// DA mechanism (blobs) a rollup uses.
+    LogsOnly,
+}
+
 /// User-friendly version of [`IExecutor::StoredBatchInfo`] containing
 /// fields that are relevant for ZKsync OS.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/contract_interface/src/models.rs
+++ b/lib/contract_interface/src/models.rs
@@ -64,8 +64,8 @@ pub enum ChainPubdataContent {
     FullPubdata,
     /// Only the mandatory L2->L1 log region — which carries the interop commitment tree leaves — is
     /// committed; state diffs and message preimages are published at the operator's discretion.
-    /// This is what a ZKsync OS validium runs with; it still publishes that region through the same
-    /// DA mechanism (blobs) a rollup uses.
+    /// This is what a ZKsync OS logs-only validium runs with; it still publishes that region through
+    /// the same DA mechanism (blobs) a rollup uses.
     LogsOnly,
 }
 

--- a/lib/native_pig/src/lib.rs
+++ b/lib/native_pig/src/lib.rs
@@ -5,6 +5,7 @@
 
 use alloy::consensus::BlobTransactionSidecar;
 use alloy::primitives::{B256, keccak256};
+use std::sync::OnceLock;
 use zksync_os_batch_types::{BlockMerkleTreeData, CanonicalBatchCommitData, PendingBatchInfo};
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_storage_api::{ReadStateHistory, ReplayRecord};
@@ -12,6 +13,40 @@ use zksync_os_types::{ProtocolSemanticVersion, ProvingVersion, PubdataMode};
 
 pub mod tree;
 mod v32;
+
+pub use zk_ee_0_4_0::common_structs::da_commitment_scheme::PubdataContent;
+
+/// The chain's pubdata content, set once at node startup from the value the chain holds on L1.
+///
+/// The node serves a single chain, and the value is part of every v32 batch's public input through
+/// the chain config hash, so it has to be identical in block execution, batch generation and proof
+/// verification alike. Rather than threading it through every one of those call paths, it is pinned
+/// here once — the chain cannot change it while committed-but-unverified batches exist (the L1
+/// `Admin.setPubdataContent` refuses), so a running node never observes it change.
+///
+/// Left unset it reads as `FullPubdata`, which is what every pre-v32 chain and every rollup runs
+/// with, and what tests and offline tooling that never talk to L1 expect.
+static CHAIN_PUBDATA_CONTENT: OnceLock<PubdataContent> = OnceLock::new();
+
+/// Pins the chain's pubdata content for this process. Called once during node startup with the value
+/// read from L1; calling it again with the same value is a no-op, with a different one is an error
+/// (nothing in a running node may execute under two different chain configs).
+pub fn set_chain_pubdata_content(pubdata_content: PubdataContent) -> anyhow::Result<()> {
+    let pinned = CHAIN_PUBDATA_CONTENT.get_or_init(|| pubdata_content);
+    anyhow::ensure!(
+        *pinned == pubdata_content,
+        "chain pubdata content already pinned to {pinned:?}, cannot switch to {pubdata_content:?}"
+    );
+    Ok(())
+}
+
+/// The pubdata content every v32 chain config in this process is built with.
+pub fn chain_pubdata_content() -> PubdataContent {
+    CHAIN_PUBDATA_CONTENT
+        .get()
+        .copied()
+        .unwrap_or(PubdataContent::FullPubdata)
+}
 
 /// Per-block input to [`generate_batch_run`].
 #[derive(Debug, Clone, Copy)]

--- a/lib/native_pig/src/v32.rs
+++ b/lib/native_pig/src/v32.rs
@@ -22,6 +22,7 @@ use zksync_os_types::{PubdataMode, ZksyncOsEncode};
 /// public input, so proof verification must reconstruct it identically.
 pub(crate) fn chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
     ChainConfig::new(chain_id, false, DEFAULT_MAX_TX_GAS_LIMIT)
+        .map(|config| config.with_pubdata_content(crate::chain_pubdata_content()))
         .map_err(|err| anyhow::anyhow!("invalid chain config: {err:?}"))
 }
 

--- a/lib/native_pig/tests/chain_pubdata_content.rs
+++ b/lib/native_pig/tests/chain_pubdata_content.rs
@@ -1,0 +1,31 @@
+//! The chain's pubdata content is pinned once per process, so these assertions live in their own
+//! test binary rather than next to the crate's unit tests.
+
+use zksync_os_native_pig::{
+    PubdataContent, chain_pubdata_content, set_chain_pubdata_content, v32_chain_config,
+    v32_chain_config_hash,
+};
+
+const CHAIN_ID: u64 = 270;
+
+#[test]
+fn pinning_logs_only_changes_the_chain_config_and_its_hash() {
+    // Unset, the process behaves as every rollup and every pre-v32 chain does.
+    assert_eq!(chain_pubdata_content(), PubdataContent::FullPubdata);
+    let full_pubdata_hash = v32_chain_config_hash(CHAIN_ID).unwrap();
+
+    set_chain_pubdata_content(PubdataContent::LogsOnly).unwrap();
+
+    assert_eq!(chain_pubdata_content(), PubdataContent::LogsOnly);
+    assert_eq!(
+        v32_chain_config(CHAIN_ID).unwrap().pubdata_content(),
+        PubdataContent::LogsOnly
+    );
+    // The content is part of the chain config hash, and therefore of the batch public input.
+    assert_ne!(v32_chain_config_hash(CHAIN_ID).unwrap(), full_pubdata_hash);
+
+    // Re-pinning the same value is a no-op; a conflicting one is refused, since a running node must
+    // never execute under two different chain configs.
+    set_chain_pubdata_content(PubdataContent::LogsOnly).unwrap();
+    assert!(set_chain_pubdata_content(PubdataContent::FullPubdata).is_err());
+}

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -68,7 +68,7 @@ use zksync_os_batch_verification::{
     BatchVerificationResponder, effective_verification_policy,
 };
 use zksync_os_contract_interface::l1_discovery::{BatchVerificationSL, L1State};
-use zksync_os_contract_interface::models::{BatchDaInputMode, ChainPubdataContent};
+use zksync_os_contract_interface::models::ChainPubdataContent;
 use zksync_os_gas_adjuster::GasAdjuster;
 use zksync_os_genesis::{FileGenesisInputSource, Genesis, GenesisInputSource};
 use zksync_os_internal_config::InternalConfigManager;
@@ -301,17 +301,18 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
     .expect("failed to pin the chain pubdata content");
     tracing::info!(pubdata_content = ?l1_state.pubdata_content, "Chain pubdata content");
 
+    // The pubdata mode has to produce the DA commitment scheme the chain is configured with: the
+    // `Committer` rejects any batch that declares a different one. This is the chain's DA *mechanism*
+    // and says nothing about its pubdata pricing — a logs-only validium publishes (little) pubdata
+    // through blobs and may still price as a validium.
     if let (Some(pubdata_mode), true) = (effective_pubdata_mode, node_role.is_main()) {
-        match (pubdata_mode, l1_state.da_input_mode) {
-            (PubdataMode::Calldata | PubdataMode::Blobs, BatchDaInputMode::Validium)
-            | (PubdataMode::Validium, BatchDaInputMode::Rollup) => {
-                panic!(
-                    "Pubdata mode doesn't correspond to pricing mode from the l1. \
-                    L1 mode: {:?}, effective pubdata mode: {:?}",
-                    l1_state.da_input_mode, pubdata_mode
-                );
-            }
-            _ => {}
+        let produced_scheme = pubdata_mode.da_commitment_scheme();
+        if produced_scheme != l1_state.l2_da_commitment_scheme {
+            panic!(
+                "Pubdata mode doesn't correspond to the DA commitment scheme from the L1. \
+                L1 scheme: {:?}, effective pubdata mode: {:?} (produces {:?})",
+                l1_state.l2_da_commitment_scheme, pubdata_mode, produced_scheme
+            );
         }
     }
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -68,7 +68,7 @@ use zksync_os_batch_verification::{
     BatchVerificationResponder, effective_verification_policy,
 };
 use zksync_os_contract_interface::l1_discovery::{BatchVerificationSL, L1State};
-use zksync_os_contract_interface::models::BatchDaInputMode;
+use zksync_os_contract_interface::models::{BatchDaInputMode, ChainPubdataContent};
 use zksync_os_gas_adjuster::GasAdjuster;
 use zksync_os_genesis::{FileGenesisInputSource, Genesis, GenesisInputSource};
 use zksync_os_internal_config::InternalConfigManager;
@@ -86,6 +86,7 @@ use zksync_os_mempool::Pool;
 use zksync_os_mempool::subpools::l2::L2Subpool;
 use zksync_os_merkle_tree::{MerkleTree, RocksDBWrapper};
 use zksync_os_metadata::NODE_VERSION;
+use zksync_os_native_pig::PubdataContent;
 use zksync_os_network::RecordOverride;
 use zksync_os_network::VerifyBatch;
 use zksync_os_network::protocol::{
@@ -290,6 +291,16 @@ pub async fn run<State: ReadStateHistory + WriteState + StateInitializer + Clone
         // External nodes do not produce blocks; pubdata mode is irrelevant for them.
         None
     };
+    // Pin the chain's pubdata content — read from L1 — before anything executes a block: it is part of
+    // every v32 batch's public input, so block execution, batch generation and proof verification all
+    // have to run with the chain's own value.
+    zksync_os_native_pig::set_chain_pubdata_content(match l1_state.pubdata_content {
+        ChainPubdataContent::FullPubdata => PubdataContent::FullPubdata,
+        ChainPubdataContent::LogsOnly => PubdataContent::LogsOnly,
+    })
+    .expect("failed to pin the chain pubdata content");
+    tracing::info!(pubdata_content = ?l1_state.pubdata_content, "Chain pubdata content");
+
     if let (Some(pubdata_mode), true) = (effective_pubdata_mode, node_role.is_main()) {
         match (pubdata_mode, l1_state.da_input_mode) {
             (PubdataMode::Calldata | PubdataMode::Blobs, BatchDaInputMode::Validium)


### PR DESCRIPTION
## Summary

v32 folds `pubdata_content` into the chain config hash and therefore into every batch's public input
(`Executor._getBatchProofPublicInputZKsyncOS`), but the node builds its config with
`ChainConfig::new(chain_id, false, DEFAULT_MAX_TX_GAS_LIMIT)` — always `FullPubdata`. The value was
never read from L1, so a chain configured `LOGS_ONLY` there would produce batches whose public input
can never verify, with nothing to say so. The zksync-os side already implements the mode fully
(`net_pubdata_used` → `net_committed_log_records_pubdata_used`, the logs-only block intrinsic, …);
only the server never selects it.

`LOGS_ONLY` is what a **ZKsync OS logs-only validium** runs with: it drops the state diffs and
message preimages but keeps publishing the mandatory L2→L1 log region — which carries the interop
commitment tree (IMT) leaves — through the same blobs a rollup uses. Same DA mechanism, narrower
content.

This PR makes the node run with the chain's own value:

- **`l1_discovery`** reads `getPubdataContent()` (and the chain's `l2DACommitmentScheme`, see below)
  from the diamond into `L1State`. The getter only
  exists on v32+ diamonds, so the protocol version is checked first rather than letting an unknown
  selector fail; anything older reports `FullPubdata`, which is exactly how a pre-v32 chain behaves —
  its batch public input carries no chain config hash at all.
- **The node pins that value once at startup**, before anything executes a block, and
  `v32_chain_config` builds every config with it.

## The startup check no longer uses pricing as a proxy for the DA mechanism

The `pubdata_mode` check compared the node's mode against the pubdata *pricing* mode read from L1
(`da_input_mode`), which was a stand-in for "what DA does this chain use". The two come apart in v32:
a logs-only validium publishes its (small) pubdata through blobs while pricing as a validium, and the
old check rejected that outright — the node would refuse to start on a perfectly well-configured
chain.

The invariant that actually matters is the one `Committer` enforces on every batch: a committed batch
must declare exactly the chain's `l2DACommitmentScheme`. The node now reads that scheme from
`getDAValidatorPair()` and requires its pubdata mode to produce it, which is both stricter (it catches
a genuine mechanism mismatch that pricing could not) and correct for a validium that publishes blobs.
Pricing goes back to being what it is — a fee-policy choice — and `da_input_mode` stays on `L1State`
for its metric.

## Why a process-wide pin

A node serves a single chain, and the value has to be identical in block execution, batch generation
and proof verification alike — `multivm::run_block` / `simulate_tx`, `generate_batch_run`, the
public-input reconstruction, the FRI/SNARK verifiers and the EN verifier all build the same config.
Threading it through each of those paths means touching the sequencer, the RPC sandbox and the prover
API; putting it in `BlockContext` (which already carries `chain_id` "temporarily … so that it can be
easily passed from the oracle") means a replay-record/wire version bump. Pinning it once keeps every
path consistent by construction, and L1 refuses to change the value while committed-but-unverified
batches exist, so a running node never observes it change.

Follow-up worth having on the record: a chain that ever *changes* its pubdata content would need the
value per block — i.e. in `BlockContext` — so that re-executing history stays exact. Nothing can
change it today without first verifying every committed batch, so this is not reachable yet.

## Behaviour for existing chains

Unchanged. v31 chains skip the read entirely; rollups read `FULL_PUBDATA`, which is what the node
already assumed. The only new work at startup is one `getProtocolVersion` call (plus one
`getPubdataContent` on v32+ chains).

## Contract side

matter-labs/era-contracts#2420 is the other half: it configures a ZKsync OS logs-only validium as
`BLOBS_ZKSYNC_OS` + the ZKsync OS blobs L1 DA validator + `pubdataContent = LOGS_ONLY`, leaving its
pubdata pricing free. matter-labs/zksync-os-integration-tests#36 carries the `zk-deployer` half.

## Testing

- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` and
  `cargo fmt --check` clean.
- New `lib/native_pig/tests/chain_pubdata_content.rs` (own test binary, since the pin is
  process-wide): the default is `FullPubdata`, pinning `LogsOnly` reaches the chain config and
  changes its hash, re-pinning the same value is a no-op and a conflicting pin is refused.