### PR TITLE
feat: derive the node pubdata mode from the chain DA commitment scheme on L1

### DIFF
--- a/lib/batch_verification/src/verifier/mod.rs
+++ b/lib/batch_verification/src/verifier/mod.rs
@@ -310,7 +310,9 @@ mod tests {
     use zksync_os_batch_types::BlockMerkleTreeData;
     use zksync_os_batch_types::PendingBatchInfo;
     use zksync_os_batch_types::batcher_model::{BatchEnvelope, BatchMetadata, ProverInput};
-    use zksync_os_contract_interface::models::{BatchDaInputMode, StoredBatchInfo};
+    use zksync_os_contract_interface::models::{
+        BatchDaInputMode, DACommitmentScheme, StoredBatchInfo,
+    };
     use zksync_os_contract_interface::{Bridgehub, ZkChain};
     use zksync_os_genesis::{FileGenesisInputSource, GenesisState, build_genesis};
     use zksync_os_interface::traits::{PreimageSource, ReadStorage};
@@ -743,6 +745,7 @@ mod tests {
             l1_block_number: 0,
             finalized_l1_block_number: 0,
             da_input_mode: BatchDaInputMode::Rollup,
+            l2_da_commitment_scheme: Some(DACommitmentScheme::BlobsZKsyncOS),
             l1_chain_id: SL_CHAIN_ID,
         }
     }

--- a/lib/contract_interface/src/l1_discovery.rs
+++ b/lib/contract_interface/src/l1_discovery.rs
@@ -1,5 +1,5 @@
 use crate::metrics::L1_STATE_METRICS;
-use crate::models::BatchDaInputMode;
+use crate::models::{BatchDaInputMode, DACommitmentScheme};
 use crate::{Bridgehub, MultisigCommitter, PubdataPricingMode, ZkChain};
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, U256};
@@ -37,6 +37,10 @@ pub struct L1State {
     /// Finalized L1 block number that was used to query `last_finalized_executed_batch`.
     pub finalized_l1_block_number: u64,
     pub da_input_mode: BatchDaInputMode,
+    /// The mechanism this chain's batches publish pubdata with. Every committed batch has to declare
+    /// exactly this scheme, so the node's pubdata mode is derived from it — and `None`, on a diamond
+    /// that predates the scheme, is what makes the node fall back to a configured mode.
+    pub l2_da_commitment_scheme: Option<DACommitmentScheme>,
     pub l1_chain_id: u64,
 }
 
@@ -126,6 +130,11 @@ impl L1State {
             v => panic!("unexpected pubdata pricing mode: {}", v as u8),
         };
 
+        let l2_da_commitment_scheme: Option<DACommitmentScheme> = diamond_proxy_l1
+            .get_l2_da_commitment_scheme()
+            .await?
+            .map(Into::into);
+
         let batch_verification = match MultisigCommitter::try_new(
             validator_timelock,
             diamond_proxy_l1.provider().clone(),
@@ -163,6 +172,7 @@ impl L1State {
             l1_block_number: latest_l1_block_number,
             finalized_l1_block_number,
             da_input_mode,
+            l2_da_commitment_scheme,
             l1_chain_id,
         })
     }
@@ -217,6 +227,7 @@ impl L1State {
             l1_block_number,
             finalized_l1_block_number,
             da_input_mode: this.da_input_mode,
+            l2_da_commitment_scheme: this.l2_da_commitment_scheme,
             l1_chain_id: this.l1_chain_id,
         })
     }

