### PR TITLE
feat(policy): send the transaction hash with /admit where it is known

### DIFF
--- a/lib/rpc/src/tx_handler.rs
+++ b/lib/rpc/src/tx_handler.rs
@@ -117,7 +117,7 @@ impl<RpcStorage: ReadRpcStorage, Mempool: L2Subpool> TxHandler<RpcStorage, Mempo
                     .unwrap_or_else(|| build_pending_block_context(&storage, chain_id));
                 let storage_view =
                     storage.state_at_block_number_or_latest(block_context.block_number)?;
-                let mut policy_session = policy_client.session(AccessType::Write);
+                let mut policy_session = policy_client.session_for_tx(AccessType::Write, hash);
                 let mut tracer = policy_session.paired_tracer();
                 crate::sandbox::execute_with(
                     zk_tx,

--- a/lib/tx_validators/src/policy_client/mod.rs
+++ b/lib/tx_validators/src/policy_client/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use secrecy::SecretString;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::tracing::{
@@ -121,6 +121,16 @@ impl PolicyClient {
             slot: tracer::new_slot(),
             pending_tx_from: None,
             access_type,
+            tx_hash: None,
+        }
+    }
+
+    /// Two transactions differing only by nonce are identical in the rest of the
+    /// request, so without the hash a decision granted for one admits the others.
+    pub fn session_for_tx(&self, access_type: AccessType, tx_hash: B256) -> PolicySession {
+        PolicySession {
+            tx_hash: Some(tx_hash),
+            ..self.session(access_type)
         }
     }
 }
@@ -132,6 +142,7 @@ pub struct PolicySession {
     slot: TraceSlot,
     pending_tx_from: Option<Address>,
     access_type: AccessType,
+    tx_hash: Option<B256>,
 }
 
 impl PolicySession {
@@ -152,8 +163,12 @@ impl PolicySession {
             metrics.admit_bypassed.inc();
             return Ok(());
         }
-        let request =
-            AdmitRequest::from_context(ctx, &self.client.protocol_version, self.access_type);
+        let request = AdmitRequest::from_context(
+            ctx,
+            &self.client.protocol_version,
+            self.access_type,
+            self.tx_hash,
+        );
         let started = Instant::now();
         let result = self.post_and_parse(Endpoint::Admit(request)).await;
         metrics.admit_latency.observe(started.elapsed());

--- a/lib/tx_validators/src/policy_client/tests.rs
+++ b/lib/tx_validators/src/policy_client/tests.rs
@@ -8,7 +8,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use alloy::primitives::{Address, U256, address};
+use alloy::primitives::{Address, U256, address, b256};
 use httpmock::{Method, MockServer};
 use serde_json::json;
 use tokio::task::spawn_blocking;
@@ -210,6 +210,45 @@ async fn serialized_request_matches_context() {
     assert_eq!(parsed["calldata"].as_str().unwrap(), "0xdeadbeef");
     assert_eq!(parsed["gasLimit"].as_u64().unwrap(), 100_000);
     assert_eq!(parsed["accessType"].as_str().unwrap(), "write");
+}
+
+/// Captures the `/admit` body of one allowed call.
+async fn admit_body(session: PolicySession, server: &MockServer) -> serde_json::Value {
+    let body: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let body_c = body.clone();
+    server.mock(|when, then| {
+        when.method(Method::POST)
+            .path("/admit")
+            .is_true(move |req| {
+                *body_c.lock().unwrap() = Some(req.body().as_ref().to_vec());
+                true
+            });
+        then.status(200).json_body(json!({"allow": true}));
+    });
+    let _ = run_begin_tx(session, test_context()).await;
+    let recorded = body.lock().unwrap().take().expect("body captured");
+    serde_json::from_slice(&recorded).unwrap()
+}
+
+#[tokio::test]
+async fn admit_carries_the_transaction_hash_when_the_transaction_is_known() {
+    let server = MockServer::start();
+    let client = PolicyClient::new(base_config(&server)).unwrap();
+    let hash = b256!("0x00000000000000000000000000000000000000000000000000000000000000aa");
+
+    let parsed = admit_body(client.session_for_tx(AccessType::Write, hash), &server).await;
+
+    assert_eq!(parsed["txHash"].as_str().unwrap(), hash.to_string());
+}
+
+#[tokio::test]
+async fn admit_omits_the_transaction_hash_where_no_transaction_is_in_hand() {
+    let server = MockServer::start();
+    let client = PolicyClient::new(base_config(&server)).unwrap();
+
+    let parsed = admit_body(client.session(AccessType::Write), &server).await;
+
+    assert!(parsed.get("txHash").is_none());
 }
 
 #[tokio::test]

--- a/lib/tx_validators/src/policy_client/wire.rs
+++ b/lib/tx_validators/src/policy_client/wire.rs
@@ -1,6 +1,6 @@
 //! JSON wire types for `/admit` and `/judge`.
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 use zksync_os_interface::tracing::BeginTxContext;
 
@@ -19,6 +19,10 @@ pub(super) struct AdmitRequest<'a> {
     pub calldata: &'a [u8],
     pub gas_limit: u64,
     pub access_type: AccessType,
+    /// Absent on the block-build and gas-estimation paths, which have no single
+    /// transaction in hand.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<B256>,
 }
 
 impl<'a> AdmitRequest<'a> {
@@ -26,6 +30,7 @@ impl<'a> AdmitRequest<'a> {
         ctx: &'a BeginTxContext<'a>,
         protocol_version: &'a str,
         access_type: AccessType,
+        tx_hash: Option<B256>,
     ) -> Self {
         Self {
             protocol_version,
@@ -35,6 +40,7 @@ impl<'a> AdmitRequest<'a> {
             calldata: ctx.calldata,
             gas_limit: ctx.gas_limit,
             access_type,
+            tx_hash,
         }
     }
 }


### PR DESCRIPTION
## Summary

A policy service decides on the fields of a transaction, and two transactions from the same signer that differ only by nonce are identical in all of them. It cannot tell them apart, so one decision can admit several transactions — a spending limit or an approval ends up bounding how often an operation is decided rather than how much it moves.

`/admit` now carries the transaction hash wherever a concrete transaction exists, so a decision can be bound to one transaction. The field is optional and additive: paths with no single transaction omit it, and a service that does not read it is unaffected.