--- a/lib/contract_interface/src/lib.rs
+++ b/lib/contract_interface/src/lib.rs
@@ -278,6 +278,7 @@ alloy::sol! {
         function getTotalBatchesExecuted() external view returns (uint256);
         function getTotalPriorityTxs() external view returns (uint256);
         function getPubdataPricingMode() external view returns (PubdataPricingMode);
+        function getDAValidatorPair() external view returns (address, L2DACommitmentScheme);
         function getAdmin() external view returns (address);
         function getChainTypeManager() external view returns (address);
         function getProtocolVersion() external view returns (uint256);
@@ -812,6 +813,28 @@ impl<P: Provider> ZkChain<P> {
             .call()
             .await
             .enrich("getPubdataPricingMode", None)
+    }
+
+    /// The chain's L2 DA commitment scheme — the mechanism its batches publish pubdata with. The
+    /// `Committer` requires every committed batch to declare exactly this scheme.
+    ///
+    /// `None` on a diamond that predates the scheme: it either has no getter at all, or returns the
+    /// L2 DA validator address where the scheme now sits, which does not decode as the enum. Such a
+    /// chain cannot have its pubdata mode derived and has to configure one.
+    pub async fn get_l2_da_commitment_scheme(&self) -> Result<Option<L2DACommitmentScheme>> {
+        match self.instance.getDAValidatorPair().call().await {
+            Ok(pair) => Ok(match pair._1 {
+                L2DACommitmentScheme::__Invalid => None,
+                scheme => Some(scheme),
+            }),
+            Err(err)
+                if is_method_missing(&err)
+                    || matches!(err, alloy::contract::Error::AbiError(_)) =>
+            {
+                Ok(None)
+            }
+            Err(err) => Err(Error::Call(Box::new(err), "getDAValidatorPair".to_string())),
+        }
     }
 
     /// Returns true iff the contract has non-empty code at `block_id`.

--- a/lib/types/src/pubdata_mode.rs
+++ b/lib/types/src/pubdata_mode.rs
@@ -1,7 +1,13 @@
 use crate::ProtocolSemanticVersion;
 use serde::{Deserialize, Serialize};
 
-/// The chain pubdata mode.
+/// The DA *mechanism* a chain publishes its pubdata with.
+///
+/// This is one half of the chain's DA configuration and is fixed by the `L2DACommitmentScheme`
+/// recorded on L1; the other half is [`crate::PubdataContent`], which says how *much* pubdata the
+/// chain produces. The two are orthogonal: a logs-only validium keeps [`PubdataMode::Blobs`] — it
+/// reaches L1 exactly like a rollup — and only narrows its pubdata content. Neither of them is a
+/// pricing decision: pubdata *pricing* is a free fee-policy choice made on L1.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum PubdataMode {
@@ -41,6 +47,22 @@ impl PubdataMode {
         self as u8
     }
 
+    /// The pubdata mode that produces `scheme`, i.e. the inverse of [`Self::da_commitment_scheme`].
+    ///
+    /// `None` for the schemes no ZKsync OS server can produce: `PubdataKeccak256` (third-party DA)
+    /// and the `None` placeholder.
+    pub fn from_da_commitment_scheme(
+        scheme: zksync_os_contract_interface::models::DACommitmentScheme,
+    ) -> Option<Self> {
+        use zksync_os_contract_interface::models::DACommitmentScheme;
+        match scheme {
+            DACommitmentScheme::BlobsZKsyncOS => Some(Self::Blobs),
+            DACommitmentScheme::BlobsAndPubdataKeccak256 => Some(Self::Calldata),
+            DACommitmentScheme::EmptyNoDA => Some(Self::Validium),
+            DACommitmentScheme::PubdataKeccak256 | DACommitmentScheme::None => None,
+        }
+    }
+
     pub fn da_commitment_scheme(&self) -> zksync_os_contract_interface::models::DACommitmentScheme {
         match self {
             Self::Blobs => zksync_os_contract_interface::models::DACommitmentScheme::BlobsZKsyncOS,
@@ -49,5 +71,40 @@ impl PubdataMode {
             }
             Self::Validium => zksync_os_contract_interface::models::DACommitmentScheme::EmptyNoDA,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PubdataMode;
+    use zksync_os_contract_interface::models::DACommitmentScheme;
+
+    #[test]
+    fn every_pubdata_mode_round_trips_through_its_da_commitment_scheme() {
+        for mode in [
+            PubdataMode::Blobs,
+            PubdataMode::Calldata,
+            PubdataMode::Validium,
+        ] {
+            assert_eq!(
+                PubdataMode::from_da_commitment_scheme(mode.da_commitment_scheme()),
+                Some(mode),
+                "{mode:?} does not round-trip through its DA commitment scheme"
+            );
+        }
+    }
+
+    #[test]
+    fn schemes_no_server_produces_have_no_pubdata_mode() {
+        // Third-party DA is not something a ZKsync OS server publishes itself, so a chain using it
+        // has to configure its pubdata mode instead of deriving one.
+        assert_eq!(
+            PubdataMode::from_da_commitment_scheme(DACommitmentScheme::PubdataKeccak256),
+            None
+        );
+        assert_eq!(
+            PubdataMode::from_da_commitment_scheme(DACommitmentScheme::None),
+            None
+        );
     }
 }

--- a/local-chains/v31.0/default/config.yaml
+++ b/local-chains/v31.0/default/config.yaml
@@ -5,7 +5,6 @@ genesis:
   chain_id: 506
 
 l1_sender:
-  pubdata_mode: Blobs
   operator_commit_sk: "0xc78123547577c67de697c0e80911cb913d2be569d182ed2d42bd7cd30851948c"
   operator_prove_sk: "0x1ed8abac5f8143e0f37cc4da4655cb14c82473c1254da12683956749b0cca5bd"
   operator_execute_sk: "0x7a2f70531f7ba8a79e74c2be455eb7dfa0526f2e802ab9d7132959f040acafc5"

--- a/local-chains/v32.0/default/config.yaml
+++ b/local-chains/v32.0/default/config.yaml
@@ -5,7 +5,6 @@ genesis:
   chain_id: 506
 
 l1_sender:
-  pubdata_mode: Blobs
   operator_commit_sk: "0xc78123547577c67de697c0e80911cb913d2be569d182ed2d42bd7cd30851948c"
   operator_prove_sk: "0x1ed8abac5f8143e0f37cc4da4655cb14c82473c1254da12683956749b0cca5bd"
   operator_execute_sk: "0x7a2f70531f7ba8a79e74c2be455eb7dfa0526f2e802ab9d7132959f040acafc5"

--- a/node/bin/src/config/mod.rs
+++ b/node/bin/src/config/mod.rs
@@ -1301,8 +1301,13 @@ pub struct L1SenderConfig {
     #[config(default_t = true)]
     pub enabled: bool,
 
-    /// Pubdata mode used by block-producing components on the Main Node. Required at runtime on
-    /// Main Nodes; External Nodes never produce blocks and may leave it unset.
+    /// Pubdata mode used by block-producing components on the Main Node: the DA *mechanism* the
+    /// chain publishes with (`Blobs`, `Calldata` or `Validium`).
+    ///
+    /// Leave it unset: the Main Node derives it from the chain's DA commitment scheme on L1, which
+    /// is the value the `Committer` enforces on every batch anyway. Set it only for a chain whose
+    /// scheme a ZKsync OS server cannot produce (third-party DA), in which case it must still agree
+    /// with L1. External Nodes never produce blocks and always leave it unset.
     #[config(with = Serde![str])]
     pub pubdata_mode: Option<PubdataMode>,
 

--- a/node/bin/src/lib.rs
+++ b/node/bin/src/lib.rs
@@ -66,7 +66,7 @@ use zksync_os_batch_verification::{
     BatchVerificationResponder, effective_verification_policy,
 };
 use zksync_os_contract_interface::l1_discovery::{BatchVerificationSL, L1State};
-use zksync_os_contract_interface::models::BatchDaInputMode;
+use zksync_os_contract_interface::models::DACommitmentScheme;
 use zksync_os_gas_adjuster::GasAdjuster;
 use zksync_os_genesis::{FileGenesisInputSource, Genesis, GenesisInputSource};
 use zksync_os_internal_config::InternalConfigManager;
@@ -281,24 +281,14 @@ pub async fn run(runtime: &Runtime, config: Config) -> ServerPorts {
 
     // Effective pubdata mode used by all block-producing components.
     let effective_pubdata_mode: Option<PubdataMode> = if node_role.is_main() {
-        Some(effective_main_node_pubdata_mode(&config))
+        Some(effective_main_node_pubdata_mode(
+            &config,
+            l1_state.l2_da_commitment_scheme,
+        ))
     } else {
         // External nodes do not produce blocks; pubdata mode is irrelevant for them.
         None
     };
-    if let (Some(pubdata_mode), true) = (effective_pubdata_mode, node_role.is_main()) {
-        match (pubdata_mode, l1_state.da_input_mode) {
-            (PubdataMode::Calldata | PubdataMode::Blobs, BatchDaInputMode::Validium)
-            | (PubdataMode::Validium, BatchDaInputMode::Rollup) => {
-                panic!(
-                    "Pubdata mode doesn't correspond to pricing mode from the l1. \
-                    L1 mode: {:?}, effective pubdata mode: {:?}",
-                    l1_state.da_input_mode, pubdata_mode
-                );
-            }
-            _ => {}
-        }
-    }
 
     prepare_raft_storage(&config).expect("failed to prepare raft storage");
 
@@ -1560,13 +1550,44 @@ fn check_batch_verification_mismatch(
     false
 }
 
-/// Returns the pubdata mode used by all block-producing components on the Main Node: the
-/// configured `l1_sender.pubdata_mode` (its presence is enforced here).
-fn effective_main_node_pubdata_mode(config: &Config) -> PubdataMode {
-    config
-        .l1_sender_config
-        .pubdata_mode
-        .expect("`l1_sender.pubdata_mode` is required on the Main Node")
+/// Returns the pubdata mode used by all block-producing components on the Main Node.
+///
+/// The chain's DA *mechanism* is already recorded on L1, and the `Committer` rejects any batch that
+/// declares a different one, so the operator does not have to restate it: with
+/// `l1_sender.pubdata_mode` unset the mode is derived from the chain's DA commitment scheme. A
+/// configured value is an override for the schemes that have none — and has to agree with L1.
+///
+/// None of this touches pubdata *pricing*, which is a free fee-policy choice: a logs-only validium
+/// publishes (little) pubdata through blobs and may still price as a validium.
+fn effective_main_node_pubdata_mode(
+    config: &Config,
+    l2_da_commitment_scheme: Option<DACommitmentScheme>,
+) -> PubdataMode {
+    match (config.l1_sender_config.pubdata_mode, l2_da_commitment_scheme) {
+        (Some(configured), Some(scheme)) => {
+            let produced_scheme = configured.da_commitment_scheme();
+            if produced_scheme != scheme {
+                panic!(
+                    "Pubdata mode doesn't correspond to the DA commitment scheme from the L1. \
+                    L1 scheme: {scheme:?}, configured pubdata mode: {configured:?} (produces \
+                    {produced_scheme:?}). Unset `l1_sender.pubdata_mode` to derive it from L1."
+                );
+            }
+            configured
+        }
+        (Some(configured), None) => configured,
+        (None, Some(scheme)) => PubdataMode::from_da_commitment_scheme(scheme).unwrap_or_else(|| {
+            panic!(
+                "The chain's DA commitment scheme on L1 ({scheme:?}) is not one a ZKsync OS server \
+                produces, so no pubdata mode can be derived from it; set `l1_sender.pubdata_mode` \
+                explicitly if this is intentional."
+            )
+        }),
+        (None, None) => panic!(
+            "`l1_sender.pubdata_mode` is required on a Main Node whose chain does not report a DA \
+            commitment scheme on L1"
+        ),
+    }
 }
 
 /// Counts commit transactions a previous session left in the L1 mempool (pending minus latest


### PR DESCRIPTION
## Summary

`l1_sender.pubdata_mode` is a required Main Node knob, and startup checks it against the pubdata
**pricing** mode read from L1 (`da_input_mode`), using pricing as a proxy for "what DA does this chain
use":

```rust
(PubdataMode::Calldata | PubdataMode::Blobs, BatchDaInputMode::Validium)
| (PubdataMode::Validium, BatchDaInputMode::Rollup) => panic!(...)
```

Pricing is a fee-policy choice and says nothing about the DA *mechanism*, so the proxy is wrong in
both directions. It rejects a valid setup — a chain that publishes through blobs while pricing as a
validium — and it misses a real mismatch: `Blobs` vs `Calldata` are both "rollup priced", so that one
only surfaces when the first commit reverts.

The invariant that actually matters is the one `Committer` enforces on every batch: a committed batch
must declare exactly the chain's `l2DACommitmentScheme`, otherwise `MismatchL2DACommitmentScheme`.
That scheme is already on L1. So the node reads it through `getDAValidatorPair()` into `L1State` and
**derives** the pubdata mode from it — the operator configures nothing.

`l1_sender.pubdata_mode` stays as an override for the schemes no ZKsync OS server can produce
(`PUBDATA_KECCAK256`, third-party DA), and when set it must agree with L1.

`L1State::l2_da_commitment_scheme` is an `Option`: a diamond that predates the scheme either has no
getter or returns the L2 DA validator address where the enum now sits, and neither decodes. Such a
chain falls back to the configured mode exactly as today — which is why the `local-chains/v30.2`
fixtures keep their `pubdata_mode` while the v31/v32 ones drop it.

`da_input_mode` stays on `L1State` for its metric; pricing goes back to being what it is.

## Why now

v32 makes the two axes come apart. A logs-only validium publishes its (small) pubdata through blobs
and may still price as a validium, so today it would be `(Blobs, Validium)` — a correct chain the
current check panics on. Its operator would also have had to write `pubdata_mode: Blobs`, the same
value a rollup writes, because the two differ in pubdata *content*, not mechanism. Now nobody writes
either.

The contract side of that chain type is matter-labs/era-contracts#2420, which configures a ZKsync OS
logs-only validium as `BLOBS_ZKSYNC_OS` + the blobs L1 DA validator + `pubdataContent = LOGS_ONLY`,
and leaves its pricing free. This PR is independent of it: it is a correctness fix for the check that
exists on `main` today, and it does not need any contract change to land.

## Testing

`cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` and
`cargo fmt --check` clean. `cargo test -p zksync_os_types` covers the new scheme↔mode round trip and
the schemes that have no mode.

Supersedes #1547, which carried the same fix stacked on #1530.
